### PR TITLE
ref(ai-monitoring): Expose GA conversations in frontend

### DIFF
--- a/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
+++ b/static/app/components/commandPalette/ui/commandPaletteGlobalActions.tsx
@@ -429,12 +429,10 @@ export function GlobalCommandPaletteActions() {
             keywords={[t('release health')]}
             to={`${prefix}/explore/releases/`}
           />
-          {organization.features.includes('gen-ai-conversations') && (
-            <CMDKAction
-              display={{label: t('Agents')}}
-              to={`${prefix}/explore/${EXPLORE_AGENTS_SUB_PATH}/?referrer=cmdk`}
-            />
-          )}
+          <CMDKAction
+            display={{label: t('Agents')}}
+            to={`${prefix}/explore/${EXPLORE_AGENTS_SUB_PATH}/?referrer=cmdk`}
+          />
           <CMDKAction
             display={{label: t('All Queries')}}
             to={`${prefix}/explore/saved-queries/`}

--- a/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
@@ -35,9 +35,7 @@ const BASE_CONVERSATION = {
   user: null,
 };
 
-const organization = OrganizationFixture({
-  features: ['gen-ai-conversations'],
-});
+const organization = OrganizationFixture();
 
 function mockConversations(body: Array<Record<string, unknown>>) {
   MockApiClient.addMockResponse({

--- a/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
@@ -22,9 +22,7 @@ const BASE_CONVERSATION = {
 };
 
 describe('useConversations', () => {
-  const organization = OrganizationFixture({
-    features: ['gen-ai-conversations'],
-  });
+  const organization = OrganizationFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();

--- a/static/app/views/explore/conversations/layout.spec.tsx
+++ b/static/app/views/explore/conversations/layout.spec.tsx
@@ -8,9 +8,7 @@ import {TopBar} from 'sentry/views/navigation/topBar';
 import ConversationsLayout from './layout';
 import {CONVERSATIONS_LANDING_TITLE, CONVERSATIONS_SIDEBAR_LABEL} from './settings';
 
-const organization = OrganizationFixture({
-  features: ['performance-view', 'gen-ai-conversations'],
-});
+const organization = OrganizationFixture({features: ['performance-view']});
 
 function renderLayout(
   location: {pathname: string; query?: Record<string, string | number | string[]>},

--- a/static/app/views/explore/conversations/layout.tsx
+++ b/static/app/views/explore/conversations/layout.tsx
@@ -35,13 +35,7 @@ function ConversationsLayout() {
       organization={organization}
       renderDisabled={NoAccess}
     >
-      <Feature
-        features="gen-ai-conversations"
-        organization={organization}
-        renderDisabled={NoAccess}
-      >
-        <ConversationsLayoutContent />
-      </Feature>
+      <ConversationsLayoutContent />
     </Feature>
   );
 }

--- a/static/app/views/explore/conversations/utils/features.ts
+++ b/static/app/views/explore/conversations/utils/features.ts
@@ -1,5 +1,0 @@
-import type {Organization} from 'sentry/types/organization';
-
-export function hasGenAiConversationsFeature(organization: Organization) {
-  return organization.features.includes('gen-ai-conversations');
-}

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -64,13 +64,11 @@ function ExploreSecondaryNavigationImpl() {
     navItems.push({label: 'Replays', to: `${baseUrl}/replays/`});
   }
   navItems.push({label: 'Releases', to: `${baseUrl}/releases/`});
-  if (organization.features.includes('gen-ai-conversations')) {
-    navItems.push({
-      label: 'Agents',
-      badge: 'new',
-      to: `${baseUrl}/${EXPLORE_AGENTS_SUB_PATH}/`,
-    });
-  }
+  navItems.push({
+    label: 'Agents',
+    badge: 'new',
+    to: `${baseUrl}/${EXPLORE_AGENTS_SUB_PATH}/`,
+  });
   if (organization.openMembership && organization.features.includes('investigations')) {
     navItems.push({
       label: 'Investigations',
@@ -203,21 +201,19 @@ function ExploreSecondaryNavigationImpl() {
                 {t('Releases')}
               </SecondaryNavigation.Link>
             </SecondaryNavigation.ListItem>
-            <Feature features="gen-ai-conversations">
-              <SecondaryNavigation.ListItem>
-                <SecondaryNavigation.Link
-                  // TODO: Remove once query performance is improved - defaults to 24h to avoid slow loads
-                  to={{
-                    pathname: `${baseUrl}/${EXPLORE_AGENTS_SUB_PATH}/`,
-                    search: '?statsPeriod=24h&referrer=sidebar',
-                  }}
-                  analyticsItemName="explore_conversations"
-                  trailingItems={<FeatureBadge type="new" />}
-                >
-                  {t('Agents')}
-                </SecondaryNavigation.Link>
-              </SecondaryNavigation.ListItem>
-            </Feature>
+            <SecondaryNavigation.ListItem>
+              <SecondaryNavigation.Link
+                // TODO: Remove once query performance is improved - defaults to 24h to avoid slow loads
+                to={{
+                  pathname: `${baseUrl}/${EXPLORE_AGENTS_SUB_PATH}/`,
+                  search: '?statsPeriod=24h&referrer=sidebar',
+                }}
+                analyticsItemName="explore_conversations"
+                trailingItems={<FeatureBadge type="new" />}
+              >
+                {t('Agents')}
+              </SecondaryNavigation.Link>
+            </SecondaryNavigation.ListItem>
             {organization.openMembership && (
               <Feature features="organizations:investigations">
                 <SecondaryNavigation.ListItem>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab.spec.tsx
@@ -1,7 +1,6 @@
 import {render, screen} from 'sentry-test/reactTestingLibrary';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {hasGenAiConversationsFeature} from 'sentry/views/explore/conversations/utils/features';
 import {useAITrace} from 'sentry/views/insights/pages/agents/hooks/useAITrace';
 import {getStringAttr} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
@@ -10,7 +9,6 @@ import {TraceAiTab} from 'sentry/views/performance/newTraceDetails/traceDrawer/t
 jest.mock('sentry/utils/analytics');
 jest.mock('sentry/views/insights/pages/agents/hooks/useAITrace');
 jest.mock('sentry/views/insights/pages/agents/utils/aiTraceNodes');
-jest.mock('sentry/views/explore/conversations/utils/features');
 jest.mock(
   'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceAiSpans',
   () => ({TraceAiSpans: () => <div>ai-spans</div>})
@@ -22,13 +20,11 @@ jest.mock(
 
 const mockUseAITrace = jest.mocked(useAITrace);
 const mockGetStringAttr = jest.mocked(getStringAttr);
-const mockHasConversations = jest.mocked(hasGenAiConversationsFeature);
 const mockTrackAnalytics = jest.mocked(trackAnalytics);
 
 describe('TraceAiTab', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockHasConversations.mockReturnValue(false);
     mockGetStringAttr.mockReturnValue(undefined);
   });
 
@@ -37,7 +33,6 @@ describe('TraceAiTab', () => {
     const {rerender} = render(<TraceAiTab traceSlug="trace-slug" />);
     expect(mockTrackAnalytics).not.toHaveBeenCalled();
 
-    mockHasConversations.mockReturnValue(true);
     mockGetStringAttr.mockReturnValue('conversation-1');
     mockUseAITrace.mockReturnValue({
       nodes: [{} as AITraceSpanNode],

--- a/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/tabs/traceAiTab.tsx
@@ -2,7 +2,6 @@ import {useEffect, useMemo, useRef} from 'react';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {hasGenAiConversationsFeature} from 'sentry/views/explore/conversations/utils/features';
 import {useAITrace} from 'sentry/views/insights/pages/agents/hooks/useAITrace';
 import {getStringAttr} from 'sentry/views/insights/pages/agents/utils/aiTraceNodes';
 import type {AITraceSpanNode} from 'sentry/views/insights/pages/agents/utils/types';
@@ -40,10 +39,7 @@ export function TraceAiTab({traceSlug}: {traceSlug: string}) {
     trackAnalytics('agent-monitoring.trace.rendered', {organization});
   }, [isLoading, error, nodes.length, traceSlug, organization]);
 
-  const hasConversations =
-    hasGenAiConversationsFeature(organization) && conversationIds.length > 0;
-
-  if (hasConversations) {
+  if (conversationIds.length > 0) {
     return (
       <TraceAiConversations
         conversationIds={conversationIds}


### PR DESCRIPTION
Agents conversations now appear in Explore navigation and command palette without the temporary rollout flag. Conversation routes retain the existing performance access check, and trace details show conversation content whenever conversation IDs are present.

Merge and deploy #123314 first so frontend rollout does not point users at feature-gated APIs.