### PR TITLE
fix(seer-infra-telemetry): Show the GCP connection check as running after a save

### DIFF
--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -388,7 +388,12 @@ describe('ConfigureIntegration GCP re-verification', () => {
   function setup({
     providerKey = 'gcp',
     connectionStatus = 'connected',
-  }: {connectionStatus?: string; providerKey?: string} = {}) {
+    verifyDelay,
+  }: {
+    connectionStatus?: string;
+    providerKey?: string;
+    verifyDelay?: number;
+  } = {}) {
     const organization = OrganizationFixture({
       access: ['org:integrations', 'org:write'],
     });
@@ -447,6 +452,7 @@ describe('ConfigureIntegration GCP re-verification', () => {
     const verifyRequest = MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/monitoring-providers/gcp/verify-connection/`,
       method: 'POST',
+      asyncDelay: verifyDelay,
       body: () => {
         // The endpoint records its result on the integration.
         storedConfig = {
@@ -549,6 +555,19 @@ describe('ConfigureIntegration GCP re-verification', () => {
     await saveNewSaEmail('new-sa@my-project.iam.gserviceaccount.com');
 
     // The check runs after the save, so the page has to refresh again to show it.
+    expect(await screen.findByText('Connected')).toBeInTheDocument();
+  });
+
+  it('reports the check as running instead of the interim unverified status', async () => {
+    setup({connectionStatus: 'unverified', verifyDelay: 50});
+
+    expect(await screen.findByText('Not verified')).toBeInTheDocument();
+
+    await saveNewSaEmail('new-sa@my-project.iam.gserviceaccount.com');
+
+    expect(await screen.findByText('Checking connection...')).toBeInTheDocument();
+    expect(screen.queryByText('Not verified')).not.toBeInTheDocument();
+
     expect(await screen.findByText('Connected')).toBeInTheDocument();
   });
 

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect} from 'react';
+import {Fragment, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {mutationOptions, useQuery, useQueryClient} from '@tanstack/react-query';
@@ -184,6 +184,8 @@ function ConfigureIntegration() {
 
   const provider = config.providers.find(p => p.key === integration?.provider.key);
   const {projects} = useProjects();
+
+  const [isVerifyingGcp, setIsVerifyingGcp] = useState(false);
 
   useRouteAnalyticsEventNames(
     'integrations.details_viewed',
@@ -398,19 +400,30 @@ function ConfigureIntegration() {
         });
       },
       onSuccess: async () => {
-        // it's important that we keep the mutation pending while the refetch is happening by awaiting it.
-        // Otherwise, clicking toggles again while the invalidation is running won't do anything because they still see old defaultValues.
-        // this makes the mutations seem to run longer than before. We could do optimistic updates here too, but I'm not sure it's worth the added complexity.
-        await queryClient.invalidateQueries(integrationQueryOptions);
+        const verifiesConnection = provider.key === 'gcp';
+        if (verifiesConnection) {
+          setIsVerifyingGcp(true);
+        }
 
-        if (provider.key === 'gcp') {
-          try {
-            await verifyGcpConnection();
-            await queryClient.invalidateQueries(integrationQueryOptions);
-          } catch (error) {
-            // The save itself succeeded; the connection stays recorded as unverified
-            // and the customer can re-test, so don't report this as a failed save.
-            Sentry.captureException(error);
+        try {
+          // it's important that we keep the mutation pending while the refetch is happening by awaiting it.
+          // Otherwise, clicking toggles again while the invalidation is running won't do anything because they still see old defaultValues.
+          // this makes the mutations seem to run longer than before. We could do optimistic updates here too, but I'm not sure it's worth the added complexity.
+          await queryClient.invalidateQueries(integrationQueryOptions);
+
+          if (verifiesConnection) {
+            try {
+              await verifyGcpConnection();
+              await queryClient.invalidateQueries(integrationQueryOptions);
+            } catch (error) {
+              // The save itself succeeded; the connection stays recorded as unverified
+              // and the customer can re-test, so don't report this as a failed save.
+              Sentry.captureException(error);
+            }
+          }
+        } finally {
+          if (verifiesConnection) {
+            setIsVerifyingGcp(false);
           }
         }
       },
@@ -422,6 +435,7 @@ function ConfigureIntegration() {
           <GcpConnectionStatus
             configData={integration.configData}
             organization={organization}
+            isVerifying={isVerifyingGcp}
             onRetested={() => queryClient.invalidateQueries(integrationQueryOptions)}
           />
         )}

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
@@ -17,15 +17,18 @@ describe('GcpConnectionStatus', () => {
 
   function renderStatus({
     configData,
+    isVerifying = false,
     onRetested = jest.fn(),
   }: {
     configData: OrganizationIntegration['configData'];
+    isVerifying?: boolean;
     onRetested?: jest.Mock;
   }) {
     render(
       <GcpConnectionStatus
         configData={configData}
         organization={organization}
+        isVerifying={isVerifying}
         onRetested={onRetested}
       />,
       {organization}
@@ -176,6 +179,22 @@ describe('GcpConnectionStatus', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
 
     await waitFor(() => expect(onRetested).toHaveBeenCalled());
+  });
+
+  it('reports a check started elsewhere on the page as running', () => {
+    renderStatus({
+      isVerifying: true,
+      configData: {
+        ...baseConfig,
+        connection_status: 'unverified',
+        project_statuses: [],
+        last_verified_at: null,
+      },
+    });
+
+    expect(screen.getByText('Checking connection...')).toBeInTheDocument();
+    expect(screen.queryByText('Not verified')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Re-test'})).toBeDisabled();
   });
 
   it('cannot be re-tested when the config is incomplete', () => {

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
@@ -24,10 +24,12 @@ interface GcpConnectionStatusProps {
   configData: OrganizationIntegration['configData'];
   onRetested: () => void | Promise<void>;
   organization: Organization;
+  isVerifying?: boolean;
 }
 
 export function GcpConnectionStatus({
   configData,
+  isVerifying = false,
   onRetested,
   organization,
 }: GcpConnectionStatusProps) {
@@ -43,7 +45,7 @@ export function GcpConnectionStatus({
 
   const payload = buildGcpVerifyPayload(configData);
 
-  const {mutate: retest, isPending} = useMutation({
+  const {mutate: retest, isPending: isRetesting} = useMutation({
     mutationFn: () =>
       fetchMutation({
         method: 'POST',
@@ -56,6 +58,8 @@ export function GcpConnectionStatus({
     onSuccess: () => onRetested(),
     onError: () => onRetested(),
   });
+
+  const isPending = isRetesting || isVerifying;
 
   return (
     <FieldGroup title={t('Connection Status')}>


### PR DESCRIPTION
Resolves https://linear.app/getsentry/issue/CW-1984/show-a-pending-state-while-the-post-save-gcp-connection-check-runs.

Saving a GCP setting records `unverified`, then re-runs verification. The status block only knew about the Re-test button's check, so for the seconds the post-save check takes it displayed "Not verified" before flipping.

This PR threads the auto-trigger's in-flight state into `GcpConnectionStatus`, where it ORs with the Re-test mutation's own pending flag. The flag is set before the first invalidation and cleared in a `finally` after the second, so it covers the whole save → verify → refresh sequence.