### PR TITLE
perf(preprod): Precompute head-image list at upload

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -77,6 +77,7 @@ from sentry.preprod.snapshots.precompute import (
     build_head_images_payload,
     head_images_key,
     load_precomputed_head_images,
+    refresh_manifest_expiration,
 )
 from sentry.preprod.snapshots.tasks import compare_snapshots
 from sentry.preprod.snapshots.utils import (
@@ -360,6 +361,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         precomputed = load_precomputed_head_images(session, extras.get("head_images_key"))
         if precomputed is not None:
             image_list, head_diff_threshold = precomputed
+            refresh_manifest_expiration(session, extras.get("manifest_key"))
         else:
             manifest_key = extras.get("manifest_key")
             if not manifest_key:

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -73,6 +73,11 @@ from sentry.preprod.snapshots.models import (
     PreprodSnapshotComparison,
     PreprodSnapshotMetrics,
 )
+from sentry.preprod.snapshots.precompute import (
+    build_head_images_payload,
+    head_images_key,
+    load_precomputed_head_images,
+)
 from sentry.preprod.snapshots.tasks import compare_snapshots
 from sentry.preprod.snapshots.utils import (
     find_base_snapshot_artifact,
@@ -348,33 +353,49 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
         except PreprodSnapshotMetrics.DoesNotExist:
             return Response({"detail": "Snapshot metrics not found"}, status=404)
 
-        manifest_key = (snapshot_metrics.extras or {}).get("manifest_key")
-        if not manifest_key:
-            return Response({"detail": "Manifest key not found"}, status=404)
+        extras = snapshot_metrics.extras or {}
+        session = get_session(UsecaseId.PREPROD, artifact.project)
 
-        try:
-            session = get_session(UsecaseId.PREPROD, artifact.project)
-            get_response = session.get(manifest_key)
-            if get_response is None:
-                raise FileNotFoundError("Manifest does not exist in objectstore")
-            with start_span(op="preprod.snapshot.read_manifest", name="read_head_manifest"):
-                raw_manifest = get_response.payload.read()
+        image_list: list[SnapshotImageResponseDict]
+        precomputed = load_precomputed_head_images(session, extras.get("head_images_key"))
+        if precomputed is not None:
+            image_list, head_diff_threshold = precomputed
+        else:
+            manifest_key = extras.get("manifest_key")
+            if not manifest_key:
+                return Response({"detail": "Manifest key not found"}, status=404)
+
+            try:
+                get_response = session.get(manifest_key)
+                if get_response is None:
+                    raise FileNotFoundError("Manifest does not exist in objectstore")
+                with start_span(op="preprod.snapshot.read_manifest", name="read_head_manifest"):
+                    raw_manifest = get_response.payload.read()
+                with start_span(
+                    op="preprod.snapshot.parse_manifest", name="parse_head_manifest"
+                ) as span:
+                    head_manifest = orjson.loads(raw_manifest)
+                    head_images: dict[str, Any] = head_manifest.get("images", {})
+                    head_diff_threshold = head_manifest.get("diff_threshold")
+                    set_span_data(span, "image_count", len(head_images))
+            except Exception:
+                logger.exception(
+                    "Failed to retrieve snapshot manifest",
+                    extra={
+                        "preprod_artifact_id": artifact.id,
+                        "manifest_key": manifest_key,
+                    },
+                )
+                return Response({"detail": "Internal server error"}, status=500)
+
             with start_span(
-                op="preprod.snapshot.parse_manifest", name="parse_head_manifest"
+                op="preprod.snapshot.serialize_images", name="serialize_head_images"
             ) as span:
-                head_manifest = orjson.loads(raw_manifest)
-                head_images: dict[str, Any] = head_manifest.get("images", {})
-                head_diff_threshold = head_manifest.get("diff_threshold")
                 set_span_data(span, "image_count", len(head_images))
-        except Exception:
-            logger.exception(
-                "Failed to retrieve snapshot manifest",
-                extra={
-                    "preprod_artifact_id": artifact.id,
-                    "manifest_key": manifest_key,
-                },
-            )
-            return Response({"detail": "Internal server error"}, status=500)
+                image_list = [
+                    build_head_image_dict(key, metadata, head_diff_threshold)
+                    for key, metadata in sorted(head_images.items())
+                ]
 
         # Build VCS info from commit_comparison
         commit_comparison = artifact.commit_comparison
@@ -484,15 +505,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                     )
                     is not None
                 )
