### PR TITLE
perf(preprod): Render snapshot details with orjson

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -56,6 +56,7 @@ from sentry.preprod.api.models.snapshots.snapshot_status import (
     SnapshotStatusInput,
     derive_snapshot_status,
 )
+from sentry.preprod.api.renderers import OrjsonRenderer
 from sentry.preprod.api.schemas import VCS_ERROR_MESSAGES, VCS_SCHEMA_PROPERTIES
 from sentry.preprod.helpers.deletion import delete_artifacts_and_eap_data
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
@@ -197,6 +198,7 @@ def _format_pydantic_error(e: pydantic.ValidationError) -> str:
 @cell_silo_endpoint
 class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
     owner = ApiOwner.EMERGE_TOOLS
+    renderer_classes = [OrjsonRenderer]
     publish_status = {
         "GET": ApiPublishStatus.PUBLIC,
         "DELETE": ApiPublishStatus.PUBLIC,

--- a/src/sentry/preprod/api/renderers.py
+++ b/src/sentry/preprod/api/renderers.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+import orjson
+from rest_framework.renderers import BaseRenderer
+
+from sentry.utils.json import better_default_encoder
+
+
+class OrjsonRenderer(BaseRenderer):
+    media_type = "application/json"
+    format = "json"
+    charset = None
+
+    def render(
+        self,
+        data: Any,
+        accepted_media_type: str | None = None,
+        renderer_context: Mapping[str, Any] | None = None,
+    ) -> bytes:
+        if data is None:
+            return b""
+        return orjson.dumps(data, default=better_default_encoder)

--- a/tests/sentry/preprod/api/test_renderers.py
+++ b/tests/sentry/preprod/api/test_renderers.py
@@ -1,0 +1,31 @@
+import orjson
+
+from sentry.preprod.api.renderers import OrjsonRenderer
+
+
+class TestOrjsonRenderer:
+    def test_media_type_and_format(self) -> None:
+        renderer = OrjsonRenderer()
+        assert renderer.media_type == "application/json"
+        assert renderer.format == "json"
+
+    def test_renders_dict_as_json_bytes(self) -> None:
+        data = {"b": "x", "a": 1, "nested": {"n": [1, 2, 3]}}
+        rendered = OrjsonRenderer().render(data)
+
+        assert isinstance(rendered, bytes)
+        assert orjson.loads(rendered) == data
+
+    def test_renders_none_as_empty_bytes(self) -> None:
+        assert OrjsonRenderer().render(None) == b""
+
+    def test_preserves_unicode_as_raw_utf8(self) -> None:
+        rendered = OrjsonRenderer().render({"name": "café"})
+
+        assert "café".encode() in rendered
+        assert b"\\u" not in rendered
+
+    def test_uses_default_encoder_for_non_primitives(self) -> None:
+        rendered = OrjsonRenderer().render({"tags": {"b", "a"}})
+
+        assert sorted(orjson.loads(rendered)["tags"]) == ["a", "b"]


### PR DESCRIPTION
## Summary

The preprod snapshot **details** endpoint (`OrganizationPreprodSnapshotEndpoint`) rendered its response through DRF's default `JSONRenderer`, a pure-Python encoder. Production traces show the `view.response.render` step costs **~70ms avg / ~210ms p95** on this endpoint, growing with the number of screenshots.

This adds a small orjson-based DRF renderer and applies it to that endpoint only.

## What changed

- New `OrjsonRenderer` (`src/sentry/preprod/api/renderers.py`): a ~10-line `BaseRenderer` that serializes with `orjson.dumps(..., default=better_default_encoder)` and returns an empty body for `None` (the 204 delete path).
- `renderer_classes = [OrjsonRenderer]` on `OrganizationPreprodSnapshotEndpoint`.

## Why it's safe

- **Output is unchanged.** The response body is entirely JSON primitives — ids, enum names, and datetimes are all stringified upstream before they reach the renderer — so orjson's Decimal/object gaps are never exercised. `better_default_encoder` covers the pydantic `extra="allow"` passthrough as defensive insurance.
- Content-Type stays `application/json`; unicode stays raw UTF-8 (matches DRF's `UNICODE_JSON`); dict insertion order is preserved.
- The `Endpoint` base does no custom renderer negotiation, and Sentry does not enable the browsable API, so a plain `renderer_classes` override is honored with nothing to preserve.
- The byte-for-byte golden suite and all existing GET/DELETE tests pass unchanged; new unit tests cover the renderer directly.

## Context

This is the low-risk first step of a broader effort to cut snapshot-details latency (p95 ~2.6s on large builds). The bigger wins — precomputing the image-dict serialization and comparison categorization at write time — are tracked separately; this renderer swap is independent and helps every response this endpoint returns.

https://claude.ai/code/session_013SAxBGjuP4a7cxRx3WmZa4
