### PR TITLE
ref(ui): Drop unused optional args in JsonForm groups

### DIFF
--- a/static/app/components/forms/jsonForm.spec.tsx
+++ b/static/app/components/forms/jsonForm.spec.tsx
@@ -72,50 +72,6 @@ describe('JsonForm', () => {
       expect(screen.queryByText('Field Label 2')).not.toBeVisible();
     });
 
-    it('initiallyCollapsed prop from children form groups override json form initiallyCollapsed prop', () => {
-      const forms: JsonFormObject[] = [
-        {
-          title: 'Form1 title',
-          fields: [
-            {
-              name: 'name',
-              type: 'string',
-              required: true,
-              label: 'Field Label 1 ',
-              placeholder: 'e.g. John Doe',
-            },
-          ],
-        },
-        {
-          title: 'Form2 title',
-          fields: [
-            {
-              name: 'name',
-              type: 'string',
-              required: true,
-              label: 'Field Label 2',
-              placeholder: 'e.g. Abdullah Khan',
-            },
-          ],
-          initiallyCollapsed: false, // Prevents this form group from being collapsed
-        },
-      ];
-      render(
-        <JsonForm
-          forms={forms}
-          additionalFieldProps={{user}}
-          collapsible
-          initiallyCollapsed
-        />
-      );
-
-      expect(screen.getByText('Form1 title')).toBeInTheDocument();
-      expect(screen.getByText('Form2 title')).toBeInTheDocument();
-
-      expect(screen.queryByText('Field Label 1')).not.toBeVisible();
-      expect(screen.queryByText('Field Label 2')).toBeVisible();
-    });
-
     it('should ALWAYS hide panel, if all fields have visible set to false AND there is no renderHeader & renderFooter', () => {
       const hiddenFields: JsonFormObject[] = [
         {

--- a/static/app/components/forms/jsonForm.tsx
+++ b/static/app/components/forms/jsonForm.tsx
@@ -106,11 +106,9 @@ function JsonForm({
     fields,
     formPanelProps,
     title: formTitle,
-    initiallyCollapsed: formInitiallyCollapsed,
   }: {
     fields: FieldObject[];
     formPanelProps: ChildFormPanelProps;
-    initiallyCollapsed?: boolean;
     title?: React.ReactNode;
   }) => {
     const displayForm = shouldDisplayForm(fields);
@@ -124,7 +122,7 @@ function JsonForm({
         title={formTitle}
         fields={fields}
         {...formPanelProps}
-        initiallyCollapsed={formInitiallyCollapsed ?? formPanelProps.initiallyCollapsed}
+        initiallyCollapsed={formPanelProps.initiallyCollapsed}
       />
     );
   };

--- a/static/app/components/forms/types.tsx
+++ b/static/app/components/forms/types.tsx
@@ -178,7 +178,6 @@ export type FieldObject = Field | (() => React.ReactNode);
 
 export type JsonFormObject = {
   fields: FieldObject[];
-  initiallyCollapsed?: boolean;
   title?: React.ReactNode;
 };
 


### PR DESCRIPTION
Follow-up unused-signatures rescan. Group-level `initiallyCollapsed` on `JsonFormObject` is never provided; JsonForm's own `initiallyCollapsed` prop stays.

## Summary
- Remove `initiallyCollapsed` from `JsonFormObject` / `renderForm` and the spec that only existed to cover that group-level override.

## Files
- `static/app/components/forms/jsonForm.tsx`
- `static/app/components/forms/jsonForm.spec.tsx`
- `static/app/components/forms/types.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

Made with [Cursor](https://cursor.com)