-
-        with start_span(
-            op="preprod.snapshot.serialize_images", name="serialize_head_images"
-        ) as span:
-            set_span_data(span, "image_count", len(head_images))
-            image_list: list[SnapshotImageResponseDict] = [
-                build_head_image_dict(key, metadata, head_diff_threshold)
-                for key, metadata in sorted(head_images.items())
-            ]
 
         images_by_file_name: dict[str, SnapshotImageResponseDict] = {
             img["image_file_name"]: img for img in image_list
@@ -817,12 +829,18 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             )
 
             manifest_key = f"{project.organization_id}/{project.id}/{artifact.id}/manifest.json"
+            head_images_key_value = head_images_key(
+                project.organization_id, project.id, artifact.id
+            )
 
             snapshot_metrics = PreprodSnapshotMetrics.objects.create(
                 preprod_artifact=artifact,
                 image_count=len(images),
                 is_selective=selective,
-                extras={"manifest_key": manifest_key},
+                extras={
+                    "manifest_key": manifest_key,
+                    "head_images_key": head_images_key_value,
+                },
             )
 
             # Write manifest inside the transaction so that a failed objectstore
@@ -831,7 +849,29 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             manifest_bytes = manifest.json(exclude_none=True).encode()
             manifest_size_bytes = len(manifest_bytes)
             session.put(manifest_bytes, key=manifest_key)
