### PR TITLE
feat(api): Publish AI conversation endpoints

### DIFF
--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta
 from typing import Any, TypedDict
 
 from django.utils import timezone
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -15,6 +16,15 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, OrganizationParams
+from sentry.apidocs.response_types import DetailResponse
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
 from sentry.search.eap.types import SearchResolverConfig
@@ -35,6 +45,22 @@ MAX_RETENTION_DAYS = 30
 MAX_PARENT_REPAIR_DEPTH = 5
 
 _WIDENING_STEPS = [timedelta(days=7), timedelta(days=14), timedelta(days=MAX_RETENTION_DAYS)]
+
+AI_CONVERSATION_ID_PARAM = OpenApiParameter(
+    name="conversation_id",
+    location="path",
+    required=True,
+    type=str,
+    description="Conversation ID recorded in `gen_ai.conversation.id`.",
+)
+
+AI_CONVERSATION_DETAILS_PER_PAGE_PARAM = OpenApiParameter(
+    name="per_page",
+    location="query",
+    required=False,
+    type=int,
+    description="Number of spans to return per page. Defaults to 100; maximum is 1,000.",
+)
 
 PARENT_SPAN_ATTRIBUTES = [
     "span_id",
@@ -96,12 +122,47 @@ class AIConversationDetailsResponse(TypedDict):
     spans: list[dict[str, Any]]
 
 
+@extend_schema(tags=["Explore"])
 @cell_silo_endpoint
 class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
-    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+    publish_status = {"GET": ApiPublishStatus.PUBLIC}
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
-    def get(self, request: Request, organization: Organization, conversation_id: str) -> Response:
+    @extend_schema(
+        operation_id="retrieveOrganizationAIConversation",
+        summary="Retrieve an Organization's AI Conversation",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            AI_CONVERSATION_ID_PARAM,
+            OrganizationParams.PROJECT,
+            GlobalParams.ENVIRONMENT,
+            GlobalParams.STATS_PERIOD,
+            GlobalParams.START,
+            GlobalParams.END,
+            CursorQueryParam,
+            AI_CONVERSATION_DETAILS_PER_PAGE_PARAM,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "RetrieveOrganizationAIConversationResponse", AIConversationDetailsResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(
+        self, request: Request, organization: Organization, conversation_id: str
+    ) -> Response[AIConversationDetailsResponse] | Response[DetailResponse] | Response[None]:
+        """Return spans recorded for one AI conversation in start-time order.
+
+        **Experimental:** This API is under active development and may change.
+
+        Message, tool, and response attributes contain their recorded string values.
+        Without an explicit range, Sentry widens the search across available retention.
+        A missing conversation returns an empty `spans` list.
+        """
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
@@ -113,15 +174,15 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
 
         if has_explicit_range:
             if snuba_params.start and snuba_params.start < max_retention_cutoff:
-                return Response(
-                    {"detail": f"start time cannot be older than {MAX_RETENTION_DAYS} days"},
-                    status=400,
+                error = DetailResponse(
+                    detail=f"start time cannot be older than {MAX_RETENTION_DAYS} days"
                 )
+                return Response(error, status=400)
             if snuba_params.end and snuba_params.end < max_retention_cutoff:
-                return Response(
-                    {"detail": f"end time cannot be older than {MAX_RETENTION_DAYS} days"},
-                    status=400,
+                error = DetailResponse(
+                    detail=f"end time cannot be older than {MAX_RETENTION_DAYS} days"
                 )
+                return Response(error, status=400)
 
         with handle_query_errors():
             if has_explicit_range:

--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 import sentry_sdk
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -23,6 +24,15 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.utils import handle_query_errors
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, OrganizationParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
+from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
 from sentry.search.eap.resolver import SearchResolver
@@ -50,7 +60,7 @@ class UserResponse(TypedDict):
 class AIConversationResponse(TypedDict):
     conversationId: str
     title: str | None
-    projectId: int | None
+    projectId: str | None
     flow: list[str]
     errors: int
     llmCalls: int
@@ -74,6 +84,35 @@ class AIConversationResponse(TypedDict):
 # Matches a query that is exactly a single gen_ai.conversation.id filter, e.g.
 # `gen_ai.conversation.id:abc` or `gen_ai.conversation.id:"slack:1234"`.
 _CONVERSATION_ID_LOOKUP_RE = re.compile(r'^gen_ai\.conversation\.id:(?:"[^"]+"|\S+)$')
+
+AI_CONVERSATIONS_QUERY_PARAM = OpenApiParameter(
+    name="query",
+    location="query",
+    required=False,
+    type=str,
+    description=(
+        "Sentry search syntax matched against spans. A conversation is returned when any "
+        "span in it matches. Summary fields include all spans in selected projects and time "
+        "range, not only matching spans."
+    ),
+)
+
+AI_CONVERSATIONS_SAMPLING_MODE_PARAM = OpenApiParameter(
+    name="samplingMode",
+    location="query",
+    required=False,
+    type=str,
+    enum=["NORMAL", "HIGHEST_ACCURACY", "HIGHEST_ACCURACY_FLEX_TIME"],
+    description="Sampling mode for finding conversation IDs. Defaults to `HIGHEST_ACCURACY`.",
+)
+
+AI_CONVERSATIONS_PER_PAGE_PARAM = OpenApiParameter(
+    name="per_page",
+    location="query",
+    required=False,
+    type=int,
+    description="Number of conversations to return per page. Defaults to 10; maximum is 100.",
+)
 
 
 def _is_conversation_id_lookup(user_query: str) -> bool:
@@ -205,7 +244,7 @@ def _build_conversation_response(
     tool_errors: int = 0,
     title: str | None = None,
     generation_duration: float = 0,
-    project_id: int | None = None,
+    project_id: str | None = None,
 ) -> AIConversationResponse:
     return {
         "conversationId": conv_id,
@@ -232,14 +271,52 @@ def _build_conversation_response(
     }
 
 
+@extend_schema(tags=["Explore"])
 @cell_silo_endpoint
 class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
-    def get(self, request: Request, organization: Organization) -> Response:
+    @extend_schema(
+        operation_id="listOrganizationAIConversations",
+        summary="List an Organization's AI Conversations",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            OrganizationParams.PROJECT,
+            GlobalParams.ENVIRONMENT,
+            GlobalParams.STATS_PERIOD,
+            GlobalParams.START,
+            GlobalParams.END,
+            AI_CONVERSATIONS_QUERY_PARAM,
+            AI_CONVERSATIONS_SAMPLING_MODE_PARAM,
+            CursorQueryParam,
+            AI_CONVERSATIONS_PER_PAGE_PARAM,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "ListOrganizationAIConversationsResponse", list[AIConversationResponse]
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(
+        self, request: Request, organization: Organization
+    ) -> (
+        Response[list[AIConversationResponse]] | Response[ValidationErrorResponse] | Response[None]
+    ):
+        """Return AI conversations ordered by latest span time.
+
+        **Experimental:** This API is under active development and may change.
+
+        `query` uses Sentry search syntax against spans. A conversation matches when
+        any span matches. Summary values then include all conversation spans inside
+        selected project, environment, and time filters.
+        """
         try:
             snuba_params = self.get_snuba_params(request, organization)
         except NoProjects:
@@ -247,7 +324,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
 
         serializer = OrganizationAIConversationsSerializer(data=request.GET)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         validated_data = serializer.validated_data
 
@@ -561,7 +638,8 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 conversation["user"] = user_by_conversation.get(conv_id)
                 conversation["toolNames"] = sorted(tool_names_by_conversation.get(conv_id, set()))
                 conversation["toolErrors"] = tool_errors_by_conversation.get(conv_id, 0)
-                conversation["projectId"] = first_project_by_conversation.get(conv_id)
+                project_id = first_project_by_conversation.get(conv_id)
+                conversation["projectId"] = str(project_id) if project_id is not None else None
 
             return project_ids_by_conversation
 

--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
@@ -60,7 +60,7 @@ class UserResponse(TypedDict):
 class AIConversationResponse(TypedDict):
     conversationId: str
     title: str | None
-    projectId: str | None
+    projectId: int | None
     flow: list[str]
     errors: int
     llmCalls: int
@@ -95,15 +95,6 @@ AI_CONVERSATIONS_QUERY_PARAM = OpenApiParameter(
         "span in it matches. Summary fields include all spans in selected projects and time "
         "range, not only matching spans."
     ),
-)
-
-AI_CONVERSATIONS_SAMPLING_MODE_PARAM = OpenApiParameter(
-    name="samplingMode",
-    location="query",
-    required=False,
-    type=str,
-    enum=["NORMAL", "HIGHEST_ACCURACY", "HIGHEST_ACCURACY_FLEX_TIME"],
-    description="Sampling mode for finding conversation IDs. Defaults to `HIGHEST_ACCURACY`.",
 )
 
 AI_CONVERSATIONS_PER_PAGE_PARAM = OpenApiParameter(
@@ -244,7 +235,7 @@ def _build_conversation_response(
     tool_errors: int = 0,
     title: str | None = None,
     generation_duration: float = 0,
-    project_id: str | None = None,
+    project_id: int | None = None,
 ) -> AIConversationResponse:
     return {
         "conversationId": conv_id,
@@ -290,7 +281,6 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             GlobalParams.START,
             GlobalParams.END,
             AI_CONVERSATIONS_QUERY_PARAM,
-            AI_CONVERSATIONS_SAMPLING_MODE_PARAM,
             CursorQueryParam,
             AI_CONVERSATIONS_PER_PAGE_PARAM,
         ],
@@ -638,8 +628,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 conversation["user"] = user_by_conversation.get(conv_id)
                 conversation["toolNames"] = sorted(tool_names_by_conversation.get(conv_id, set()))
                 conversation["toolErrors"] = tool_errors_by_conversation.get(conv_id, 0)
-                project_id = first_project_by_conversation.get(conv_id)
-                conversation["projectId"] = str(project_id) if project_id is not None else None
+                conversation["projectId"] = first_project_by_conversation.get(conv_id)
 
             return project_ids_by_conversation
 

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -33,6 +33,8 @@ _OWNERSHIP_FILE = "api_ownership_stats_dont_modify.json"
 # but do not want to document it
 EXCLUSION_PATH_PREFIXES = [
     "/api/0/monitors/",
+    # Legacy aliases for the documented agents/conversations endpoints.
+    "/api/0/organizations/{organization_id_or_slug}/ai-conversations/",
     # Issue URLS have an expression of group|issue that resolves to `var`
     "/api/0/{var}/{issue_id}/",
 ]

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -245,7 +245,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["inputTokens"] == LLM_INPUT_TOKENS * 2
         assert conversation["outputTokens"] == LLM_OUTPUT_TOKENS * 2
         assert conversation["totalCost"] == LLM_COST * 2
-        assert conversation["projectId"] == self.project.id
+        assert conversation["projectId"] == str(self.project.id)
         assert conversation["generationDuration"] > 0
         assert conversation["traceCount"] == 1
         assert conversation["startTimestamp"] > 0

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -245,7 +245,7 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["inputTokens"] == LLM_INPUT_TOKENS * 2
         assert conversation["outputTokens"] == LLM_OUTPUT_TOKENS * 2
         assert conversation["totalCost"] == LLM_COST * 2
-        assert conversation["projectId"] == str(self.project.id)
+        assert conversation["projectId"] == self.project.id
         assert conversation["generationDuration"] > 0
         assert conversation["traceCount"] == 1
         assert conversation["startTimestamp"] > 0

--- a/tests/sentry/seer/endpoints/test_organization_agent_token.py
+++ b/tests/sentry/seer/endpoints/test_organization_agent_token.py
@@ -1161,6 +1161,7 @@ class AgentTokenPublicGetMatrixTest(APITestCase):
         # A well-formed nonexistent identifier still exercises authentication, endpoint
         # scopes, URL conversion, and the outer resource permission boundary.
         opaque_values = {
+            "conversation_id": uuid4().hex,
             "external_issue_id": "1",
             "profile_id": uuid4().hex,
             "snapshot_id": "1",


### PR DESCRIPTION
AI conversation list and detail APIs are now available in public OpenAPI docs under the canonical `/agents/conversations/` routes. The docs cover filtering, pagination, response envelopes, and experimental status while keeping detail spans in their existing raw shape.

Legacy `/ai-conversations/` aliases remain callable but stay out of generated docs. List responses now serialize `projectId` as a string so the new public contract follows API ID conventions.

Closes [TET-2819: Document conversations API endpoint](https://linear.app/getsentry/issue/TET-2819/document-conversations-api-endpoint)