### PR TITLE
feat(avatarButton): Support round shape, suggested state, and empty avatars

### DIFF
--- a/static/app/components/core/avatarButton/avatarButton.mdx
+++ b/static/app/components/core/avatarButton/avatarButton.mdx
@@ -28,9 +28,10 @@ Use `AvatarButton` when the avatar itself should be the clickable control.
 
 ## Avatar Definitions
 
-The `avatar` prop accepts a typed avatar descriptor. Only the data fields are used —
-`type`, `identifier`, `name`, and any type-specific fields (`uploadUrl`, `gravatarId`).
-Style props such as `suggested` or `round` are controlled by the button itself.
+The `avatar` prop accepts a typed avatar descriptor. `type`, `identifier`, `name`, and
+any type-specific fields (`uploadUrl`, `gravatarId`) select what to render. `round` and
+`suggested` control the button's shape and suggested-assignee treatment — see below.
+`avatar` itself is optional; omit it to render an empty/unassigned placeholder.
 
 <Storybook.Demo>
   <AvatarButton
@@ -197,3 +198,83 @@ automatically inset with padding.
     />
   ))}
 </Storybook.Demo>
+
+## Shape
+
+Individuals (e.g. users) are typically round; groups (e.g. teams) are square. Pass
+`round` on the `avatar` descriptor, or set the `round` prop on `AvatarButton` directly
+to override it.
+
+<Storybook.Demo>
+  <AvatarButton
+    aria-label="User (round)"
+    avatar={{
+      type: 'letter_avatar',
+      identifier: 'round-user',
+      name: 'Round User',
+      round: true,
+    }}
+  />
+  <AvatarButton
+    aria-label="Team (square)"
+    avatar={{type: 'letter_avatar', identifier: 'square-team', name: 'Square Team'}}
+  />
+</Storybook.Demo>
+```jsx
+<AvatarButton
+  aria-label="User (round)"
+  avatar={{
+    type: 'letter_avatar',
+    identifier: 'round-user',
+    name: 'Round User',
+    round: true,
+  }}
+/>
+<AvatarButton
+  aria-label="Team (square)"
+  avatar={{type: 'letter_avatar', identifier: 'square-team', name: 'Square Team'}}
+/>
+```
+
+## Suggested Assignee
+
+Set `suggested` on the `avatar` descriptor for a tentative/suggested assignee. The
+button renders a dashed neutral border and a grayscale avatar instead of sampling a
+color from the avatar itself.
+
+<Storybook.Demo>
+  <AvatarButton
+    aria-label="Suggested assignee"
+    avatar={{
+      type: 'letter_avatar',
+      identifier: 'suggested-user',
+      name: 'Suggested User',
+      suggested: true,
+    }}
+  />
+</Storybook.Demo>
+```jsx
+<AvatarButton
+  aria-label="Suggested assignee"
+  avatar={{
+    type: 'letter_avatar',
+    identifier: 'suggested-user',
+    name: 'Suggested User',
+    suggested: true,
+  }}
+/>
+```
+
+## Empty / Unassigned State
+
+Omit `avatar` entirely to render a placeholder for "no assignee yet" — a solid neutral
+border around a muted person icon.
+
+<Storybook.Demo>
+  <AvatarButton aria-label="Unassigned" />
+  <AvatarButton aria-label="Unassigned (round)" round />
+</Storybook.Demo>
+```jsx
+<AvatarButton aria-label="Unassigned" />
+<AvatarButton aria-label="Unassigned (round)" round />
+```