-            del manifest_bytes
+
+        # Best-effort: precompute the serialized head-image list so reads skip the
+        # per-image build. A miss here just falls back to rebuilding from the manifest.
+        try:
+            parsed_manifest = orjson.loads(manifest_bytes)
+            session.put(
+                orjson.dumps(
+                    build_head_images_payload(
+                        parsed_manifest.get("images", {}),
+                        parsed_manifest.get("diff_threshold"),
+                    )
+                ),
+                key=head_images_key_value,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to write precomputed head images",
+                extra={
+                    "preprod_artifact_id": artifact.id,
+                    "head_images_key": head_images_key_value,
+                },
+            )
+        del manifest_bytes
 
         logger.info(
             "Created preprod artifact and stored snapshot manifest",

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -67,7 +67,7 @@ from sentry.preprod.snapshots.constants import (
     MISSING_BASE_GRACE_PERIOD_SECONDS,
     SNAPSHOT_ARCHIVE_MANIFEST_FILENAME,
 )
-from sentry.preprod.snapshots.image_serialization import build_head_image_dict
+from sentry.preprod.snapshots.image_serialization import build_head_image_list
 from sentry.preprod.snapshots.manifest import SnapshotManifest
 from sentry.preprod.snapshots.models import (
     PreprodSnapshotComparison,
@@ -392,10 +392,7 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 op="preprod.snapshot.serialize_images", name="serialize_head_images"
             ) as span:
                 set_span_data(span, "image_count", len(head_images))
-                image_list = [
-                    build_head_image_dict(key, metadata, head_diff_threshold)
-                    for key, metadata in sorted(head_images.items())
-                ]
+                image_list = build_head_image_list(head_images, head_diff_threshold)
 
         # Build VCS info from commit_comparison
         commit_comparison = artifact.commit_comparison
@@ -850,8 +847,6 @@ class ProjectPreprodSnapshotEndpoint(ProjectEndpoint):
             manifest_size_bytes = len(manifest_bytes)
             session.put(manifest_bytes, key=manifest_key)
 
-        # Best-effort: precompute the serialized head-image list so reads skip the
-        # per-image build. A miss here just falls back to rebuilding from the manifest.
         try:
             parsed_manifest = orjson.loads(manifest_bytes)
             session.put(

--- a/src/sentry/preprod/helpers/deletion.py
+++ b/src/sentry/preprod/helpers/deletion.py
@@ -110,7 +110,7 @@ def _collect_snapshot_objectstore_keys(
     preprod_artifacts: list[PreprodArtifact],
 ) -> list[tuple[int, int, str]]:
     # Collects three types of objectstore keys for the given artifacts:
-    # 1. Snapshot manifest keys (per-snapshot JSON manifests from PreprodSnapshotMetrics)
+    # 1. Snapshot manifest and precomputed head-images keys (from PreprodSnapshotMetrics)
     # 2. Comparison manifest keys (diff manifests from PreprodSnapshotComparison)
     # 3. Diff mask image keys (per-image diff masks referenced within comparison manifests)
     # Note: shared content-addressed image keys are NOT collected — they expire via X-day TTL.
@@ -131,13 +131,12 @@ def _collect_snapshot_objectstore_keys(
         project_id = sm.preprod_artifact.project_id
         metrics_ids.append(sm.id)
 
-        manifest_key = (sm.extras or {}).get("manifest_key")
-        if not manifest_key:
-            continue
-
-        # Image keys are content-addressed and shared across snapshots;
-        # only delete the manifest, not images (they expire via X-day TTL).
-        keys.append((org_id, project_id, manifest_key))
+        # Delete the per-snapshot manifest and precomputed head-images blob. Shared
+        # content-addressed image keys are left to expire via idle TTL.
+        extras = sm.extras or {}
+        for key in (extras.get("manifest_key"), extras.get("head_images_key")):
+            if key:
+                keys.append((org_id, project_id, key))
 
     for comp in PreprodSnapshotComparison.objects.filter(
         Q(head_snapshot_metrics_id__in=metrics_ids) | Q(base_snapshot_metrics_id__in=metrics_ids)

--- a/src/sentry/preprod/snapshots/image_serialization.py
+++ b/src/sentry/preprod/snapshots/image_serialization.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any, cast
 
 from sentry.preprod.api.models.public.snapshots import SnapshotImageResponseDict
@@ -37,6 +38,15 @@ def build_head_image_dict(
             "diff_threshold": dt if dt is not None else global_diff_threshold,
         },
     )
+
+
+def build_head_image_list(
+    images: Mapping[str, Any], global_diff_threshold: float | None
+) -> list[SnapshotImageResponseDict]:
+    return [
+        build_head_image_dict(image_file_name, image, global_diff_threshold)
+        for image_file_name, image in sorted(images.items())
+    ]
 
 
 def minimal_image_dict(

--- a/src/sentry/preprod/snapshots/precompute.py
+++ b/src/sentry/preprod/snapshots/precompute.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from typing import Any, TypedDict
+
+import orjson
+from objectstore_client import Session
+
+from sentry.preprod.api.models.public.snapshots import SnapshotImageResponseDict
+from sentry.preprod.snapshots.image_serialization import build_head_image_dict
+from sentry.utils.tracing import set_span_data, start_span
+
+logger = logging.getLogger(__name__)
+
+# Bump whenever the shape of a precomputed head-image dict changes, so stale blobs
+# are treated as a cache miss and the read path rebuilds from the manifest.
+HEAD_IMAGES_SCHEMA_VERSION = 1
+
+
+class HeadImagesPayload(TypedDict):
+    schema_version: int
+    diff_threshold: float | None
+    images: list[SnapshotImageResponseDict]
+
+
+def head_images_key(organization_id: int, project_id: int, artifact_id: int) -> str:
+    return f"{organization_id}/{project_id}/{artifact_id}/snapshot_head_images.json"
+
+
+def build_head_images_payload(
+    images: Mapping[str, Any], diff_threshold: float | None
+) -> HeadImagesPayload:
+    return {
+        "schema_version": HEAD_IMAGES_SCHEMA_VERSION,
+        "diff_threshold": diff_threshold,
+        "images": [
+            build_head_image_dict(image_file_name, metadata, diff_threshold)
+            for image_file_name, metadata in sorted(images.items())
+        ],
+    }
+
+
+def load_precomputed_head_images(
+    session: Session, key: str | None
+) -> tuple[list[SnapshotImageResponseDict], float | None] | None:
+    if not key:
+        return None
+    try:
+        response = session.get(key)
+        if response is None:
+            return None
+        with start_span(
+            op="preprod.snapshot.read_precomputed_head_images",
+            name="read_precomputed_head_images",
+        ) as span:
+            raw = response.payload.read()
+            payload = orjson.loads(raw)
+            if payload.get("schema_version") != HEAD_IMAGES_SCHEMA_VERSION:
+                return None
+            images = payload["images"]
+            set_span_data(span, "image_count", len(images))
+            return images, payload.get("diff_threshold")
+    except Exception:
+        logger.exception("Failed to read precomputed head images", extra={"key": key})
+        return None

--- a/src/sentry/preprod/snapshots/precompute.py
+++ b/src/sentry/preprod/snapshots/precompute.py
@@ -36,6 +36,15 @@ def build_head_images_payload(
     }
 
 
+def refresh_manifest_expiration(session: Session, manifest_key: str | None) -> None:
+    if not manifest_key:
+        return
+    try:
+        session.head(manifest_key)
+    except Exception:
+        logger.exception("Failed to refresh manifest expiration", extra={"key": manifest_key})
+
+
 def load_precomputed_head_images(
     session: Session, key: str | None
 ) -> tuple[list[SnapshotImageResponseDict], float | None] | None:

--- a/src/sentry/preprod/snapshots/precompute.py
+++ b/src/sentry/preprod/snapshots/precompute.py
@@ -8,13 +8,11 @@ import orjson
 from objectstore_client import Session
 
 from sentry.preprod.api.models.public.snapshots import SnapshotImageResponseDict
-from sentry.preprod.snapshots.image_serialization import build_head_image_dict
+from sentry.preprod.snapshots.image_serialization import build_head_image_list
 from sentry.utils.tracing import set_span_data, start_span
 
 logger = logging.getLogger(__name__)
 
-# Bump whenever the shape of a precomputed head-image dict changes, so stale blobs
-# are treated as a cache miss and the read path rebuilds from the manifest.
 HEAD_IMAGES_SCHEMA_VERSION = 1
 
 
@@ -34,10 +32,7 @@ def build_head_images_payload(
     return {
         "schema_version": HEAD_IMAGES_SCHEMA_VERSION,
         "diff_threshold": diff_threshold,
-        "images": [
-            build_head_image_dict(image_file_name, metadata, diff_threshold)
-            for image_file_name, metadata in sorted(images.items())
-        ],
+        "images": build_head_image_list(images, diff_threshold),
     }
 
 
@@ -56,7 +51,10 @@ def load_precomputed_head_images(
         ) as span:
             raw = response.payload.read()
             payload = orjson.loads(raw)
-            if payload.get("schema_version") != HEAD_IMAGES_SCHEMA_VERSION:
+            if (
+                payload.get("schema_version") != HEAD_IMAGES_SCHEMA_VERSION
+                or "images" not in payload
+            ):
                 return None
             images = payload["images"]
             set_span_data(span, "image_count", len(images))

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -702,7 +702,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
                 "height": 1920,
             },
         }
-        artifact, snapshot_metrics, _, _, _ = self._create_artifact_with_manifest(images)
+        artifact, snapshot_metrics, manifest_key, _, _ = self._create_artifact_with_manifest(images)
         head_key = f"{self.org.id}/{self.project.id}/{artifact.id}/snapshot_head_images.json"
         snapshot_metrics.extras["head_images_key"] = head_key
         snapshot_metrics.save()
@@ -724,6 +724,7 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
 
         assert response.status_code == 200
         assert [img["key"] for img in response.data["images"]] == ["img1", "img2"]
+        mock_session.head.assert_called_once_with(manifest_key)
 
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_details_returns_canvas_theme(self, mock_get_session):

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -709,8 +709,6 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
 
         blob = orjson.dumps(build_head_images_payload(images, None))
 
-        # Only the precomputed blob resolves; a manifest read would return None and
-        # 500, so a 200 proves the fast path served the response.
         def _get(key):
             if key == head_key:
                 result = MagicMock()
@@ -1610,9 +1608,6 @@ class PreprodSnapshotGoldenResponseTest(APITestCase):
         metrics.extras["head_images_key"] = head_key
         metrics.save(update_fields=["extras"])
 
-        # Only the precomputed blob is available; the manifest key is absent, so a
-        # fallback read would 500. Matching the golden proves the fast path served a
-        # byte-identical response.
         self._mock_multi_session(
             mock_get_session, {head_key: self._head_images_blob_bytes(head_images)}
         )

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -19,6 +19,7 @@ from sentry.preprod.snapshots.manifest import (
     SnapshotManifest,
 )
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.snapshots.precompute import build_head_images_payload
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
 
@@ -209,6 +210,34 @@ class ProjectPreprodSnapshotTest(APITestCase):
             f"{self.project.organization_id}/{self.project.id}/{artifact_id}/manifest.json"
         )
         assert snapshot_metrics.extras["manifest_key"] == expected_key
+
+    def test_snapshot_upload_stores_head_images_key(self) -> None:
+        url = self._get_create_url()
+        data = {
+            "app_id": "com.example.app",
+            "images": {
+                "hash1": {
+                    "content_hash": "hash1",
+                    "display_name": "Screen 1",
+                    "image_file_name": "screen1.png",
+                    "width": 100,
+                    "height": 200,
+                },
+            },
+        }
+
+        response = self.client.post(url, data, format="json")
+
+        assert response.status_code == 200
+
+        snapshot_metrics = PreprodSnapshotMetrics.objects.get(id=response.data["snapshotMetricsId"])
+        assert snapshot_metrics.extras is not None
+        artifact_id = response.data["artifactId"]
+        expected_key = (
+            f"{self.project.organization_id}/{self.project.id}/"
+            f"{artifact_id}/snapshot_head_images.json"
+        )
+        assert snapshot_metrics.extras["head_images_key"] == expected_key
 
     def test_snapshot_with_empty_images(self) -> None:
         url = self._get_create_url()
@@ -656,6 +685,47 @@ class ProjectPreprodSnapshotGetTest(APITestCase):
         assert response.data["images"][0]["key"] == "img1"
         assert response.data["images"][0]["image_file_name"] == "img1"
         assert response.data["images"][1]["key"] == "img2"
+
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
+    def test_get_snapshot_details_uses_precomputed_head_images(self, mock_get_session):
+        images = {
+            "img1": {
+                "content_hash": "img1",
+                "display_name": "Screen1",
+                "width": 375,
+                "height": 812,
+            },
+            "img2": {
+                "content_hash": "img2",
+                "display_name": "Screen2",
+                "width": 1080,
+                "height": 1920,
+            },
+        }
+        artifact, snapshot_metrics, _, _, _ = self._create_artifact_with_manifest(images)
+        head_key = f"{self.org.id}/{self.project.id}/{artifact.id}/snapshot_head_images.json"
+        snapshot_metrics.extras["head_images_key"] = head_key
+        snapshot_metrics.save()
+
+        blob = orjson.dumps(build_head_images_payload(images, None))
+
+        # Only the precomputed blob resolves; a manifest read would return None and
+        # 500, so a 200 proves the fast path served the response.
+        def _get(key):
+            if key == head_key:
+                result = MagicMock()
+                result.payload.read.return_value = blob
+                return result
+            return None
+
+        mock_session = MagicMock()
+        mock_session.get.side_effect = _get
+        mock_get_session.return_value = mock_session
+
+        response = self.client.get(self._get_detail_url(artifact.id))
+
+        assert response.status_code == 200
+        assert [img["key"] for img in response.data["images"]] == ["img1", "img2"]
 
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_get_snapshot_details_returns_canvas_theme(self, mock_get_session):
@@ -1525,7 +1595,54 @@ class PreprodSnapshotGoldenResponseTest(APITestCase):
             {"head_artifact_id": "<HEAD_ID>", "project_id": "<PROJECT_ID>"},
         )
 
-    def _setup_diff(self, mock_get_session):
+    def _head_images_blob_bytes(self, head_images):
+        parsed = orjson.loads(self._snapshot_manifest_bytes(head_images, 0.2))
+        return orjson.dumps(
+            build_head_images_payload(parsed["images"], parsed.get("diff_threshold"))
+        )
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
+    def test_golden_solo_precomputed_head_images(self, mock_get_session, mock_record):
+        head_images = self._head_images()
+        artifact, metrics = self._create_artifact(image_count=len(head_images))
+        head_key = f"{self.org.id}/{self.project.id}/{artifact.id}/snapshot_head_images.json"
+        metrics.extras["head_images_key"] = head_key
+        metrics.save(update_fields=["extras"])
+
+        # Only the precomputed blob is available; the manifest key is absent, so a
+        # fallback read would 500. Matching the golden proves the fast path served a
+        # byte-identical response.
+        self._mock_multi_session(
+            mock_get_session, {head_key: self._head_images_blob_bytes(head_images)}
+        )
+
+        response = self.client.get(self._get_detail_url(artifact.id))
+
+        self._assert_golden(
+            "snapshot_solo.json",
+            response,
+            {"head_artifact_id": "<HEAD_ID>", "project_id": "<PROJECT_ID>"},
+        )
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
+    def test_golden_diff_precomputed_head_images(self, mock_get_session, mock_record):
+        head_artifact, _ = self._setup_diff(mock_get_session, use_precomputed_head=True)
+
+        response = self.client.get(self._get_detail_url(head_artifact.id))
+
+        self._assert_golden(
+            "snapshot_diff.json",
+            response,
+            {
+                "head_artifact_id": "<HEAD_ID>",
+                "base_artifact_id": "<BASE_ID>",
+                "project_id": "<PROJECT_ID>",
+            },
+        )
+
+    def _setup_diff(self, mock_get_session, use_precomputed_head=False):
         head_images = self._head_images()
         base_images = self._base_images()
         head_artifact, head_metrics = self._create_artifact(image_count=len(head_images))
@@ -1542,14 +1659,23 @@ class PreprodSnapshotGoldenResponseTest(APITestCase):
         comparison.extras = {"comparison_key": comparison_key}
         comparison.save(update_fields=["extras"])
 
-        self._mock_multi_session(
-            mock_get_session,
-            {
-                self._manifest_key(head_artifact): self._snapshot_manifest_bytes(head_images, 0.2),
-                self._manifest_key(base_artifact): self._snapshot_manifest_bytes(base_images),
-                comparison_key: self._comparison_manifest_bytes(head_artifact, base_artifact),
-            },
-        )
+        session_objects = {
+            self._manifest_key(base_artifact): self._snapshot_manifest_bytes(base_images),
+            comparison_key: self._comparison_manifest_bytes(head_artifact, base_artifact),
+        }
+        if use_precomputed_head:
+            head_key = (
+                f"{self.org.id}/{self.project.id}/{head_artifact.id}/snapshot_head_images.json"
+            )
+            head_metrics.extras["head_images_key"] = head_key
+            head_metrics.save(update_fields=["extras"])
+            session_objects[head_key] = self._head_images_blob_bytes(head_images)
+        else:
+            session_objects[self._manifest_key(head_artifact)] = self._snapshot_manifest_bytes(
+                head_images, 0.2
+            )
+
+        self._mock_multi_session(mock_get_session, session_objects)
         return head_artifact, base_artifact
 
     @patch("sentry.analytics.record")

--- a/tests/sentry/preprod/helpers/test_deletion.py
+++ b/tests/sentry/preprod/helpers/test_deletion.py
@@ -1,0 +1,24 @@
+from sentry.preprod.helpers.deletion import _collect_snapshot_objectstore_keys
+from sentry.preprod.models import PreprodArtifact
+from sentry.testutils.cases import TestCase
+
+
+class CollectSnapshotObjectstoreKeysTest(TestCase):
+    def test_collects_manifest_and_head_images_keys(self) -> None:
+        artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADED,
+            app_id="com.example.app",
+        )
+        manifest_key = f"{self.organization.id}/{self.project.id}/{artifact.id}/manifest.json"
+        head_images_key = (
+            f"{self.organization.id}/{self.project.id}/{artifact.id}/snapshot_head_images.json"
+        )
+        metrics = self.create_preprod_snapshot_metrics(preprod_artifact=artifact, image_count=0)
+        metrics.extras = {"manifest_key": manifest_key, "head_images_key": head_images_key}
+        metrics.save(update_fields=["extras"])
+
+        collected = {key for _, _, key in _collect_snapshot_objectstore_keys([artifact])}
+
+        assert manifest_key in collected
+        assert head_images_key in collected

