### PR TITLE
ref(ui): Drop unused optional args in insights useDiscover

### DIFF
--- a/static/app/views/insights/common/queries/useDiscover.ts
+++ b/static/app/views/insights/common/queries/useDiscover.ts
@@ -22,10 +22,8 @@ interface UseDiscoverOptions<Fields> {
   enabled?: boolean;
   extrapolationMode?: ExtrapolationMode;
   fields?: Fields;
-  keepPreviousData?: boolean;
   limit?: number;
   noPagination?: boolean;
-  orderby?: string | string[];
   pageFilters?: PageFilters;
   projectIds?: number[];
   /**
@@ -66,7 +64,6 @@ const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, Respo
     pageFilters: pageFiltersFromOptions,
     noPagination,
     projectIds,
-    orderby,
     samplingMode = DEFAULT_SAMPLING_MODE,
     extrapolationMode,
     useQueryOptions,
@@ -80,8 +77,7 @@ const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, Respo
     sorts,
     pageFiltersFromOptions ?? pageFilters.selection,
     dataset,
-    projectIds,
-    orderby
+    projectIds
   );
 
   const queryFn = options.queryWithoutPageFilters
@@ -100,7 +96,6 @@ const useDiscover = <T extends Array<Extract<keyof ResponseType, string>>, Respo
     extrapolationMode,
     additionalQueryKey: useQueryOptions?.additonalQueryKey,
     refetchInterval: useQueryOptions?.refetchInterval,
-    keepPreviousData: options.keepPreviousData,
   });
 
   // This type is a little awkward but it explicitly states that the response could be empty. This doesn't enable unchecked access errors, but it at least indicates that it's possible that there's no data
@@ -119,8 +114,7 @@ export function getEventView(
   sorts: Sort[] = [],
   pageFilters: PageFilters,
   dataset: DiscoverDatasets,
-  projectIds?: number[],
-  orderby?: string | string[]
+  projectIds?: number[]
 ) {
   const query = typeof search === 'string' ? search : (search?.formatString() ?? '');
 
@@ -131,7 +125,6 @@ export function getEventView(
       fields,
       dataset,
       version: 2,
-      orderby,
     },
     pageFilters
   );


### PR DESCRIPTION
Follow-up unused-signatures rescan. `keepPreviousData` and `orderby` on `UseDiscoverOptions` are never provided. The 7th `orderby` argument is also unused on exported `getEventView` (other callers already pass 6 args).

## Summary
- Remove unused `keepPreviousData` / `orderby` from the hook options and `getEventView`.

## Files
- `static/app/views/insights/common/queries/useDiscover.ts`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

Made with [Cursor](https://cursor.com)