### PR TITLE
ref(ui): Drop unused optional args in seer explorer drawer

### DIFF
--- a/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.spec.tsx
+++ b/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.spec.tsx
@@ -88,22 +88,6 @@ describe('useSeerExplorerDrawer', () => {
       expect(sessionStorageWrapper.getItem('seer-explorer-run-id')).toBe('99');
     });
 
-    it('clears runId when startNewRun is true', () => {
-      sessionStorageWrapper.setItem('seer-explorer-run-id', '42');
-
-      const {result} = renderHookWithProviders(() => useSeerExplorerDrawer(), {
-        additionalWrapper: SeerExplorerChatStateProvider,
-        organization: enabledOrg,
-      });
-
-      act(() => result.current.openSeerExplorerDrawer({startNewRun: true}));
-
-      // setRunId(null) writes JSON.stringify(null) = "null"; parsing it back gives null
-      expect(
-        JSON.parse(sessionStorageWrapper.getItem('seer-explorer-run-id')!)
-      ).toBeNull();
-    });
-
     it('does not touch sessionStorage when no options provided', () => {
       sessionStorageWrapper.setItem('seer-explorer-run-id', '55');
 

--- a/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.tsx
+++ b/static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.tsx
@@ -25,14 +25,8 @@ export type OpenSeerExplorerDrawerOptions = {
   initialQuery?: string;
   /**
    * Optional run ID to open. If provided, opens an existing session.
-   * Cannot be used together with `startNewRun`.
    */
   runId?: SeerExplorerRunId;
-  /**
-   * If true, switches to a new session before opening.
-   * Cannot be used together with `runId`.
-   */
-  startNewRun?: boolean;
 };
 
 export const useSeerExplorerDrawer = (options?: {onClose?: () => void}) => {
@@ -71,12 +65,7 @@ export const useSeerExplorerDrawer = (options?: {onClose?: () => void}) => {
 
   const openSeerExplorerDrawer = useCallback(
     (drawerOptions?: OpenSeerExplorerDrawerOptions) => {
-      const {
-        runId: openRunId,
-        startNewRun,
-        initialQuery,
-        appendToOpenRun,
-      } = drawerOptions ?? {};
+      const {runId: openRunId, initialQuery, appendToOpenRun} = drawerOptions ?? {};
 
       if (initialQuery) {
         // A forwarded query starts a fresh session unless the caller asked to
@@ -88,8 +77,6 @@ export const useSeerExplorerDrawer = (options?: {onClose?: () => void}) => {
         return;
       } else if (openRunId !== undefined) {
         dispatch({type: 'set run id', payload: openRunId});
-      } else if (startNewRun) {
-        dispatch({type: 'set run id', payload: null});
       }
 
       openDrawer(

--- a/static/app/views/seerExplorer/useSeerExplorerContext.tsx
+++ b/static/app/views/seerExplorer/useSeerExplorerContext.tsx
@@ -216,12 +216,7 @@ export function SeerExplorerContextProvider({children}: {children: ReactNode}) {
         // Mirror `useSeerExplorerDrawer`'s option handling so deep links
         // (runId), the command palette (initialQuery), and session switching
         // behave the same in sidebar mode as in the drawer.
-        const {
-          runId: openRunId,
-          startNewRun,
-          initialQuery,
-          appendToOpenRun,
-        } = drawerOptions ?? {};
+        const {runId: openRunId, initialQuery, appendToOpenRun} = drawerOptions ?? {};
         if (initialQuery) {
           // A forwarded query starts a fresh session unless the caller asked to
           // add to the open run. Bump the nonce either way so re-forwarding the
@@ -234,8 +229,6 @@ export function SeerExplorerContextProvider({children}: {children: ReactNode}) {
           return;
         } else if (openRunId !== undefined) {
           dispatch({type: 'set run id', payload: openRunId});
-        } else if (startNewRun) {
-          dispatch({type: 'set run id', payload: null});
         }
         setSidebarInitialQuery(initialQuery);
         setSidebarAppendInitialQuery(!!appendToOpenRun);


### PR DESCRIPTION
Follow-up unused-signatures rescan. `startNewRun` on `OpenSeerExplorerDrawerOptions` is only used in a spec. The drawer and sidebar-context mirror both drop it.

## Summary
- Remove `startNewRun` and the spec that cleared `runId` through that flag.

## Files
- `static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.tsx`
- `static/app/views/seerExplorer/components/drawer/useSeerExplorerDrawer.spec.tsx`
- `static/app/views/seerExplorer/useSeerExplorerContext.tsx`

## Test plan
- [ ] CI typecheck / frontend tests for this slice.
- [ ] Spot-check call sites.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.

Made with [Cursor](https://cursor.com)