### PR TITLE
ref(performance): Replace legacy span attribute lookups

### DIFF
--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/attributes.tsx
@@ -17,6 +17,7 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
 import {FieldKey} from 'sentry/utils/fields';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import {formatDollars} from 'sentry/utils/formatters';
 import {generateProfileFlamechartRoute} from 'sentry/utils/profiling/routes';
 import {ellipsize} from 'sentry/utils/string/ellipsize';
@@ -34,7 +35,6 @@ import {SectionKey} from 'sentry/views/issueDetails/context';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {
-  findSpanAttributeValue,
   getTraceAttributesTreeActions,
   sortAttributes,
   tryParseJsonRecursive,
@@ -250,7 +250,7 @@ export function AttributesContent({
             getCustomActions={getTraceAttributesTreeActions({
               location,
               organization,
-              projectIds: findSpanAttributeValue(attributes, 'project_id'),
+              projectIds: getAttributeValue(attributes, 'project_id')?.toString(),
             })}
           />
         </div>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/eapSections/description.tsx
@@ -43,7 +43,6 @@ import {getHighlightedSpanAttributes} from 'sentry/views/performance/newTraceDet
 import {SpanSummaryLink} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/span/components/spanSummaryLink';
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {
-  findSpanAttributeValue,
   getSearchInExploreTarget,
   TraceDrawerActionKind,
 } from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
@@ -319,7 +318,11 @@ function ResourceImageDescription({
 
   const [showLinks, setShowLinks] = useLocalStorageState(LOCAL_STORAGE_SHOW_LINKS, false);
 
-  const size = findSpanAttributeValue(attributes, 'http.decoded_response_content_length');
+  const size = getAttributeValue(
+    attributes,
+    'http.decoded_response_content_length',
+    'number'
+  );
 
   return (
     <StyledDescriptionWrapper>

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/index.tsx
@@ -22,6 +22,7 @@ import type {Project} from 'sentry/types/project';
 import {LogsAnalyticsPageSource} from 'sentry/utils/analytics/logsAnalyticsEvent';
 import {defined} from 'sentry/utils/defined';
 import {EventView} from 'sentry/utils/discover/eventView';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useProjects} from 'sentry/utils/useProjects';
@@ -57,7 +58,6 @@ import {MCPOutputSection} from 'sentry/views/performance/newTraceDetails/traceDr
 import {TraceDrawerComponents} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/styles';
 import {BreadCrumbs} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/breadCrumbs';
 import {ReplayPreview} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/transaction/sections/replayPreview';
-import {findSpanAttributeValue} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import type {TraceTreeNodeDetailsProps} from 'sentry/views/performance/newTraceDetails/traceDrawer/tabs/traceTreeNodeDetails';
 import {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 import type {BaseNode} from 'sentry/views/performance/newTraceDetails/traceModels/traceTreeNode/baseNode';
@@ -641,8 +641,8 @@ function EAPSpanNodeDetailsContent({
         {isTransaction ? (
           <ReplayPreview
             replayId={
-              findSpanAttributeValue(attributes, 'replay.id') ||
-              findSpanAttributeValue(attributes, 'replayId')
+              getAttributeValue(attributes, 'replay.id', 'string') ||
+              getAttributeValue(attributes, 'replayId', 'string')
             }
             eventTimestampMs={Math.floor(node.value.start_timestamp * 1000)}
             organization={organization}

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/utils.tsx
@@ -11,7 +11,6 @@ import {FieldValueType, getFieldDefinition} from 'sentry/utils/fields';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {copyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import type {AttributesTreeContent} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
-import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import {
   SENTRY_SEARCHABLE_SPAN_NUMBER_TAGS,
   SENTRY_SEARCHABLE_SPAN_STRING_TAGS,
@@ -109,22 +108,6 @@ export function getSearchInExploreTarget(
       project: projectIds ? projectIds : ALL_ACCESS_PROJECTS,
     },
   };
-}
-
-export function findSpanAttributeValue(
-  attributes: TraceItemResponseAttribute[],
-  attributeName: string
-) {
-  // An attribute whose stored key collides with a known public alias comes back
-  // wrapped as `tags[name,type]`, and older data is prefixed with `sentry.`.
-  // prettifyAttributeName reduces both forms to the plain public alias, but an
-  // exact match wins so that a span carrying both forms keeps resolving to the
-  // same attribute it did before.
-  const attribute =
-    attributes.find(({name}) => name === attributeName) ??
-    attributes.find(({name}) => prettifyAttributeName(name) === attributeName);
-
-  return attribute?.value.toString();
 }
 
 // Sort attributes so that span.* attributes are at the beginning and

--- a/static/app/views/performance/newTraceDetails/traceHeader/highlights.spec.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/highlights.spec.tsx
@@ -170,6 +170,28 @@ describe('Highlights', () => {
     expect(screen.queryByText('18.0.0')).not.toBeInTheDocument();
   });
 
+  it('keeps the deprecated runtime name and version paired when both versions exist', () => {
+    const rootEventResults = {
+      data: makeTraceItemDetailsResponse([
+        {name: 'runtime.name', type: 'str', value: 'node'},
+        {name: 'process.runtime.version', type: 'str', value: '3.12.0'},
+        {name: 'runtime.version', type: 'str', value: '18.0.0'},
+      ]),
+    } as TraceRootEventQueryResults;
+
+    render(
+      <Highlights
+        rootEventResults={rootEventResults}
+        organization={organization}
+        project={project}
+      />
+    );
+
+    expect(screen.getByText('node')).toBeInTheDocument();
+    expect(screen.getByText('18.0.0')).toBeInTheDocument();
+    expect(screen.queryByText('3.12.0')).not.toBeInTheDocument();
+  });
+
   it('does not render os, browser, or runtime highlights when name attribute is missing', () => {
     const rootEventResults = {
       data: makeTraceItemDetailsResponse([

--- a/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
@@ -16,10 +16,11 @@ import {IconWindow} from 'sentry/icons/iconWindow';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
+import {prettifyAttributeName} from 'sentry/views/explore/components/traceItemAttributes/utils';
 import type {TraceItemDetailsResponse} from 'sentry/views/explore/hooks/useTraceItemDetails';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
-import {findSpanAttributeValue} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 
 type HighlightDefinition = {
   getSummary: () => {description: React.ReactNode; icon: React.ReactNode} | null;
@@ -44,13 +45,17 @@ function AttributesHighlights({
       getSummary: () => {
         // Resolve the name and version as a pair so a span that has only part of
         // each family can't report a version belonging to a different runtime.
-        const otelName = findSpanAttributeValue(attributes, 'process.runtime.name');
-        const [name, version] = otelName
-          ? [otelName, findSpanAttributeValue(attributes, 'process.runtime.version')]
-          : [
-              findSpanAttributeValue(attributes, 'runtime.name'),
-              findSpanAttributeValue(attributes, 'runtime.version'),
-            ];
+        const isOtelRuntime = attributes.some(
+          ({name}) => prettifyAttributeName(name) === 'process.runtime.name'
+        );
+        const nameKey = isOtelRuntime ? 'process.runtime.name' : 'runtime.name';
+        const versionKey = isOtelRuntime ? 'process.runtime.version' : 'runtime.version';
+        const name = getAttributeValue(attributes, nameKey, 'string');
+        const version = attributes.some(
+          attribute => prettifyAttributeName(attribute.name) === versionKey
+        )
+          ? getAttributeValue(attributes, versionKey, 'string')
+          : undefined;
 
         if (!name) {
           return null;
@@ -85,9 +90,9 @@ function AttributesHighlights({
     {
       key: 'user',
       getSummary: () => {
-        const email = findSpanAttributeValue(attributes, 'user.email');
-        const ip_address = findSpanAttributeValue(attributes, 'user.ip');
-        const id = findSpanAttributeValue(attributes, 'user.id');
+        const email = getAttributeValue(attributes, 'user.email', 'string');
+        const ip_address = getAttributeValue(attributes, 'user.ip', 'string');
+        const id = getAttributeValue(attributes, 'user.id', 'string');
 
         if (!email && !ip_address) {
           return null;
@@ -119,8 +124,8 @@ function AttributesHighlights({
     {
       key: 'browser',
       getSummary: () => {
-        const name = findSpanAttributeValue(attributes, 'browser.name');
-        const version = findSpanAttributeValue(attributes, 'browser.version');
+        const name = getAttributeValue(attributes, 'browser.name', 'string');
+        const version = getAttributeValue(attributes, 'browser.version', 'string');
 
         if (!name) {
           return null;
@@ -155,8 +160,8 @@ function AttributesHighlights({
     {
       key: 'os',
       getSummary: () => {
-        const name = findSpanAttributeValue(attributes, 'os.name');
-        const version = findSpanAttributeValue(attributes, 'os.version');
+        const name = getAttributeValue(attributes, 'os.name', 'string');
+        const version = getAttributeValue(attributes, 'os.version', 'string');
 
         if (!name) {
           return null;
@@ -193,7 +198,7 @@ function AttributesHighlights({
           return null;
         }
 
-        const version = findSpanAttributeValue(attributes, 'release');
+        const version = getAttributeValue(attributes, 'release', 'string');
 
         if (!version) {
           return null;
@@ -216,7 +221,7 @@ function AttributesHighlights({
     {
       key: 'uptime-check-region',
       getSummary: () => {
-        const region = findSpanAttributeValue(attributes, 'region');
+        const region = getAttributeValue(attributes, 'region', 'string');
 
         if (!region) {
           return null;
@@ -231,7 +236,7 @@ function AttributesHighlights({
     {
       key: 'environment',
       getSummary: () => {
-        const environment = findSpanAttributeValue(attributes, 'environment');
+        const environment = getAttributeValue(attributes, 'environment', 'string');
         if (!environment) {
           return null;
         }

--- a/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/highlights.tsx
@@ -51,11 +51,13 @@ function AttributesHighlights({
         const nameKey = isOtelRuntime ? 'process.runtime.name' : 'runtime.name';
         const versionKey = isOtelRuntime ? 'process.runtime.version' : 'runtime.version';
         const name = getAttributeValue(attributes, nameKey, 'string');
-        const version = attributes.some(
-          attribute => prettifyAttributeName(attribute.name) === versionKey
-        )
-          ? getAttributeValue(attributes, versionKey, 'string')
-          : undefined;
+        const version = getAttributeValue(
+          attributes.filter(
+            attribute => prettifyAttributeName(attribute.name) === versionKey
+          ),
+          versionKey,
+          'string'
+        );
 
         if (!name) {
           return null;

--- a/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
+++ b/static/app/views/performance/newTraceDetails/traceHeader/title.tsx
@@ -9,13 +9,13 @@ import {IconPlay} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {ReplayContextKey} from 'sentry/types/event';
 import {FieldKey} from 'sentry/utils/fields';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
 import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
 import {Divider} from 'sentry/views/issueDetails/divider';
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
-import {findSpanAttributeValue} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {TraceHeaderComponents} from 'sentry/views/performance/newTraceDetails/traceHeader/styles';
 import type {TraceTree} from 'sentry/views/performance/newTraceDetails/traceModels/traceTree';
 
@@ -53,7 +53,7 @@ function ContextBadges({rootEventResults}: Pick<TitleProps, 'rootEventResults'>)
   }
 
   const replayId = isTraceItemDetailsResponse(rootEventResults.data)
-    ? findSpanAttributeValue(rootEventResults.data.attributes, FieldKey.REPLAY_ID)
+    ? getAttributeValue(rootEventResults.data.attributes, FieldKey.REPLAY_ID, 'string')
     : rootEventResults.data.contexts.replay?.[ReplayContextKey.REPLAY_ID];
 
   if (!replayId) {

--- a/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
+++ b/static/app/views/performance/newTraceDetails/tracePreferencesDropdown.tsx
@@ -12,6 +12,7 @@ import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {IconSettings} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Project} from 'sentry/types/project';
+import {getAttributeValue} from 'sentry/utils/fields/getAttributeValue';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {OurLogKnownFieldKey} from 'sentry/views/explore/logs/types';
@@ -19,7 +20,6 @@ import {traceAnalytics} from 'sentry/views/performance/newTraceDetails/traceAnal
 import type {TraceRootEventQueryResults} from 'sentry/views/performance/newTraceDetails/traceApi/useTraceRootEvent';
 import {isTraceItemDetailsResponse} from 'sentry/views/performance/newTraceDetails/traceApi/utils';
 import {getCustomInstrumentationLink} from 'sentry/views/performance/newTraceDetails/traceConfigurations';
-import {findSpanAttributeValue} from 'sentry/views/performance/newTraceDetails/traceDrawer/details/utils';
 import {TraceShortcutsModal} from 'sentry/views/performance/newTraceDetails/traceShortcutsModal';
 import {TRACE_WATERFALL_TIME_COMPRESSION_FEATURE} from 'sentry/views/performance/newTraceDetails/traceState/tracePreferences';
 
@@ -173,7 +173,7 @@ function getTraceProject(
     const projectId =
       OurLogKnownFieldKey.PROJECT_ID in attributes
         ? attributes[OurLogKnownFieldKey.PROJECT_ID]
-        : findSpanAttributeValue(attributes, 'project_id');
+        : getAttributeValue(attributes, 'project_id')?.toString();
     return projects.find(p => p.id === projectId);
   }
 


### PR DESCRIPTION
## Summary

- replace the remaining `findSpanAttributeValue` call sites with `getAttributeValue`
- preserve runtime name/version family pairing while using deprecation-aware lookups
- remove the unused `findSpanAttributeValue` helper and its supporting import