### PR TITLE
fix(workflows): Validate Sentry App settings as a list

### DIFF
--- a/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
+++ b/src/sentry/notifications/notification_action/action_handler_registry/sentry_app_handler.py
@@ -33,7 +33,7 @@ class SentryAppActionHandler(ActionHandler):
         "description": "The data schema for a Sentry App Action",
         "type": "object",
         "properties": {
-            "settings": {"type": ["array", "object"]},
+            "settings": {"type": "array"},
         },
         "additionalProperties": False,
     }

--- a/tests/sentry/workflow_engine/endpoints/validators/actions/test_sentry_app.py
+++ b/tests/sentry/workflow_engine/endpoints/validators/actions/test_sentry_app.py
@@ -61,6 +61,18 @@ class TestSentryAppActionValidator(BaseWorkflowTest):
         assert result is True
         validator.save()
 
+    def test_validate_rejects_non_list_settings(self) -> None:
+        validator = BaseActionValidator(
+            data={
+                **self.valid_data,
+                "data": {"settings": {"channel": "#ignored-errors"}},
+            },
+            context={"organization": self.organization},
+        )
+
+        assert not validator.is_valid()
+        assert "data" in validator.errors
+
     @mock.patch(
         "sentry.rules.actions.sentry_apps.utils.app_service.trigger_sentry_app_action_creators"
     )


### PR DESCRIPTION
We assume `settings` is an array here: https://github.com/getsentry/sentry/blob/f5465b21f3b2d263f8809223171185c1763901d5/src/sentry/notifications/notification_action/action_validation.py#L273

Return a 400 instead of a 500 when this isn't an array.


Fixes SENTRY-5V24