### PR TITLE
chore(seer): Start sending category key over with investigations

### DIFF
--- a/src/sentry/investigations/agent.py
+++ b/src/sentry/investigations/agent.py
@@ -57,6 +57,7 @@ MAX_TRANSCRIPT_BYTES = 1024 * 1024
 MAX_TOOL_CONTENT_CHARS = 100_000
 MAX_QUERY_LINK_PARAM_CHARS = 2000
 IMPORT_NOT_ALLOWED_ERROR = "This import is not allowed in an investigation query."
+SEER_CATEGORY_KEY = "investigation"
 PRIVATE_TRANSCRIPT_KEYS = {
     "authorization",
     "credentials",
@@ -176,6 +177,8 @@ def start_execution_run(
     if client is None:
         client = SeerAgentClient(organization, user)
     client.on_completion_hook = InvestigationAgentCompletionHook
+    client.category_key = SEER_CATEGORY_KEY
+    client.category_value = str(execution.block.investigation_id)
     client.is_interactive = is_query
     client.enable_code_mode_tools = "only" if is_query else "off"
     client.enable_coding = False
@@ -980,6 +983,8 @@ def _maybe_start_title_generation(investigation: Investigation, user_id: int | N
     client = SeerAgentClient(
         investigation.organization,
         user,
+        category_key=SEER_CATEGORY_KEY,
+        category_value=str(investigation.id),
         on_completion_hook=InvestigationAgentCompletionHook,
         enable_code_mode_tools="only",
         enable_coding=False,

--- a/tests/sentry/investigations/test_agent.py
+++ b/tests/sentry/investigations/test_agent.py
@@ -305,6 +305,14 @@ class InvestigationAgentTest(TestCase):
             "2026-08-14T23:56:02+00:00"
         )
 
+    def test_start_run_categorizes_the_run_as_an_investigation(self) -> None:
+        client = MagicMock()
+
+        start_execution_run(self.execution, self.organization, self.user, client)
+
+        assert client.category_key == "investigation"
+        assert client.category_value == str(self.investigation.id)
+
     @patch("sentry.investigations.agent.record_execution_started")
     def test_start_run_records_execution_started(self, record_started: MagicMock) -> None:
         pending_execution = self.create_investigation_block_execution(
@@ -1176,6 +1184,18 @@ class InvestigationAgentTest(TestCase):
         assert "casual, plain language" in prompt
         assert "1 or 2 short" in prompt
         assert "Avoid headings and jargon" in prompt
+
+    @patch("sentry.investigations.agent.SeerAgentClient")
+    def test_title_generation_categorizes_the_run_as_an_investigation(
+        self, mock_client: MagicMock
+    ) -> None:
+        self.investigation.update(title=DEFAULT_INVESTIGATION_TITLE)
+
+        _maybe_start_title_generation(self.investigation, None)
+
+        kwargs = mock_client.call_args.kwargs
+        assert kwargs["category_key"] == "investigation"
+        assert kwargs["category_value"] == str(self.investigation.id)
 
     @patch("sentry.investigations.agent.record_investigation_completed")
     @patch("sentry.investigations.agent.SeerAgentClient")


### PR DESCRIPTION
Investigation runs currently start with no `category_key`, so Seer treats every block run and title run as plain Explorer chat. Tag them `category_key="investigation"` (paired with the investigation id) so they drop out of the chat evals and are separable in chat-session agent monitoring.