### PR TITLE
fix(replays): Bound recording segment decompression at ingest

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -528,6 +528,14 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Maximum number of bytes a single recording segment may decompress to at ingest. Segments
+# which inflate past this limit are dropped instead of stored.
+register(
+    "replay.consumer.max-segment-decompressed-size",
+    type=Int,
+    default=100 * 1024 * 1024,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Enable new database query caching.
 register(
     "replay.consumer.enable_new_query_caching_system",

--- a/src/sentry/replays/consumers/recording.py
+++ b/src/sentry/replays/consumers/recording.py
@@ -1,6 +1,6 @@
 import logging
 import zlib
-from typing import cast
+from typing import NoReturn, cast
 
 import sentry_sdk
 from sentry_kafka_schemas.codecs import Codec, ValidationError
@@ -37,7 +37,10 @@ class DropSilently(Exception):
 @trace
 def process_message(message: bytes) -> ProcessedEvent | None:
     try:
-        recording_event = parse_recording_event(message)
+        recording_event = parse_recording_event(
+            message,
+            max_segment_size=options.get("replay.consumer.max-segment-decompressed-size"),
+        )
         set_tag("org_id", recording_event["context"]["org_id"])
         sentry_sdk.set_attribute("org_id", recording_event["context"]["org_id"])
         set_tag("project_id", recording_event["context"]["project_id"])
@@ -54,10 +57,10 @@ def process_message(message: bytes) -> ProcessedEvent | None:
 
 
 @trace
-def parse_recording_event(message: bytes) -> Event:
+def parse_recording_event(message: bytes, max_segment_size: int) -> Event:
     recording = parse_request_message(message)
     segment_id, payload = parse_headers(cast(bytes, recording["payload"]), recording["replay_id"])
-    compressed, decompressed = decompress_segment(payload)
+    compressed, decompressed = decompress_segment(payload, max_segment_size)
 
     replay_event_json = recording.get("replay_event")
     if replay_event_json:
@@ -111,15 +114,45 @@ def parse_request_message(message: bytes) -> ReplayRecording:
 
 
 @trace
-def decompress_segment(segment: bytes) -> tuple[bytes, bytes]:
+def decompress_segment(segment: bytes, max_size: int) -> tuple[bytes, bytes]:
+    """Return the compressed and decompressed forms of a recording segment.
+
+    Decompression is bounded to `max_size` bytes. Stored segments are inflated again on every
+    read, so a segment with an implausible compression ratio is a durable, repeatable cost on
+    the read path -- we drop it here rather than persist it.
+    """
     try:
-        return (segment, zlib.decompress(segment))
+        # Ask for one byte past the limit so an oversized segment is detectable without ever
+        # materializing more than `max_size + 1` bytes.
+        decompressor = zlib.decompressobj()
+        decompressed = decompressor.decompress(segment, max_size + 1)
+
+        # The incremental API returns partial output where `zlib.decompress` raised on a
+        # truncated stream. Normalize so malformed bodies take the branch below.
+        if not decompressor.eof and not decompressor.unconsumed_tail:
+            raise zlib.error("incomplete or truncated stream")
     except zlib.error:
         if segment and segment[0] == ord("["):
+            if len(segment) > max_size:
+                _drop_oversized_segment(len(segment), max_size)
             return (zlib.compress(segment), segment)
         else:
             logger.exception("Invalid recording body.")
             raise DropSilently()
+
+    if len(decompressed) > max_size:
+        _drop_oversized_segment(len(segment), max_size)
+
+    return (segment, decompressed)
+
+
+def _drop_oversized_segment(compressed_size: int, max_size: int) -> NoReturn:
+    metrics.incr("replays.consumer.recording.oversized_segment")
+    logger.warning(
+        "Dropped a recording segment which decompressed past the size limit.",
+        extra={"compressed_size": compressed_size, "max_size": max_size},
+    )
+    raise DropSilently()
 
 
 @trace

--- a/tests/sentry/replays/integration/consumers/test_recording.py
+++ b/tests/sentry/replays/integration/consumers/test_recording.py
@@ -9,10 +9,14 @@ import msgpack
 from sentry.replays.tasks import process_replay_recording
 from sentry.utils import json
 
+# Options read on this path are boolean toggles we want enabled, except for the segment size
+# limit which needs a real byte count.
+_OPTIONS: dict[str, object] = {"replay.consumer.max-segment-decompressed-size": 100 * 1024 * 1024}
+
 
 @mock.patch("sentry.options.get")
 def test_recording_task(options_get: MagicMock) -> None:
-    options_get.return_value = True
+    options_get.side_effect = lambda key, *args, **kwargs: _OPTIONS.get(key, True)
 
     headers = json.dumps({"segment_id": 42}).encode()
     recording_payload = headers + b"\n" + zlib.compress(json.dumps(MOCK_EVENTS).encode())

--- a/tests/sentry/replays/unit/consumers/test_recording.py
+++ b/tests/sentry/replays/unit/consumers/test_recording.py
@@ -15,8 +15,11 @@ from sentry.replays.consumers.recording import (
 from sentry.replays.usecases.ingest import ProcessedEvent
 from sentry.replays.usecases.ingest.event_parser import ParsedEventMeta
 from sentry.replays.usecases.pack import pack
+from sentry.testutils.helpers import override_options
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.utils import json
+
+MAX_SIZE = 100 * 1024 * 1024
 
 
 def test_decompress_segment_success() -> None:
@@ -24,11 +27,11 @@ def test_decompress_segment_success() -> None:
     data = b"[hello, world!]"
     compressed_data = zlib.compress(data)
 
-    compressed, decompressed = decompress_segment(compressed_data)
+    compressed, decompressed = decompress_segment(compressed_data, MAX_SIZE)
     assert compressed == compressed_data
     assert decompressed == data
 
-    compressed, decompressed = decompress_segment(data)
+    compressed, decompressed = decompress_segment(data, MAX_SIZE)
     assert compressed == compressed_data
     assert decompressed == data
 
@@ -38,7 +41,7 @@ def test_decompress_segment_already_decompressed() -> None:
     data = b"[hello, world!]"
     compressed_data = zlib.compress(data)
 
-    compressed, decompressed = decompress_segment(data)
+    compressed, decompressed = decompress_segment(data, MAX_SIZE)
     assert compressed == compressed_data
     assert decompressed == data
 
@@ -46,13 +49,71 @@ def test_decompress_segment_already_decompressed() -> None:
 def test_decompress_segment_unexpected_start_character() -> None:
     """Test handling of invalid data that can't be decompressed"""
     with pytest.raises(DropSilently):
-        decompress_segment(b"hello, world!")
+        decompress_segment(b"hello, world!", MAX_SIZE)
 
 
 def test_decompress_segment_empty_data() -> None:
     """Test handling of empty data"""
     with pytest.raises(DropSilently):
-        decompress_segment(b"")
+        decompress_segment(b"", MAX_SIZE)
+
+
+def test_decompress_segment_exceeds_max_size() -> None:
+    """Test a segment which inflates past the limit is dropped"""
+    payload = b"[" + b" " * (1024 * 1024) + b"]"
+    bomb = zlib.compress(payload, 9)
+    # A kilobyte of stored input, a megabyte of output on every read.
+    assert len(payload) // len(bomb) > 500
+
+    with pytest.raises(DropSilently):
+        decompress_segment(bomb, 1024)
+
+
+def test_decompress_segment_at_max_size() -> None:
+    """Test a segment which inflates to exactly the limit is accepted"""
+    data = b"[hello, world!]"
+    compressed_data = zlib.compress(data)
+
+    compressed, decompressed = decompress_segment(compressed_data, len(data))
+    assert compressed == compressed_data
+    assert decompressed == data
+
+    with pytest.raises(DropSilently):
+        decompress_segment(compressed_data, len(data) - 1)
+
+
+def test_decompress_segment_uncompressed_exceeds_max_size() -> None:
+    """Test an uncompressed segment larger than the limit is dropped"""
+    data = b"[" + b" " * 1024 + b"]"
+
+    with pytest.raises(DropSilently):
+        decompress_segment(data, 512)
+
+
+@django_db_all
+def test_process_message_oversized_segment() -> None:
+    """Test "process_message" function drops a segment which inflates past the limit."""
+    bomb = zlib.compress(b"[" + b" " * (1024 * 1024) + b"]", 9)
+    message = {
+        "type": "replay_recording_not_chunked",
+        "org_id": 3,
+        "project_id": 4,
+        "replay_id": "1",
+        "received": 2,
+        "retention_days": 30,
+        "payload": json.dumps({"segment_id": 42}).encode() + b"\n" + bomb,
+        "key_id": 1,
+        "replay_event": b"{}",
+        "replay_video": b"",
+        "version": 0,
+    }
+
+    kafka_message = make_kafka_message(message)
+    with override_options({"replay.consumer.max-segment-decompressed-size": 1024}):
+        assert process_message(kafka_message) is None
+
+    # The same message is accepted under the default limit.
+    assert process_message(kafka_message) is not None
 
 
 def test_parse_headers_success() -> None:
@@ -143,7 +204,7 @@ def test_parse_recording_event_success() -> None:
         "version": 0,
     }
 
-    result = parse_recording_event(msgpack.packb(message))
+    result = parse_recording_event(msgpack.packb(message), MAX_SIZE)
 
     expected = {
         "context": {
@@ -191,7 +252,7 @@ def test_parse_recording_event_with_replay_event() -> None:
         "version": 0,
     }
 
-    result = parse_recording_event(msgpack.packb(message))
+    result = parse_recording_event(msgpack.packb(message), MAX_SIZE)
 
     expected = {
         "context": {
@@ -226,7 +287,7 @@ def test_parse_recording_event_missing_payload() -> None:
         "version": 0,
     }
     with pytest.raises(DropSilently):
-        parse_recording_event(msgpack.packb(message))
+        parse_recording_event(msgpack.packb(message), MAX_SIZE)
 
 
 def test_parse_recording_event_invalid_compression() -> None:
@@ -242,7 +303,7 @@ def test_parse_recording_event_invalid_compression() -> None:
         "version": 0,
     }
     with pytest.raises(DropSilently):
-        parse_recording_event(msgpack.packb(message))
+        parse_recording_event(msgpack.packb(message), MAX_SIZE)
 
 
 def test_parse_recording_event_invalid_headers() -> None:
@@ -258,7 +319,7 @@ def test_parse_recording_event_invalid_headers() -> None:
         "version": 0,
     }
     with pytest.raises(DropSilently):
-        parse_recording_event(msgpack.packb(message))
+        parse_recording_event(msgpack.packb(message), MAX_SIZE)
 
 
 @django_db_all


### PR DESCRIPTION
Backend only (`src/`, `tests/`).

## Problem

`decompress_segment` inflated recording segments with an uncapped `zlib.decompress` before the consumer stored them. Relay bounds the compressed payload at 10 MiB, but only applies its 100 MiB *uncompressed* bound for orgs that have recording scrubbing enabled with a non-empty PII config. For everyone else nothing checked how large a segment became once inflated, and the consumer stored the client's compressed bytes verbatim.

## Change

- `decompress_segment` now takes a `max_size` and decompresses incrementally via `zlib.decompressobj`, requesting one byte past the limit so an oversized segment is detected without ever materializing more than `max_size + 1` bytes. Segments over the limit raise `DropSilently`.
- New `replay.consumer.max-segment-decompressed-size` option, default 100 MiB, `FLAG_AUTOMATOR_MODIFIABLE` — so the limit can be raised or lowered without a deploy.
- Drops are counted under `replays.consumer.recording.oversized_segment` and logged with the compressed size and the limit.
- `parse_recording_event` takes the limit as an argument rather than reading the option itself, keeping the parse path free of DB access. `process_message` reads the option, alongside the existing `msgspec_recording_parser` read.

Behavior for well-formed and already-uncompressed segments is unchanged. `zlib.decompressobj` returns partial output on a truncated stream where the one-shot `zlib.decompress` raised, so that case is normalized back to `zlib.error` to preserve the existing handling.

## Rollout note

The default matches the uncompressed bound Relay already applies to scrubbing-enabled orgs, so it should be a no-op for segments produced by SDKs. If it turns out legitimate segments sit closer to the limit than expected, `replays.consumer.recording.oversized_segment` will show it and the option can be raised immediately. Worth watching that metric before considering this settled.

Refs REPLAY-994