### PR TITLE
feat(inbox): show autofix progress messages

### DIFF
--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixPlanSection.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixPlanSection.tsx
@@ -51,7 +51,9 @@ export function IssuePreviewAutofixPlanSection({
             prompt={t('How can this plan be improved?')}
           />
           {section.status === 'processing' ? (
-            <WorkingIndicator>{t('Generating implementation plan...')}</WorkingIndicator>
+            <WorkingIndicator blocks={section.blocks}>
+              {t('Generating implementation plan...')}
+            </WorkingIndicator>
           ) : plan ? (
             <Markdown raw={plan.one_line_summary} />
           ) : (

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixProposalSection.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixProposalSection.tsx
@@ -65,7 +65,9 @@ export function IssuePreviewAutofixProposalSection({
             prompt={t('How can this code change be improved?')}
           />
           {section.status === 'processing' ? (
-            <WorkingIndicator>{t('Generating code changes...')}</WorkingIndicator>
+            <WorkingIndicator blocks={section.blocks}>
+              {t('Generating code changes...')}
+            </WorkingIndicator>
           ) : patchesByRepo.size > 0 ? (
             <Text>{proposalSummary}</Text>
           ) : (

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixRootCauseSection.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixRootCauseSection.tsx
@@ -53,7 +53,9 @@ export function IssuePreviewAutofixRootCauseSection({
             prompt={t('How can this root cause be improved?')}
           />
           {section.status === 'processing' ? (
-            <WorkingIndicator>{t('Generating root cause...')}</WorkingIndicator>
+            <WorkingIndicator blocks={section.blocks}>
+              {t('Generating root cause...')}
+            </WorkingIndicator>
           ) : rootCause ? (
             <Markdown raw={rootCause.one_line_description} />
           ) : (

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -252,6 +252,82 @@ describe('IssuePreviewAutofixSummary', () => {
     expect(screen.queryByRole('region', {name: 'Code Changes'})).not.toBeInTheDocument();
   });
 
+  it('renders progress messages only from the current PR iteration', () => {
+    render(
+      <IssuePreviewAutofixSummary
+        autofix={ExplorerAutofixFixture({
+          runState: ExplorerAutofixStateFixture({
+            blocks: [
+              ExplorerAutofixBlockFixture({
+                id: 'code-changes-start',
+                artifacts: undefined,
+                message: {
+                  content: 'Generate the initial code changes',
+                  metadata: {step: 'code_changes'},
+                  role: 'user',
+                },
+              }),
+              ExplorerAutofixBlockFixture({
+                id: 'initial-progress',
+                artifacts: undefined,
+                message: {
+                  content: 'Editing the initial implementation...',
+                  role: 'assistant',
+                },
+              }),
+              ExplorerAutofixBlockFixture({
+                id: 'first-iteration-start',
+                artifacts: undefined,
+                message: {
+                  content: 'Address the first review',
+                  metadata: {step: 'pr_iteration', iteration_index: '0'},
+                  role: 'user',
+                },
+              }),
+              ExplorerAutofixBlockFixture({
+                id: 'first-iteration-progress',
+                artifacts: undefined,
+                message: {
+                  content: 'Applying the first review...',
+                  role: 'assistant',
+                },
+              }),
+              ExplorerAutofixBlockFixture({
+                id: 'second-iteration-start',
+                artifacts: undefined,
+                message: {
+                  content: 'Address the second review',
+                  metadata: {step: 'pr_iteration', iteration_index: '1'},
+                  role: 'user',
+                },
+              }),
+              ExplorerAutofixBlockFixture({
+                id: 'second-iteration-progress',
+                artifacts: undefined,
+                message: {
+                  content: 'Thinking...',
+                  role: 'assistant',
+                  thinking_content: 'Applying the second review...',
+                },
+              }),
+            ],
+            status: 'processing',
+          }),
+        })}
+        groupId="preview-group"
+      />
+    );
+
+    const proposal = screen.getByRole('region', {name: 'Code Changes'});
+    expect(within(proposal).getByText('Applying the second review...')).toBeVisible();
+    expect(
+      within(proposal).queryByText('Editing the initial implementation...')
+    ).not.toBeInTheDocument();
+    expect(
+      within(proposal).queryByText('Applying the first review...')
+    ).not.toBeInTheDocument();
+  });
+
   it.each([
     [
       'errored step',

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixSummary.spec.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreviewAutofixSummary.spec.tsx
@@ -198,7 +198,7 @@ describe('IssuePreviewAutofixSummary', () => {
     expect(screen.queryByRole('region', {name: 'Code Changes'})).not.toBeInTheDocument();
   });
 
-  it('renders the section with a loading indicator while it is processing', () => {
+  it('renders progress messages with a loading indicator while processing', () => {
     render(
       <IssuePreviewAutofixSummary
         autofix={ExplorerAutofixFixture({
@@ -207,8 +207,25 @@ describe('IssuePreviewAutofixSummary', () => {
               ExplorerAutofixBlockFixture({
                 artifacts: undefined,
                 message: {
-                  content: 'Thinking...',
+                  content: 'Start the root cause analysis',
                   metadata: {step: 'root_cause'},
+                  role: 'user',
+                },
+              }),
+              ExplorerAutofixBlockFixture({
+                id: 'progress',
+                artifacts: undefined,
+                message: {
+                  content: 'Tracing the failing request...',
+                  role: 'assistant',
+                },
+              }),
+              ExplorerAutofixBlockFixture({
+                id: 'thinking',
+                artifacts: undefined,
+                message: {
+                  content: 'Thinking...',
+                  thinking_content: 'Inspecting the event context...',
                   role: 'assistant',
                 },
               }),
@@ -222,6 +239,12 @@ describe('IssuePreviewAutofixSummary', () => {
 
     const rootCause = screen.getByRole('region', {name: 'Root Cause'});
     expect(within(rootCause).getByText('Generating root cause...')).toBeInTheDocument();
+    expect(within(rootCause).getByText('Inspecting the event context...')).toBeVisible();
+    expect(within(rootCause).getByText('Tracing the failing request...')).toBeVisible();
+    expect(within(rootCause).queryByText('Thinking...')).not.toBeInTheDocument();
+    expect(
+      within(rootCause).queryByText('Start the root cause analysis')
+    ).not.toBeInTheDocument();
     expect(within(rootCause).getByTestId('loading-indicator')).toBeInTheDocument();
     expect(
       screen.queryByRole('region', {name: 'Implementation Plan'})

--- a/static/app/views/issueList/pages/inbox/issuePreview/workingIndicator.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/workingIndicator.tsx
@@ -16,6 +16,10 @@ export function WorkingIndicator({
   children: React.ReactNode;
 }) {
   const {containerRef, onScrollHandler} = useAutoScroll({key: blocks});
+  const currentStepStart = blocks.findLastIndex(
+    block => block.message.metadata?.step !== undefined
+  );
+  const currentStepBlocks = blocks.slice(Math.max(0, currentStepStart));
 
   return (
     <Stack
@@ -25,7 +29,7 @@ export function WorkingIndicator({
       overflowY="auto"
       onScroll={onScrollHandler}
     >
-      {blocks.map(block => {
+      {currentStepBlocks.map(block => {
         if (block.message.role === 'user') {
           return null;
         }

--- a/static/app/views/issueList/pages/inbox/issuePreview/workingIndicator.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/workingIndicator.tsx
@@ -1,16 +1,50 @@
 import styled from '@emotion/styled';
 
-import {Flex} from '@sentry/scraps/layout';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 
+import {type AutofixSection} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {useAutoScroll} from 'sentry/utils/useAutoScroll';
 
-export function WorkingIndicator({children}: {children: React.ReactNode}) {
+export function WorkingIndicator({
+  blocks,
+  children,
+}: {
+  blocks: AutofixSection['blocks'];
+  children: React.ReactNode;
+}) {
+  const {containerRef, onScrollHandler} = useAutoScroll({key: blocks});
+
   return (
-    <Flex align="center" gap="sm">
-      <WorkingSpinner size={16} />
-      <Text variant="muted">{children}</Text>
-    </Flex>
+    <Stack
+      ref={containerRef}
+      gap="md"
+      maxHeight="200px"
+      overflowY="auto"
+      onScroll={onScrollHandler}
+    >
+      {blocks.map(block => {
+        if (block.message.role === 'user') {
+          return null;
+        }
+
+        if (block.message.content && block.message.content !== 'Thinking...') {
+          return <Markdown key={block.id} raw={block.message.content} />;
+        }
+
+        if (block.message.thinking_content) {
+          return <Markdown key={block.id} raw={block.message.thinking_content} />;
+        }
+
+        return null;
+      })}
+      <Flex align="center" gap="sm" paddingTop="xs">
+        <WorkingSpinner size={16} />
+        <Text variant="muted">{children}</Text>
+      </Flex>
+    </Stack>
   );
 }
 


### PR DESCRIPTION
Closes ISWF-3395

While autofix is in progress, shows the in-progress thinking content in a scrollable container. This matches how the existing autofix drawer displays progress and keeps the user engaged.