### PR TITLE
ref(ui): Drop unused optional args in pipeline modal

### DIFF
--- a/static/app/components/pipeline/modal.tsx
+++ b/static/app/components/pipeline/modal.tsx
@@ -26,13 +26,9 @@ interface PipelineModalProps<
 > extends ModalRenderProps {
   provider: P;
   type: T;
-  /** Overrides the step's default descriptive copy. */
-  description?: string;
   initialData?: Record<string, string>;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
   onError?: (error: string) => void;
-  /** Overrides the header title (defaults to the pipeline's `actionTitle`). */
-  title?: string;
 }
 
 function PipelineModal<
@@ -47,8 +43,6 @@ function PipelineModal<
   initialData,
   onComplete,
   onError,
-  title,
-  description,
 }: PipelineModalProps<T, P>) {
   const handleComplete = (data: CompletionDataFor<T, P>) => {
     onComplete?.(data);
@@ -58,7 +52,6 @@ function PipelineModal<
   const pipeline = usePipeline(type, provider, {
     onComplete: handleComplete,
     initialData,
-    description,
   });
   const {stepDefinition} = pipeline;
   // Keeps `onError` out of the deps below. Every distinct error is reported, so a
@@ -89,7 +82,7 @@ function PipelineModal<
   return (
     <Fragment>
       <Header closeButton>
-        <Text size="lg">{title ?? pipeline.definition.actionTitle}</Text>
+        <Text size="lg">{pipeline.definition.actionTitle}</Text>
       </Header>
       <Body>
         <Stack gap="2xl">
@@ -162,12 +155,10 @@ interface OpenPipelineModalOptions<
 > {
   provider: P;
   type: T;
-  description?: string;
   initialData?: Record<string, string>;
   onClose?: () => void;
   onComplete?: (data: CompletionDataFor<T, P>) => void;
   onError?: (error: string) => void;
-  title?: string;
 }
 
 export function openPipelineModal<
@@ -180,8 +171,6 @@ export function openPipelineModal<
   onComplete,
   onClose,
   onError,
-  title,
-  description,
 }: OpenPipelineModalOptions<T, P>) {
   openModal(
     deps => (
@@ -192,8 +181,6 @@ export function openPipelineModal<
         initialData={initialData}
         onComplete={onComplete}
         onError={onError}
-        title={title}
-        description={description}
       />
     ),
     {onClose, closeEvents: 'none'}


### PR DESCRIPTION
Follow-up unused-signatures rescan. Nothing passes `title` or `description` into the pipeline modal; the header always uses `pipeline.definition.actionTitle`.

## Summary
- Remove unused `title` / `description` from `OpenPipelineModalOptions` and `PipelineModalProps`.

## Files
- `static/app/components/pipeline/modal.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

Made with [Cursor](https://cursor.com)