### PR TITLE
feat(usageStats): Add `callback_error` client discard reason

### DIFF
--- a/static/app/views/organizationStats/getReasonGroupName.spec.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.spec.ts
@@ -104,6 +104,10 @@ describe('getReasonGroupName', () => {
     expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'no_parent_span')).toBe(
       ClientDiscardReason.NO_PARENT_SPAN
     );
+
+    expect(getReasonGroupName(Outcome.CLIENT_DISCARD, 'callback_error')).toBe(
+      ClientDiscardReason.CALLBACK_ERROR
+    );
   });
 
   it('handles abuse limit reason types', () => {

--- a/static/app/views/organizationStats/getReasonGroupName.ts
+++ b/static/app/views/organizationStats/getReasonGroupName.ts
@@ -85,6 +85,7 @@ export enum ClientDiscardReason {
   BACKPRESSURE = 'backpressure',
   IGNORED = 'ignored',
   NO_PARENT_SPAN = 'no_parent_span',
+  CALLBACK_ERROR = 'callback_error',
 }
 
 enum RateLimitedReason {
@@ -242,6 +243,7 @@ function getClientDiscardReasonGroupName(reason: ClientDiscardReason): string {
     case ClientDiscardReason.BACKPRESSURE:
     case ClientDiscardReason.IGNORED:
     case ClientDiscardReason.NO_PARENT_SPAN:
+    case ClientDiscardReason.CALLBACK_ERROR:
       return reason;
     default:
       return 'other';


### PR DESCRIPTION
This adds the new `callback_error` client discard reason to usage stats. Used in SDKs to indicate that an event was discarded because a user-provided callback threw an error.

ref https://github.com/getsentry/snuba/pull/8422
ref https://linear.app/getsentry/project/wrap-all-sdk-user-callbacks-in-a-try-catch-6bfdbe9f7268/overview