### PR TITLE
fix(issues): Fall back to the exception type for synthetic exceptions

### DIFF
--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -34,13 +34,13 @@ class BaseEvent:
 
         return metadata
 
-    def get_title(self, metadata: Mapping[str, str | None]) -> str:
+    def get_title(self, metadata: Mapping[str, Any]) -> str:
         title = metadata.get("title")
         if title is not None:
             return title
         return self.compute_title(metadata) or "<untitled>"
 
-    def compute_title(self, metadata: Mapping[str, str | None]) -> str | None:
+    def compute_title(self, metadata: Mapping[str, Any]) -> str | None:
         return None
 
     def extract_metadata(self, metadata: MutableMapping[str, Any]) -> dict[str, str]:

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -24,8 +24,7 @@ EventTypeStr = Literal[
 class BaseEvent:
     key: ClassVar[EventTypeStr]  # abstract
 
-    # Not `dict[str, str]`: error metadata carries a boolean `synthetic` flag alongside the
-    # strings, so the values are only as narrow as the concrete subclass's `extract_metadata`.
+    # Error metadata carries a boolean `synthetic` flag alongside its strings.
     def get_metadata(self, data: MutableMapping[str, Any]) -> dict[str, Any]:
         metadata = self.extract_metadata(data)
         title = data.get("title")

--- a/src/sentry/eventtypes/base.py
+++ b/src/sentry/eventtypes/base.py
@@ -24,7 +24,9 @@ EventTypeStr = Literal[
 class BaseEvent:
     key: ClassVar[EventTypeStr]  # abstract
 
-    def get_metadata(self, data: MutableMapping[str, Any]) -> dict[str, str]:
+    # Not `dict[str, str]`: error metadata carries a boolean `synthetic` flag alongside the
+    # strings, so the values are only as narrow as the concrete subclass's `extract_metadata`.
+    def get_metadata(self, data: MutableMapping[str, Any]) -> dict[str, Any]:
         metadata = self.extract_metadata(data)
         title = data.get("title")
         if title is not None:

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -55,11 +55,13 @@ class ErrorEvent(BaseEvent):
         if not exception:
             return {}
         rv = {"value": trim(get_path(exception, "value", default=""), 1024)}
+        rv["type"] = trim(get_path(exception, "type", default="Error"), 128)
 
-        # If the exception mechanism indicates a synthetic exception we do not
-        # want to record the type and value into the metadata.
-        if not get_path(exception, "mechanism", "synthetic"):
-            rv["type"] = trim(get_path(exception, "type", default="Error"), 128)
+        # A synthetic exception's type is a platform label (`SIGSEGV`, `AppHang`) rather than the
+        # identity of what went wrong, so grouping ignores it. Record it anyway: it is all that is
+        # left to show when an event has no usable crash location.
+        if get_path(exception, "mechanism", "synthetic"):
+            rv["synthetic"] = True
 
         # Attach crash location if available
         loc = get_crash_location(data)
@@ -72,12 +74,17 @@ class ErrorEvent(BaseEvent):
 
         return rv
 
-    def compute_title(self, metadata: Mapping[str, str | None]) -> str:
+    def compute_title(self, metadata: Mapping[str, Any]) -> str:
         title = metadata.get("type")
         if title is not None:
             value = metadata.get("value")
             if value:
                 title += f": {truncatechars(value.splitlines()[0], 256)}"
+
+        # The type says little about what went wrong, so the crash location makes the better
+        # title. Falling back to it keeps unsymbolicated events from being titled `<unknown>`.
+        if metadata.get("synthetic"):
+            return metadata.get("function") or title or "<unknown>"
 
         return title or metadata.get("function") or "<unknown>"
 

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -57,15 +57,10 @@ class ErrorEvent(BaseEvent):
         rv = {"value": trim(get_path(exception, "value", default=""), 1024)}
         rv["type"] = trim(get_path(exception, "type", default="Error"), 128)
 
-        # A synthetic exception's type is a platform label (`SIGSEGV`, `AppHang`) rather than the
-        # identity of what went wrong, so grouping ignores it. Record it anyway: it is all that is
-        # left to show when an event has no usable crash location.
-        #
-        # Written unconditionally so it stays in lockstep with the `type` above. Group metadata is
-        # merged key by key across a group's events (`_process_existing_aggregate`) and a merge
-        # cannot delete keys, so a flag written only when true would outlive the type it describes:
-        # one synthetic event would mark the group synthetic forever, even after later events
-        # overwrite `type` with a real one.
+        # A synthetic exception's type is a platform label (`SIGSEGV`, `AppHang`), not the identity
+        # of what went wrong. Keep it as a last-resort title, flagged so readers can tell it apart.
+        # Always written: group metadata never deletes keys, so an omitted flag would outlive
+        # the type it describes.
         rv["synthetic"] = bool(get_path(exception, "mechanism", "synthetic"))
 
         # Attach crash location if available
@@ -86,8 +81,8 @@ class ErrorEvent(BaseEvent):
             if value:
                 title += f": {truncatechars(value.splitlines()[0], 256)}"
 
-        # The type says little about what went wrong, so the crash location makes the better
-        # title. Falling back to it keeps unsymbolicated events from being titled `<unknown>`.
+        # The crash location identifies a synthetic exception better than its type, and the type
+        # still beats `<unknown>` when nothing symbolicated.
         if metadata.get("synthetic"):
             return metadata.get("function") or title or "<unknown>"
 

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -60,8 +60,13 @@ class ErrorEvent(BaseEvent):
         # A synthetic exception's type is a platform label (`SIGSEGV`, `AppHang`) rather than the
         # identity of what went wrong, so grouping ignores it. Record it anyway: it is all that is
         # left to show when an event has no usable crash location.
-        if get_path(exception, "mechanism", "synthetic"):
-            rv["synthetic"] = True
+        #
+        # Written unconditionally so it stays in lockstep with the `type` above. Group metadata is
+        # merged key by key across a group's events (`_process_existing_aggregate`) and a merge
+        # cannot delete keys, so a flag written only when true would outlive the type it describes:
+        # one synthetic event would mark the group synthetic forever, even after later events
+        # overwrite `type` with a real one.
+        rv["synthetic"] = bool(get_path(exception, "mechanism", "synthetic"))
 
         # Attach crash location if available
         loc = get_crash_location(data)

--- a/src/sentry/eventtypes/error.py
+++ b/src/sentry/eventtypes/error.py
@@ -55,12 +55,12 @@ class ErrorEvent(BaseEvent):
         if not exception:
             return {}
         rv = {"value": trim(get_path(exception, "value", default=""), 1024)}
-        rv["type"] = trim(get_path(exception, "type", default="Error"), 128)
 
         # A synthetic exception's type is a platform label (`SIGSEGV`, `AppHang`), not the identity
         # of what went wrong. Keep it as a last-resort title, flagged so readers can tell it apart.
-        # Always written: group metadata never deletes keys, so an omitted flag would outlive
-        # the type it describes.
+        # (We record a value for `synthetic` even for non-synthetic errors so even a missing flag
+        # updates the data.)
+        rv["type"] = trim(get_path(exception, "type", default="Error"), 128)
         rv["synthetic"] = bool(get_path(exception, "mechanism", "synthetic"))
 
         # Attach crash location if available
@@ -81,8 +81,9 @@ class ErrorEvent(BaseEvent):
             if value:
                 title += f": {truncatechars(value.splitlines()[0], 256)}"
 
-        # The crash location identifies a synthetic exception better than its type, and the type
-        # still beats `<unknown>` when nothing symbolicated.
+        # Synthetic exceptions (dummy exceptions created by the SDK to carry a stacktrace)
+        # have types which are platform-specific and not reflective of what actually went
+        # wrong, so prefer function name if we have it
         if metadata.get("synthetic"):
             return metadata.get("function") or title or "<unknown>"
 

--- a/src/sentry/eventtypes/security.py
+++ b/src/sentry/eventtypes/security.py
@@ -18,7 +18,7 @@ class SecurityEvent(BaseEvent):
         )
         return {"message": message}
 
-    def get_title(self, metadata: Mapping[str, str | None]) -> str:
+    def get_title(self, metadata: Mapping[str, Any]) -> str:
         # Due to a regression (https://github.com/getsentry/sentry/pull/19794)
         # some events did not have message persisted but title. Because of this
         # the title code has to take these into account.

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -504,8 +504,8 @@ def _get_event_exception(event: Event) -> tuple[str | None, str | None]:
     produced the parent's values), which respects ``main_exception_id``. Returns ``(None, None)``
     when there is no exception to compare.
 
-    The type is withheld for synthetic exceptions, matching regular grouping: it varies by
-    platform and says nothing about what went wrong, so it must not count as a mismatch.
+    A synthetic exception's type is withheld: it is a platform label, so a difference in it is
+    not a real mismatch.
 
     Note: this reads the exception values directly (via ErrorEvent), so it does not depend on
     the event's ``type`` discriminator being populated.
@@ -550,8 +550,7 @@ def _should_use_seer_match_for_grouping(
         raise SimilarHashMissingGroupError(
             f"Seer-matched grouphash {parent_grouphash.hash} unexpectedly has no group"
         )
-    # A synthetic parent's stored type must not count as a mismatch either. Same reasoning as
-    # `_get_event_exception`.
+    # Same for a synthetic parent's stored type.
     parent_exception_type = (
         None
         if get_path(parent_group.data, "metadata", "synthetic")

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -501,13 +501,18 @@ def _get_event_exception(event: Event) -> tuple[str | None, str | None]:
     Return the event's main exception type and value, normalized exactly as they are stored in
     group metadata (``group.data.metadata.{type,value}``) — so they compare apples-to-apples with
     the parent's stored values. Reuses ``ErrorEvent.extract_metadata`` (the same code path that
-    produced the parent's values), which respects ``main_exception_id`` and returns nothing for
-    synthetic exceptions. Returns ``(None, None)`` when there is no exception to compare.
+    produced the parent's values), which respects ``main_exception_id``. Returns ``(None, None)``
+    when there is no exception to compare.
+
+    The type is withheld for synthetic exceptions, matching regular grouping: it varies by
+    platform and says nothing about what went wrong, so it must not count as a mismatch.
 
     Note: this reads the exception values directly (via ErrorEvent), so it does not depend on
     the event's ``type`` discriminator being populated.
     """
     metadata = ErrorEvent().extract_metadata(event.data)
+    if metadata.get("synthetic"):
+        return None, metadata.get("value")
     return metadata.get("type"), metadata.get("value")
 
 
@@ -545,7 +550,13 @@ def _should_use_seer_match_for_grouping(
         raise SimilarHashMissingGroupError(
             f"Seer-matched grouphash {parent_grouphash.hash} unexpectedly has no group"
         )
-    parent_exception_type = get_path(parent_group.data, "metadata", "type")
+    # A synthetic parent's stored type must not count as a mismatch either. Same reasoning as
+    # `_get_event_exception`.
+    parent_exception_type = (
+        None
+        if get_path(parent_group.data, "metadata", "synthetic")
+        else get_path(parent_group.data, "metadata", "type")
+    )
     if (
         event_exception_type
         and parent_exception_type

--- a/src/sentry/grouping/ingest/seer.py
+++ b/src/sentry/grouping/ingest/seer.py
@@ -550,7 +550,6 @@ def _should_use_seer_match_for_grouping(
         raise SimilarHashMissingGroupError(
             f"Seer-matched grouphash {parent_grouphash.hash} unexpectedly has no group"
         )
-    # Same for a synthetic parent's stored type.
     parent_exception_type = (
         None
         if get_path(parent_group.data, "metadata", "synthetic")

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -71,8 +71,12 @@ def build_attachment_title(obj: Group | Event | GroupEvent) -> str:
     ev_type = obj.get_event_type()
     title = obj.title
 
-    if ev_type == "error" and "type" in ev_metadata:
-        title = ev_metadata["type"]
+    if ev_type == "error":
+        # A synthetic exception's type is a platform label (`SIGSEGV`, `AppHang`) rather than the
+        # identity of what went wrong, so it makes a poor title. Leave those on `obj.title`, which
+        # prefers the crash location and only falls back to the type when nothing symbolicated.
+        if "type" in ev_metadata and not ev_metadata.get("synthetic"):
+            title = ev_metadata["type"]
 
     elif ev_type == "csp":
         title = f"{ev_metadata['directive']} - {ev_metadata['uri']}"

--- a/src/sentry/integrations/messaging/message_builder.py
+++ b/src/sentry/integrations/messaging/message_builder.py
@@ -72,9 +72,8 @@ def build_attachment_title(obj: Group | Event | GroupEvent) -> str:
     title = obj.title
 
     if ev_type == "error":
-        # A synthetic exception's type is a platform label (`SIGSEGV`, `AppHang`) rather than the
-        # identity of what went wrong, so it makes a poor title. Leave those on `obj.title`, which
-        # prefers the crash location and only falls back to the type when nothing symbolicated.
+        # A synthetic exception's type is a platform label, not the identity of what went wrong,
+        # so it makes a poor title.
         if "type" in ev_metadata and not ev_metadata.get("synthetic"):
             title = ev_metadata["type"]
 

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -572,10 +572,17 @@ def get_group_display(group: Group) -> dict[str, str]:
     custom_title = metadata.get("title")
 
     if event_type == "error":
+        if metadata.get("synthetic"):
+            # A synthetic exception's type is a platform label (`SIGSEGV`, `AppHang`) rather than
+            # the identity of what went wrong, so the crash location makes the better title. Same
+            # ordering as `ErrorEvent.compute_title`.
+            fallback = metadata.get("function") or metadata.get("type")
+        else:
+            fallback = metadata.get("type") or metadata.get("function")
         title = (
             custom_title
             if custom_title and custom_title != "<unlabeled event>"
-            else metadata.get("type") or metadata.get("function") or "<unknown>"
+            else fallback or "<unknown>"
         )
         message = metadata.get("value")
     elif event_type in ("transaction", "generic"):

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -573,9 +573,8 @@ def get_group_display(group: Group) -> dict[str, str]:
 
     if event_type == "error":
         if metadata.get("synthetic"):
-            # A synthetic exception's type is a platform label (`SIGSEGV`, `AppHang`) rather than
-            # the identity of what went wrong, so the crash location makes the better title. Same
-            # ordering as `ErrorEvent.compute_title`.
+            # A synthetic exception's type is a platform label, not the identity of what went
+            # wrong, so the crash location is the better title.
             fallback = metadata.get("function") or metadata.get("type")
         else:
             fallback = metadata.get("type") or metadata.get("function")

--- a/src/sentry/tasks/summaries/weekly_reports.py
+++ b/src/sentry/tasks/summaries/weekly_reports.py
@@ -574,7 +574,7 @@ def get_group_display(group: Group) -> dict[str, str]:
     if event_type == "error":
         if metadata.get("synthetic"):
             # A synthetic exception's type is a platform label, not the identity of what went
-            # wrong, so the crash location is the better title.
+            # wrong, so the function name is the better title.
             fallback = metadata.get("function") or metadata.get("type")
         else:
             fallback = metadata.get("type") or metadata.get("function")

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -1884,6 +1884,7 @@ class EventManagerTest(TestCase, SnubaTestCase, EventManagerTestMixin, Performan
         assert group.data.get("metadata") == {
             "type": "Foo",
             "value": "bar",
+            "synthetic": False,
             "initial_priority": PriorityLevel.HIGH,
         }
 

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -123,7 +123,7 @@ class GetMetadataTest(TestCase):
 
         merged = {**inst.get_metadata(synthetic), **inst.get_metadata(real)}
 
-        assert merged["synthetic"] is False
+        assert merged == {"type": "ValueError", "value": "bad", "synthetic": False}
         assert inst.get_title(merged) == "ValueError: bad"
 
     def test_multiple_exceptions_default(self) -> None:

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -58,6 +58,41 @@ class GetMetadataTest(TestCase):
             "value": "",
         }
 
+    def test_synthetic_records_type_and_flag(self) -> None:
+        # Grouping ignores a synthetic type, but it is recorded anyway as a title of last resort.
+        inst = ErrorEvent()
+        data = {
+            "exception": {
+                "values": [
+                    {
+                        "type": "SIGSEGV",
+                        "value": "Signal 11, Code 1",
+                        "mechanism": {"type": "signal", "synthetic": True},
+                    }
+                ]
+            }
+        }
+        assert inst.get_metadata(data) == {
+            "type": "SIGSEGV",
+            "value": "Signal 11, Code 1",
+            "synthetic": True,
+        }
+
+    def test_non_synthetic_carries_no_flag(self) -> None:
+        inst = ErrorEvent()
+        data = {
+            "exception": {
+                "values": [
+                    {
+                        "type": "ValueError",
+                        "value": "bad",
+                        "mechanism": {"type": "signal"},
+                    }
+                ]
+            }
+        }
+        assert inst.get_metadata(data) == {"type": "ValueError", "value": "bad"}
+
     def test_multiple_exceptions_default(self) -> None:
         inst = ErrorEvent()
         data = {
@@ -106,3 +141,52 @@ class GetTitleTest(TestCase):
         inst = ErrorEvent()
         result = inst.get_title({"type": "Error", "value": ""})
         assert result == "Error"
+
+    def test_synthetic_prefers_the_crash_location(self) -> None:
+        # Built by hand on purpose: the ordering inside `compute_title` only shows up once both
+        # a type and a function have been recorded.
+        inst = ErrorEvent()
+        metadata = {
+            "type": "SIGSEGV",
+            "value": "Signal 11, Code 1",
+            "function": "U3CCrashCaptureU3Ed__11_MoveNext",
+            "synthetic": True,
+        }
+        assert inst.get_title(metadata) == "U3CCrashCaptureU3Ed__11_MoveNext"
+
+    def test_synthetic_falls_back_to_the_type(self) -> None:
+        # The case this change exists for, and it only holds end to end: recording the type is
+        # what leaves `compute_title` something better than `<unknown>` when nothing symbolicated.
+        inst = ErrorEvent()
+        data = {
+            "platform": "native",
+            "exception": {
+                "values": [
+                    {
+                        "type": "SIGSEGV",
+                        "value": "Signal 11, Code 1",
+                        "mechanism": {"type": "signal", "synthetic": True},
+                        "stacktrace": {"frames": [{"in_app": True, "instruction_addr": "0x1"}]},
+                    }
+                ]
+            },
+        }
+        assert inst.get_title(inst.get_metadata(data)) == "SIGSEGV: Signal 11, Code 1"
+
+    def test_synthetic_with_nothing_to_show(self) -> None:
+        inst = ErrorEvent()
+        assert inst.get_title({"value": "", "synthetic": True}) == "<unknown>"
+
+    def test_non_synthetic_still_prefers_the_type(self) -> None:
+        # Only synthetic exceptions reorder; everything else is untouched.
+        inst = ErrorEvent()
+        metadata = {"type": "ValueError", "value": "bad", "function": "do_thing"}
+        assert inst.get_title(metadata) == "ValueError: bad"
+
+    def test_metadata_stored_before_this_change_is_untouched(self) -> None:
+        # Forward-only: groups stored before this change have no `synthetic` key, so they take
+        # the branch they always took and nothing re-titles on read.
+        inst = ErrorEvent()
+        assert inst.get_title({"value": "Signal 11, Code 1"}) == "<unknown>"
+        assert inst.get_title({"value": "Signal 11, Code 1", "function": "top_func"}) == "top_func"
+        assert inst.get_title({"type": "ValueError", "value": "bad"}) == "ValueError: bad"

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -14,6 +14,7 @@ class GetMetadataTest(TestCase):
         assert inst.get_metadata(data) == {
             "type": "Exception",
             "value": "Foo",
+            "synthetic": False,
         }
 
     def test_no_exception_type_or_value(self) -> None:
@@ -24,6 +25,7 @@ class GetMetadataTest(TestCase):
         assert inst.get_metadata(data) == {
             "type": "Error",
             "value": "",
+            "synthetic": False,
         }
 
     def test_pulls_top_function(self) -> None:
@@ -48,6 +50,7 @@ class GetMetadataTest(TestCase):
             "type": "Error",
             "value": "",
             "function": "top_func",
+            "synthetic": False,
         }
 
     def test_none_frame(self) -> None:
@@ -56,6 +59,7 @@ class GetMetadataTest(TestCase):
         assert inst.get_metadata(data) == {
             "type": "Error",
             "value": "",
+            "synthetic": False,
         }
 
     def test_synthetic_records_type_and_flag(self) -> None:
@@ -78,7 +82,10 @@ class GetMetadataTest(TestCase):
             "synthetic": True,
         }
 
-    def test_non_synthetic_carries_no_flag(self) -> None:
+    def test_non_synthetic_flag_is_written_as_false(self) -> None:
+        # The flag is always written, never merely omitted. Group metadata is merged key by key
+        # across a group's events and a merge cannot delete keys, so an omitted flag would let one
+        # synthetic event mark the group synthetic forever. See `test_synthetic_flag_clears`.
         inst = ErrorEvent()
         data = {
             "exception": {
@@ -91,7 +98,33 @@ class GetMetadataTest(TestCase):
                 ]
             }
         }
-        assert inst.get_metadata(data) == {"type": "ValueError", "value": "bad"}
+        assert inst.get_metadata(data) == {
+            "type": "ValueError",
+            "value": "bad",
+            "synthetic": False,
+        }
+
+    def test_synthetic_flag_clears(self) -> None:
+        # A group that saw a synthetic event and then a real one must end up describing the real
+        # exception. This mirrors the metadata merge in `_process_existing_aggregate`.
+        inst = ErrorEvent()
+        synthetic = {
+            "exception": {
+                "values": [
+                    {
+                        "type": "SIGSEGV",
+                        "value": "Signal 11, Code 1",
+                        "mechanism": {"type": "signal", "synthetic": True},
+                    }
+                ]
+            }
+        }
+        real = {"exception": {"values": [{"type": "ValueError", "value": "bad"}]}}
+
+        merged = {**inst.get_metadata(synthetic), **inst.get_metadata(real)}
+
+        assert merged["synthetic"] is False
+        assert inst.get_title(merged) == "ValueError: bad"
 
     def test_multiple_exceptions_default(self) -> None:
         inst = ErrorEvent()
@@ -106,6 +139,7 @@ class GetMetadataTest(TestCase):
         assert inst.get_metadata(data) == {
             "type": "Exception",
             "value": "Foo",
+            "synthetic": False,
         }
 
     def test_multiple_exceptions_main_indicated(self) -> None:
@@ -122,6 +156,7 @@ class GetMetadataTest(TestCase):
         assert inst.get_metadata(data) == {
             "type": "Exception",
             "value": "Bar",
+            "synthetic": False,
         }
 
 

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -63,7 +63,7 @@ class GetMetadataTest(TestCase):
         }
 
     def test_synthetic_records_type_and_flag(self) -> None:
-        # Grouping ignores a synthetic type, but it is recorded anyway as a title of last resort.
+        # Grouping ignores a synthetic type; it is recorded as a title of last resort.
         inst = ErrorEvent()
         data = {
             "exception": {
@@ -83,9 +83,8 @@ class GetMetadataTest(TestCase):
         }
 
     def test_non_synthetic_flag_is_written_as_false(self) -> None:
-        # The flag is always written, never merely omitted. Group metadata is merged key by key
-        # across a group's events and a merge cannot delete keys, so an omitted flag would let one
-        # synthetic event mark the group synthetic forever. See `test_synthetic_flag_clears`.
+        # Group metadata never deletes keys, so an omitted flag would outlive the type it
+        # describes.
         inst = ErrorEvent()
         data = {
             "exception": {
@@ -105,8 +104,7 @@ class GetMetadataTest(TestCase):
         }
 
     def test_synthetic_flag_clears(self) -> None:
-        # A group that saw a synthetic event and then a real one must end up describing the real
-        # exception. This mirrors the metadata merge in `_process_existing_aggregate`.
+        # A group that saw a synthetic event and then a real one must describe the real exception.
         inst = ErrorEvent()
         synthetic = {
             "exception": {
@@ -178,8 +176,7 @@ class GetTitleTest(TestCase):
         assert result == "Error"
 
     def test_synthetic_prefers_the_crash_location(self) -> None:
-        # Built by hand on purpose: the ordering inside `compute_title` only shows up once both
-        # a type and a function have been recorded.
+        # Hand-built: the ordering only shows once both a type and a function are recorded.
         inst = ErrorEvent()
         metadata = {
             "type": "SIGSEGV",
@@ -190,8 +187,7 @@ class GetTitleTest(TestCase):
         assert inst.get_title(metadata) == "U3CCrashCaptureU3Ed__11_MoveNext"
 
     def test_synthetic_falls_back_to_the_type(self) -> None:
-        # The case this change exists for, and it only holds end to end: recording the type is
-        # what leaves `compute_title` something better than `<unknown>` when nothing symbolicated.
+        # Built from event data: the fallback only holds if the type is actually recorded.
         inst = ErrorEvent()
         data = {
             "platform": "native",
@@ -218,9 +214,8 @@ class GetTitleTest(TestCase):
         metadata = {"type": "ValueError", "value": "bad", "function": "do_thing"}
         assert inst.get_title(metadata) == "ValueError: bad"
 
-    def test_metadata_stored_before_this_change_is_untouched(self) -> None:
-        # Forward-only: groups stored before this change have no `synthetic` key, so they take
-        # the branch they always took and nothing re-titles on read.
+    def test_metadata_without_the_flag_is_untouched(self) -> None:
+        # Stored group metadata predating the flag must keep resolving to the same title.
         inst = ErrorEvent()
         assert inst.get_title({"value": "Signal 11, Code 1"}) == "<unknown>"
         assert inst.get_title({"value": "Signal 11, Code 1", "function": "top_func"}) == "top_func"

--- a/tests/sentry/eventtypes/test_error.py
+++ b/tests/sentry/eventtypes/test_error.py
@@ -83,8 +83,8 @@ class GetMetadataTest(TestCase):
         }
 
     def test_non_synthetic_flag_is_written_as_false(self) -> None:
-        # Group metadata never deletes keys, so an omitted flag would outlive the type it
-        # describes.
+        # Group metadata never deletes keys, so we need to proactively overwrite the metadata's
+        # `synthetic` flag in cases where the event doesn't have it, in case a previous event did
         inst = ErrorEvent()
         data = {
             "exception": {
@@ -175,8 +175,7 @@ class GetTitleTest(TestCase):
         result = inst.get_title({"type": "Error", "value": ""})
         assert result == "Error"
 
-    def test_synthetic_prefers_the_crash_location(self) -> None:
-        # Hand-built: the ordering only shows once both a type and a function are recorded.
+    def test_synthetic_prefers_function_over_type(self) -> None:
         inst = ErrorEvent()
         metadata = {
             "type": "SIGSEGV",
@@ -186,8 +185,7 @@ class GetTitleTest(TestCase):
         }
         assert inst.get_title(metadata) == "U3CCrashCaptureU3Ed__11_MoveNext"
 
-    def test_synthetic_falls_back_to_the_type(self) -> None:
-        # Built from event data: the fallback only holds if the type is actually recorded.
+    def test_synthetic_falls_back_to_type_if_function_missing(self) -> None:
         inst = ErrorEvent()
         data = {
             "platform": "native",
@@ -208,14 +206,12 @@ class GetTitleTest(TestCase):
         inst = ErrorEvent()
         assert inst.get_title({"value": "", "synthetic": True}) == "<unknown>"
 
-    def test_non_synthetic_still_prefers_the_type(self) -> None:
-        # Only synthetic exceptions reorder; everything else is untouched.
+    def test_non_synthetic_prefers_type_to_function(self) -> None:
         inst = ErrorEvent()
         metadata = {"type": "ValueError", "value": "bad", "function": "do_thing"}
         assert inst.get_title(metadata) == "ValueError: bad"
 
-    def test_metadata_without_the_flag_is_untouched(self) -> None:
-        # Stored group metadata predating the flag must keep resolving to the same title.
+    def test_metadata_without_synthetic_flag(self) -> None:
         inst = ErrorEvent()
         assert inst.get_title({"value": "Signal 11, Code 1"}) == "<unknown>"
         assert inst.get_title({"value": "Signal 11, Code 1", "function": "top_func"}) == "top_func"

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -775,8 +775,7 @@ class ExceptionTypeMismatchTest(TestCase):
         )
 
     def test_skips_check_when_parent_is_synthetic(self) -> None:
-        # The parent does have a stored type; it is skipped because the metadata marks it
-        # synthetic, the same way regular grouping ignores it.
+        # The parent has a stored type; it is skipped because the metadata marks it synthetic.
         self._assert_match_result(
             parent_type="Error",
             parent_synthetic=True,

--- a/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
+++ b/tests/sentry/grouping/seer_similarity/test_get_seer_similar_issues.py
@@ -774,8 +774,9 @@ class ExceptionTypeMismatchTest(TestCase):
             new_event=self._synthetic_new_event(),
         )
 
-    def test_skips_check_when_parent_has_no_type(self) -> None:
-        # The parent has no stored exception type (synthetic), so there's nothing to compare.
+    def test_skips_check_when_parent_is_synthetic(self) -> None:
+        # The parent does have a stored type; it is skipped because the metadata marks it
+        # synthetic, the same way regular grouping ignores it.
         self._assert_match_result(
             parent_type="Error",
             parent_synthetic=True,

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -234,6 +234,44 @@ def build_test_message_blocks(
     }
 
 
+class BuildAttachmentTitleTest(TestCase):
+    def test_uses_the_exception_type(self) -> None:
+        group = self.create_group(
+            data={"type": "error", "metadata": {"type": "ValueError", "value": "bad"}}
+        )
+        assert build_attachment_title(group) == "ValueError"
+
+    def test_synthetic_prefers_the_crash_location(self) -> None:
+        # A synthetic type is a platform label (`SIGSEGV`, `AppHang`), not the identity of what
+        # went wrong, so the notification keeps the crash-location title instead.
+        group = self.create_group(
+            data={
+                "type": "error",
+                "metadata": {
+                    "type": "SIGSEGV",
+                    "value": "Signal 11, Code 1",
+                    "function": "top_func",
+                    "synthetic": True,
+                },
+            }
+        )
+        assert build_attachment_title(group) == "top_func"
+
+    def test_synthetic_falls_back_to_the_type(self) -> None:
+        # Nothing symbolicated, so the type is all that is left — still better than `<unknown>`.
+        group = self.create_group(
+            data={
+                "type": "error",
+                "metadata": {
+                    "type": "SIGSEGV",
+                    "value": "Signal 11, Code 1",
+                    "synthetic": True,
+                },
+            }
+        )
+        assert build_attachment_title(group) == "SIGSEGV: Signal 11, Code 1"
+
+
 class BuildGroupAttachmentTest(TestCase, PerformanceIssueTestCase, OccurrenceTestMixin):
     def test_build_group_block(self) -> None:
         release = self.create_release(project=self.project)

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -242,8 +242,7 @@ class BuildAttachmentTitleTest(TestCase):
         assert build_attachment_title(group) == "ValueError"
 
     def test_synthetic_prefers_the_crash_location(self) -> None:
-        # A synthetic type is a platform label (`SIGSEGV`, `AppHang`), not the identity of what
-        # went wrong, so the notification keeps the crash-location title instead.
+        # The type is a platform label, so the crash-location title is better.
         group = self.create_group(
             data={
                 "type": "error",

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -241,8 +241,8 @@ class BuildAttachmentTitleTest(TestCase):
         )
         assert build_attachment_title(group) == "ValueError"
 
-    def test_synthetic_prefers_the_crash_location(self) -> None:
-        # The type is a platform label, so the crash-location title is better.
+    def test_synthetic_prefers_function_to_type(self) -> None:
+        # The type is a platform label, so the function-based title is better.
         group = self.create_group(
             data={
                 "type": "error",
@@ -256,7 +256,7 @@ class BuildAttachmentTitleTest(TestCase):
         )
         assert build_attachment_title(group) == "top_func"
 
-    def test_synthetic_falls_back_to_the_type(self) -> None:
+    def test_synthetic_falls_back_to_type_if_function_missing(self) -> None:
         # Nothing symbolicated, so the type is all that is left — still better than `<unknown>`.
         group = self.create_group(
             data={

--- a/tests/sentry/tasks/test_weekly_report_utils.py
+++ b/tests/sentry/tasks/test_weekly_report_utils.py
@@ -897,8 +897,7 @@ class GetGroupDisplayTest(TestCase):
         }
 
     def test_synthetic_prefers_the_crash_location(self) -> None:
-        # A synthetic type is a platform label (`SIGSEGV`, `AppHang`), not the identity of what
-        # went wrong, so the weekly report keeps the crash location.
+        # The type is a platform label, so the crash location is the better title.
         assert self._display(
             {
                 "type": "SIGSEGV",

--- a/tests/sentry/tasks/test_weekly_report_utils.py
+++ b/tests/sentry/tasks/test_weekly_report_utils.py
@@ -37,6 +37,7 @@ from sentry.tasks.summaries.utils import (
     project_past_resolved_issues,
     user_project_ownership,
 )
+from sentry.tasks.summaries.weekly_reports import get_group_display
 from sentry.testutils.cases import (
     BaseSpansTestCase,
     OccurrenceTestCase,
@@ -883,3 +884,43 @@ class PastResolvedIssuesTest(TestCase):
             "Resolved in release",
             "https://gitlab.com/getsentry/sentry/merge_requests/42",
         )
+
+
+class GetGroupDisplayTest(TestCase):
+    def _display(self, metadata: dict[str, object]) -> dict[str, str]:
+        return get_group_display(self.create_group(data={"type": "error", "metadata": metadata}))
+
+    def test_uses_the_exception_type(self) -> None:
+        assert self._display({"type": "ValueError", "value": "bad"}) == {
+            "title": "ValueError",
+            "message": "bad",
+        }
+
+    def test_synthetic_prefers_the_crash_location(self) -> None:
+        # A synthetic type is a platform label (`SIGSEGV`, `AppHang`), not the identity of what
+        # went wrong, so the weekly report keeps the crash location.
+        assert self._display(
+            {
+                "type": "SIGSEGV",
+                "value": "Signal 11, Code 1",
+                "function": "top_func",
+                "synthetic": True,
+            }
+        ) == {"title": "top_func", "message": "Signal 11, Code 1"}
+
+    def test_synthetic_falls_back_to_the_type(self) -> None:
+        # Nothing symbolicated, so the type is all that is left — still better than `<unknown>`.
+        assert self._display(
+            {"type": "SIGSEGV", "value": "Signal 11, Code 1", "synthetic": True}
+        ) == {"title": "SIGSEGV", "message": "Signal 11, Code 1"}
+
+    def test_custom_title_still_wins(self) -> None:
+        assert self._display(
+            {
+                "title": "Custom",
+                "type": "SIGSEGV",
+                "value": "Signal 11, Code 1",
+                "function": "top_func",
+                "synthetic": True,
+            }
+        ) == {"title": "Custom", "message": "Signal 11, Code 1"}

--- a/tests/sentry/tasks/test_weekly_report_utils.py
+++ b/tests/sentry/tasks/test_weekly_report_utils.py
@@ -896,8 +896,8 @@ class GetGroupDisplayTest(TestCase):
             "message": "bad",
         }
 
-    def test_synthetic_prefers_the_crash_location(self) -> None:
-        # The type is a platform label, so the crash location is the better title.
+    def test_synthetic_prefers_function_to_type(self) -> None:
+        # The type is a platform label, so the function name is the better title.
         assert self._display(
             {
                 "type": "SIGSEGV",
@@ -907,13 +907,13 @@ class GetGroupDisplayTest(TestCase):
             }
         ) == {"title": "top_func", "message": "Signal 11, Code 1"}
 
-    def test_synthetic_falls_back_to_the_type(self) -> None:
+    def test_synthetic_falls_back_to_type_if_function_missing(self) -> None:
         # Nothing symbolicated, so the type is all that is left — still better than `<unknown>`.
         assert self._display(
             {"type": "SIGSEGV", "value": "Signal 11, Code 1", "synthetic": True}
         ) == {"title": "SIGSEGV", "message": "Signal 11, Code 1"}
 
-    def test_custom_title_still_wins(self) -> None:
+    def test_custom_title_takes_precedence(self) -> None:
         assert self._display(
             {
                 "title": "Custom",


### PR DESCRIPTION
### The Goal

This does two things: 
1. To have descriptive issue titles where possible, even when no debug symbols are available. This relies on the frontend change in https://github.com/getsentry/sentry/pull/123430
2. Enables events sent from sentry-cocoa to be grouped with all other platforms by getting in sync with the dev docs about synthetic exceptions (without regressions).

#### Before
**No debug symbols**
<img width="308" height="132" alt="Screenshot 2026-09-02 at 14 57 12" src="https://github.com/user-attachments/assets/2a68b37a-e987-4eab-a7ba-d5827dc376e8" />

**Yes debug symbols**
<img width="308" height="141" alt="Screenshot 2026-09-02 at 15 42 17" src="https://github.com/user-attachments/assets/bc382834-e431-4389-8f48-c3acfaa0c769" />

#### After

**No debug symbols**
<img width="299" height="136" alt="Screenshot 2026-09-02 at 14 57 33" src="https://github.com/user-attachments/assets/575ba403-089b-4f0d-9eba-0d1a5b797fc0" />

**Yes debug symbols**
<img width="304" height="143" alt="Screenshot 2026-09-02 at 15 42 23" src="https://github.com/user-attachments/assets/5f6f2713-da8f-4b98-b8c4-def829c5f902" />

### All the context

A synthetic exception is a dummy the SDK created to carry a stacktrace, so its type is a platform-specific label rather than the identity of what went wrong. We already drop that type from the grouping hash, but we also drop it from `metadata.type`, which leaves `compute_title` with only the crash location to work with. When no frame has a function i.e. an unsymbolicated minidump, the issue is titled `<unknown>`.

Record the type in the metadata and mark the exception synthetic instead, then have `compute_title` prefer the crash location and use `type: value` only as a fallback. Titles that resolve to a function today are unchanged.

Grouping is untouched: `single_exception` still ignores the type for synthetic exceptions, so this changes no hashes. Seer's exception-type mismatch check keeps its current behaviour by withholding the type for synthetic exceptions on both the event and the parent side, rather than relying on the metadata being empty.

Severity is unaffected in practice: `_get_severity_metadata_for_group` only scores platforms starting with `python` or `javascript`, and synthetic exceptions are a native/cocoa mechanism, so those events return before `_get_severity_score` is reached. Note that `PLATFORMS_WITH_PRIORITY_ALERTS` is a rollout list rather than a permanent boundary. Were it to grow, the severity payload's `message` would follow the new title, because it is derived from `event.title` and from `metadata.type` rather than being computed independently -- and for an unsymbolicated synthetic exception that means a real score where we previously returned `0.0, "bad_title"`.

There is no backfill and nothing regroups, but existing groups are not frozen either: `_process_existing_aggregate` merges each event's freshly computed metadata into `group.data["metadata"]`, so an active group picks up `synthetic` and `type` on its next event. `_get_updated_group_title` then prefers the incoming title, since `<unknown>` is a placeholder and `SIGSEGV: ...` is not.

So live issues currently titled `<unknown>` retitle on their next event, which is the point of the change rather than a side effect of it. Groups that have stopped receiving events keep the title they have. Groups whose title already resolves to a function are unchanged either way.

