### PR TITLE
ref(ui): Drop unused optional args in search tag escaping

### DIFF
--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.spec.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.spec.tsx
@@ -168,10 +168,6 @@ describe('escapeTagValueForSearch', () => {
     expect(escapeTagValueForSearch('foo\\\\*bar')).toBe('foo\\\\\\*bar');
   });
 
-  it('preserves quoting when forced', () => {
-    expect(escapeTagValueForSearch('foo*bar', {forceQuote: true})).toBe('"foo\\*bar"');
-  });
-
   it('respects allowArrayValue when disabled by the caller', () => {
     expect(escapeTagValueForSearch('[foo*bar]', {allowArrayValue: false})).toBe(
       '[foo\\*bar]'

--- a/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
+++ b/static/app/components/searchQueryBuilder/tokens/filter/utils.tsx
@@ -112,9 +112,8 @@ function shouldEscapeTagValue(
   value: string,
   options: EscapeTagValueOptions = {}
 ): boolean {
-  const {allowArrayValue = true, forceQuote = false} = options;
+  const {allowArrayValue = true} = options;
   return (
-    forceQuote ||
     SHOULD_ESCAPE_REGEX.test(value) ||
     (allowArrayValue && value.startsWith('[') && value.endsWith(']'))
   );
@@ -122,7 +121,6 @@ function shouldEscapeTagValue(
 
 interface EscapeTagValueOptions {
   allowArrayValue?: boolean;
-  forceQuote?: boolean;
 }
 
 export function escapeTagValue(


### PR DESCRIPTION
Follow-up unused-signatures rescan. `forceQuote` on `EscapeTagValueOptions` is only asserted in a spec; no production caller sets it.

## Summary
- Remove `forceQuote` and the spec that forced quoting.

## Files
- `static/app/components/searchQueryBuilder/tokens/filter/utils.tsx`
- `static/app/components/searchQueryBuilder/tokens/filter/utils.spec.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

Made with [Cursor](https://cursor.com)