### PR TITLE
test(auth): Wait for authenticated SSO state

### DIFF
--- a/tests/acceptance/test_auth_react.py
+++ b/tests/acceptance/test_auth_react.py
@@ -346,6 +346,7 @@ class ReactAuthTest(AcceptanceTestCase):
         # Password authentication establishes the account session, but the protected
         # destination takes precedence over the password-capable fallback organization.
         self.submit_visible_credentials(user.email, PASSWORD)
+        self.browser.wait_until_not('[aria-label="Email"]')
         self.browser.wait_until_script_execution(
             f"return window.location.pathname === '/auth/login/{sso_organization.slug}/'"
         )


### PR DESCRIPTION
The password-to-SSO acceptance flow stays on the same organization login pathname while the page transitions into its authenticated state. Waiting on that pathname returned immediately and allowed the test to click the SSO button while React was replacing it, producing stale-element and missing-element failures.

Wait for the pre-authentication email form to disappear before asserting that the organization-scoped pathname was preserved and continuing into SSO.

Tested with `.venv/bin/pytest -n0 -svv --reuse-db tests/acceptance/test_auth_react.py::ReactAuthTest::test_password_login_preserves_sso_organization_destination` and `.venv/bin/prek run -q --files tests/acceptance/test_auth_react.py`.
