### PR TITLE
fix(seer): Fix dashboard preview chart behavior

### DIFF
--- a/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/dashboardBlock.tsx
@@ -76,6 +76,20 @@ function getDashboardPreview(dashboard: DashboardDetails): DashboardDetails {
   };
 }
 
+function getWidgetPreview(widget: Widget): Widget {
+  return {
+    ...widget,
+    // Embedded widgets should keep legend interactions local instead of
+    // persisting them to the host route as saved dashboard widgets do.
+    id: undefined,
+    tempId: widget.tempId ?? widget.id,
+    limit: Math.min(
+      widget.limit ?? MAX_PREVIEW_ITEMS_PER_WIDGET,
+      MAX_PREVIEW_ITEMS_PER_WIDGET
+    ),
+  };
+}
+
 function DashboardWidgetPreview({
   dashboard,
   selection,
@@ -89,6 +103,8 @@ function DashboardWidgetPreview({
   widgetInterval: string;
   widgetLegendState: LocalWidgetLegendSelectionState;
 }) {
+  const previewWidget = useMemo(() => getWidgetPreview(widget), [widget]);
+
   return (
     <Container minHeight="240px">
       <ErrorBoundary mini>
@@ -100,11 +116,8 @@ function DashboardWidgetPreview({
             dashboardFilters={dashboard.filters}
             selection={selection}
             showContextMenu={false}
-            tableItemLimit={Math.min(
-              widget.limit ?? MAX_PREVIEW_ITEMS_PER_WIDGET,
-              MAX_PREVIEW_ITEMS_PER_WIDGET
-            )}
-            widget={{...widget}}
+            tableItemLimit={previewWidget.limit ?? MAX_PREVIEW_ITEMS_PER_WIDGET}
+            widget={previewWidget}
             widgetInterval={widgetInterval}
             widgetLegendState={widgetLegendState}
             widgetLimitReached={false}

--- a/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceEmbeds.spec.tsx
@@ -1,6 +1,7 @@
 import {DashboardFixture} from 'sentry-fixture/dashboard';
 import {EventsStatsFixture} from 'sentry-fixture/events';
 import {WidgetFixture} from 'sentry-fixture/widget';
+import {WidgetQueryFixture} from 'sentry-fixture/widgetQuery';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
@@ -76,6 +77,7 @@ describe('Seer resource embeds', () => {
           displayType: index === 0 ? DisplayType.LINE : DisplayType.TEXT,
           widgetType: index === 0 ? WidgetType.ERRORS : undefined,
           description: `${title} details`,
+          limit: index === 0 ? 20 : undefined,
         })
     );
     const dashboardRequest = MockApiClient.addMockResponse({
@@ -125,10 +127,60 @@ describe('Seer resource embeds', () => {
             interval: '10m',
             project: [1],
             statsPeriod: '24h',
+            topEvents: 5,
           }),
         })
       )
     );
+    unmount();
+  });
+
+  it('keeps dashboard legend interactions local to the embed', async () => {
+    const widget = WidgetFixture({
+      id: '1',
+      title: 'Errors',
+      displayType: DisplayType.LINE,
+      widgetType: WidgetType.ERRORS,
+      queries: [
+        WidgetQueryFixture({
+          name: 'Current',
+          conditions: 'release:current',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+        }),
+        WidgetQueryFixture({
+          name: 'Previous',
+          conditions: 'release:previous',
+          fields: ['count()'],
+          aggregates: ['count()'],
+          columns: [],
+        }),
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/123/',
+      body: DashboardFixture([widget], {id: '123', title: 'Application health'}),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-stats/',
+      body: EventsStatsFixture(),
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/stats/',
+      body: [],
+    });
+
+    const {router, unmount} = renderEmbed({name: 'dashboard', data: {id: '123'}});
+    await userEvent.click(await screen.findByRole('button', {name: '+2 more'}));
+    const option = await screen.findByRole('option', {name: /Current : count\(\)/});
+
+    expect(option).toHaveAttribute('aria-selected', 'true');
+
+    await userEvent.click(option);
+
+    expect(option).toHaveAttribute('aria-selected', 'false');
+    expect(router.location.query.unselectedSeries).toBeUndefined();
     unmount();
   });
 


### PR DESCRIPTION
Dashboard block previews now cap chart series at five and keep legend selection local
to the embedded widget, so previews avoid oversized requests and legend clicks work
without mutating the host route state.

Follow-up to #122836 and [the missed review comment](https://github.com/getsentry/sentry/pull/122836#discussion_r3899512465).
