### PR TITLE
ref(ui): Drop unused optional args in events timeseries

### DIFF
--- a/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
+++ b/static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx
@@ -37,10 +37,6 @@ interface UseFetchEventsTimeSeriesOptions<YAxis, Attribute> {
    */
   enabled?: boolean;
   /**
-   * If true, the query will exclude the "other" group.
-   */
-  excludeOther?: boolean;
-  /**
    * Whether the request should enable aggregate extrapolation. Extrapolation is on by default.
    */
   extrapolate?: boolean;
@@ -108,7 +104,6 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
 ) {
   const {
     yAxis,
-    excludeOther,
     enabled,
     groupBy,
     extrapolate,
@@ -151,7 +146,7 @@ export function useFetchEventsTimeSeries<YAxis extends string, Attribute extends
         path: {organizationIdOrSlug: organization.slug},
         query: {
           partial: 1,
-          excludeOther: excludeOther ? 1 : 0,
+          excludeOther: 0,
           dataset,
           referrer,
           yAxis,


### PR DESCRIPTION
Follow-up unused-signatures rescan. `excludeOther` on `UseFetchEventsTimeSeriesOptions` is never provided. The request still sends `excludeOther: 0`.

## Summary
- Remove the unused option and keep the request default.

## Files
- `static/app/utils/timeSeries/useFetchEventsTimeSeries.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

Made with [Cursor](https://cursor.com)