--- a/tests/sentry/preprod/snapshots/test_precompute.py
+++ b/tests/sentry/preprod/snapshots/test_precompute.py
@@ -75,6 +75,11 @@ class TestLoadPrecomputedHeadImages:
 
         assert load_precomputed_head_images(_mock_session(raw), "k") is None
 
+    def test_returns_none_when_images_key_absent(self) -> None:
+        raw = orjson.dumps({"schema_version": HEAD_IMAGES_SCHEMA_VERSION, "diff_threshold": 0.1})
+
+        assert load_precomputed_head_images(_mock_session(raw), "k") is None
+
     def test_returns_none_on_read_error(self) -> None:
         session = MagicMock()
         result = MagicMock()

--- a/tests/sentry/preprod/snapshots/test_precompute.py
+++ b/tests/sentry/preprod/snapshots/test_precompute.py
@@ -1,0 +1,84 @@
+from typing import Any, cast
+from unittest.mock import MagicMock
+
+import orjson
+
+from sentry.preprod.snapshots.precompute import (
+    HEAD_IMAGES_SCHEMA_VERSION,
+    build_head_images_payload,
+    head_images_key,
+    load_precomputed_head_images,
+)
+
+_IMAGES = {
+    "b.png": {"content_hash": "hb", "display_name": "B", "width": 1, "height": 2},
+    "a.png": {"content_hash": "ha", "display_name": "A", "width": 3, "height": 4},
+}
+
+
+class TestHeadImagesKey:
+    def test_key_format(self) -> None:
+        assert head_images_key(1, 2, 3) == "1/2/3/snapshot_head_images.json"
+
+
+class TestBuildHeadImagesPayload:
+    def test_schema_version_and_diff_threshold(self) -> None:
+        payload = build_head_images_payload(_IMAGES, 0.1)
+
+        assert payload["schema_version"] == HEAD_IMAGES_SCHEMA_VERSION
+        assert payload["diff_threshold"] == 0.1
+
+    def test_images_sorted_by_file_name(self) -> None:
+        payload = build_head_images_payload(_IMAGES, None)
+
+        assert [img["image_file_name"] for img in payload["images"]] == ["a.png", "b.png"]
+        assert payload["images"][0]["key"] == "ha"
+
+    def test_global_diff_threshold_baked_into_images(self) -> None:
+        payload = build_head_images_payload(_IMAGES, 0.1)
+
+        assert all(cast(dict[str, Any], img)["diff_threshold"] == 0.1 for img in payload["images"])
+
+
+def _mock_session(raw: bytes | None) -> MagicMock:
+    session = MagicMock()
+    if raw is None:
+        session.get.return_value = None
+    else:
+        result = MagicMock()
+        result.payload.read.return_value = raw
+        session.get.return_value = result
+    return session
+
+
+class TestLoadPrecomputedHeadImages:
+    def test_returns_none_when_key_missing(self) -> None:
+        assert load_precomputed_head_images(_mock_session(b""), None) is None
+
+    def test_returns_none_when_object_missing(self) -> None:
+        assert load_precomputed_head_images(_mock_session(None), "k") is None
+
+    def test_returns_images_and_threshold_on_hit(self) -> None:
+        raw = orjson.dumps(build_head_images_payload(_IMAGES, 0.1))
+
+        result = load_precomputed_head_images(_mock_session(raw), "k")
+
+        assert result is not None
+        images, diff_threshold = result
+        assert diff_threshold == 0.1
+        assert [img["image_file_name"] for img in images] == ["a.png", "b.png"]
+
+    def test_returns_none_on_schema_version_mismatch(self) -> None:
+        payload = build_head_images_payload(_IMAGES, 0.1)
+        payload["schema_version"] = HEAD_IMAGES_SCHEMA_VERSION + 999
+        raw = orjson.dumps(payload)
+
+        assert load_precomputed_head_images(_mock_session(raw), "k") is None
+
+    def test_returns_none_on_read_error(self) -> None:
+        session = MagicMock()
+        result = MagicMock()
+        result.payload.read.side_effect = OSError("boom")
+        session.get.return_value = result
+
+        assert load_precomputed_head_images(session, "k") is None

