### PR TITLE
feat(hybrid-cloud): Measure synchronous outbox flush duration

### DIFF
--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -201,11 +201,23 @@ class OutboxBase(Model):
             )
 
         if _outbox_context.flushing_enabled:
-            transaction.on_commit(lambda: self.drain_shard(), using=router.db_for_write(type(self)))
+            transaction.on_commit(
+                self._drain_shard_with_metrics, using=router.db_for_write(type(self))
+            )
 
         tags = {"category": OutboxCategory(self.category).name}
         metrics.incr("outbox.saved", 1, tags=tags)
         super().save(*args, **kwargs)
+
+    def _drain_shard_with_metrics(self) -> None:
+        with metrics.timer(
+            "outbox.sync_shard_drain.duration",
+            tags={
+                "category": OutboxCategory(self.category).name,
+                "outbox_name": self._meta.label,
+            },
+        ):
+            self.drain_shard()
 
     @contextlib.contextmanager
     def process_shard(self, latest_shard_row: OutboxBase | None) -> Generator[OutboxBase | None]:

--- a/tests/sentry/hybridcloud/models/test_outbox.py
+++ b/tests/sentry/hybridcloud/models/test_outbox.py
@@ -6,7 +6,7 @@ from typing import Any
 from unittest.mock import Mock, call, patch
 
 import pytest
-from django.db import OperationalError, connections
+from django.db import OperationalError, connections, router, transaction
 from pytest import raises
 
 from sentry.hybridcloud.models.outbox import (
@@ -299,6 +299,24 @@ class OutboxDrainTest(TransactionTestCase):
 
 
 class CellOutboxTest(TestCase):
+    @patch.object(CellOutbox, "drain_shard")
+    @patch("sentry.hybridcloud.models.outbox.metrics.timer")
+    def test_sync_shard_drain_records_duration(
+        self, mock_timer: Mock, mock_drain_shard: Mock
+    ) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            with outbox_context(transaction.atomic(router.db_for_write(CellOutbox))):
+                Organization(id=10).outbox_for_update().save()
+
+        mock_timer.assert_called_once_with(
+            "outbox.sync_shard_drain.duration",
+            tags={
+                "category": "ORGANIZATION_UPDATE",
+                "outbox_name": "sentry.CellOutbox",
+            },
+        )
+        mock_drain_shard.assert_called_once_with()
+
     def test_creating_org_outboxes(self) -> None:
         with outbox_context(flush=False):
             Organization(id=10).outbox_for_update().save()


### PR DESCRIPTION
With the group action log outbox, we want to be able to measure the total latency added by the synchronous outbox write. Add a new metric that will help us measure the latency impact of writing to the GAL by callers.