### PR TITLE
feat(investigations): Wire orchestration execution

### DIFF
--- a/src/sentry/investigations/endpoints/organization_investigation_details.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_details.py
@@ -11,6 +11,7 @@ from sentry.api.serializers import serialize
 from sentry.investigations.endpoints.base import (
     OrganizationInvestigationEndpoint,
     service_error,
+    user_id,
 )
 from sentry.investigations.endpoints.serializers import InvestigationDetailsSerializer
 from sentry.investigations.endpoints.validators import (
@@ -18,7 +19,10 @@ from sentry.investigations.endpoints.validators import (
     InvestigationUpdateValidator,
 )
 from sentry.investigations.models import Investigation, InvestigationStatus
-from sentry.investigations.services import archive_investigation, update_investigation
+from sentry.investigations.services import (
+    archive_investigation_with_orchestration,
+    update_investigation_with_orchestration,
+)
 from sentry.models.organization import Organization
 
 
@@ -76,8 +80,10 @@ class OrganizationInvestigationsDetailsEndpoint(OrganizationInvestigationEndpoin
                     status=status.HTTP_400_BAD_REQUEST,
                 )
             try:
-                archived = archive_investigation(
-                    investigation=investigation, expected_version=expected_version
+                archived = archive_investigation_with_orchestration(
+                    investigation=investigation,
+                    expected_version=expected_version,
+                    actor_id=user_id(request),
                 )
             except Exception as error:
                 response = service_error(error)
@@ -92,7 +98,7 @@ class OrganizationInvestigationsDetailsEndpoint(OrganizationInvestigationEndpoin
                 )
             )
         try:
-            updated = update_investigation(
+            updated = update_investigation_with_orchestration(
                 investigation=investigation,
                 expected_version=expected_version,
                 fields=values,
@@ -118,9 +124,10 @@ class OrganizationInvestigationsDetailsEndpoint(OrganizationInvestigationEndpoin
         if not validator.is_valid():
             return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
         try:
-            archive_investigation(
+            archive_investigation_with_orchestration(
                 investigation=investigation,
                 expected_version=validator.validated_data["investigation_version"],
+                actor_id=user_id(request),
             )
         except Exception as error:
             response = service_error(error)

--- a/src/sentry/investigations/endpoints/organization_investigation_details.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_details.py
@@ -11,7 +11,6 @@ from sentry.api.serializers import serialize
 from sentry.investigations.endpoints.base import (
     OrganizationInvestigationEndpoint,
     service_error,
-    user_id,
 )
 from sentry.investigations.endpoints.serializers import InvestigationDetailsSerializer
 from sentry.investigations.endpoints.validators import (
@@ -83,7 +82,7 @@ class OrganizationInvestigationsDetailsEndpoint(OrganizationInvestigationEndpoin
                 archived = archive_investigation_with_orchestration(
                     investigation=investigation,
                     expected_version=expected_version,
-                    actor_id=user_id(request),
+                    actor_id=request.user.id,
                 )
             except Exception as error:
                 response = service_error(error)
@@ -127,7 +126,7 @@ class OrganizationInvestigationsDetailsEndpoint(OrganizationInvestigationEndpoin
             archive_investigation_with_orchestration(
                 investigation=investigation,
                 expected_version=validator.validated_data["investigation_version"],
-                actor_id=user_id(request),
+                actor_id=request.user.id,
             )
         except Exception as error:
             response = service_error(error)

--- a/src/sentry/investigations/endpoints/organization_investigation_orchestration.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_orchestration.py
@@ -80,6 +80,8 @@ class OrganizationInvestigationOrchestrationCommandsEndpoint(OrganizationInvesti
                 "accepted": True,
                 "duplicate": accepted.duplicate,
                 "workflowVersion": accepted.workflow_version,
+                "commandStatus": accepted.status,
+                "commandError": accepted.error,
                 "projection": accepted.projection,
             },
             status=status.HTTP_200_OK,

--- a/src/sentry/investigations/services/orchestration.py
+++ b/src/sentry/investigations/services/orchestration.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from copy import deepcopy
 from dataclasses import dataclass
 from functools import partial
@@ -36,6 +37,8 @@ from sentry.investigations.services.investigations import (
     update_investigation,
 )
 from sentry.models.organization import Organization
+
+logger = logging.getLogger(__name__)
 
 _ARCHIVE_CANCEL_NAMESPACE = UUID("cde61615-4bc3-43a4-a022-1608dc33d512")
 _CONTROL_KEY = "_sentryControl"
@@ -187,6 +190,7 @@ def _hypothesis_ids(run: InvestigationOrchestrationRun) -> set[str]:
 def _validate_command_target(
     run: InvestigationOrchestrationRun,
     *,
+    request_id: UUID,
     command_type: str,
     payload: dict[str, Any],
 ) -> None:
@@ -200,6 +204,16 @@ def _validate_command_target(
     if targets_hypothesis and (
         not isinstance(hypothesis_id, str) or hypothesis_id not in _hypothesis_ids(run)
     ):
+        logger.info(
+            "investigation.orchestration.command.invalid_hypothesis",
+            extra={
+                "investigation_id": run.investigation_id,
+                "orchestration_run_id": run.id,
+                "request_id": str(request_id),
+                "command_type": command_type,
+                "hypothesis_id": hypothesis_id if isinstance(hypothesis_id, str) else None,
+            },
+        )
         raise InvestigationValidationError({"detail": "Hypothesis was not found."})
 
 
@@ -690,7 +704,9 @@ def accept_orchestration_command(
         if run.workflow_version != expected_workflow_version:
             raise InvestigationConflictError("Workflow version does not match.")
 
-        _validate_command_target(run, command_type=command_type, payload=payload)
+        _validate_command_target(
+            run, request_id=request_id, command_type=command_type, payload=payload
+        )
 
         if run.seer_run_id is None and _is_run_retry(command_type, payload):
             command = InvestigationOrchestrationCommand.objects.create(

--- a/src/sentry/investigations/services/orchestration.py
+++ b/src/sentry/investigations/services/orchestration.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid5
 from django.db import IntegrityError, router, transaction
 from django.db.models import Max
 from django.utils import timezone
+from rest_framework.exceptions import PermissionDenied
 
 from sentry.investigations.models import (
     Investigation,
@@ -310,7 +311,7 @@ def _schedule_orchestration_commands(run_id: int) -> None:
 
 
 def archive_investigation_with_orchestration(
-    *, investigation: Investigation, expected_version: int, actor_id: int
+    *, investigation: Investigation, expected_version: int, actor_id: int | None
 ) -> Investigation:
     database = router.db_for_write(InvestigationOrchestrationRun)
     with transaction.atomic(using=database):
@@ -325,6 +326,8 @@ def archive_investigation_with_orchestration(
             .filter(investigation=locked_investigation)
             .first()
         )
+        if run is not None and actor_id is None:
+            raise PermissionDenied
         archive_version = expected_version
         if run is None:
             if locked_investigation.version != expected_version:
@@ -340,6 +343,7 @@ def archive_investigation_with_orchestration(
             InvestigationOrchestrationStatus.FAILED,
             InvestigationOrchestrationStatus.CANCELLED,
         }:
+            assert actor_id is not None
             accept_orchestration_command(
                 investigation=locked_investigation,
                 request_id=uuid5(

--- a/src/sentry/investigations/services/orchestration.py
+++ b/src/sentry/investigations/services/orchestration.py
@@ -208,10 +208,9 @@ def _clear_command_dispatch_error(
     *,
     request_id: UUID,
 ) -> None:
-    projection = deepcopy(run.projection)
-    errors = projection.get("errors")
+    errors = run.projection.get("errors")
     if isinstance(errors, list):
-        projection["errors"] = [
+        run.projection["errors"] = [
             error
             for error in errors
             if not (
@@ -226,7 +225,6 @@ def _clear_command_dispatch_error(
         and run.error.get("requestId") == str(request_id)
     ):
         run.error = None
-    run.projection = projection
 
 
 def _requeue_failed_command(
@@ -264,8 +262,7 @@ def _command_can_be_requeued(command: InvestigationOrchestrationCommand) -> bool
 
 
 def _reset_create_dispatch_failure(run: InvestigationOrchestrationRun) -> None:
-    projection = deepcopy(run.projection)
-    awaiting_input = isinstance(projection.get("pendingInput"), dict)
+    awaiting_input = isinstance(run.projection.get("pendingInput"), dict)
     run.phase = (
         InvestigationOrchestrationPhase.INTAKE
         if awaiting_input
@@ -277,15 +274,14 @@ def _reset_create_dispatch_failure(run: InvestigationOrchestrationRun) -> None:
         else InvestigationOrchestrationStatus.PENDING
     )
     run.error = None
-    projection.update({"phase": run.phase, "status": run.status})
-    errors = projection.get("errors")
+    run.projection.update({"phase": run.phase, "status": run.status})
+    errors = run.projection.get("errors")
     if isinstance(errors, list):
-        projection["errors"] = [
+        run.projection["errors"] = [
             error
             for error in errors
             if not (isinstance(error, dict) and error.get("code") == "seer_dispatch_failed")
         ]
-    run.projection = projection
 
 
 def _is_run_retry(command_type: str, payload: dict[str, Any]) -> bool:
@@ -357,11 +353,9 @@ def archive_investigation_with_orchestration(
             )
         if run is not None:
             run.refresh_from_db(fields=["generation", "projection"])
-            projection = deepcopy(run.projection)
-            control = projection.setdefault(_CONTROL_KEY, {})
+            control = run.projection.setdefault(_CONTROL_KEY, {})
             assert isinstance(control, dict)
             control["notebookWriteFenceGeneration"] = run.generation
-            run.projection = projection
             run.date_updated = timezone.now()
             run.save(update_fields=["projection", "date_updated"])
             now = timezone.now()
@@ -425,8 +419,7 @@ def update_investigation_with_orchestration(
             project_ids=project_ids,
         )
         if run is not None and "title" in fields:
-            projection = deepcopy(run.projection)
-            control = projection.setdefault(_CONTROL_KEY, {})
+            control = run.projection.setdefault(_CONTROL_KEY, {})
             assert isinstance(control, dict)
             control.update(
                 {
@@ -435,7 +428,6 @@ def update_investigation_with_orchestration(
                     "titleStarted": True,
                 }
             )
-            run.projection = projection
             run.date_updated = timezone.now()
             run.save(update_fields=["projection", "date_updated"])
         return updated
@@ -634,7 +626,7 @@ def _command_acceptance(
         duplicate=duplicate,
         workflow_version=run.workflow_version,
         status=command.status,
-        error=deepcopy(command.error),
+        error=command.error,
         projection=_serialize_orchestration_run(run),
     )
 
@@ -708,7 +700,7 @@ def accept_orchestration_command(
                 expected_workflow_version=expected_workflow_version,
                 resulting_workflow_version=run.workflow_version,
                 type=command_type,
-                payload=deepcopy(payload),
+                payload=payload,
                 status=InvestigationOrchestrationCommandStatus.ACKNOWLEDGED,
             )
             _reset_create_dispatch_failure(run)

--- a/src/sentry/investigations/services/orchestration.py
+++ b/src/sentry/investigations/services/orchestration.py
@@ -348,7 +348,7 @@ def archive_investigation_with_orchestration(
                 investigation=locked_investigation,
                 request_id=uuid5(
                     _ARCHIVE_CANCEL_NAMESPACE,
-                    f"{locked_investigation.id}:{expected_version}",
+                    f"{locked_investigation.id}:{archive_version}",
                 ),
                 expected_workflow_version=run.workflow_version,
                 command_type="cancel",
@@ -408,7 +408,12 @@ def update_investigation_with_orchestration(
             .filter(investigation=locked_investigation)
             .first()
         )
-        if run is not None and set(fields) == {"title"} and project_ids is None:
+        if (
+            run is not None
+            and locked_investigation.status == InvestigationStatus.ACTIVE
+            and set(fields) == {"title"}
+            and project_ids is None
+        ):
             control = run.projection.get(_CONTROL_KEY, {})
             assert isinstance(control, dict)
             if control.get("manualTitleOverride") is not True:

--- a/src/sentry/investigations/services/orchestration.py
+++ b/src/sentry/investigations/services/orchestration.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from copy import deepcopy
 from dataclasses import dataclass
+from functools import partial
 from typing import Any
-from uuid import UUID
+from uuid import UUID, uuid5
 
 from django.db import IntegrityError, router, transaction
 from django.db.models import Max
@@ -11,7 +12,11 @@ from django.utils import timezone
 
 from sentry.investigations.models import (
     Investigation,
+    InvestigationBlockExecution,
+    InvestigationBlockExecutionStatus,
     InvestigationOrchestrationCommand,
+    InvestigationOrchestrationCommandStatus,
+    InvestigationOrchestrationPhase,
     InvestigationOrchestrationRun,
     InvestigationOrchestrationStatus,
     InvestigationSourceType,
@@ -25,9 +30,14 @@ from sentry.investigations.services.investigations import (
     InvestigationValidationError,
     _create_project_links,
     _legacy_storage_filters,
+    archive_investigation,
     investigation_lineage_key,
+    update_investigation,
 )
 from sentry.models.organization import Organization
+
+_ARCHIVE_CANCEL_NAMESPACE = UUID("cde61615-4bc3-43a4-a022-1608dc33d512")
+_CONTROL_KEY = "_sentryControl"
 
 
 @dataclass(frozen=True)
@@ -36,6 +46,8 @@ class AcceptedOrchestrationCommand:
     request_id: UUID
     duplicate: bool
     workflow_version: int
+    status: str
+    error: dict[str, Any] | None
     projection: dict[str, Any]
 
 
@@ -43,9 +55,11 @@ __all__ = [
     "AcceptedOrchestrationCommand",
     "accept_orchestration_command",
     "agentic_breached_metric_lineage_key",
+    "archive_investigation_with_orchestration",
     "create_agentic_breached_metric_investigation",
     "create_agentic_manual_investigation",
     "get_orchestration_projection",
+    "update_investigation_with_orchestration",
 ]
 
 
@@ -154,7 +168,268 @@ def _create_agentic_investigation(
             source=deepcopy(orchestration_source),
             projection=projection,
         )
+        _schedule_orchestration_create(orchestration_run.id)
     return investigation, orchestration_run
+
+
+def _hypothesis_ids(run: InvestigationOrchestrationRun) -> set[str]:
+    hypotheses = run.projection.get("hypotheses")
+    if not isinstance(hypotheses, list):
+        return set()
+    return {
+        hypothesis["id"]
+        for hypothesis in hypotheses
+        if isinstance(hypothesis, dict) and isinstance(hypothesis.get("id"), str)
+    }
+
+
+def _validate_command_target(
+    run: InvestigationOrchestrationRun,
+    *,
+    command_type: str,
+    payload: dict[str, Any],
+) -> None:
+    hypothesis_id: Any = None
+    targets_hypothesis = command_type == "set_hypothesis_disposition"
+    if targets_hypothesis:
+        hypothesis_id = payload.get("hypothesisId")
+    elif command_type in {"steer", "retry"} and payload.get("target") == "hypothesis":
+        targets_hypothesis = True
+        hypothesis_id = payload.get("targetId")
+    if targets_hypothesis and (
+        not isinstance(hypothesis_id, str) or hypothesis_id not in _hypothesis_ids(run)
+    ):
+        raise InvestigationValidationError({"detail": "Hypothesis was not found."})
+
+
+def _clear_command_dispatch_error(
+    run: InvestigationOrchestrationRun,
+    *,
+    request_id: UUID,
+) -> None:
+    projection = deepcopy(run.projection)
+    errors = projection.get("errors")
+    if isinstance(errors, list):
+        projection["errors"] = [
+            error
+            for error in errors
+            if not (
+                isinstance(error, dict)
+                and error.get("code") == "seer_command_dispatch_failed"
+                and error.get("requestId") == str(request_id)
+            )
+        ]
+    if (
+        isinstance(run.error, dict)
+        and run.error.get("code") == "seer_command_dispatch_failed"
+        and run.error.get("requestId") == str(request_id)
+    ):
+        run.error = None
+    run.projection = projection
+
+
+def _requeue_failed_command(
+    run: InvestigationOrchestrationRun,
+    command: InvestigationOrchestrationCommand,
+) -> None:
+    queued: list[InvestigationOrchestrationCommand] = []
+    now = timezone.now()
+    for candidate in InvestigationOrchestrationCommand.objects.filter(
+        orchestration_run=run,
+        id__gte=command.id,
+        status=InvestigationOrchestrationCommandStatus.FAILED,
+    ).order_by("id"):
+        error_code = candidate.error.get("code") if isinstance(candidate.error, dict) else None
+        if candidate.id == command.id or error_code == "earlier_command_failed":
+            candidate.status = InvestigationOrchestrationCommandStatus.ACCEPTED
+            candidate.error = None
+            candidate.date_updated = now
+            queued.append(candidate)
+    if queued:
+        InvestigationOrchestrationCommand.objects.bulk_update(
+            queued,
+            ["status", "error", "date_updated"],
+        )
+    _clear_command_dispatch_error(run, request_id=command.request_id)
+    run.save(update_fields=["projection", "error", "date_updated"])
+
+
+def _command_can_be_requeued(command: InvestigationOrchestrationCommand) -> bool:
+    return (
+        isinstance(command.error, dict)
+        and command.error.get("code") == "seer_command_dispatch_failed"
+        and command.error.get("retryable") is True
+    )
+
+
+def _reset_create_dispatch_failure(run: InvestigationOrchestrationRun) -> None:
+    projection = deepcopy(run.projection)
+    awaiting_input = isinstance(projection.get("pendingInput"), dict)
+    run.phase = (
+        InvestigationOrchestrationPhase.INTAKE
+        if awaiting_input
+        else InvestigationOrchestrationPhase.BROAD_SCAN
+    )
+    run.status = (
+        InvestigationOrchestrationStatus.AWAITING_INPUT
+        if awaiting_input
+        else InvestigationOrchestrationStatus.PENDING
+    )
+    run.error = None
+    projection.update({"phase": run.phase, "status": run.status})
+    errors = projection.get("errors")
+    if isinstance(errors, list):
+        projection["errors"] = [
+            error
+            for error in errors
+            if not (isinstance(error, dict) and error.get("code") == "seer_dispatch_failed")
+        ]
+    run.projection = projection
+
+
+def _is_run_retry(command_type: str, payload: dict[str, Any]) -> bool:
+    return command_type == "retry" and payload.get("target") == "run"
+
+
+def _schedule_orchestration_create(run_id: int) -> None:
+    from sentry.tasks.seer.investigation import dispatch_investigation_orchestration_create
+
+    transaction.on_commit(
+        partial(dispatch_investigation_orchestration_create.delay, run_id),
+        using=router.db_for_write(InvestigationOrchestrationRun),
+    )
+
+
+def _schedule_orchestration_commands(run_id: int) -> None:
+    from sentry.tasks.seer.investigation import dispatch_investigation_orchestration_commands
+
+    transaction.on_commit(
+        partial(dispatch_investigation_orchestration_commands.delay, run_id),
+        using=router.db_for_write(InvestigationOrchestrationRun),
+    )
+
+
+def archive_investigation_with_orchestration(
+    *, investigation: Investigation, expected_version: int, actor_id: int
+) -> Investigation:
+    database = router.db_for_write(InvestigationOrchestrationRun)
+    with transaction.atomic(using=database):
+        try:
+            locked_investigation = Investigation.objects.select_for_update().get(
+                id=investigation.id
+            )
+        except Investigation.DoesNotExist:
+            raise InvestigationSourceNotFound
+        run = (
+            InvestigationOrchestrationRun.objects.select_for_update()
+            .filter(investigation=locked_investigation)
+            .first()
+        )
+        archive_version = expected_version
+        if run is None:
+            if locked_investigation.version != expected_version:
+                raise InvestigationConflictError("Investigation has changed.")
+        else:
+            if expected_version > locked_investigation.version:
+                raise InvestigationConflictError("Investigation has changed.")
+            archive_version = locked_investigation.version
+        if locked_investigation.status == InvestigationStatus.ARCHIVED:
+            return locked_investigation
+        if run is not None and run.status not in {
+            InvestigationOrchestrationStatus.COMPLETED,
+            InvestigationOrchestrationStatus.FAILED,
+            InvestigationOrchestrationStatus.CANCELLED,
+        }:
+            accept_orchestration_command(
+                investigation=locked_investigation,
+                request_id=uuid5(
+                    _ARCHIVE_CANCEL_NAMESPACE,
+                    f"{locked_investigation.id}:{expected_version}",
+                ),
+                expected_workflow_version=run.workflow_version,
+                command_type="cancel",
+                payload={"reason": "investigation_archived"},
+                actor_id=actor_id,
+            )
+        if run is not None:
+            run.refresh_from_db(fields=["generation", "projection"])
+            projection = deepcopy(run.projection)
+            control = projection.setdefault(_CONTROL_KEY, {})
+            assert isinstance(control, dict)
+            control["notebookWriteFenceGeneration"] = run.generation
+            run.projection = projection
+            run.date_updated = timezone.now()
+            run.save(update_fields=["projection", "date_updated"])
+            now = timezone.now()
+            InvestigationBlockExecution.objects.filter(
+                block__investigation=locked_investigation,
+                status__in=(
+                    InvestigationBlockExecutionStatus.PENDING,
+                    InvestigationBlockExecutionStatus.RUNNING,
+                    InvestigationBlockExecutionStatus.AWAITING_INPUT,
+                    InvestigationBlockExecutionStatus.STOPPING,
+                ),
+            ).update(
+                status=InvestigationBlockExecutionStatus.CANCELLED,
+                error={
+                    "code": "investigation_archived",
+                    "message": "The investigation was archived.",
+                },
+                completed_at=now,
+                date_updated=now,
+            )
+        return archive_investigation(
+            investigation=locked_investigation,
+            expected_version=archive_version,
+        )
+
+
+def update_investigation_with_orchestration(
+    *,
+    investigation: Investigation,
+    expected_version: int,
+    fields: dict[str, Any],
+    project_ids: list[int] | None,
+) -> Investigation:
+    database = router.db_for_write(InvestigationOrchestrationRun)
+    with transaction.atomic(using=database):
+        try:
+            locked_investigation = Investigation.objects.select_for_update().get(
+                id=investigation.id
+            )
+        except Investigation.DoesNotExist:
+            raise InvestigationSourceNotFound
+        run = (
+            InvestigationOrchestrationRun.objects.select_for_update()
+            .filter(investigation=locked_investigation)
+            .first()
+        )
+        if run is not None and set(fields) == {"title"} and project_ids is None:
+            control = run.projection.get(_CONTROL_KEY, {})
+            assert isinstance(control, dict)
+            if control.get("manualTitleOverride") is not True:
+                expected_version = locked_investigation.version
+        updated = update_investigation(
+            investigation=locked_investigation,
+            expected_version=expected_version,
+            fields=fields,
+            project_ids=project_ids,
+        )
+        if run is not None and "title" in fields:
+            projection = deepcopy(run.projection)
+            control = projection.setdefault(_CONTROL_KEY, {})
+            assert isinstance(control, dict)
+            control.update(
+                {
+                    "manualTitleOverride": True,
+                    "titleBuffer": updated.title,
+                    "titleStarted": True,
+                }
+            )
+            run.projection = projection
+            run.date_updated = timezone.now()
+            run.save(update_fields=["projection", "date_updated"])
+        return updated
 
 
 def _manual_orchestration_source(source: dict[str, Any]) -> dict[str, Any]:
@@ -300,6 +575,7 @@ def _serialize_orchestration_run(run: InvestigationOrchestrationRun) -> dict[str
     """Overlay projection JSON with the run's authoritative scalar fields."""
 
     projection = deepcopy(run.projection)
+    projection.pop(_CONTROL_KEY, None)
     projection.update(
         {
             "runId": (
@@ -317,7 +593,9 @@ def _serialize_orchestration_run(run: InvestigationOrchestrationRun) -> dict[str
             "updatedAt": run.date_updated,
         }
     )
-    projection["report"]["notebookRevision"] = run.notebook_revision
+    report = projection["report"]
+    assert isinstance(report, dict)
+    report["notebookRevision"] = run.notebook_revision
     return projection
 
 
@@ -346,6 +624,8 @@ def _command_acceptance(
         request_id=command.request_id,
         duplicate=duplicate,
         workflow_version=run.workflow_version,
+        status=command.status,
+        error=deepcopy(command.error),
         projection=_serialize_orchestration_run(run),
     )
 
@@ -360,6 +640,7 @@ def accept_orchestration_command(
     actor_id: int,
 ) -> AcceptedOrchestrationCommand:
     with transaction.atomic(using=router.db_for_write(InvestigationOrchestrationRun)):
+        # Investigation-wide mutations lock the aggregate root before subordinate rows.
         try:
             locked_investigation = Investigation.objects.select_for_update().get(
                 id=investigation.id
@@ -389,10 +670,51 @@ def accept_orchestration_command(
                 raise InvestigationConflictError(
                     "Request ID was already used for a different command."
                 )
+            if run.seer_run_id is None and _is_run_retry(existing.type, existing.payload):
+                _schedule_orchestration_create(run.id)
+            elif (
+                existing.status == InvestigationOrchestrationCommandStatus.FAILED
+                and _command_can_be_requeued(existing)
+            ):
+                _requeue_failed_command(run, existing)
+                existing.refresh_from_db(fields=["status", "error"])
+                _schedule_orchestration_commands(run.id)
+            elif existing.status in {
+                InvestigationOrchestrationCommandStatus.ACCEPTED,
+                InvestigationOrchestrationCommandStatus.DISPATCHED,
+            }:
+                _schedule_orchestration_commands(run.id)
             return _command_acceptance(run, existing, duplicate=True)
 
         if run.workflow_version != expected_workflow_version:
             raise InvestigationConflictError("Workflow version does not match.")
+
+        _validate_command_target(run, command_type=command_type, payload=payload)
+
+        if run.seer_run_id is None and _is_run_retry(command_type, payload):
+            command = InvestigationOrchestrationCommand.objects.create(
+                orchestration_run=run,
+                request_id=request_id,
+                actor_id=actor_id,
+                expected_workflow_version=expected_workflow_version,
+                resulting_workflow_version=run.workflow_version,
+                type=command_type,
+                payload=deepcopy(payload),
+                status=InvestigationOrchestrationCommandStatus.ACKNOWLEDGED,
+            )
+            _reset_create_dispatch_failure(run)
+            run.date_updated = timezone.now()
+            run.save(
+                update_fields=[
+                    "phase",
+                    "status",
+                    "projection",
+                    "error",
+                    "date_updated",
+                ]
+            )
+            _schedule_orchestration_create(run.id)
+            return _command_acceptance(run, command, duplicate=False)
 
         resulting_version = run.workflow_version + 1
         command = InvestigationOrchestrationCommand.objects.create(
@@ -409,5 +731,12 @@ def accept_orchestration_command(
         run.workflow_version = resulting_version
         run.projection = projection
         run.date_updated = timezone.now()
-        run.save(update_fields=["workflow_version", "projection", "date_updated"])
+        run.save(
+            update_fields=[
+                "workflow_version",
+                "projection",
+                "date_updated",
+            ]
+        )
+        _schedule_orchestration_commands(run.id)
         return _command_acceptance(run, command, duplicate=False)

--- a/src/sentry/investigations/services/orchestration_events.py
+++ b/src/sentry/investigations/services/orchestration_events.py
@@ -187,8 +187,19 @@ def _report_revision(run: InvestigationOrchestrationRun) -> int:
     return value if isinstance(value, int) and not isinstance(value, bool) and value >= 0 else 0
 
 
-def _notebook_writes_are_fenced(run: InvestigationOrchestrationRun) -> bool:
-    return run.investigation.status == InvestigationStatus.ARCHIVED
+def _notebook_writes_are_fenced(
+    run: InvestigationOrchestrationRun,
+    *,
+    event_generation: int,
+) -> bool:
+    if run.investigation.status == InvestigationStatus.ARCHIVED:
+        return True
+    fence_generation = _control(run).get("notebookWriteFenceGeneration")
+    return (
+        isinstance(fence_generation, int)
+        and not isinstance(fence_generation, bool)
+        and event_generation <= fence_generation
+    )
 
 
 def _set_projection(
@@ -351,7 +362,17 @@ def _adopt_preserved_report_revision(
     run: InvestigationOrchestrationRun, projection: dict[str, Any]
 ) -> bool:
     report = projection.get("report")
-    if not isinstance(report, dict) or report.get("clearIntent") is not None:
+    if not isinstance(report, dict):
+        return False
+    clear_intent = report.get("clearIntent")
+    if isinstance(clear_intent, dict):
+        revision = clear_intent.get("revision")
+        if (
+            clear_intent.get("completed") is True
+            and isinstance(revision, int)
+            and not isinstance(revision, bool)
+        ):
+            return _clear_report(run, revision, bump=False)
         return False
     revision = report.get("revision")
     if (
@@ -714,9 +735,11 @@ def _complete_metadata(
     investigation.summary_description = description
     title = payload.get("title")
     if title is not None:
-        investigation.title = title
-        update_fields.append("title")
-        _control(run)["titleBuffer"] = title
+        control = _control(run)
+        if control.get("manualTitleOverride") is not True:
+            investigation.title = title
+            update_fields.append("title")
+            control["titleBuffer"] = title
     investigation.version += 1
     investigation.date_updated = timezone.now()
     investigation.save(update_fields=update_fields)
@@ -792,7 +815,10 @@ def _apply_event(
     )
     if generation > run.generation and not carries_projection:
         return False, "future_generation_without_projection"
-    notebook_writes_are_fenced = _notebook_writes_are_fenced(run)
+    notebook_writes_are_fenced = _notebook_writes_are_fenced(
+        run,
+        event_generation=generation,
+    )
     if notebook_writes_are_fenced and event.type in _NOTEBOOK_EVENT_TYPES:
         return False, "notebook_write_fenced"
 
@@ -915,20 +941,24 @@ def _apply_event(
                 _bump_notebook(run, run.investigation)
         elif event.type == "title_delta":
             control = _control(run)
-            title = (
-                control.get("titleBuffer", "")
-                if control.get("titleStarted") and payload.get("reset") is not True
-                else ""
-            )
-            title = f"{title}{payload['delta']}"[:255]
-            control.update({"titleBuffer": title, "titleStarted": True})
             investigation = run.investigation
-            investigation.title = title
-            investigation.save(update_fields=["title", "date_updated"])
             metadata = run.projection.setdefault("report", {}).setdefault("metadata", {})
-            if isinstance(metadata, dict):
-                metadata.update({"status": "generating", "title": title})
-            _bump_notebook(run, investigation)
+            if control.get("manualTitleOverride") is True:
+                if isinstance(metadata, dict):
+                    metadata.update({"status": "generating", "title": investigation.title})
+            else:
+                title = (
+                    control.get("titleBuffer", "")
+                    if control.get("titleStarted") and payload.get("reset") is not True
+                    else ""
+                )
+                title = f"{title}{payload['delta']}"[:255]
+                control.update({"titleBuffer": title, "titleStarted": True})
+                investigation.title = title
+                investigation.save(update_fields=["title", "date_updated"])
+                if isinstance(metadata, dict):
+                    metadata.update({"status": "generating", "title": title})
+                _bump_notebook(run, investigation)
         elif event.type == "metadata_completed":
             _complete_metadata(run, payload)
     elif event.type == "workflow_failed":
@@ -1266,7 +1296,10 @@ def _synchronize_orchestration_projection(
             generation >= run.generation
             and not _projection_is_stale(run, projection, event_generation=generation)
         ):
-            notebook_writes_are_fenced = _notebook_writes_are_fenced(run)
+            notebook_writes_are_fenced = _notebook_writes_are_fenced(
+                run,
+                event_generation=generation,
+            )
             notebook_changed = False
             if not notebook_writes_are_fenced:
                 notebook_changed = _adopt_preserved_report_revision(run, projection)

--- a/src/sentry/tasks/seer/investigation.py
+++ b/src/sentry/tasks/seer/investigation.py
@@ -221,16 +221,17 @@ def _reconcile_command_version_conflict(
     response_run_id = response["runId"]
     projection = response["projection"]
     try:
-        reconcile_orchestration_projection(
-            orchestration_run_id=run.id,
-            seer_run_id=response_run_id,
-            projection=projection,
-            expected_last_event_sequence=run.last_event_sequence,
-            expected_workflow_version=run.workflow_version,
-        )
+        with transaction.atomic(using=router.db_for_write(InvestigationOrchestrationRun)):
+            reconcile_orchestration_projection(
+                orchestration_run_id=run.id,
+                seer_run_id=response_run_id,
+                projection=projection,
+                expected_last_event_sequence=run.last_event_sequence,
+                expected_workflow_version=run.workflow_version,
+            )
+            _mark_command_version_conflicted(command.id)
     except InvestigationOrchestrationEventConflict as error:
         raise SeerApiError("Investigation changed while reconciling", 502) from error
-    _mark_command_version_conflicted(command.id)
 
 
 def _mark_command_dispatch_acknowledged(

--- a/src/sentry/tasks/seer/investigation.py
+++ b/src/sentry/tasks/seer/investigation.py
@@ -33,6 +33,7 @@ from sentry.investigations.services import (
     mark_block_execution_dispatch_started,
 )
 from sentry.investigations.services.orchestration_events import (
+    InvestigationOrchestrationEventConflict,
     reconcile_orchestration_projection,
     synchronize_orchestration_projection,
 )
@@ -210,6 +211,7 @@ def _reconcile_command_version_conflict(
     command: InvestigationOrchestrationCommand,
     viewer_context: SeerViewerContext,
 ) -> None:
+    run.refresh_from_db()
     if run.seer_run_id is None:
         raise SeerApiError("Investigation orchestration run is missing", 502)
     response = get_investigation_orchestration_run(
@@ -218,11 +220,16 @@ def _reconcile_command_version_conflict(
     )
     response_run_id = response["runId"]
     projection = response["projection"]
-    reconcile_orchestration_projection(
-        orchestration_run_id=run.id,
-        seer_run_id=response_run_id,
-        projection=projection,
-    )
+    try:
+        reconcile_orchestration_projection(
+            orchestration_run_id=run.id,
+            seer_run_id=response_run_id,
+            projection=projection,
+            expected_last_event_sequence=run.last_event_sequence,
+            expected_workflow_version=run.workflow_version,
+        )
+    except InvestigationOrchestrationEventConflict as error:
+        raise SeerApiError("Investigation changed while reconciling", 502) from error
     _mark_command_version_conflicted(command.id)
 
 

--- a/src/sentry/tasks/seer/investigation.py
+++ b/src/sentry/tasks/seer/investigation.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from copy import deepcopy
 
 from django.db import router, transaction
 from django.utils import timezone
@@ -89,12 +88,10 @@ def _mark_create_dispatch_failed(run_id: int) -> None:
         run.phase = InvestigationOrchestrationPhase.FAILED
         run.status = InvestigationOrchestrationStatus.FAILED
         run.error = detail
-        projection = deepcopy(run.projection)
-        projection.update({"phase": run.phase, "status": run.status})
-        errors = projection.setdefault("errors", [])
+        run.projection.update({"phase": run.phase, "status": run.status})
+        errors = run.projection.setdefault("errors", [])
         if isinstance(errors, list):
             errors.append(detail)
-        run.projection = projection
         run.save(update_fields=["phase", "status", "error", "projection", "date_updated"])
 
 
@@ -142,12 +139,10 @@ def _mark_command_dispatch_failed(command_id: int) -> None:
             },
             date_updated=timezone.now(),
         )
-        projection = deepcopy(run.projection)
-        errors = projection.setdefault("errors", [])
+        errors = run.projection.setdefault("errors", [])
         if isinstance(errors, list):
             errors.append(detail)
         run.error = detail
-        run.projection = projection
         run.save(update_fields=["error", "projection", "date_updated"])
 
 
@@ -196,13 +191,11 @@ def _mark_command_version_conflicted(command_id: int) -> None:
             },
             date_updated=timezone.now(),
         )
-        projection = deepcopy(run.projection)
-        errors = projection.setdefault("errors", [])
+        errors = run.projection.setdefault("errors", [])
         if isinstance(errors, list):
-            projection["errors"] = [detail, *errors]
+            run.projection["errors"] = [detail, *errors]
         if run.error is None:
             run.error = detail
-        run.projection = projection
         run.save(update_fields=["error", "projection", "date_updated"])
 
 
@@ -279,10 +272,9 @@ def _mark_command_dispatch_acknowledged(
                     requeued_commands,
                     ["status", "error", "date_updated"],
                 )
-        projection = deepcopy(run.projection)
-        errors = projection.get("errors")
+        errors = run.projection.get("errors")
         if isinstance(errors, list):
-            projection["errors"] = [
+            run.projection["errors"] = [
                 item
                 for item in errors
                 if not (
@@ -297,7 +289,6 @@ def _mark_command_dispatch_acknowledged(
             and run.error.get("requestId") == str(command.request_id)
         ):
             run.error = None
-        run.projection = projection
         run.save(update_fields=["error", "projection", "date_updated"])
 
 

--- a/src/sentry/tasks/seer/investigation.py
+++ b/src/sentry/tasks/seer/investigation.py
@@ -1,22 +1,452 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
+
+from django.db import router, transaction
+from django.utils import timezone
+from rest_framework import serializers
+from taskbroker_client.retry import Retry
+from taskbroker_client.state import current_task
+from urllib3.exceptions import HTTPError
 
 from sentry.investigations.agent import (
     cancel_investigation_executions_after_failure,
     start_execution_run,
 )
-from sentry.investigations.models import InvestigationBlockExecution
+from sentry.investigations.models import (
+    Investigation,
+    InvestigationBlockExecution,
+    InvestigationOrchestrationCommand,
+    InvestigationOrchestrationCommandStatus,
+    InvestigationOrchestrationPhase,
+    InvestigationOrchestrationRun,
+    InvestigationOrchestrationStatus,
+)
+from sentry.investigations.seer_client import (
+    create_investigation_orchestration_run,
+    dispatch_investigation_orchestration_command,
+    get_investigation_orchestration_run,
+)
 from sentry.investigations.services import (
     mark_block_execution_dispatch_failed,
     mark_block_execution_dispatch_started,
 )
+from sentry.investigations.services.orchestration_events import (
+    reconcile_orchestration_projection,
+    synchronize_orchestration_projection,
+)
 from sentry.investigations.telemetry import record_execution_failed
+from sentry.seer.models import SeerApiError
+from sentry.seer.signed_seer_api import SeerViewerContext
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import seer_tasks
 from sentry.users.services.user.service import user_service
 
 logger = logging.getLogger(__name__)
+
+ORCHESTRATION_DISPATCH_RETRIES = 3
+CREATE_DISPATCH_ERROR_MESSAGE = "Unable to start this investigation. Try again."
+COMMAND_DISPATCH_ERROR_MESSAGE = "Unable to deliver this investigation command. Try again."
+COMMAND_VERSION_CONFLICT_MESSAGE = (
+    "The investigation changed before this update could be applied. "
+    "Progress was refreshed; try again."
+)
+
+
+def _is_last_dispatch_attempt() -> bool:
+    task_state = current_task()
+    return task_state is not None and not task_state.retries_remaining
+
+
+def _lock_orchestration_run(run_id: int) -> InvestigationOrchestrationRun | None:
+    investigation = (
+        Investigation.objects.select_for_update(of=("self",))
+        .filter(orchestration_run__id=run_id)
+        .first()
+    )
+    if investigation is None:
+        return None
+    return (
+        InvestigationOrchestrationRun.objects.select_for_update(of=("self",))
+        .filter(id=run_id)
+        .first()
+    )
+
+
+def _mark_create_dispatch_failed(run_id: int) -> None:
+    database = router.db_for_write(InvestigationOrchestrationRun)
+    with transaction.atomic(using=database):
+        run = _lock_orchestration_run(run_id)
+        if run is None or run.seer_run_id is not None:
+            return
+        detail = {
+            "code": "seer_dispatch_failed",
+            "message": CREATE_DISPATCH_ERROR_MESSAGE,
+            "retryable": True,
+        }
+        run.phase = InvestigationOrchestrationPhase.FAILED
+        run.status = InvestigationOrchestrationStatus.FAILED
+        run.error = detail
+        projection = deepcopy(run.projection)
+        projection.update({"phase": run.phase, "status": run.status})
+        errors = projection.setdefault("errors", [])
+        if isinstance(errors, list):
+            errors.append(detail)
+        run.projection = projection
+        run.save(update_fields=["phase", "status", "error", "projection", "date_updated"])
+
+
+def _mark_command_dispatch_failed(command_id: int) -> None:
+    database = router.db_for_write(InvestigationOrchestrationCommand)
+    with transaction.atomic(using=database):
+        command_snapshot = InvestigationOrchestrationCommand.objects.filter(id=command_id).first()
+        if command_snapshot is None:
+            return
+        run = _lock_orchestration_run(command_snapshot.orchestration_run_id)
+        if run is None:
+            return
+        command = (
+            InvestigationOrchestrationCommand.objects.select_for_update()
+            .filter(id=command_id)
+            .first()
+        )
+        if (
+            command is None
+            or command.status == InvestigationOrchestrationCommandStatus.ACKNOWLEDGED
+        ):
+            return
+        detail = {
+            "code": "seer_command_dispatch_failed",
+            "message": COMMAND_DISPATCH_ERROR_MESSAGE,
+            "requestId": str(command.request_id),
+            "commandType": command.type,
+            "retryable": True,
+        }
+        command.status = InvestigationOrchestrationCommandStatus.FAILED
+        command.error = detail
+        command.save(update_fields=["status", "error", "date_updated"])
+        InvestigationOrchestrationCommand.objects.filter(
+            orchestration_run=run,
+            id__gt=command.id,
+            status__in=(
+                InvestigationOrchestrationCommandStatus.ACCEPTED,
+                InvestigationOrchestrationCommandStatus.DISPATCHED,
+            ),
+        ).update(
+            status=InvestigationOrchestrationCommandStatus.FAILED,
+            error={
+                "code": "earlier_command_failed",
+                "message": "An earlier workflow command could not be delivered.",
+            },
+            date_updated=timezone.now(),
+        )
+        projection = deepcopy(run.projection)
+        errors = projection.setdefault("errors", [])
+        if isinstance(errors, list):
+            errors.append(detail)
+        run.error = detail
+        run.projection = projection
+        run.save(update_fields=["error", "projection", "date_updated"])
+
+
+def _mark_command_version_conflicted(command_id: int) -> None:
+    database = router.db_for_write(InvestigationOrchestrationCommand)
+    with transaction.atomic(using=database):
+        command_snapshot = InvestigationOrchestrationCommand.objects.filter(id=command_id).first()
+        if command_snapshot is None:
+            return
+        run = _lock_orchestration_run(command_snapshot.orchestration_run_id)
+        if run is None:
+            return
+        command = (
+            InvestigationOrchestrationCommand.objects.select_for_update()
+            .filter(id=command_id)
+            .first()
+        )
+        if (
+            command is None
+            or command.status == InvestigationOrchestrationCommandStatus.ACKNOWLEDGED
+        ):
+            return
+        detail = {
+            "code": "seer_command_dispatch_failed",
+            "message": COMMAND_VERSION_CONFLICT_MESSAGE,
+            "requestId": str(command.request_id),
+            "commandType": command.type,
+            "reason": "workflow_version_conflict",
+            "retryable": False,
+        }
+        command.status = InvestigationOrchestrationCommandStatus.FAILED
+        command.error = detail
+        command.save(update_fields=["status", "error", "date_updated"])
+        InvestigationOrchestrationCommand.objects.filter(
+            orchestration_run=run,
+            id__gt=command.id,
+            status__in=(
+                InvestigationOrchestrationCommandStatus.ACCEPTED,
+                InvestigationOrchestrationCommandStatus.DISPATCHED,
+            ),
+        ).update(
+            status=InvestigationOrchestrationCommandStatus.FAILED,
+            error={
+                "code": "earlier_command_conflicted",
+                "message": "An earlier workflow update conflicted with Seer's current state.",
+            },
+            date_updated=timezone.now(),
+        )
+        projection = deepcopy(run.projection)
+        errors = projection.setdefault("errors", [])
+        if isinstance(errors, list):
+            projection["errors"] = [detail, *errors]
+        if run.error is None:
+            run.error = detail
+        run.projection = projection
+        run.save(update_fields=["error", "projection", "date_updated"])
+
+
+def _reconcile_command_version_conflict(
+    run: InvestigationOrchestrationRun,
+    command: InvestigationOrchestrationCommand,
+    viewer_context: SeerViewerContext,
+) -> None:
+    if run.seer_run_id is None:
+        raise SeerApiError("Investigation orchestration run is missing", 502)
+    response = get_investigation_orchestration_run(
+        run,
+        viewer_context=viewer_context,
+    )
+    response_run_id = response["runId"]
+    projection = response["projection"]
+    reconcile_orchestration_projection(
+        orchestration_run_id=run.id,
+        seer_run_id=response_run_id,
+        projection=projection,
+    )
+    _mark_command_version_conflicted(command.id)
+
+
+def _mark_command_dispatch_acknowledged(
+    orchestration_run_id: int,
+    command_id: int,
+) -> None:
+    database = router.db_for_write(InvestigationOrchestrationCommand)
+    with transaction.atomic(using=database):
+        run = _lock_orchestration_run(orchestration_run_id)
+        if run is None:
+            return
+        command = InvestigationOrchestrationCommand.objects.select_for_update().get(id=command_id)
+        recovered_dispatch_failure = (
+            command.status == InvestigationOrchestrationCommandStatus.FAILED
+            and isinstance(command.error, dict)
+            and command.error.get("code") == "seer_command_dispatch_failed"
+            and command.error.get("retryable") is True
+        )
+        command.status = InvestigationOrchestrationCommandStatus.ACKNOWLEDGED
+        command.error = None
+        command.save(update_fields=["status", "error", "date_updated"])
+        if recovered_dispatch_failure:
+            blocked_commands = list(
+                InvestigationOrchestrationCommand.objects.select_for_update()
+                .filter(
+                    orchestration_run=run,
+                    id__gt=command.id,
+                    status=InvestigationOrchestrationCommandStatus.FAILED,
+                )
+                .order_by("id")
+            )
+            now = timezone.now()
+            requeued_commands = []
+            for blocked_command in blocked_commands:
+                if (
+                    isinstance(blocked_command.error, dict)
+                    and blocked_command.error.get("code") == "earlier_command_failed"
+                ):
+                    blocked_command.status = InvestigationOrchestrationCommandStatus.ACCEPTED
+                    blocked_command.error = None
+                    blocked_command.date_updated = now
+                    requeued_commands.append(blocked_command)
+            if requeued_commands:
+                InvestigationOrchestrationCommand.objects.bulk_update(
+                    requeued_commands,
+                    ["status", "error", "date_updated"],
+                )
+        projection = deepcopy(run.projection)
+        errors = projection.get("errors")
+        if isinstance(errors, list):
+            projection["errors"] = [
+                item
+                for item in errors
+                if not (
+                    isinstance(item, dict)
+                    and item.get("code") == "seer_command_dispatch_failed"
+                    and item.get("requestId") == str(command.request_id)
+                )
+            ]
+        if (
+            isinstance(run.error, dict)
+            and run.error.get("code") == "seer_command_dispatch_failed"
+            and run.error.get("requestId") == str(command.request_id)
+        ):
+            run.error = None
+        run.projection = projection
+        run.save(update_fields=["error", "projection", "date_updated"])
+
+
+@instrumented_task(
+    name="sentry.tasks.seer.investigation.dispatch_investigation_orchestration_create",
+    namespace=seer_tasks,
+    retry=Retry(
+        times=ORCHESTRATION_DISPATCH_RETRIES,
+        delay=2,
+        on=(SeerApiError, HTTPError),
+    ),
+)
+def dispatch_investigation_orchestration_create(orchestration_run_id: int) -> None:
+    run = (
+        InvestigationOrchestrationRun.objects.select_related("investigation__organization")
+        .filter(id=orchestration_run_id)
+        .first()
+    )
+    if run is None:
+        return
+    if run.seer_run_id is not None:
+        dispatch_investigation_orchestration_commands.delay(run.id)
+        return
+    viewer_context = SeerViewerContext(organization_id=run.investigation.organization_id)
+    if run.investigation.created_by_id is not None:
+        viewer_context["user_id"] = run.investigation.created_by_id
+    try:
+        response = create_investigation_orchestration_run(run, viewer_context=viewer_context)
+        seer_run_id = response["runId"]
+        projection = response["projection"]
+        synchronize_orchestration_projection(
+            orchestration_run_id=run.id,
+            seer_run_id=seer_run_id,
+            projection=projection,
+        )
+    except (SeerApiError, HTTPError):
+        if _is_last_dispatch_attempt():
+            logger.exception("investigations.orchestration.create_dispatch_failed")
+            _mark_create_dispatch_failed(run.id)
+            return
+        raise
+    except serializers.ValidationError:
+        logger.exception("investigations.orchestration.create_response_invalid")
+        _mark_create_dispatch_failed(run.id)
+        return
+    dispatch_investigation_orchestration_commands.delay(run.id)
+
+
+@instrumented_task(
+    name="sentry.tasks.seer.investigation.dispatch_investigation_orchestration_commands",
+    namespace=seer_tasks,
+    retry=Retry(
+        times=ORCHESTRATION_DISPATCH_RETRIES,
+        delay=2,
+        on=(SeerApiError, HTTPError),
+    ),
+)
+def dispatch_investigation_orchestration_commands(orchestration_run_id: int) -> None:
+    run = (
+        InvestigationOrchestrationRun.objects.select_related("investigation__organization")
+        .filter(id=orchestration_run_id)
+        .first()
+    )
+    if run is None:
+        return
+    if run.seer_run_id is None:
+        dispatch_investigation_orchestration_create.delay(run.id)
+        return
+
+    while True:
+        command = (
+            InvestigationOrchestrationCommand.objects.select_related(
+                "orchestration_run__investigation__organization"
+            )
+            .filter(
+                orchestration_run=run,
+                status__in=(
+                    InvestigationOrchestrationCommandStatus.ACCEPTED,
+                    InvestigationOrchestrationCommandStatus.DISPATCHED,
+                ),
+            )
+            .order_by("id")
+            .first()
+        )
+        if command is None:
+            return
+        if command.status == InvestigationOrchestrationCommandStatus.ACCEPTED:
+            InvestigationOrchestrationCommand.objects.filter(
+                id=command.id,
+                status=InvestigationOrchestrationCommandStatus.ACCEPTED,
+            ).update(
+                status=InvestigationOrchestrationCommandStatus.DISPATCHED,
+                date_updated=timezone.now(),
+            )
+            command.status = InvestigationOrchestrationCommandStatus.DISPATCHED
+
+        viewer_context = SeerViewerContext(organization_id=run.investigation.organization_id)
+        if command.actor_id is not None:
+            viewer_context["user_id"] = command.actor_id
+        try:
+            response = dispatch_investigation_orchestration_command(
+                command,
+                viewer_context=viewer_context,
+            )
+            response_run_id = response["runId"]
+            projection = response["projection"]
+            if response.get("requestId") != str(command.request_id):
+                raise SeerApiError("Seer acknowledged a different command", 502)
+            synchronize_orchestration_projection(
+                orchestration_run_id=run.id,
+                seer_run_id=response_run_id,
+                projection=projection,
+            )
+        except SeerApiError as error:
+            if error.status == 409:
+                logger.warning(
+                    "investigations.orchestration.command_version_conflict",
+                    extra={
+                        "orchestration_run_id": run.id,
+                        "seer_run_id": run.seer_run_id,
+                        "command_id": command.id,
+                        "expected_workflow_version": command.expected_workflow_version,
+                    },
+                )
+                try:
+                    _reconcile_command_version_conflict(run, command, viewer_context)
+                except (SeerApiError, HTTPError):
+                    if _is_last_dispatch_attempt():
+                        logger.exception(
+                            "investigations.orchestration.command_conflict_reconciliation_failed"
+                        )
+                        _mark_command_dispatch_failed(command.id)
+                        return
+                    raise
+                except serializers.ValidationError:
+                    logger.exception(
+                        "investigations.orchestration.command_conflict_response_invalid"
+                    )
+                    _mark_command_dispatch_failed(command.id)
+                return
+            if _is_last_dispatch_attempt():
+                logger.exception("investigations.orchestration.command_dispatch_failed")
+                _mark_command_dispatch_failed(command.id)
+                return
+            raise
+        except HTTPError:
+            if _is_last_dispatch_attempt():
+                logger.exception("investigations.orchestration.command_dispatch_failed")
+                _mark_command_dispatch_failed(command.id)
+                return
+            raise
+        except serializers.ValidationError:
+            logger.exception("investigations.orchestration.command_response_invalid")
+            _mark_command_dispatch_failed(command.id)
+            return
+
+        _mark_command_dispatch_acknowledged(run.id, command.id)
 
 
 @instrumented_task(

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_details.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_details.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
+from unittest import mock
+
 from django.urls import reverse
 
 from sentry.investigations.models import (
     Investigation,
     InvestigationBlockExecutionStatus,
+    InvestigationOrchestrationCommand,
+    InvestigationOrchestrationCommandStatus,
     InvestigationProject,
     InvestigationSourceType,
     InvestigationStatus,
@@ -79,6 +83,8 @@ class OrganizationInvestigationDetailsTest(APITestCase):
             self.collection_url, data={"title": "Running investigation"}, format="json"
         ).data
         investigation = Investigation.objects.get(id=created["id"])
+        investigation.version += 3
+        investigation.save(update_fields=["version", "date_updated"])
         block = self.create_investigation_block(investigation=investigation, kind="text")
         self.create_investigation_block_execution(
             block=block,
@@ -105,6 +111,94 @@ class OrganizationInvestigationDetailsTest(APITestCase):
         assert response.data == {
             "detail": "Stop active block runs before archiving this investigation."
         }
+
+    def test_archiving_agentic_investigation_durably_queues_cancellation(self) -> None:
+        created = self.client.post(
+            self.collection_url,
+            data={"source": {"type": "manual", "seed": {}}},
+            format="json",
+        ).data
+        investigation = Investigation.objects.get(id=created["id"])
+        block = self.create_investigation_block(
+            investigation=investigation,
+            kind="text",
+            report_revision=1,
+            stable_agent_key="streaming-summary",
+        )
+        execution = self.create_investigation_block_execution(
+            block=block,
+            executor="code_mode",
+            status=InvestigationBlockExecutionStatus.RUNNING,
+            block_version=block.version,
+            input_snapshot={"projectIds": [self.project.id]},
+        )
+        investigation.version += 3
+        investigation.save(update_fields=["version", "date_updated"])
+
+        with mock.patch(
+            "sentry.investigations.services.orchestration.transaction.on_commit"
+        ) as schedule:
+            response = self.client.delete(
+                self.details_url(investigation),
+                data={"investigationVersion": created["version"]},
+                format="json",
+            )
+
+        assert response.status_code == 204
+        investigation.refresh_from_db()
+        assert investigation.status == InvestigationStatus.ARCHIVED
+        execution.refresh_from_db()
+        assert execution.status == InvestigationBlockExecutionStatus.CANCELLED
+        assert execution.error == {
+            "code": "investigation_archived",
+            "message": "The investigation was archived.",
+        }
+        command = InvestigationOrchestrationCommand.objects.get(
+            orchestration_run__investigation=investigation
+        )
+        assert command.type == "cancel"
+        assert command.payload == {"reason": "investigation_archived"}
+        assert command.status == InvestigationOrchestrationCommandStatus.ACCEPTED
+        run = investigation.orchestration_run
+        assert run.projection["_sentryControl"]["notebookWriteFenceGeneration"] == run.generation
+        schedule.assert_called_once()
+
+    def test_agentic_title_update_marks_a_manual_override(self) -> None:
+        created = self.client.post(
+            self.collection_url,
+            data={"source": {"type": "manual", "seed": {}}},
+            format="json",
+        ).data
+        investigation = Investigation.objects.get(id=created["id"])
+
+        response = self.client.put(
+            self.details_url(investigation),
+            data={
+                "investigationVersion": created["version"],
+                "title": "My incident title",
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200, response.data
+        run = investigation.orchestration_run
+        assert run.projection["_sentryControl"] == {
+            "manualTitleOverride": True,
+            "titleBuffer": "My incident title",
+            "titleStarted": True,
+        }
+
+        stale_response = self.client.put(
+            self.details_url(investigation),
+            data={
+                "investigationVersion": created["version"],
+                "title": "Overwrite from a stale editor",
+            },
+            format="json",
+        )
+        assert stale_response.status_code == 409
+        investigation.refresh_from_db()
+        assert investigation.title == "My incident title"
 
     def test_metadata_update_persists_and_stale_version_rolls_back(self) -> None:
         created = self.client.post(

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_details.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_details.py
@@ -13,8 +13,11 @@ from sentry.investigations.models import (
     InvestigationSourceType,
     InvestigationStatus,
 )
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import assume_test_silo_mode
+from sentry.utils.security.orgauthtoken_token import generate_token, hash_token
 
 FEATURE = "organizations:investigations"
 
@@ -77,6 +80,49 @@ class OrganizationInvestigationDetailsTest(APITestCase):
         )
         assert response.status_code == 200
         assert response.data["status"] == "active"
+
+    def test_org_token_can_archive_a_legacy_investigation(self) -> None:
+        investigation = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Legacy investigation"
+        )
+        token = generate_token(self.organization.slug, "")
+        self.create_org_auth_token(
+            organization_id=self.organization.id,
+            name="investigation token",
+            token_hashed=hash_token(token),
+            token_last_characters=token[-4:],
+            scope_list=["org:read"],
+        )
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.client.logout()
+
+        response = self.client.put(
+            self.details_url(investigation),
+            data={"investigationVersion": investigation.version, "status": "archived"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert response.status_code == 200, response.data
+        investigation.refresh_from_db()
+        assert investigation.status == InvestigationStatus.ARCHIVED
+
+        restored = self.client.put(
+            self.details_url(investigation),
+            data={"investigationVersion": investigation.version, "status": "active"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert restored.status_code == 200, restored.data
+        investigation.refresh_from_db()
+        deleted = self.client.delete(
+            self.details_url(investigation),
+            data={"investigationVersion": investigation.version},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert deleted.status_code == 204, deleted.data
+        investigation.refresh_from_db()
+        assert investigation.status == InvestigationStatus.ARCHIVED
 
     def test_archive_rejects_an_active_block_run(self) -> None:
         created = self.client.post(

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_details.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_details.py
@@ -209,6 +209,28 @@ class OrganizationInvestigationDetailsTest(APITestCase):
         assert run.projection["_sentryControl"]["notebookWriteFenceGeneration"] == run.generation
         schedule.assert_called_once()
 
+        restored = self.client.put(
+            self.details_url(investigation),
+            data={"investigationVersion": investigation.version, "status": "active"},
+            format="json",
+        )
+        assert restored.status_code == 200, restored.data
+        with mock.patch(
+            "sentry.tasks.seer.investigation.dispatch_investigation_orchestration_commands.delay"
+        ):
+            for _ in range(2):
+                archived = self.client.delete(
+                    self.details_url(investigation),
+                    data={"investigationVersion": created["version"]},
+                    format="json",
+                )
+                assert archived.status_code == 204, archived.data
+        investigation.refresh_from_db()
+        assert investigation.status == InvestigationStatus.ARCHIVED
+        assert list(
+            run.commands.order_by("id").values_list("expected_workflow_version", flat=True)
+        ) == [1, 2]
+
     def test_agentic_title_update_marks_a_manual_override(self) -> None:
         created = self.client.post(
             self.collection_url,

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
@@ -110,6 +110,19 @@ class OrganizationInvestigationIndexTest(APITestCase):
         assert run.projection["pendingInput"] is None
         assert run.projection["broadScan"]["status"] == "queued"
 
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_create.delay")
+    def test_agentic_creation_schedules_automatic_execution(self, dispatch: mock.Mock) -> None:
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                self.collection_url,
+                data={"source": {"type": "manual", "prompt": "Investigate latency"}},
+                format="json",
+            )
+
+        assert response.status_code == 201, response.data
+        run = InvestigationOrchestrationRun.objects.get(investigation_id=response.data["id"])
+        dispatch.assert_called_once_with(run.id)
+
     def test_agentic_creation_rejects_an_inaccessible_project_atomically(self) -> None:
         foreign_project = self.create_project(organization=self.create_organization())
 

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_orchestration.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_orchestration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any
+from unittest import mock
 from uuid import uuid4
 
 from django.urls import reverse
@@ -8,6 +9,7 @@ from django.utils import timezone
 
 from sentry.investigations.models import (
     Investigation,
+    InvestigationBlockExecutionStatus,
     InvestigationOrchestrationCommand,
     InvestigationOrchestrationCommandStatus,
     InvestigationOrchestrationRun,
@@ -182,16 +184,23 @@ class OrganizationInvestigationOrchestrationCommandsTest(APITestCase):
         body.update(overrides)
         return body
 
-    def test_accepts_a_command_and_advances_the_workflow_version(self) -> None:
+    @mock.patch(
+        "sentry.tasks.seer.investigation.dispatch_investigation_orchestration_commands.delay"
+    )
+    def test_accepts_a_command_and_advances_the_workflow_version(self, dispatch: mock.Mock) -> None:
         body = self.command()
 
-        response = self.client.post(self.command_url, data=body, format="json")
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(self.command_url, data=body, format="json")
 
         assert response.status_code == 200, response.data
+        dispatch.assert_called_once_with(self.orchestration_run.id)
         assert response.data["requestId"] == body["requestId"]
         assert response.data["accepted"] is True
         assert response.data["duplicate"] is False
         assert response.data["workflowVersion"] == 2
+        assert response.data["commandStatus"] == InvestigationOrchestrationCommandStatus.ACCEPTED
+        assert response.data["commandError"] is None
         assert response.data["projection"]["workflowVersion"] == 2
         stored = InvestigationOrchestrationCommand.objects.get(request_id=body["requestId"])
         assert stored.type == "add_hypothesis"
@@ -226,7 +235,54 @@ class OrganizationInvestigationOrchestrationCommandsTest(APITestCase):
         assert replay.status_code == 200, replay.data
         assert replay.data["duplicate"] is True
         assert replay.data["workflowVersion"] == 2
+        assert replay.data["commandStatus"] == InvestigationOrchestrationCommandStatus.ACCEPTED
+        assert replay.data["commandError"] is None
         assert InvestigationOrchestrationCommand.objects.count() == 1
+
+    def test_hypothesis_target_uses_wire_casing(self) -> None:
+        self.orchestration_run.update(
+            projection={**self.orchestration_run.projection, "hypotheses": [{"id": "h-1"}]}
+        )
+        body = self.command(
+            command={
+                "type": "steer",
+                "target": "hypothesis",
+                "targetId": "h-1",
+                "instruction": "Check the release",
+            }
+        )
+
+        response = self.client.post(self.command_url, data=body, format="json")
+
+        assert response.status_code == 200, response.data
+        stored = self.orchestration_run.commands.get()
+        assert stored.payload["targetId"] == "h-1"
+
+    def test_workflow_command_preserves_notebook_until_seer_clears_the_report(self) -> None:
+        block = self.create_investigation_block(
+            investigation=self.investigation,
+            kind="text",
+            report_revision=1,
+            stable_agent_key="summary",
+        )
+        execution = self.create_investigation_block_execution(
+            block=block,
+            executor="code_mode",
+            status=InvestigationBlockExecutionStatus.RUNNING,
+            block_version=block.version,
+        )
+
+        response = self.client.post(self.command_url, data=self.command(), format="json")
+
+        assert response.status_code == 200, response.data
+        assert response.data["projection"]["notebookRevision"] == 0
+        assert "_sentryControl" not in response.data["projection"]
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.notebook_revision == 0
+        block.refresh_from_db()
+        assert block.deleted_at is None
+        execution.refresh_from_db()
+        assert execution.status == InvestigationBlockExecutionStatus.RUNNING
 
     def test_reusing_a_request_id_for_a_different_command_conflicts(self) -> None:
         body = self.command()

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_orchestration.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_orchestration.py
@@ -258,6 +258,44 @@ class OrganizationInvestigationOrchestrationCommandsTest(APITestCase):
         stored = self.orchestration_run.commands.get()
         assert stored.payload["targetId"] == "h-1"
 
+    @mock.patch("sentry.investigations.services.orchestration.logger")
+    @mock.patch(
+        "sentry.tasks.seer.investigation.dispatch_investigation_orchestration_commands.delay"
+    )
+    def test_unknown_hypothesis_logs_identifiers_without_the_payload(
+        self, dispatch: mock.Mock, logger: mock.Mock
+    ) -> None:
+        body = self.command(
+            command={
+                "type": "steer",
+                "target": "hypothesis",
+                "targetId": "missing-hypothesis",
+                "instruction": "User-provided investigation context must not appear in logs",
+            }
+        )
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(self.command_url, data=body, format="json")
+
+        assert response.status_code == 400
+        assert response.data == {"detail": "Hypothesis was not found."}
+        assert logger.mock_calls == [
+            mock.call.info(
+                "investigation.orchestration.command.invalid_hypothesis",
+                extra={
+                    "investigation_id": self.investigation.id,
+                    "orchestration_run_id": self.orchestration_run.id,
+                    "request_id": body["requestId"],
+                    "command_type": "steer",
+                    "hypothesis_id": "missing-hypothesis",
+                },
+            )
+        ]
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 1
+        assert not self.orchestration_run.commands.exists()
+        dispatch.assert_not_called()
+
     def test_workflow_command_preserves_notebook_until_seer_clears_the_report(self) -> None:
         block = self.create_investigation_block(
             investigation=self.investigation,

--- a/tests/sentry/investigations/services/test_auto_run.py
+++ b/tests/sentry/investigations/services/test_auto_run.py
@@ -18,6 +18,7 @@ from sentry.investigations.models import (
 )
 from sentry.investigations.services.auto_run import schedule_eligible_auto_run_blocks
 from sentry.investigations.services.orchestration import accept_orchestration_command
+from sentry.investigations.services.orchestration_events import deliver_orchestration_event
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRunMirrorStatus, SeerRunType
 from sentry.tasks.seer.investigation import (
@@ -712,6 +713,83 @@ class InvestigationOrchestrationDispatchTest(TestCase):
         command.refresh_from_db()
         assert command.status == InvestigationOrchestrationCommandStatus.FAILED
         schedule.assert_not_called()
+
+    @mock.patch("sentry.tasks.seer.investigation.current_task")
+    @mock.patch("sentry.tasks.seer.investigation.get_investigation_orchestration_run")
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_command")
+    def test_command_conflict_retries_after_a_callback_during_recovery(
+        self,
+        dispatch: mock.Mock,
+        get_run: mock.Mock,
+        current_task: mock.Mock,
+    ) -> None:
+        self.orchestration_run.update(
+            seer_run_id=self.seer_run_id,
+            workflow_version=2,
+            projection=self.projection(workflow_version=2),
+        )
+        command = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=1,
+            resulting_workflow_version=2,
+            type="add_hypothesis",
+            payload={"statement": "A release caused this"},
+        )
+        latest_projection = self.projection(
+            workflow_version=3, phase="completed", status="completed"
+        )
+
+        def get_with_callback(*args: Any, **kwargs: Any) -> dict[str, Any]:
+            deliver_orchestration_event(
+                organization_id=self.organization.id,
+                event={
+                    "schema_version": 1,
+                    "event_id": uuid4(),
+                    "run_id": self.seer_run_id,
+                    "investigation_id": self.investigation.id,
+                    "sequence": 1,
+                    "generation": 1,
+                    "type": "workflow_updated",
+                    "payload": {"projection": latest_projection},
+                },
+            )
+            return {
+                "runId": self.seer_run_id,
+                "created": False,
+                "projection": self.projection(workflow_version=1),
+            }
+
+        dispatch.side_effect = SeerApiError("conflict", 409)
+        get_run.side_effect = get_with_callback
+        current_task.return_value = SimpleNamespace(retries_remaining=True)
+
+        with pytest.raises(SeerApiError, match="Investigation changed while reconciling"):
+            dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+
+        self.orchestration_run.refresh_from_db()
+        command.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 3
+        assert self.orchestration_run.status == "completed"
+        assert self.orchestration_run.last_event_sequence == 1
+        assert command.status == InvestigationOrchestrationCommandStatus.DISPATCHED
+
+        get_run.side_effect = None
+        get_run.return_value = {
+            "runId": self.seer_run_id,
+            "created": False,
+            "projection": latest_projection,
+        }
+        dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+
+        self.orchestration_run.refresh_from_db()
+        command.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 3
+        assert self.orchestration_run.status == "completed"
+        assert self.orchestration_run.last_event_sequence == 1
+        assert command.status == InvestigationOrchestrationCommandStatus.FAILED
+        assert command.error["reason"] == "workflow_version_conflict"
 
     @mock.patch("sentry.tasks.seer.investigation.current_task")
     @mock.patch("sentry.tasks.seer.investigation.create_investigation_orchestration_run")

--- a/tests/sentry/investigations/services/test_auto_run.py
+++ b/tests/sentry/investigations/services/test_auto_run.py
@@ -7,6 +7,7 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
+from django.db import router, transaction
 from django.utils import timezone
 
 from sentry.investigations.models import (
@@ -15,14 +16,19 @@ from sentry.investigations.models import (
     InvestigationBlockExecutionStatus,
     InvestigationBlockKind,
     InvestigationOrchestrationCommandStatus,
+    InvestigationOrchestrationRun,
 )
 from sentry.investigations.services.auto_run import schedule_eligible_auto_run_blocks
-from sentry.investigations.services.orchestration import accept_orchestration_command
+from sentry.investigations.services.orchestration import (
+    accept_orchestration_command,
+    create_agentic_manual_investigation,
+)
 from sentry.investigations.services.orchestration_events import deliver_orchestration_event
 from sentry.seer.models import SeerApiError
 from sentry.seer.models.run import SeerRunMirrorStatus, SeerRunType
 from sentry.tasks.seer.investigation import (
     _mark_command_dispatch_failed,
+    _reconcile_command_version_conflict,
     dispatch_investigation_execution,
     dispatch_investigation_orchestration_commands,
     dispatch_investigation_orchestration_create,
@@ -309,6 +315,37 @@ class InvestigationOrchestrationDispatchTest(TestCase):
             "errors": [],
             "heartbeatAt": "2025-01-01T00:00:00+00:00",
         }
+
+    @mock.patch(
+        "sentry.tasks.seer.investigation.dispatch_investigation_orchestration_commands.delay"
+    )
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_create.delay")
+    def test_creation_and_commands_dispatch_only_after_commit(
+        self, dispatch_create: mock.Mock, dispatch_commands: mock.Mock
+    ) -> None:
+        with transaction.atomic(using=router.db_for_write(InvestigationOrchestrationRun)):
+            investigation, run = create_agentic_manual_investigation(
+                organization=self.organization,
+                user_id=self.user.id,
+                title=None,
+                source={"type": "manual", "prompt": "Investigate latency"},
+                project_ids=[],
+                filters={},
+            )
+            dispatch_create.assert_not_called()
+        dispatch_create.assert_called_once_with(run.id)
+
+        with transaction.atomic(using=router.db_for_write(InvestigationOrchestrationRun)):
+            accept_orchestration_command(
+                investigation=investigation,
+                request_id=uuid4(),
+                expected_workflow_version=1,
+                command_type="add_hypothesis",
+                payload={"statement": "A release caused this"},
+                actor_id=self.user.id,
+            )
+            dispatch_commands.assert_not_called()
+        dispatch_commands.assert_called_once_with(run.id)
 
     @mock.patch(
         "sentry.tasks.seer.investigation.dispatch_investigation_orchestration_commands.delay"
@@ -714,6 +751,49 @@ class InvestigationOrchestrationDispatchTest(TestCase):
         assert command.status == InvestigationOrchestrationCommandStatus.FAILED
         schedule.assert_not_called()
 
+    @mock.patch("sentry.tasks.seer.investigation._mark_command_version_conflicted")
+    @mock.patch("sentry.tasks.seer.investigation.get_investigation_orchestration_run")
+    def test_conflict_reconciliation_and_stale_queue_update_are_atomic(
+        self, get_run: mock.Mock, mark_conflicted: mock.Mock
+    ) -> None:
+        self.orchestration_run.update(
+            seer_run=self.create_seer_run(
+                organization=self.organization,
+                type=SeerRunType.INVESTIGATION,
+                seer_run_state_id=self.seer_run_id,
+                mirror_status=SeerRunMirrorStatus.LIVE,
+            ),
+            workflow_version=2,
+            projection=self.projection(workflow_version=2),
+        )
+        command = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=1,
+            resulting_workflow_version=2,
+            type="add_hypothesis",
+            payload={"statement": "A release caused this"},
+        )
+        get_run.return_value = {
+            "runId": self.seer_run_id,
+            "projection": self.projection(workflow_version=1),
+        }
+        mark_conflicted.side_effect = RuntimeError("Stale command update failed")
+
+        with pytest.raises(RuntimeError, match="Stale command update failed"):
+            _reconcile_command_version_conflict(
+                self.orchestration_run,
+                command,
+                {"organization_id": self.organization.id, "user_id": self.user.id},
+            )
+
+        self.orchestration_run.refresh_from_db()
+        command.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 2
+        assert self.orchestration_run.projection["workflowVersion"] == 2
+        assert command.status == InvestigationOrchestrationCommandStatus.ACCEPTED
+
     @mock.patch("sentry.tasks.seer.investigation.current_task")
     @mock.patch("sentry.tasks.seer.investigation.get_investigation_orchestration_run")
     @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_command")
@@ -724,7 +804,12 @@ class InvestigationOrchestrationDispatchTest(TestCase):
         current_task: mock.Mock,
     ) -> None:
         self.orchestration_run.update(
-            seer_run_id=self.seer_run_id,
+            seer_run=self.create_seer_run(
+                organization=self.organization,
+                type=SeerRunType.INVESTIGATION,
+                seer_run_state_id=self.seer_run_id,
+                mirror_status=SeerRunMirrorStatus.LIVE,
+            ),
             workflow_version=2,
             projection=self.projection(workflow_version=2),
         )

--- a/tests/sentry/investigations/services/test_auto_run.py
+++ b/tests/sentry/investigations/services/test_auto_run.py
@@ -1,8 +1,12 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from types import SimpleNamespace
+from typing import Any
 from unittest import mock
+from uuid import uuid4
 
+import pytest
 from django.utils import timezone
 
 from sentry.investigations.models import (
@@ -10,9 +14,18 @@ from sentry.investigations.models import (
     InvestigationBlockExecution,
     InvestigationBlockExecutionStatus,
     InvestigationBlockKind,
+    InvestigationOrchestrationCommandStatus,
 )
 from sentry.investigations.services.auto_run import schedule_eligible_auto_run_blocks
-from sentry.tasks.seer.investigation import dispatch_investigation_execution
+from sentry.investigations.services.orchestration import accept_orchestration_command
+from sentry.seer.models import SeerApiError
+from sentry.seer.models.run import SeerRunMirrorStatus, SeerRunType
+from sentry.tasks.seer.investigation import (
+    _mark_command_dispatch_failed,
+    dispatch_investigation_execution,
+    dispatch_investigation_orchestration_commands,
+    dispatch_investigation_orchestration_create,
+)
 from sentry.testutils.cases import TestCase
 
 
@@ -236,3 +249,503 @@ class InvestigationAutoRunTest(TestCase):
             failed_execution, reason="dispatch_failed", seer_run_id=None
         )
         start_run.assert_called_once()
+
+
+class InvestigationOrchestrationDispatchTest(TestCase):
+    seer_run_id = 8128
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.investigation = self.create_investigation(
+            organization=self.organization,
+            created_by=self.user,
+            source={"type": "manual"},
+        )
+        self.orchestration_run = self.create_investigation_orchestration_run(
+            investigation=self.investigation,
+            source={
+                "type": "manual",
+                "prompt": "Investigate checkout latency",
+                "timeRange": {
+                    "start": "2025-01-01T00:00:00+00:00",
+                    "end": "2025-01-01T01:00:00+00:00",
+                },
+            },
+            projection=self.projection(workflow_version=1),
+        )
+
+    def projection(
+        self,
+        *,
+        workflow_version: int,
+        generation: int = 1,
+        phase: str = "broad_scan",
+        status: str = "processing",
+    ) -> dict[str, Any]:
+        return {
+            "runId": self.seer_run_id,
+            "investigationId": str(self.investigation.id),
+            "sourceType": "manual",
+            "workflowVersion": workflow_version,
+            "generation": generation,
+            "phase": phase,
+            "status": status,
+            "broadScan": {"status": "running"},
+            "hypotheses": [],
+            "report": {
+                "revision": 0,
+                "status": "not_started",
+                "notebookRevision": 0,
+                "metadata": {
+                    "status": "not_started",
+                    "title": None,
+                    "summary": None,
+                    "summaryDescription": None,
+                    "error": None,
+                },
+            },
+            "pendingInput": None,
+            "errors": [],
+            "heartbeatAt": "2025-01-01T00:00:00+00:00",
+        }
+
+    @mock.patch(
+        "sentry.tasks.seer.investigation.dispatch_investigation_orchestration_commands.delay"
+    )
+    @mock.patch("sentry.tasks.seer.investigation.create_investigation_orchestration_run")
+    def test_create_dispatch_persists_projection_and_starts_commands(
+        self,
+        create_run: mock.Mock,
+        dispatch_commands: mock.Mock,
+    ) -> None:
+        create_run.return_value = {
+            "runId": self.seer_run_id,
+            "projection": self.projection(workflow_version=1),
+        }
+
+        dispatch_investigation_orchestration_create(self.orchestration_run.id)
+
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.seer_run is not None
+        assert self.orchestration_run.seer_run.seer_run_state_id == self.seer_run_id
+        assert self.orchestration_run.phase == "broad_scan"
+        assert self.orchestration_run.status == "processing"
+        assert create_run.call_args.kwargs["viewer_context"] == {
+            "organization_id": self.organization.id,
+            "user_id": self.user.id,
+        }
+        dispatch_commands.assert_called_once_with(self.orchestration_run.id)
+
+    @mock.patch("sentry.tasks.seer.investigation.current_task")
+    @mock.patch("sentry.tasks.seer.investigation.create_investigation_orchestration_run")
+    def test_create_dispatch_retries_then_persists_retryable_failure(
+        self,
+        create_run: mock.Mock,
+        current_task: mock.Mock,
+    ) -> None:
+        create_run.side_effect = SeerApiError("unavailable: secret=do-not-expose", 503)
+        current_task.return_value = SimpleNamespace(retries_remaining=True)
+
+        with pytest.raises(SeerApiError):
+            dispatch_investigation_orchestration_create(self.orchestration_run.id)
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.status == "pending"
+
+        current_task.return_value = SimpleNamespace(retries_remaining=False)
+        dispatch_investigation_orchestration_create(self.orchestration_run.id)
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.status == "failed"
+        assert self.orchestration_run.error == {
+            "code": "seer_dispatch_failed",
+            "message": "Unable to start this investigation. Try again.",
+            "retryable": True,
+        }
+        assert "do-not-expose" not in str(self.orchestration_run.projection)
+
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_command")
+    def test_command_dispatch_acknowledges_in_order(self, dispatch: mock.Mock) -> None:
+        self.orchestration_run.seer_run = self.create_seer_run(
+            organization=self.organization,
+            type=SeerRunType.INVESTIGATION,
+            seer_run_state_id=self.seer_run_id,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+        )
+        self.orchestration_run.workflow_version = 3
+        self.orchestration_run.projection = self.projection(workflow_version=3)
+        self.orchestration_run.save()
+        first = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=1,
+            resulting_workflow_version=2,
+            type="add_hypothesis",
+            payload={"statement": "A release caused this"},
+        )
+        second = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=2,
+            resulting_workflow_version=3,
+            type="cancel",
+            payload={},
+        )
+        dispatch.side_effect = [
+            {
+                "runId": self.seer_run_id,
+                "requestId": str(first.request_id),
+                "projection": self.projection(workflow_version=2),
+            },
+            {
+                "runId": self.seer_run_id,
+                "requestId": str(second.request_id),
+                "projection": self.projection(workflow_version=3),
+            },
+        ]
+
+        dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.status == InvestigationOrchestrationCommandStatus.ACKNOWLEDGED
+        assert second.status == InvestigationOrchestrationCommandStatus.ACKNOWLEDGED
+        assert [call.args[0].id for call in dispatch.call_args_list] == [first.id, second.id]
+        assert dispatch.call_args.kwargs["viewer_context"] == {
+            "organization_id": self.organization.id,
+            "user_id": self.user.id,
+        }
+
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_create.delay")
+    def test_command_dispatch_repairs_a_missing_parent_run(
+        self, dispatch_create: mock.Mock
+    ) -> None:
+        command = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=1,
+            resulting_workflow_version=2,
+            type="provide_input",
+            payload={"prompt": "Investigate checkout latency"},
+        )
+
+        dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+
+        command.refresh_from_db()
+        assert command.status == InvestigationOrchestrationCommandStatus.ACCEPTED
+        dispatch_create.assert_called_once_with(self.orchestration_run.id)
+
+    @mock.patch("sentry.tasks.seer.investigation.current_task")
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_command")
+    def test_failed_command_can_redeliver_the_same_idempotent_request(
+        self,
+        dispatch: mock.Mock,
+        current_task: mock.Mock,
+    ) -> None:
+        self.orchestration_run.seer_run = self.create_seer_run(
+            organization=self.organization,
+            type=SeerRunType.INVESTIGATION,
+            seer_run_state_id=self.seer_run_id,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+        )
+        self.orchestration_run.workflow_version = 2
+        self.orchestration_run.projection = self.projection(workflow_version=2)
+        self.orchestration_run.save()
+        request_id = uuid4()
+        command = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=request_id,
+            actor_id=self.user.id,
+            expected_workflow_version=1,
+            resulting_workflow_version=2,
+            type="add_hypothesis",
+            payload={"statement": "A release caused this"},
+        )
+        current_task.return_value = SimpleNamespace(retries_remaining=False)
+        dispatch.side_effect = SeerApiError("unavailable: token=do-not-expose", 503)
+
+        dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+
+        command.refresh_from_db()
+        self.orchestration_run.refresh_from_db()
+        assert command.status == InvestigationOrchestrationCommandStatus.FAILED
+        assert self.orchestration_run.error == {
+            "code": "seer_command_dispatch_failed",
+            "message": "Unable to deliver this investigation command. Try again.",
+            "requestId": str(request_id),
+            "commandType": "add_hypothesis",
+            "retryable": True,
+        }
+        assert "do-not-expose" not in str(self.orchestration_run.projection)
+
+        with mock.patch(
+            "sentry.investigations.services.orchestration.transaction.on_commit"
+        ) as schedule:
+            accepted = accept_orchestration_command(
+                investigation=self.investigation,
+                request_id=request_id,
+                expected_workflow_version=1,
+                command_type="add_hypothesis",
+                payload={"statement": "A release caused this"},
+                actor_id=self.user.id,
+            )
+        assert accepted.duplicate is True
+        assert accepted.status == InvestigationOrchestrationCommandStatus.ACCEPTED
+        assert accepted.error is None
+        command.refresh_from_db()
+        assert command.status == InvestigationOrchestrationCommandStatus.ACCEPTED
+        schedule.assert_called_once()
+
+        dispatch.side_effect = None
+        dispatch.return_value = {
+            "runId": self.seer_run_id,
+            "requestId": str(request_id),
+            "projection": self.projection(workflow_version=2),
+        }
+        dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+        command.refresh_from_db()
+        self.orchestration_run.refresh_from_db()
+        assert command.status == InvestigationOrchestrationCommandStatus.ACKNOWLEDGED
+        assert self.orchestration_run.error is None
+        assert self.orchestration_run.projection["errors"] == []
+
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_command")
+    def test_late_success_recovers_commands_blocked_by_a_dispatch_failure(
+        self,
+        dispatch: mock.Mock,
+    ) -> None:
+        self.orchestration_run.seer_run = self.create_seer_run(
+            organization=self.organization,
+            type=SeerRunType.INVESTIGATION,
+            seer_run_state_id=self.seer_run_id,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+        )
+        self.orchestration_run.workflow_version = 3
+        self.orchestration_run.projection = self.projection(workflow_version=3)
+        self.orchestration_run.save()
+        first = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=1,
+            resulting_workflow_version=2,
+            type="add_hypothesis",
+            payload={"statement": "A release caused this"},
+        )
+        second = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=2,
+            resulting_workflow_version=3,
+            type="cancel",
+            payload={},
+        )
+
+        def dispatch_with_racing_failure(command: Any, **kwargs: Any) -> dict[str, Any]:
+            if command.id == first.id:
+                _mark_command_dispatch_failed(first.id)
+            return {
+                "runId": self.seer_run_id,
+                "requestId": str(command.request_id),
+                "projection": self.projection(workflow_version=command.resulting_workflow_version),
+            }
+
+        dispatch.side_effect = dispatch_with_racing_failure
+        dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+
+        first.refresh_from_db()
+        second.refresh_from_db()
+        assert first.status == InvestigationOrchestrationCommandStatus.ACKNOWLEDGED
+        assert second.status == InvestigationOrchestrationCommandStatus.ACKNOWLEDGED
+        assert second.error is None
+        assert [call.args[0].id for call in dispatch.call_args_list] == [first.id, second.id]
+
+    @mock.patch("sentry.tasks.seer.investigation.current_task")
+    @mock.patch("sentry.tasks.seer.investigation.get_investigation_orchestration_run")
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_command")
+    def test_command_conflict_reconciliation_retries_then_persists_failure(
+        self,
+        dispatch: mock.Mock,
+        get_run: mock.Mock,
+        current_task: mock.Mock,
+    ) -> None:
+        self.orchestration_run.seer_run = self.create_seer_run(
+            organization=self.organization,
+            type=SeerRunType.INVESTIGATION,
+            seer_run_state_id=self.seer_run_id,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+        )
+        self.orchestration_run.workflow_version = 2
+        self.orchestration_run.projection = self.projection(workflow_version=2)
+        self.orchestration_run.save()
+        command = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=1,
+            resulting_workflow_version=2,
+            type="add_hypothesis",
+            payload={"statement": "A release caused this"},
+        )
+        dispatch.side_effect = SeerApiError("conflict", 409)
+        get_run.side_effect = SeerApiError("unavailable", 503)
+        current_task.return_value = SimpleNamespace(retries_remaining=True)
+
+        with pytest.raises(SeerApiError):
+            dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+        command.refresh_from_db()
+        assert command.status == InvestigationOrchestrationCommandStatus.DISPATCHED
+
+        current_task.return_value = SimpleNamespace(retries_remaining=False)
+        dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+
+        command.refresh_from_db()
+        assert command.status == InvestigationOrchestrationCommandStatus.FAILED
+        assert command.error["code"] == "seer_command_dispatch_failed"
+        assert command.error["retryable"] is True
+
+    @mock.patch("sentry.tasks.seer.investigation.get_investigation_orchestration_run")
+    @mock.patch("sentry.tasks.seer.investigation.dispatch_investigation_orchestration_command")
+    def test_command_version_conflict_reconciles_and_fails_stale_queue(
+        self,
+        dispatch: mock.Mock,
+        get_run: mock.Mock,
+    ) -> None:
+        self.orchestration_run.seer_run = self.create_seer_run(
+            organization=self.organization,
+            type=SeerRunType.INVESTIGATION,
+            seer_run_state_id=self.seer_run_id,
+            mirror_status=SeerRunMirrorStatus.LIVE,
+        )
+        self.orchestration_run.workflow_version = 12
+        self.orchestration_run.generation = 3
+        self.orchestration_run.projection = self.projection(
+            workflow_version=12,
+            generation=3,
+            phase="intake",
+            status="awaiting_input",
+        )
+        self.orchestration_run.save()
+        request_id = uuid4()
+        command = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=request_id,
+            actor_id=self.user.id,
+            expected_workflow_version=2,
+            resulting_workflow_version=3,
+            type="provide_input",
+            payload={"prompt": "Investigate checkout latency"},
+        )
+        later_command = self.create_investigation_orchestration_command(
+            orchestration_run=self.orchestration_run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=3,
+            resulting_workflow_version=4,
+            type="add_hypothesis",
+            payload={"statement": "A release caused this"},
+        )
+        dispatch.side_effect = SeerApiError("conflict", 409)
+        authoritative_error = {
+            "code": "broad_scan_failed",
+            "message": "The broad investigation failed.",
+            "retryable": True,
+        }
+        authoritative_projection = {
+            **self.projection(
+                workflow_version=7,
+                generation=2,
+                phase="failed",
+                status="failed",
+            ),
+            "broadScan": {"status": "failed", "error": authoritative_error},
+            "errors": [authoritative_error],
+            "error": authoritative_error,
+        }
+        get_run.return_value = {
+            "runId": self.seer_run_id,
+            "created": False,
+            "projection": authoritative_projection,
+        }
+
+        dispatch_investigation_orchestration_commands(self.orchestration_run.id)
+
+        self.orchestration_run.refresh_from_db()
+        command.refresh_from_db()
+        later_command.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 7
+        assert self.orchestration_run.generation == 2
+        assert self.orchestration_run.phase == "failed"
+        assert self.orchestration_run.status == "failed"
+        assert self.orchestration_run.error == authoritative_error
+        assert command.status == InvestigationOrchestrationCommandStatus.FAILED
+        assert command.error == {
+            "code": "seer_command_dispatch_failed",
+            "message": (
+                "The investigation changed before this update could be applied. "
+                "Progress was refreshed; try again."
+            ),
+            "requestId": str(request_id),
+            "commandType": "provide_input",
+            "reason": "workflow_version_conflict",
+            "retryable": False,
+        }
+        assert later_command.status == InvestigationOrchestrationCommandStatus.FAILED
+        assert later_command.error["code"] == "earlier_command_conflicted"
+
+        with mock.patch(
+            "sentry.investigations.services.orchestration.transaction.on_commit"
+        ) as schedule:
+            accepted = accept_orchestration_command(
+                investigation=self.investigation,
+                request_id=request_id,
+                expected_workflow_version=2,
+                command_type="provide_input",
+                payload={"prompt": "Investigate checkout latency"},
+                actor_id=self.user.id,
+            )
+        assert accepted.duplicate is True
+        assert accepted.status == InvestigationOrchestrationCommandStatus.FAILED
+        assert accepted.error == command.error
+        command.refresh_from_db()
+        assert command.status == InvestigationOrchestrationCommandStatus.FAILED
+        schedule.assert_not_called()
+
+    @mock.patch("sentry.tasks.seer.investigation.current_task")
+    @mock.patch("sentry.tasks.seer.investigation.create_investigation_orchestration_run")
+    def test_retry_run_recovers_an_initial_create_failure_without_version_drift(
+        self,
+        create_run: mock.Mock,
+        current_task: mock.Mock,
+    ) -> None:
+        create_run.side_effect = SeerApiError("unavailable", 503)
+        current_task.return_value = SimpleNamespace(retries_remaining=False)
+        dispatch_investigation_orchestration_create(self.orchestration_run.id)
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.status == "failed"
+
+        request_id = uuid4()
+        with mock.patch(
+            "sentry.investigations.services.orchestration.transaction.on_commit"
+        ) as schedule:
+            accepted = accept_orchestration_command(
+                investigation=self.investigation,
+                request_id=request_id,
+                expected_workflow_version=1,
+                command_type="retry",
+                payload={"target": "run"},
+                actor_id=self.user.id,
+            )
+
+        assert accepted.workflow_version == 1
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 1
+        assert self.orchestration_run.phase == "broad_scan"
+        assert self.orchestration_run.status == "pending"
+        assert self.orchestration_run.error is None
+        command = self.orchestration_run.commands.get(request_id=request_id)
+        assert command.status == InvestigationOrchestrationCommandStatus.ACKNOWLEDGED
+        assert command.resulting_workflow_version == 1
+        schedule.assert_called_once()

--- a/tests/sentry/investigations/services/test_orchestration_events.py
+++ b/tests/sentry/investigations/services/test_orchestration_events.py
@@ -24,6 +24,7 @@ from sentry.investigations.models import (
     InvestigationOrchestrationPhase,
     InvestigationOrchestrationRun,
     InvestigationOrchestrationStatus,
+    InvestigationStatus,
 )
 from sentry.investigations.services.investigations import (
     archive_investigation,
@@ -31,7 +32,9 @@ from sentry.investigations.services.investigations import (
 )
 from sentry.investigations.services.orchestration import (
     accept_orchestration_command,
+    archive_investigation_with_orchestration,
     create_agentic_manual_investigation,
+    update_investigation_with_orchestration,
 )
 from sentry.investigations.services.orchestration_events import (
     MAX_ORCHESTRATION_EVENT_BYTES,
@@ -877,6 +880,12 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
             generation=3,
             phase="investigating",
         )
+        block = self.create_investigation_block(
+            investigation=self.investigation,
+            kind="text",
+            report_revision=1,
+            stable_agent_key="stale-summary",
+        )
 
         reconcile_orchestration_projection(
             orchestration_run_id=self.orchestration_run.id,
@@ -887,14 +896,132 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
                 workflow_version=2,
                 generation=2,
                 phase="planning",
+                report_revision=2,
+                clear_intent={
+                    "id": "clear-report-2",
+                    "revision": 2,
+                    "reason": "workflow_changed",
+                    "requestedAt": "2025-01-01T00:00:00+00:00",
+                    "completed": True,
+                },
             ),
         )
 
         self.orchestration_run.refresh_from_db()
+        block.refresh_from_db()
         assert self.orchestration_run.workflow_version == 2
         assert self.orchestration_run.generation == 2
         assert self.orchestration_run.phase == "planning"
         assert self.orchestration_run.last_event_sequence == 0
+        assert self.orchestration_run.notebook_revision == 1
+        assert block.deleted_at is not None
+
+    def test_manual_title_override_survives_generated_title_events(self) -> None:
+        self.investigation.title = "My incident title"
+        self.investigation.save(update_fields=["title", "date_updated"])
+        projection = self.orchestration_run.projection
+        projection["_sentryControl"] = {
+            "manualTitleOverride": True,
+            "titleBuffer": "My incident title",
+            "titleStarted": True,
+        }
+        self.orchestration_run.projection = projection
+        self.orchestration_run.save(update_fields=["projection", "date_updated"])
+
+        self.deliver(self.event(1, "report_clear", {"reportRevision": 1}))
+        self.deliver(
+            self.event(
+                2,
+                "title_delta",
+                {"reportRevision": 1, "delta": "Generated title", "reset": True},
+            )
+        )
+        self.deliver(
+            self.event(
+                3,
+                "metadata_completed",
+                {
+                    "reportRevision": 1,
+                    "title": "Final generated title",
+                    "summary": "Root cause found",
+                    "summaryDescription": "A release changed routing.",
+                },
+            )
+        )
+
+        self.investigation.refresh_from_db()
+        self.orchestration_run.refresh_from_db()
+        assert self.investigation.title == "My incident title"
+        assert self.investigation.summary == "Root cause found"
+        assert self.orchestration_run.projection["report"]["metadata"]["title"] == (
+            "My incident title"
+        )
+
+    def test_archive_generation_fence_survives_restore_until_a_new_generation(self) -> None:
+        block = self.create_investigation_block(
+            investigation=self.investigation,
+            kind="text",
+            report_revision=1,
+            stable_agent_key="preserved-summary",
+        )
+        archived = archive_investigation_with_orchestration(
+            investigation=self.investigation,
+            expected_version=self.investigation.version,
+            actor_id=self.user.id,
+        )
+        assert archived.status == InvestigationStatus.ARCHIVED
+        delayed_projection = self.projection(
+            workflow_version=2,
+            generation=1,
+            report_revision=2,
+        )
+        synchronize_orchestration_projection(
+            orchestration_run_id=self.orchestration_run.id,
+            seer_run_id=self.seer_run_id,
+            projection=delayed_projection,
+        )
+        block.refresh_from_db()
+        assert block.deleted_at is None
+        assert block.report_revision == 1
+        restored = update_investigation_with_orchestration(
+            investigation=archived,
+            expected_version=archived.version,
+            fields={"status": InvestigationStatus.ACTIVE},
+            project_ids=None,
+        )
+        assert restored.status == InvestigationStatus.ACTIVE
+        synchronize_orchestration_projection(
+            orchestration_run_id=self.orchestration_run.id,
+            seer_run_id=self.seer_run_id,
+            projection=delayed_projection,
+        )
+        block.refresh_from_db()
+        assert block.deleted_at is None
+        assert block.report_revision == 1
+
+        fenced = self.deliver(self.event(1, "report_clear", {"reportRevision": 1}, generation=1))
+        assert fenced.application_status == InvestigationOrchestrationEventStatus.IGNORED
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.notebook_revision == 0
+
+        self.deliver(
+            self.event(
+                2,
+                "workflow_updated",
+                {
+                    "projection": self.projection(
+                        workflow_version=2,
+                        generation=2,
+                    )
+                },
+                generation=2,
+            )
+        )
+        accepted = self.deliver(self.event(3, "report_clear", {"reportRevision": 1}, generation=2))
+
+        assert accepted.application_status == InvestigationOrchestrationEventStatus.APPLIED
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.notebook_revision == 1
 
     def test_text_and_title_stream_resets_replace_stale_content(self) -> None:
         manual = self.create_investigation_block(

--- a/tests/sentry/investigations/services/test_orchestration_events.py
+++ b/tests/sentry/investigations/services/test_orchestration_events.py
@@ -27,6 +27,7 @@ from sentry.investigations.models import (
     InvestigationStatus,
 )
 from sentry.investigations.services.investigations import (
+    InvestigationConflictError,
     archive_investigation,
     update_investigation,
 )
@@ -956,6 +957,29 @@ class InvestigationOrchestrationEventTest(SeerRunMirrorMixin, TestCase):
         assert self.orchestration_run.projection["report"]["metadata"]["title"] == (
             "My incident title"
         )
+
+    def test_first_title_edit_cannot_race_with_archiving(self) -> None:
+        original_title = self.investigation.title
+        original_version = self.investigation.version
+        archive_investigation_with_orchestration(
+            investigation=self.investigation,
+            expected_version=original_version,
+            actor_id=self.user.id,
+        )
+
+        with pytest.raises(InvestigationConflictError):
+            update_investigation_with_orchestration(
+                investigation=self.investigation,
+                expected_version=original_version,
+                fields={"title": "A late title edit"},
+                project_ids=None,
+            )
+
+        self.investigation.refresh_from_db()
+        self.orchestration_run.refresh_from_db()
+        assert self.investigation.status == InvestigationStatus.ARCHIVED
+        assert self.investigation.title == original_title
+        assert not self.orchestration_run.projection["_sentryControl"].get("manualTitleOverride")
 
     def test_archive_generation_fence_survives_restore_until_a_new_generation(self) -> None:
         block = self.create_investigation_block(


### PR DESCRIPTION
Agentic investigations now start their Seer run after the Sentry transaction commits, and versioned user commands are durably dispatched in order. Transient failures retry before becoming visible failures. Workflow-version conflicts refresh from Seer and fail the stale command queue atomically; command responses expose the stored status and error so replaying a request does not hide a failed dispatch.

Seer owns generated notebook changes. Report reconciliation repairs missed clear events, archive fences late writes until a new generation, and human title edits survive generated metadata. Two lifecycle details are intentional: retrying a failed initial create acknowledges the retry without advancing the workflow version because Seer has not accepted a command; archiving an agentic investigation accepts an older notebook version so background report updates cannot prevent cancellation. Future versions still conflict, and legacy investigations retain strict version checks and existing API-token access.

This is based on master after #123281, #123364, and #123537. Existing manual and template-based investigations stay on v0; no records are converted. There are no migrations or frontend changes. The shared gate is `organizations:investigations`, not a separate v1 flag. Deploy the compatible Seer runtime stack through getsentry/seer#7997 before using the source-only v1 creation path, which this PR makes active.
