### PR TITLE
fix(source-maps): left-align artifact column contents

### DIFF
--- a/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
+++ b/static/app/views/settings/projectSourceMaps/sourceMapsDetails.tsx
@@ -68,7 +68,7 @@ function ArtifactsTableRow({
 
   return (
     <SimpleTable.Row>
-      <ArtifactColumn>
+      <ArtifactColumn align="stretch" direction="column" justify="center">
         <Flex justify="start" align="center">
           {name || `(${t('empty')})`}
         </Flex>
@@ -390,9 +390,6 @@ const ArtifactColumn = styled(SimpleTable.RowCell)`
   overflow-wrap: break-word;
   word-break: break-all;
   line-height: 140%;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
 `;
 
 const AlignedRightColumn = styled(SimpleTable.RowCell)`


### PR DESCRIPTION
I'd missed this in migrating tables over.

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1630" height="480" alt="Screenshot 2026-09-01 at 10 23 46 AM" src="https://github.com/user-attachments/assets/4534f579-7942-4912-b35b-83f56d44823f" />
</td>
<td>
<img width="1630" height="480" alt="Screenshot 2026-09-01 at 10 23 21 AM" src="https://github.com/user-attachments/assets/dc28e8de-3e6d-4a1d-a0b6-bf7dc47b8d6c" />
</td>
</tbody>
</table>



Closes DE-1586.