--- a/tests/sentry/preprod/snapshots/test_precompute.py
+++ b/tests/sentry/preprod/snapshots/test_precompute.py
@@ -8,6 +8,7 @@ from sentry.preprod.snapshots.precompute import (
     build_head_images_payload,
     head_images_key,
     load_precomputed_head_images,
+    refresh_manifest_expiration,
 )
 
 _IMAGES = {
@@ -38,6 +39,28 @@ class TestBuildHeadImagesPayload:
         payload = build_head_images_payload(_IMAGES, 0.1)
 
         assert all(cast(dict[str, Any], img)["diff_threshold"] == 0.1 for img in payload["images"])
+
+
+class TestRefreshManifestExpiration:
+    def test_heads_the_manifest_key(self) -> None:
+        session = MagicMock()
+
+        refresh_manifest_expiration(session, "mk")
+
+        session.head.assert_called_once_with("mk")
+
+    def test_noop_when_key_missing(self) -> None:
+        session = MagicMock()
+
+        refresh_manifest_expiration(session, None)
+
+        session.head.assert_not_called()
+
+    def test_swallows_errors(self) -> None:
+        session = MagicMock()
+        session.head.side_effect = OSError("boom")
+
+        refresh_manifest_expiration(session, "mk")
 
 
 def _mock_session(raw: bytes | None) -> MagicMock:


### PR DESCRIPTION
In one sentence: instead of rebuilding every screenshot's JSON on each snapshot-details read, we build it once when the snapshot is uploaded, save it to object storage, and just load that on reads (falling back to the old build if it's missing).

## Summary

Building the per-image head dicts on every snapshot-details GET is the **single largest span** in the endpoint — production traces show `serialize_head_images` at **~338ms avg / ~1.3s p95** on large builds, and it scales with screenshot count. It's recomputed on every read even though its only input (the head manifest) is immutable.

This precomputes that work once, at upload, and serves it from objectstore on read.

## What changed

- **New `precompute.py`**: `build_head_images_payload()` (the sorted, per-image head-dict list + a `schema_version` + `diff_threshold`), a deterministic `head_images_key()`, and `load_precomputed_head_images()` (fetch + version-check, returns `None` on any miss/mismatch/error).
- **Upload (`post`)**: after writing the manifest, best-effort write the head-image blob keyed on the head artifact, and record its key in `PreprodSnapshotMetrics.extras`. The write runs **outside the DB transaction** — a failure logs and leaves reads to fall back; it never fails the upload.
- **Read (`get`)**: if the blob is present and its `schema_version` matches, use it and **skip both the manifest parse and the per-image build**. Otherwise fall back to the existing rebuild-from-manifest path.
