### PR TITLE
fix(auth): Shorten passkey waiting message

### DIFF
--- a/static/app/views/authV2/authLogin/components/secondFactorAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/secondFactorAuth.spec.tsx
@@ -107,9 +107,7 @@ describe('SecondFactorAuth', () => {
     );
 
     expect(
-      screen.getByText(
-        'Waiting for passkey, biometric, or hardware key authentication...'
-      )
+      screen.getByText('Waiting for passkey, biometric, or hardware key')
     ).toBeInTheDocument();
     await waitFor(() => expect(challengeRequest).toHaveBeenCalledTimes(1));
     await waitFor(() =>

--- a/static/app/views/authV2/authLogin/components/webAuthn2faMethod.tsx
+++ b/static/app/views/authV2/authLogin/components/webAuthn2faMethod.tsx
@@ -147,7 +147,7 @@ export function WebAuthn2FAMethod({
 
   return (
     <Text as="p" align="center">
-      {t('Waiting for passkey, biometric, or hardware key authentication...')}
+      {t('Waiting for passkey, biometric, or hardware key')}
     </Text>
   );
 }


### PR DESCRIPTION
Shorten the passkey pending-state copy by removing the redundant authentication suffix and trailing ellipsis.