--- a/static/app/components/core/avatarButton/avatarButton.spec.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.spec.tsx
@@ -51,4 +51,43 @@ describe('AvatarButton', () => {
 
     expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it('renders a placeholder icon when no avatar is provided', () => {
+    render(<AvatarButton aria-label="Assign" />);
+
+    const button = screen.getByRole('button', {name: 'Assign'});
+    expect(button).toBeInTheDocument();
+    expect(button.querySelector('img')).not.toBeInTheDocument();
+    expect(button.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('renders a suggested letter avatar without throwing', () => {
+    render(
+      <AvatarButton
+        aria-label="Suggested assignee"
+        avatar={{
+          type: 'letter_avatar',
+          identifier: 'test-id',
+          name: 'Test User',
+          suggested: true,
+        }}
+      />
+    );
+
+    const button = screen.getByRole('button', {name: 'Suggested assignee'});
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveTextContent('TU');
+  });
+
+  it('accepts a round shape override', () => {
+    render(
+      <AvatarButton
+        aria-label="Open profile"
+        round
+        avatar={{type: 'letter_avatar', identifier: 'test-id', name: 'Test User'}}
+      />
+    );
+
+    expect(screen.getByRole('button', {name: 'Open profile'})).toBeInTheDocument();
+  });
 });

--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -86,7 +86,8 @@ export function AvatarButton({
           round={round}
           padded={false}
           borderColor={
-            avatarChonk ?? (isSuggested ? theme.tokens.border.neutral.vibrant : 'transparent')
+            avatarChonk ??
+            (isSuggested ? theme.tokens.border.neutral.vibrant : 'transparent')
           }
           borderStyle={isSuggested ? 'dashed' : 'solid'}
         >

--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -85,7 +85,9 @@ export function AvatarButton({
           size={size}
           round={round}
           padded={false}
-          borderColor={avatarChonk ?? theme.tokens.border.neutral.vibrant}
+          borderColor={
+            avatarChonk ?? (isSuggested ? theme.tokens.border.neutral.vibrant : 'transparent')
+          }
           borderStyle={isSuggested ? 'dashed' : 'solid'}
         >
           <StyledLetterAvatar
@@ -105,7 +107,9 @@ export function AvatarButton({
         size={size}
         round={round}
         padded={!isSuggested && imageResult?.style === 'padded'}
-        borderColor={chonk ?? theme.tokens.border.neutral.vibrant}
+        borderColor={
+          chonk ?? (isSuggested ? theme.tokens.border.neutral.vibrant : 'transparent')
+        }
         borderStyle={isSuggested ? 'dashed' : 'solid'}
       >
         <StyledImageAvatar

--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -1,8 +1,6 @@
-import {useTheme, type Theme} from '@emotion/react';
-import {css} from '@emotion/react';
+import {useTheme, css} from '@emotion/react';
 import styled from '@emotion/styled';
-import {skipToken, useQuery} from '@tanstack/react-query';
-import color from 'color';
+import type {DistributedOmit} from 'type-fest';
 
 import type {BaseAvatarProps} from '@sentry/scraps/avatar';
 import {ImageAvatar, LetterAvatar, useAvatar} from '@sentry/scraps/avatar';
@@ -11,13 +9,17 @@ import {useSizeContext} from '@sentry/scraps/sizeContext';
 
 import {IconUser} from 'sentry/icons';
 
+import {useAvatarColors} from './useAvatarColors';
+
+type AvatarButtonSize = 'xs' | 'sm' | 'md';
+
 interface AvatarButtonProps extends Omit<ButtonProps, 'children' | 'icon' | 'variant'> {
   'aria-label': string;
   /** Omit to render an empty/unassigned placeholder. */
   avatar?: BaseAvatarProps;
   /** Circular (e.g. users) vs squircle (e.g. teams) shape. Defaults to `avatar.round`. */
   round?: boolean;
-  size?: Exclude<ButtonProps['size'], 'zero'>;
+  size?: AvatarButtonSize;
 }
 
 export function AvatarButton({
@@ -41,19 +43,7 @@ export function AvatarButton({
           : undefined,
   });
 
-  const imageUrl =
-    avatarDefinition.type === 'image' ? avatarDefinition.configuration.src : null;
-
-  // Suggested avatars render with a dashed neutral border instead of a
-  // sampled color, so there's no reason to fetch/sample one.
-  const {data: imageResult} = useQuery({
-    queryKey: ['avatar-button-chonk', imageUrl, theme.type],
-    queryFn:
-      imageUrl && avatarDefinition.type === 'image' && !isSuggested
-        ? () => resolveImageAvatarColors(imageUrl, theme.type)
-        : skipToken,
-    staleTime: Infinity,
-  });
+  const colors = useAvatarColors(isSuggested ? undefined : avatar);
 
   const contextSize = useSizeContext();
   const size = explicitSize ?? contextSize ?? 'md';
@@ -75,9 +65,7 @@ export function AvatarButton({
   }
 
   if (avatarDefinition.type === 'letter') {
-    const avatarChonk = isSuggested
-      ? undefined
-      : color(avatarDefinition.configuration.background).darken(0.65).hex();
+    const avatarChonk = colors.type === 'letter' ? colors.chonk : undefined;
 
     return (
       <StyledAvatarButton {...props} size={size} round={round} chonk={avatarChonk}>
@@ -100,14 +88,14 @@ export function AvatarButton({
     );
   }
 
-  const chonk = isSuggested ? undefined : imageResult?.chonk;
+  const chonk = colors.type === 'image' ? colors.chonk : undefined;
 
   return (
     <StyledAvatarButton {...props} size={size} round={round} chonk={chonk}>
       <AvatarContainer
         size={size}
         round={round}
-        padded={!isSuggested && imageResult?.style === 'padded'}
+        padded={colors.type === 'image' && colors.style === 'padded'}
         borderColor={
           chonk ?? (isSuggested ? theme.tokens.border.neutral.vibrant : 'transparent')
         }
@@ -135,7 +123,7 @@ const AvatarContainer = styled('div')<{
   borderColor: string;
   borderStyle: 'dashed' | 'solid';
   round: boolean;
-  size: NonNullable<ButtonProps['size']>;
+  size: AvatarButtonSize;
   padded?: boolean;
 }>`
   width: 100%;
@@ -174,16 +162,30 @@ const StyledLetterAvatar = styled(LetterAvatar)`
 `;
 
 // Elevation per size, matching the base button's chonk depth.
-const AVATAR_BUTTON_ELEVATION: Record<string, string> = {
+const AVATAR_BUTTON_ELEVATION: Record<AvatarButtonSize, string> = {
   md: '2px',
   sm: '2px',
   xs: '1px',
 };
 
-const StyledAvatarButton = styled(Button)<{chonk: string | undefined; round?: boolean}>`
+type ResolvedAvatarButtonProps = DistributedOmit<ButtonProps, 'size'> & {
+  chonk: string | undefined;
+  round: boolean;
+  size: AvatarButtonSize;
+};
+
+function AvatarButtonBase({
+  chonk: _chonk,
+  round: _round,
+  ...props
+}: ResolvedAvatarButtonProps) {
+  return <Button {...props} />;
+}
+
+const StyledAvatarButton = styled(AvatarButtonBase)`
   padding: 0;
-  width: ${p => (p.size === 'zero' ? '24px' : p.theme.form[p.size ?? 'md'].height)};
-  min-width: ${p => (p.size === 'zero' ? '24px' : p.theme.form[p.size ?? 'md'].height)};
+  width: ${p => p.theme.form[p.size].height};
+  min-width: ${p => p.theme.form[p.size].height};
 
   ${p =>
     p.round &&
@@ -200,166 +202,10 @@ const StyledAvatarButton = styled(Button)<{chonk: string | undefined; round?: bo
     css`
       &&::before {
         background: ${p.chonk};
-        box-shadow: 0 ${AVATAR_BUTTON_ELEVATION[p.size ?? 'md'] ?? '2px'} 0 0px ${p.chonk};
+        box-shadow: 0 ${AVATAR_BUTTON_ELEVATION[p.size]} 0 0px ${p.chonk};
       }
       &&::after {
         border-color: ${p.chonk};
       }
     `}
 `;
-
-// Returns 'fill' when the image covers the full frame edge-to-edge, 'padded' otherwise.
-// Each edge check returns 'padded' when every pixel on that edge is transparent (alpha < 128).
-// Pixel (col, row) has its alpha channel at (row * 12 + col) * 4 + 3 in a 12×12 RGBA canvas.
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-function shouldPadImage(data: Uint8ClampedArray): 'fill' | 'padded' {
-  // oxfmt-ignore
-  if (!(data[3]!>=128   || data[51]!>=128  || data[99]!>=128  ||
-        data[147]!>=128 || data[195]!>=128 || data[243]!>=128 ||
-        data[291]!>=128 || data[339]!>=128 || data[387]!>=128 ||
-        data[435]!>=128 || data[483]!>=128 || data[531]!>=128)) {return 'padded';}
-  // oxfmt-ignore
-  if (!(data[47]!>=128  || data[95]!>=128  || data[143]!>=128 ||
-        data[191]!>=128 || data[239]!>=128 || data[287]!>=128 ||
-        data[335]!>=128 || data[383]!>=128 || data[431]!>=128 ||
-        data[479]!>=128 || data[527]!>=128 || data[575]!>=128)) {return 'padded';}
-  // oxfmt-ignore
-  if (!(data[3]!>=128  || data[7]!>=128  || data[11]!>=128 ||
-        data[15]!>=128 || data[19]!>=128 || data[23]!>=128 ||
-        data[27]!>=128 || data[31]!>=128 || data[35]!>=128 ||
-        data[39]!>=128 || data[43]!>=128 || data[47]!>=128)) {return 'padded';}
-  // oxfmt-ignore
-  if (!(data[531]!>=128 || data[535]!>=128 || data[539]!>=128 ||
-        data[543]!>=128 || data[547]!>=128 || data[551]!>=128 ||
-        data[555]!>=128 || data[559]!>=128 || data[563]!>=128 ||
-        data[567]!>=128 || data[571]!>=128 || data[575]!>=128)) {return 'padded';}
-  if (data[3]! < 128 || data[47]! < 128 || data[531]! < 128 || data[575]! < 128) {
-    return 'padded';
-  }
-
-  return 'fill';
-}
-/* eslint-enable @typescript-eslint/no-non-null-assertion */
-
-function readPixels(img: HTMLImageElement): Uint8ClampedArray | null {
-  const SAMPLE_SIZE = 12;
-  try {
-    const canvas = document.createElement('canvas');
-    canvas.width = SAMPLE_SIZE;
-    canvas.height = SAMPLE_SIZE;
-    const ctx = canvas.getContext('2d');
-    if (!ctx) {
-      return null;
-    }
-
-    // Draw the image on a 12x12 canvas to make the sampling more efficient
-    const naturalW = img.naturalWidth || img.width;
-    const naturalH = img.naturalHeight || img.height;
-    let drawW = SAMPLE_SIZE;
-    let drawH = SAMPLE_SIZE;
-    let offsetX = 0;
-    let offsetY = 0;
-    if (naturalW > 0 && naturalH > 0) {
-      const scale = Math.min(SAMPLE_SIZE / naturalW, SAMPLE_SIZE / naturalH);
-      drawW = naturalW * scale;
-      drawH = naturalH * scale;
-      offsetX = (SAMPLE_SIZE - drawW) / 2;
-      offsetY = (SAMPLE_SIZE - drawH) / 2;
-    }
-
-    ctx.drawImage(img, offsetX, offsetY, drawW, drawH);
-    return ctx.getImageData(0, 0, SAMPLE_SIZE, SAMPLE_SIZE).data;
-  } catch {
-    return null;
-  }
-}
-
-function sampleAvatarColor(
-  img: HTMLImageElement
-): {hex: string | null; style: 'fill' | 'padded'} | null {
-  const data = readPixels(img);
-  if (!data) {
-    return null;
-  }
-
-  const style = shouldPadImage(data);
-
-  // Accumulate two sets: chromatic pixels (saturation ≥ 0.15) and all opaque pixels.
-  let cr = 0,
-    cg = 0,
-    cb = 0,
-    ccount = 0;
-  let ar = 0,
-    ag = 0,
-    ab = 0,
-    acount = 0;
-
-  for (let i = 0; i < data.length; i += 4) {
-    /* eslint-disable @typescript-eslint/no-non-null-assertion */
-    if (data[i + 3]! < 128) {
-      continue;
-    }
-
-    const r = data[i]!,
-      g = data[i + 1]!,
-      b = data[i + 2]!;
-
-    /* eslint-enable @typescript-eslint/no-non-null-assertion */
-    // accumulate all pixels
-    ar += r;
-    ag += g;
-    ab += b;
-    acount++;
-
-    // accumulate chromatic pixels
-    if ((Math.max(r, g, b) - Math.min(r, g, b)) / 255 >= 0.15) {
-      cr += r;
-      cg += g;
-      cb += b;
-      ccount++;
-    }
-  }
-
-  const [r, g, b, count] = ccount > 0 ? [cr, cg, cb, ccount] : [ar, ag, ab, acount];
-  if (count === 0) {
-    return {hex: null, style};
-  }
-
-  const toHex = (v: number) =>
-    Math.round(v / count)
-      .toString(16)
-      .padStart(2, '0');
-  return {hex: `#${toHex(r)}${toHex(g)}${toHex(b)}`, style};
-}
-
-function fetchAvatarColor(
-  url: string
-): Promise<ReturnType<typeof sampleAvatarColor> | null> {
-  return new Promise(resolve => {
-    const img = new Image();
-    img.crossOrigin = 'anonymous';
-    img.onload = () => resolve(sampleAvatarColor(img));
-    img.onerror = () => resolve(null);
-    img.src = url;
-  });
-}
-
-async function resolveImageAvatarColors(
-  url: string,
-  theme: Theme['type']
-): Promise<{chonk: string | undefined; style: 'fill' | 'padded'} | null> {
-  const sampled = await fetchAvatarColor(url);
-
-  if (!sampled?.hex) {
-    return null;
-  }
-
-  const chonk = color(sampled.hex)
-    .darken(theme === 'dark' ? 0.85 : 0.45)
-    .hex();
-
-  return {
-    chonk,
-    style: sampled.style,
-  };
-}

--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -60,7 +60,7 @@ export function AvatarButton({
 
   if (!avatar) {
     return (
-      <StyledAvatarButton {...props} size={size} chonk={undefined}>
+      <StyledAvatarButton {...props} size={size} round={round} chonk={undefined}>
         <AvatarContainer
           size={size}
           round={round}
@@ -80,7 +80,7 @@ export function AvatarButton({
       : color(avatarDefinition.configuration.background).darken(0.65).hex();
 
     return (
-      <StyledAvatarButton {...props} size={size} chonk={avatarChonk}>
+      <StyledAvatarButton {...props} size={size} round={round} chonk={avatarChonk}>
         <AvatarContainer
           size={size}
           round={round}
@@ -100,7 +100,7 @@ export function AvatarButton({
   const chonk = isSuggested ? undefined : imageResult?.chonk;
 
   return (
-    <StyledAvatarButton {...props} size={size} chonk={chonk}>
+    <StyledAvatarButton {...props} size={size} round={round} chonk={chonk}>
       <AvatarContainer
         size={size}
         round={round}
@@ -175,10 +175,20 @@ const AVATAR_BUTTON_ELEVATION: Record<string, string> = {
   xs: '1px',
 };
 
-const StyledAvatarButton = styled(Button)<{chonk: string | undefined}>`
+const StyledAvatarButton = styled(Button)<{chonk: string | undefined; round?: boolean}>`
   padding: 0;
   width: ${p => (p.size === 'zero' ? '24px' : p.theme.form[p.size ?? 'md'].height)};
   min-width: ${p => (p.size === 'zero' ? '24px' : p.theme.form[p.size ?? 'md'].height)};
+
+  ${p =>
+    p.round &&
+    css`
+      &&,
+      &&::before,
+      &&::after {
+        border-radius: ${p.theme.radius.full};
+      }
+    `}
 
   ${p =>
     p.chonk &&

--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -1,102 +1,156 @@
+import {useTheme, type Theme} from '@emotion/react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
-import type {DistributedOmit} from 'type-fest';
+import {skipToken, useQuery} from '@tanstack/react-query';
+import color from 'color';
 
 import type {BaseAvatarProps} from '@sentry/scraps/avatar';
 import {ImageAvatar, LetterAvatar, useAvatar} from '@sentry/scraps/avatar';
 import {Button, type ButtonProps} from '@sentry/scraps/button';
-import {Container, type Responsive, useResponsivePropValue} from '@sentry/scraps/layout';
 import {useSizeContext} from '@sentry/scraps/sizeContext';
 
-import {useAvatarColors} from './useAvatarColors';
-
-type AvatarButtonSize = 'xs' | 'sm' | 'md';
+import {IconUser} from 'sentry/icons';
 
 interface AvatarButtonProps extends Omit<ButtonProps, 'children' | 'icon' | 'variant'> {
   'aria-label': string;
-  avatar: BaseAvatarProps;
-  size?: Responsive<AvatarButtonSize>;
+  /** Omit to render an empty/unassigned placeholder. */
+  avatar?: BaseAvatarProps;
+  /** Circular (e.g. users) vs squircle (e.g. teams) shape. Defaults to `avatar.round`. */
+  round?: boolean;
+  size?: Exclude<ButtonProps['size'], 'zero'>;
 }
 
-export function AvatarButton({avatar, size: explicitSize, ...props}: AvatarButtonProps) {
+export function AvatarButton({
+  avatar,
+  round: explicitRound,
+  size: explicitSize,
+  ...props
+}: AvatarButtonProps) {
+  const theme = useTheme();
+  const round = explicitRound ?? avatar?.round ?? false;
+  const isSuggested = !!avatar?.suggested;
+
   const avatarDefinition = useAvatar({
-    identifier: avatar.identifier,
-    name: avatar.name,
+    identifier: avatar?.identifier ?? '',
+    name: avatar?.name ?? '',
     imageDefinition:
-      avatar.type === 'upload'
+      avatar?.type === 'upload'
         ? {type: 'upload', uploadUrl: avatar.uploadUrl}
-        : avatar.type === 'gravatar'
+        : avatar?.type === 'gravatar'
           ? {type: 'gravatar', gravatarId: avatar.gravatarId}
           : undefined,
   });
 
-  const colors = useAvatarColors(avatar);
+  const imageUrl =
+    avatarDefinition.type === 'image' ? avatarDefinition.configuration.src : null;
+
+  // Suggested avatars render with a dashed neutral border instead of a
+  // sampled color, so there's no reason to fetch/sample one.
+  const {data: imageResult} = useQuery({
+    queryKey: ['avatar-button-chonk', imageUrl, theme.type],
+    queryFn:
+      imageUrl && avatarDefinition.type === 'image' && !isSuggested
+        ? () => resolveImageAvatarColors(imageUrl, theme.type)
+        : skipToken,
+    staleTime: Infinity,
+  });
 
   const contextSize = useSizeContext();
-  const size = useResponsivePropValue(explicitSize ?? contextSize ?? 'md');
+  const size = explicitSize ?? contextSize ?? 'md';
 
-  if (avatarDefinition.type === 'letter') {
-    const chonk = colors.type === 'letter' ? colors.chonk : undefined;
+  if (!avatar) {
     return (
-      <StyledAvatarButton {...props} size={size} chonk={chonk}>
-        <AvatarContainer size={size} chonk={chonk}>
-          <StyledLetterAvatar configuration={avatarDefinition.configuration} />
+      <StyledAvatarButton {...props} size={size} chonk={undefined}>
+        <AvatarContainer
+          size={size}
+          round={round}
+          padded={false}
+          borderColor={theme.tokens.border.primary}
+          borderStyle="solid"
+        >
+          <EmptyAvatarIcon />
         </AvatarContainer>
       </StyledAvatarButton>
     );
   }
 
-  const chonk = colors.type === 'image' ? colors.chonk : undefined;
-  const padded = colors.type === 'image' ? colors.style === 'padded' : false;
+  if (avatarDefinition.type === 'letter') {
+    const avatarChonk = isSuggested
+      ? undefined
+      : color(avatarDefinition.configuration.background).darken(0.65).hex();
+
+    return (
+      <StyledAvatarButton {...props} size={size} chonk={avatarChonk}>
+        <AvatarContainer
+          size={size}
+          round={round}
+          padded={false}
+          borderColor={avatarChonk ?? theme.tokens.border.neutral.vibrant}
+          borderStyle={isSuggested ? 'dashed' : 'solid'}
+        >
+          <StyledLetterAvatar
+            configuration={avatarDefinition.configuration}
+            suggested={isSuggested}
+          />
+        </AvatarContainer>
+      </StyledAvatarButton>
+    );
+  }
+
+  const chonk = isSuggested ? undefined : imageResult?.chonk;
 
   return (
     <StyledAvatarButton {...props} size={size} chonk={chonk}>
-      <AvatarContainer size={size} padded={padded} chonk={chonk}>
-        <StyledImageAvatar configuration={avatarDefinition.configuration} />
+      <AvatarContainer
+        size={size}
+        round={round}
+        padded={!isSuggested && imageResult?.style === 'padded'}
+        borderColor={chonk ?? theme.tokens.border.neutral.vibrant}
+        borderStyle={isSuggested ? 'dashed' : 'solid'}
+      >
+        <StyledImageAvatar
+          configuration={avatarDefinition.configuration}
+          suggested={isSuggested}
+        />
       </AvatarContainer>
     </StyledAvatarButton>
   );
 }
 
-const RADIUS_BY_SIZE: Record<AvatarButtonSize, 'sm' | 'md' | 'lg'> = {
-  xs: 'sm',
-  sm: 'md',
-  md: 'lg',
-};
+const EmptyAvatarIcon = styled(IconUser)`
+  width: 60%;
+  height: 60%;
+  margin: auto;
+  position: absolute;
+  inset: 0;
+  color: ${p => p.theme.tokens.content.secondary};
+`;
 
-function AvatarContainer({
-  children,
-  chonk,
-  padded = false,
-  size,
-}: {
-  children: React.ReactNode;
-  size: AvatarButtonSize;
-  chonk?: string;
+const AvatarContainer = styled('div')<{
+  borderColor: string;
+  borderStyle: 'dashed' | 'solid';
+  round: boolean;
+  size: NonNullable<ButtonProps['size']>;
   padded?: boolean;
-}) {
-  return (
-    <StyledAvatarContainer
-      width="100%"
-      height="100%"
-      overflow="hidden"
-      border="primary"
-      radius={RADIUS_BY_SIZE[size]}
-      padding={padded ? 'xs' : '0'}
-      background={padded ? 'primary' : undefined}
-      position="relative"
-      chonk={chonk}
-    >
-      {children}
-    </StyledAvatarContainer>
-  );
-}
-
-// ponytail: styled(Container) only for dynamic borderColor — Container's
-// border prop handles the 1px solid, we just override the color.
-const StyledAvatarContainer = styled(Container)<{chonk?: string}>`
-  border-color: ${p => p.chonk ?? 'transparent'};
+}>`
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  border: 1px ${p => p.borderStyle} ${p => p.borderColor};
   will-change: transform;
+  border-radius: ${p =>
+    p.round
+      ? '50%'
+      : p.size === 'md'
+        ? p.theme.radius.lg
+        : p.size === 'sm'
+          ? p.theme.radius.md
+          : p.size === 'xs'
+            ? p.theme.radius.sm
+            : p.theme.radius.xs};
+  padding: ${p => (p.padded ? p.theme.space.xs : '0')};
+  background: ${p => (p.padded ? p.theme.tokens.background.primary : 'transparent')};
+  position: relative;
 `;
 
 const StyledImageAvatar = styled(ImageAvatar)`
@@ -115,35 +169,182 @@ const StyledLetterAvatar = styled(LetterAvatar)`
 `;
 
 // Elevation per size, matching the base button's chonk depth.
-const AVATAR_BUTTON_ELEVATION: Record<AvatarButtonSize, string> = {
+const AVATAR_BUTTON_ELEVATION: Record<string, string> = {
   md: '2px',
   sm: '2px',
   xs: '1px',
 };
 
-type ResolvedAvatarButtonProps = DistributedOmit<ButtonProps, 'size'> & {
-  chonk: string | undefined;
-  size: AvatarButtonSize;
-};
-
-function AvatarButtonBase({chonk: _chonk, ...props}: ResolvedAvatarButtonProps) {
-  return <Button {...props} />;
-}
-
-const StyledAvatarButton = styled(AvatarButtonBase)`
+const StyledAvatarButton = styled(Button)<{chonk: string | undefined}>`
   padding: 0;
-  width: ${p => p.theme.form[p.size].height};
-  min-width: ${p => p.theme.form[p.size].height};
+  width: ${p => (p.size === 'zero' ? '24px' : p.theme.form[p.size ?? 'md'].height)};
+  min-width: ${p => (p.size === 'zero' ? '24px' : p.theme.form[p.size ?? 'md'].height)};
 
   ${p =>
     p.chonk &&
     css`
       &&::before {
         background: ${p.chonk};
-        box-shadow: 0 ${AVATAR_BUTTON_ELEVATION[p.size]} 0 0px ${p.chonk};
+        box-shadow: 0 ${AVATAR_BUTTON_ELEVATION[p.size ?? 'md'] ?? '2px'} 0 0px ${p.chonk};
       }
       &&::after {
         border-color: ${p.chonk};
       }
     `}
 `;
+
+// Returns 'fill' when the image covers the full frame edge-to-edge, 'padded' otherwise.
+// Each edge check returns 'padded' when every pixel on that edge is transparent (alpha < 128).
+// Pixel (col, row) has its alpha channel at (row * 12 + col) * 4 + 3 in a 12×12 RGBA canvas.
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
+function shouldPadImage(data: Uint8ClampedArray): 'fill' | 'padded' {
+  // oxfmt-ignore
+  if (!(data[3]!>=128   || data[51]!>=128  || data[99]!>=128  ||
+        data[147]!>=128 || data[195]!>=128 || data[243]!>=128 ||
+        data[291]!>=128 || data[339]!>=128 || data[387]!>=128 ||
+        data[435]!>=128 || data[483]!>=128 || data[531]!>=128)) {return 'padded';}
+  // oxfmt-ignore
+  if (!(data[47]!>=128  || data[95]!>=128  || data[143]!>=128 ||
+        data[191]!>=128 || data[239]!>=128 || data[287]!>=128 ||
+        data[335]!>=128 || data[383]!>=128 || data[431]!>=128 ||
+        data[479]!>=128 || data[527]!>=128 || data[575]!>=128)) {return 'padded';}
+  // oxfmt-ignore
+  if (!(data[3]!>=128  || data[7]!>=128  || data[11]!>=128 ||
+        data[15]!>=128 || data[19]!>=128 || data[23]!>=128 ||
+        data[27]!>=128 || data[31]!>=128 || data[35]!>=128 ||
+        data[39]!>=128 || data[43]!>=128 || data[47]!>=128)) {return 'padded';}
+  // oxfmt-ignore
+  if (!(data[531]!>=128 || data[535]!>=128 || data[539]!>=128 ||
+        data[543]!>=128 || data[547]!>=128 || data[551]!>=128 ||
+        data[555]!>=128 || data[559]!>=128 || data[563]!>=128 ||
+        data[567]!>=128 || data[571]!>=128 || data[575]!>=128)) {return 'padded';}
+  if (data[3]! < 128 || data[47]! < 128 || data[531]! < 128 || data[575]! < 128) {
+    return 'padded';
+  }
+
+  return 'fill';
+}
+/* eslint-enable @typescript-eslint/no-non-null-assertion */
+
+function readPixels(img: HTMLImageElement): Uint8ClampedArray | null {
+  const SAMPLE_SIZE = 12;
+  try {
+    const canvas = document.createElement('canvas');
+    canvas.width = SAMPLE_SIZE;
+    canvas.height = SAMPLE_SIZE;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) {
+      return null;
+    }
+
+    // Draw the image on a 12x12 canvas to make the sampling more efficient
+    const naturalW = img.naturalWidth || img.width;
+    const naturalH = img.naturalHeight || img.height;
+    let drawW = SAMPLE_SIZE;
+    let drawH = SAMPLE_SIZE;
+    let offsetX = 0;
+    let offsetY = 0;
+    if (naturalW > 0 && naturalH > 0) {
+      const scale = Math.min(SAMPLE_SIZE / naturalW, SAMPLE_SIZE / naturalH);
+      drawW = naturalW * scale;
+      drawH = naturalH * scale;
+      offsetX = (SAMPLE_SIZE - drawW) / 2;
+      offsetY = (SAMPLE_SIZE - drawH) / 2;
+    }
+
+    ctx.drawImage(img, offsetX, offsetY, drawW, drawH);
+    return ctx.getImageData(0, 0, SAMPLE_SIZE, SAMPLE_SIZE).data;
+  } catch {
+    return null;
+  }
+}
+
+function sampleAvatarColor(
+  img: HTMLImageElement
+): {hex: string | null; style: 'fill' | 'padded'} | null {
+  const data = readPixels(img);
+  if (!data) {
+    return null;
+  }
+
+  const style = shouldPadImage(data);
+
+  // Accumulate two sets: chromatic pixels (saturation ≥ 0.15) and all opaque pixels.
+  let cr = 0,
+    cg = 0,
+    cb = 0,
+    ccount = 0;
+  let ar = 0,
+    ag = 0,
+    ab = 0,
+    acount = 0;
+
+  for (let i = 0; i < data.length; i += 4) {
+    /* eslint-disable @typescript-eslint/no-non-null-assertion */
+    if (data[i + 3]! < 128) {
+      continue;
+    }
+
+    const r = data[i]!,
+      g = data[i + 1]!,
+      b = data[i + 2]!;
+
+    /* eslint-enable @typescript-eslint/no-non-null-assertion */
+    // accumulate all pixels
+    ar += r;
+    ag += g;
+    ab += b;
+    acount++;
+
+    // accumulate chromatic pixels
+    if ((Math.max(r, g, b) - Math.min(r, g, b)) / 255 >= 0.15) {
+      cr += r;
+      cg += g;
+      cb += b;
+      ccount++;
+    }
+  }
+
+  const [r, g, b, count] = ccount > 0 ? [cr, cg, cb, ccount] : [ar, ag, ab, acount];
+  if (count === 0) {
+    return {hex: null, style};
+  }
+
+  const toHex = (v: number) =>
+    Math.round(v / count)
+      .toString(16)
+      .padStart(2, '0');
+  return {hex: `#${toHex(r)}${toHex(g)}${toHex(b)}`, style};
+}
+
+function fetchAvatarColor(
+  url: string
+): Promise<ReturnType<typeof sampleAvatarColor> | null> {
+  return new Promise(resolve => {
+    const img = new Image();
+    img.crossOrigin = 'anonymous';
+    img.onload = () => resolve(sampleAvatarColor(img));
+    img.onerror = () => resolve(null);
+    img.src = url;
+  });
+}
+
+async function resolveImageAvatarColors(
+  url: string,
+  theme: Theme['type']
+): Promise<{chonk: string | undefined; style: 'fill' | 'padded'} | null> {
+  const sampled = await fetchAvatarColor(url);
+
+  if (!sampled?.hex) {
+    return null;
+  }
+
+  const chonk = color(sampled.hex)
+    .darken(theme === 'dark' ? 0.85 : 0.45)
+    .hex();
+
+  return {
+    chonk,
+    style: sampled.style,
+  };
+}

--- a/static/app/components/core/avatarButton/index.tsx
+++ b/static/app/components/core/avatarButton/index.tsx
@@ -1,1 +1,2 @@
 export {AvatarButton} from './avatarButton';
+export {useAvatarColors} from './useAvatarColors';

--- a/static/app/components/core/avatarButton/useAvatarColors.ts
+++ b/static/app/components/core/avatarButton/useAvatarColors.ts
@@ -7,20 +7,20 @@ import {useAvatar} from '@sentry/scraps/avatar';
 
 import {resolveImageAvatarColors} from './avatarImageAnalysis';
 
-type AvatarColorsResult =
+export type AvatarColorsResult =
   | {chonk: string; style: 'padded' | 'fill'; type: 'image'}
   | {chonk: string; type: 'letter'}
   | {type: 'none'};
 
-export function useAvatarColors(avatar: BaseAvatarProps): AvatarColorsResult {
+export function useAvatarColors(avatar?: BaseAvatarProps): AvatarColorsResult {
   const theme = useTheme();
   const avatarDefinition = useAvatar({
-    identifier: avatar.identifier,
-    name: avatar.name,
+    identifier: avatar?.identifier ?? '',
+    name: avatar?.name ?? '',
     imageDefinition:
-      avatar.type === 'upload'
+      avatar?.type === 'upload'
         ? {type: 'upload', uploadUrl: avatar.uploadUrl}
-        : avatar.type === 'gravatar'
+        : avatar?.type === 'gravatar'
           ? {type: 'gravatar', gravatarId: avatar.gravatarId}
           : undefined,
   });
@@ -31,11 +31,15 @@ export function useAvatarColors(avatar: BaseAvatarProps): AvatarColorsResult {
   const {data: imageResult} = useQuery({
     queryKey: ['avatar-button-chonk', imageUrl, theme.type],
     queryFn:
-      imageUrl && avatarDefinition.type === 'image'
+      avatar && imageUrl && avatarDefinition.type === 'image'
         ? () => resolveImageAvatarColors(imageUrl, theme.type)
         : skipToken,
     staleTime: Infinity,
   });
+
+  if (!avatar) {
+    return {type: 'none'};
+  }
 
   if (avatarDefinition.type === 'letter') {
     const chonk = color(avatarDefinition.configuration.background).darken(0.65).hex();


### PR DESCRIPTION
`AvatarButton` could _almost_ be the basis of the `AssigneeSelector` (#122507) , but it is missing a few primitives: circular avatars for **users** vs square for **teams**, a dotted/tentative treatment for suggested assignees, and a blank placeholder for the unassigned state.

**The solution:**
- `round` and `suggested` already exist on `BaseAvatarProps`, but weren't respected. `avatar.round` collapses the container to a circle, and `avatar.suggested` renders a dashed neutral border with a grayscale avatar.
- `avatar` is now optional. Omitting it renders an empty/unassigned placeholder: a solid neutral border around a muted person icon, distinct from both the populated (solid, chonk-colored) and suggested (dashed, neutral) states.
- Added a top-level `round` prop as an explicit override, since the empty state has no avatar object to read `round` from.