### PR TITLE
feat(agents): Group overview chart by agent name

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
@@ -40,12 +40,46 @@ describe('ConversationsChart', () => {
           query: expect.objectContaining({
             yAxis: ['count_unique(gen_ai.conversation.id)'],
             query: 'has:gen_ai.conversation.id',
+            groupBy: ['gen_ai.agent.name'],
+            topEvents: 10,
+            sort: '-count_unique(gen_ai.conversation.id)',
           }),
         })
       );
     });
 
     expect(screen.getByRole('button', {name: 'Conversation Count'})).toBeInTheDocument();
+  });
+
+  it('renders all agent groups returned by the API', async () => {
+    MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      body: {
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'count_unique(gen_ai.conversation.id)',
+            groupBy: [{key: 'gen_ai.agent.name', value: 'Agent A'}],
+            meta: {valueType: 'number', valueUnit: null, interval: 1_800_000},
+          }),
+          TimeSeriesFixture({
+            yAxis: 'count_unique(gen_ai.conversation.id)',
+            groupBy: [{key: 'gen_ai.agent.name', value: 'Agent B'}],
+            meta: {valueType: 'number', valueUnit: null, interval: 1_800_000},
+          }),
+        ],
+      },
+    });
+
+    render(<ConversationsChart />, {
+      organization,
+      initialRouterConfig: {
+        location: {pathname: '/', query: {query: 'agent-test'}},
+      },
+    });
+
+    expect(await screen.findByText('Agent A')).toBeInTheDocument();
+    expect(screen.getByText('Agent B')).toBeInTheDocument();
   });
 
   it('switches the visualization via the title dropdown', async () => {
@@ -67,6 +101,9 @@ describe('ConversationsChart', () => {
           query: expect.objectContaining({
             yAxis: ['sum(gen_ai.cost.total_tokens)'],
             query: 'has:gen_ai.conversation.id gen_ai.operation.type:ai_client',
+            groupBy: ['gen_ai.agent.name'],
+            topEvents: 10,
+            sort: '-sum(gen_ai.cost.total_tokens)',
           }),
         })
       );
@@ -240,6 +277,7 @@ describe('ConversationsChart', () => {
             queries: [
               expect.objectContaining({
                 aggregates: ['count_unique(gen_ai.conversation.id)'],
+                columns: ['gen_ai.agent.name'],
                 conditions: 'has:gen_ai.conversation.id',
               }),
             ],

--- a/static/app/views/explore/conversations/components/conversationsChart.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.tsx
@@ -50,6 +50,8 @@ import {SpanFields} from 'sentry/views/insights/types';
 
 const CONVERSATION_SPANS_FILTER = `has:${SpanFields.GEN_AI_CONVERSATION_ID}`;
 const AI_CLIENT_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:ai_client`;
+const AGENT_NAME_GROUP_BY = [SpanFields.GEN_AI_AGENT_NAME];
+const TOP_AGENTS = 10;
 
 const CHART_VISUALIZATIONS = {
   chats: {
@@ -120,24 +122,24 @@ export function ConversationsChart() {
       yAxis: [yAxis],
       query,
       interval,
+      groupBy: AGENT_NAME_GROUP_BY,
+      topEvents: TOP_AGENTS,
+      sort: {field: yAxis, kind: 'desc'},
     },
     Referrer.CHART
   );
 
-  const timeSeries = data?.timeSeries[0];
-
   const plottables = useMemo(() => {
-    if (!timeSeries) {
+    const timeSeries = data?.timeSeries;
+    if (!timeSeries?.length) {
       return [];
     }
     const PlottableConstructor =
       chartType === 'line' ? Line : chartType === 'area' ? Area : Bars;
-    return [
-      new PlottableConstructor(markDelayedData(timeSeries, INGESTION_DELAY), {
-        alias: label,
-      }),
-    ];
-  }, [timeSeries, chartType, label]);
+    return timeSeries.map(series => {
+      return new PlottableConstructor(markDelayedData(series, INGESTION_DELAY));
+    });
+  }, [data?.timeSeries, chartType]);
 
   const chartTypeLabel =
     CHART_TYPE_OPTIONS.find(option => option.value === chartType)?.label ?? '';
@@ -336,7 +338,7 @@ function ContextMenu({
 
           const discoverQuery: NewQuery = {
             name: DEFAULT_WIDGET_NAME,
-            fields: [yAxis],
+            fields: [...AGENT_NAME_GROUP_BY, yAxis],
             query,
             version: 2,
             dataset: DiscoverDatasets.SPANS,

--- a/static/app/views/explore/conversations/components/conversationsChart.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.tsx
@@ -134,10 +134,15 @@ export function ConversationsChart() {
     if (!timeSeries?.length) {
       return [];
     }
-    const PlottableConstructor =
-      chartType === 'line' ? Line : chartType === 'area' ? Area : Bars;
     return timeSeries.map(series => {
-      return new PlottableConstructor(markDelayedData(series, INGESTION_DELAY));
+      const markedSeries = markDelayedData(series, INGESTION_DELAY);
+      if (chartType === 'bar') {
+        return new Bars(markedSeries, {stack: 'agents'});
+      }
+      if (chartType === 'area') {
+        return new Area(markedSeries);
+      }
+      return new Line(markedSeries);
     });
   }, [data?.timeSeries, chartType]);
 


### PR DESCRIPTION
The Agents overview chart now groups each metric by agent name and renders all returned agent series, making agent-level trends visible over time. Adding the chart to a dashboard also preserves the agent grouping.

The `(no value)` series remains visible because it can represent a significant portion of the data.

Refs TET-2860