### PR TITLE
perf(preprod): Cache categorized comparison response on read

### DIFF
--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -74,7 +74,6 @@ from sentry.preprod.snapshots.models import (
     PreprodSnapshotMetrics,
 )
 from sentry.preprod.snapshots.precompute import (
-    build_comparison_payload,
     build_head_images_payload,
     comparison_response_key,
     head_images_key,
@@ -552,22 +551,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                 comparison_type = "waiting_for_base"
             else:
                 comparison_type = "solo"
-
-            if comparison_manifest is not None and comparison_response_key_value is not None:
-                try:
-                    session.put(
-                        orjson.dumps(
-                            build_comparison_payload(
-                                categorized, comparison_type, base_artifact_id, head_diff_threshold
-                            )
-                        ),
-                        key=comparison_response_key_value,
-                    )
-                except Exception:
-                    logger.exception(
-                        "Failed to write precomputed comparison",
-                        extra={"preprod_artifact_id": artifact.id},
-                    )
 
         if commit_comparison:
             vcs_info = BuildDetailsVcsInfo(

--- a/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
+++ b/src/sentry/preprod/api/endpoints/snapshots/preprod_artifact_snapshot.py
@@ -74,9 +74,13 @@ from sentry.preprod.snapshots.models import (
     PreprodSnapshotMetrics,
 )
 from sentry.preprod.snapshots.precompute import (
+    build_comparison_payload,
     build_head_images_payload,
+    comparison_response_key,
     head_images_key,
+    load_precomputed_comparison,
     load_precomputed_head_images,
+    refresh_expiration,
     refresh_manifest_expiration,
 )
 from sentry.preprod.snapshots.tasks import compare_snapshots
@@ -356,48 +360,215 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
 
         extras = snapshot_metrics.extras or {}
         session = get_session(UsecaseId.PREPROD, artifact.project)
-
-        image_list: list[SnapshotImageResponseDict]
-        precomputed = load_precomputed_head_images(session, extras.get("head_images_key"))
-        if precomputed is not None:
-            image_list, head_diff_threshold = precomputed
-            refresh_manifest_expiration(session, extras.get("manifest_key"))
-        else:
-            manifest_key = extras.get("manifest_key")
-            if not manifest_key:
-                return Response({"detail": "Manifest key not found"}, status=404)
-
-            try:
-                get_response = session.get(manifest_key)
-                if get_response is None:
-                    raise FileNotFoundError("Manifest does not exist in objectstore")
-                with start_span(op="preprod.snapshot.read_manifest", name="read_head_manifest"):
-                    raw_manifest = get_response.payload.read()
-                with start_span(
-                    op="preprod.snapshot.parse_manifest", name="parse_head_manifest"
-                ) as span:
-                    head_manifest = orjson.loads(raw_manifest)
-                    head_images: dict[str, Any] = head_manifest.get("images", {})
-                    head_diff_threshold = head_manifest.get("diff_threshold")
-                    set_span_data(span, "image_count", len(head_images))
-            except Exception:
-                logger.exception(
-                    "Failed to retrieve snapshot manifest",
-                    extra={
-                        "preprod_artifact_id": artifact.id,
-                        "manifest_key": manifest_key,
-                    },
-                )
-                return Response({"detail": "Internal server error"}, status=500)
-
-            with start_span(
-                op="preprod.snapshot.serialize_images", name="serialize_head_images"
-            ) as span:
-                set_span_data(span, "image_count", len(head_images))
-                image_list = build_head_image_list(head_images, head_diff_threshold)
-
-        # Build VCS info from commit_comparison
         commit_comparison = artifact.commit_comparison
+
+        all_comparisons = list(
+            PreprodSnapshotComparison.objects.select_related("base_snapshot_metrics")
+            .filter(head_snapshot_metrics=snapshot_metrics)
+            .order_by("-id")
+        )
+        latest_comparison = all_comparisons[0] if all_comparisons else None
+        comparison = next(
+            (c for c in all_comparisons if c.state == PreprodSnapshotComparison.State.SUCCESS),
+            None,
+        )
+
+        image_list: list[SnapshotImageResponseDict] = []
+        head_diff_threshold: float | None = None
+        base_artifact_id: str | None = None
+        comparison_manifest: dict[str, Any] | None = None
+        base_manifest: dict[str, Any] | None = None
+        comparison_type: str
+
+        comparison_response_key_value: str | None = None
+        if comparison is not None:
+            comparison_response_key_value = comparison_response_key(
+                organization.id,
+                artifact.project_id,
+                artifact.id,
+                comparison.base_snapshot_metrics.preprod_artifact_id,
+            )
+        cached_comparison = load_precomputed_comparison(session, comparison_response_key_value)
+
+        if cached_comparison is not None and comparison is not None:
+            comparison_type = "diff"
+            base_artifact_id = cached_comparison["base_artifact_id"]
+            head_diff_threshold = cached_comparison["diff_threshold"]
+            categorized = CategorizedComparison(
+                added=cached_comparison["added"],
+                removed=cached_comparison["removed"],
+                renamed=cached_comparison["renamed"],
+                changed=cached_comparison["changed"],
+                unchanged=cached_comparison["unchanged"],
+                errored=cached_comparison["errored"],
+                skipped=cached_comparison["skipped"],
+            )
+            # Bump the idle expiry of the objects a live recompute would need, so the
+            # fallback stays viable across schema-version bumps.
+            refresh_expiration(
+                session,
+                (
+                    extras.get("head_images_key"),
+                    extras.get("manifest_key"),
+                    (comparison.extras or {}).get("comparison_key"),
+                    (comparison.base_snapshot_metrics.extras or {}).get("manifest_key"),
+                ),
+            )
+        else:
+            precomputed = load_precomputed_head_images(session, extras.get("head_images_key"))
+            if precomputed is not None:
+                image_list, head_diff_threshold = precomputed
+                refresh_manifest_expiration(session, extras.get("manifest_key"))
+            else:
+                manifest_key = extras.get("manifest_key")
+                if not manifest_key:
+                    return Response({"detail": "Manifest key not found"}, status=404)
+
+                try:
+                    get_response = session.get(manifest_key)
+                    if get_response is None:
+                        raise FileNotFoundError("Manifest does not exist in objectstore")
+                    with start_span(op="preprod.snapshot.read_manifest", name="read_head_manifest"):
+                        raw_manifest = get_response.payload.read()
+                    with start_span(
+                        op="preprod.snapshot.parse_manifest", name="parse_head_manifest"
+                    ) as span:
+                        head_manifest = orjson.loads(raw_manifest)
+                        head_images: dict[str, Any] = head_manifest.get("images", {})
+                        head_diff_threshold = head_manifest.get("diff_threshold")
+                        set_span_data(span, "image_count", len(head_images))
+                except Exception:
+                    logger.exception(
+                        "Failed to retrieve snapshot manifest",
+                        extra={
+                            "preprod_artifact_id": artifact.id,
+                            "manifest_key": manifest_key,
+                        },
+                    )
+                    return Response({"detail": "Internal server error"}, status=500)
+
+                with start_span(
+                    op="preprod.snapshot.serialize_images", name="serialize_head_images"
+                ) as span:
+                    set_span_data(span, "image_count", len(head_images))
+                    image_list = build_head_image_list(head_images, head_diff_threshold)
+
+            if comparison:
+                comparison_key = (comparison.extras or {}).get("comparison_key")
+                if comparison_key:
+                    try:
+                        response = session.get(comparison_key)
+                        if response is None:
+                            raise FileNotFoundError(
+                                "Comparison manifest does not exist in objectstore"
+                            )
+                        with start_span(
+                            op="preprod.snapshot.read_manifest", name="read_comparison_manifest"
+                        ):
+                            raw_comparison_manifest = response.payload.read()
+                        with start_span(
+                            op="preprod.snapshot.parse_manifest", name="parse_comparison_manifest"
+                        ) as span:
+                            comparison_manifest = orjson.loads(raw_comparison_manifest)
+                            if "base_artifact_id" not in comparison_manifest:
+                                raise ValueError("comparison manifest missing base_artifact_id")
+                            set_span_data(
+                                span, "image_count", len(comparison_manifest.get("images", {}))
+                            )
+                    except Exception:
+                        comparison_manifest = None
+                        logger.exception(
+                            "Failed to fetch comparison manifest",
+                            extra={
+                                "preprod_artifact_id": artifact.id,
+                            },
+                        )
+
+            if comparison_manifest is not None and comparison is not None:
+                base_manifest_key = (comparison.base_snapshot_metrics.extras or {}).get(
+                    "manifest_key"
+                )
+                if base_manifest_key:
+                    try:
+                        response = session.get(base_manifest_key)
+                        if response is None:
+                            raise FileNotFoundError("Base manifest does not exist in objectstore")
+                        with start_span(
+                            op="preprod.snapshot.read_manifest", name="read_base_manifest"
+                        ):
+                            raw_base_manifest = response.payload.read()
+                        with start_span(
+                            op="preprod.snapshot.parse_manifest", name="parse_base_manifest"
+                        ) as span:
+                            base_manifest = orjson.loads(raw_base_manifest)
+                            set_span_data(span, "image_count", len(base_manifest.get("images", {})))
+                    except Exception:
+                        logger.exception(
+                            "Failed to fetch base manifest",
+                            extra={"preprod_artifact_id": artifact.id},
+                        )
+
+            images_by_file_name: dict[str, SnapshotImageResponseDict] = {
+                img["image_file_name"]: img for img in image_list
+            }
+
+            if comparison_manifest is not None:
+                base_artifact_id = str(comparison_manifest["base_artifact_id"])
+                comparison_images = comparison_manifest.get("images", {})
+                with start_span(
+                    op="preprod.snapshot.categorize_comparison", name="categorize_comparison_images"
+                ) as span:
+                    set_span_data(span, "image_count", len(comparison_images))
+                    categorized = categorize_comparison_images(
+                        comparison_images,
+                        images_by_file_name,
+                        base_manifest.get("images", {}) if base_manifest else None,
+                    )
+                    set_span_data(span, "changed_count", len(categorized.changed))
+                    set_span_data(span, "unchanged_count", len(categorized.unchanged))
+            else:
+                if comparison is not None:
+                    base_artifact_id = str(comparison.base_snapshot_metrics.preprod_artifact_id)
+                categorized = CategorizedComparison()
+                pending_or_failed_state = next(
+                    (
+                        c.state
+                        for c in all_comparisons
+                        if c.state
+                        in (
+                            PreprodSnapshotComparison.State.PENDING,
+                            PreprodSnapshotComparison.State.PROCESSING,
+                            PreprodSnapshotComparison.State.FAILED,
+                        )
+                    ),
+                    None,
+                )
+
+            if comparison_manifest is not None:
+                comparison_type = "diff"
+            elif (
+                commit_comparison and commit_comparison.base_sha and pending_or_failed_state is None
+            ):
+                comparison_type = "waiting_for_base"
+            else:
+                comparison_type = "solo"
+
+            if comparison_manifest is not None and comparison_response_key_value is not None:
+                try:
+                    session.put(
+                        orjson.dumps(
+                            build_comparison_payload(
+                                categorized, comparison_type, base_artifact_id, head_diff_threshold
+                            )
+                        ),
+                        key=comparison_response_key_value,
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to write precomputed comparison",
+                        extra={"preprod_artifact_id": artifact.id},
+                    )
+
         if commit_comparison:
             vcs_info = BuildDetailsVcsInfo(
                 head_sha=commit_comparison.head_sha,
@@ -411,67 +582,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
             )
         else:
             vcs_info = BuildDetailsVcsInfo()
-
-        comparison_manifest: dict[str, Any] | None = None
-        base_manifest: dict[str, Any] | None = None
-        all_comparisons = list(
-            PreprodSnapshotComparison.objects.select_related("base_snapshot_metrics")
-            .filter(head_snapshot_metrics=snapshot_metrics)
-            .order_by("-id")
-        )
-        latest_comparison = all_comparisons[0] if all_comparisons else None
-        comparison = next(
-            (c for c in all_comparisons if c.state == PreprodSnapshotComparison.State.SUCCESS),
-            None,
-        )
-        if comparison:
-            comparison_key = (comparison.extras or {}).get("comparison_key")
-            if comparison_key:
-                try:
-                    response = session.get(comparison_key)
-                    if response is None:
-                        raise FileNotFoundError("Comparison manifest does not exist in objectstore")
-                    with start_span(
-                        op="preprod.snapshot.read_manifest", name="read_comparison_manifest"
-                    ):
-                        raw_comparison_manifest = response.payload.read()
-                    with start_span(
-                        op="preprod.snapshot.parse_manifest", name="parse_comparison_manifest"
-                    ) as span:
-                        comparison_manifest = orjson.loads(raw_comparison_manifest)
-                        if "base_artifact_id" not in comparison_manifest:
-                            raise ValueError("comparison manifest missing base_artifact_id")
-                        set_span_data(
-                            span, "image_count", len(comparison_manifest.get("images", {}))
-                        )
-                except Exception:
-                    comparison_manifest = None
-                    logger.exception(
-                        "Failed to fetch comparison manifest",
-                        extra={
-                            "preprod_artifact_id": artifact.id,
-                        },
-                    )
-
-        if comparison_manifest is not None and comparison is not None:
-            base_manifest_key = (comparison.base_snapshot_metrics.extras or {}).get("manifest_key")
-            if base_manifest_key:
-                try:
-                    response = session.get(base_manifest_key)
-                    if response is None:
-                        raise FileNotFoundError("Base manifest does not exist in objectstore")
-                    with start_span(op="preprod.snapshot.read_manifest", name="read_base_manifest"):
-                        raw_base_manifest = response.payload.read()
-                    with start_span(
-                        op="preprod.snapshot.parse_manifest", name="parse_base_manifest"
-                    ) as span:
-                        base_manifest = orjson.loads(raw_base_manifest)
-                        set_span_data(span, "image_count", len(base_manifest.get("images", {})))
-                except Exception:
-                    logger.exception(
-                        "Failed to fetch base manifest",
-                        extra={"preprod_artifact_id": artifact.id},
-                    )
 
         analytics.record(
             PreprodArtifactApiGetSnapshotDetailsEvent(
@@ -504,48 +614,6 @@ class OrganizationPreprodSnapshotEndpoint(OrganizationEndpoint):
                     )
                     is not None
                 )
-
-        images_by_file_name: dict[str, SnapshotImageResponseDict] = {
-            img["image_file_name"]: img for img in image_list
-        }
-
-        base_artifact_id: str | None = None
-
-        if comparison_manifest is not None:
-            base_artifact_id = str(comparison_manifest["base_artifact_id"])
-            comparison_images = comparison_manifest.get("images", {})
-            with start_span(
-                op="preprod.snapshot.categorize_comparison", name="categorize_comparison_images"
-            ) as span:
-                set_span_data(span, "image_count", len(comparison_images))
-                categorized = categorize_comparison_images(
-                    comparison_images,
-                    images_by_file_name,
-                    base_manifest.get("images", {}) if base_manifest else None,
-                )
-        else:
-            if comparison is not None:
-                base_artifact_id = str(comparison.base_snapshot_metrics.preprod_artifact_id)
-            categorized = CategorizedComparison()
-            pending_or_failed_state = next(
-                (
-                    c.state
-                    for c in all_comparisons
-                    if c.state
-                    in (
-                        PreprodSnapshotComparison.State.PENDING,
-                        PreprodSnapshotComparison.State.PROCESSING,
-                        PreprodSnapshotComparison.State.FAILED,
-                    )
-                ),
-                None,
-            )
-        if comparison_manifest is not None:
-            comparison_type = "diff"
-        elif commit_comparison and commit_comparison.base_sha and pending_or_failed_state is None:
-            comparison_type = "waiting_for_base"
-        else:
-            comparison_type = "solo"
 
         all_approvals = list(
             PreprodComparisonApproval.objects.filter(

--- a/src/sentry/preprod/helpers/deletion.py
+++ b/src/sentry/preprod/helpers/deletion.py
@@ -22,6 +22,7 @@ from sentry.preprod.eap.constants import get_preprod_trace_id
 from sentry.preprod.models import PreprodArtifact, PreprodArtifactSizeMetrics
 from sentry.preprod.snapshots.manifest import ComparisonManifest
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
+from sentry.preprod.snapshots.precompute import comparison_response_key
 from sentry.utils import snuba_rpc
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
@@ -111,7 +112,7 @@ def _collect_snapshot_objectstore_keys(
 ) -> list[tuple[int, int, str]]:
     # Collects three types of objectstore keys for the given artifacts:
     # 1. Snapshot manifest and precomputed head-images keys (from PreprodSnapshotMetrics)
-    # 2. Comparison manifest keys (diff manifests from PreprodSnapshotComparison)
+    # 2. Comparison manifest and precomputed comparison-response keys (from PreprodSnapshotComparison)
     # 3. Diff mask image keys (per-image diff masks referenced within comparison manifests)
     # Note: shared content-addressed image keys are NOT collected — they expire via X-day TTL.
     artifact_ids = [a.id for a in preprod_artifacts]
@@ -140,9 +141,22 @@ def _collect_snapshot_objectstore_keys(
 
     for comp in PreprodSnapshotComparison.objects.filter(
         Q(head_snapshot_metrics_id__in=metrics_ids) | Q(base_snapshot_metrics_id__in=metrics_ids)
-    ).select_related("head_snapshot_metrics__preprod_artifact__project"):
+    ).select_related("head_snapshot_metrics__preprod_artifact__project", "base_snapshot_metrics"):
         org_id = comp.head_snapshot_metrics.preprod_artifact.project.organization_id
         project_id = comp.head_snapshot_metrics.preprod_artifact.project_id
+
+        keys.append(
+            (
+                org_id,
+                project_id,
+                comparison_response_key(
+                    org_id,
+                    project_id,
+                    comp.head_snapshot_metrics.preprod_artifact_id,
+                    comp.base_snapshot_metrics.preprod_artifact_id,
+                ),
+            )
+        )
 
         comparison_key = (comp.extras or {}).get("comparison_key")
         if not comparison_key:

--- a/src/sentry/preprod/snapshots/precompute.py
+++ b/src/sentry/preprod/snapshots/precompute.py
@@ -1,19 +1,34 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
+from collections.abc import Iterable, Mapping
 from typing import Any, TypedDict
 
 import orjson
 from objectstore_client import Session
 
-from sentry.preprod.api.models.public.snapshots import SnapshotImageResponseDict
+from sentry.preprod.api.models.public.snapshots import (
+    SnapshotDiffPairResponseDict,
+    SnapshotImageResponseDict,
+)
+from sentry.preprod.snapshots.comparison_categorizer import CategorizedComparison
 from sentry.preprod.snapshots.image_serialization import build_head_image_list
 from sentry.utils.tracing import set_span_data, start_span
 
 logger = logging.getLogger(__name__)
 
 HEAD_IMAGES_SCHEMA_VERSION = 1
+COMPARISON_SCHEMA_VERSION = 1
+
+_COMPARISON_BUCKETS = (
+    "added",
+    "removed",
+    "renamed",
+    "changed",
+    "unchanged",
+    "errored",
+    "skipped",
+)
 
 
 class HeadImagesPayload(TypedDict):
@@ -36,13 +51,18 @@ def build_head_images_payload(
     }
 
 
+def refresh_expiration(session: Session, keys: Iterable[str | None]) -> None:
+    for key in keys:
+        if not key:
+            continue
+        try:
+            session.head(key)
+        except Exception:
+            logger.exception("Failed to refresh expiration", extra={"key": key})
+
+
 def refresh_manifest_expiration(session: Session, manifest_key: str | None) -> None:
-    if not manifest_key:
-        return
-    try:
-        session.head(manifest_key)
-    except Exception:
-        logger.exception("Failed to refresh manifest expiration", extra={"key": manifest_key})
+    refresh_expiration(session, (manifest_key,))
 
 
 def load_precomputed_head_images(
@@ -70,4 +90,73 @@ def load_precomputed_head_images(
             return images, payload.get("diff_threshold")
     except Exception:
         logger.exception("Failed to read precomputed head images", extra={"key": key})
+        return None
+
+
+class ComparisonPayload(TypedDict):
+    schema_version: int
+    comparison_type: str
+    base_artifact_id: str | None
+    diff_threshold: float | None
+    added: list[SnapshotImageResponseDict]
+    removed: list[SnapshotImageResponseDict]
+    renamed: list[SnapshotDiffPairResponseDict]
+    changed: list[SnapshotDiffPairResponseDict]
+    unchanged: list[SnapshotImageResponseDict]
+    errored: list[SnapshotDiffPairResponseDict]
+    skipped: list[SnapshotImageResponseDict]
+
+
+def comparison_response_key(
+    organization_id: int, project_id: int, head_artifact_id: int, base_artifact_id: int
+) -> str:
+    return (
+        f"{organization_id}/{project_id}/{head_artifact_id}/{base_artifact_id}"
+        "/snapshot_comparison_response.json"
+    )
+
+
+def build_comparison_payload(
+    categorized: CategorizedComparison,
+    comparison_type: str,
+    base_artifact_id: str | None,
+    diff_threshold: float | None,
+) -> ComparisonPayload:
+    return {
+        "schema_version": COMPARISON_SCHEMA_VERSION,
+        "comparison_type": comparison_type,
+        "base_artifact_id": base_artifact_id,
+        "diff_threshold": diff_threshold,
+        "added": categorized.added,
+        "removed": categorized.removed,
+        "renamed": categorized.renamed,
+        "changed": categorized.changed,
+        "unchanged": categorized.unchanged,
+        "errored": categorized.errored,
+        "skipped": categorized.skipped,
+    }
+
+
+def load_precomputed_comparison(session: Session, key: str | None) -> ComparisonPayload | None:
+    if not key:
+        return None
+    try:
+        response = session.get(key)
+        if response is None:
+            return None
+        with start_span(
+            op="preprod.snapshot.read_precomputed_comparison",
+            name="read_precomputed_comparison",
+        ) as span:
+            payload = orjson.loads(response.payload.read())
+            if payload.get("schema_version") != COMPARISON_SCHEMA_VERSION or not all(
+                bucket in payload for bucket in _COMPARISON_BUCKETS
+            ):
+                return None
+            set_span_data(
+                span, "image_count", sum(len(payload[bucket]) for bucket in _COMPARISON_BUCKETS)
+            )
+            return payload
+    except Exception:
+        logger.exception("Failed to read precomputed comparison", extra={"key": key})
         return None

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -151,6 +151,7 @@ def _write_comparison_response_blob(
     head_artifact_id: int,
     base_artifact_id: int,
 ) -> None:
+    key = comparison_response_key(org_id, project_id, head_artifact_id, base_artifact_id)
     metrics_by_artifact = {
         m.preprod_artifact_id: m
         for m in PreprodSnapshotMetrics.objects.filter(
@@ -159,16 +160,17 @@ def _write_comparison_response_blob(
     }
     head_metrics = metrics_by_artifact.get(head_artifact_id)
     base_metrics = metrics_by_artifact.get(base_artifact_id)
-    if head_metrics is None or base_metrics is None:
-        return
-    head_manifest_key = (head_metrics.extras or {}).get("manifest_key")
-    base_manifest_key = (base_metrics.extras or {}).get("manifest_key")
-    if not head_manifest_key or not base_manifest_key:
-        return
-    head_manifest = _load_raw_manifest(session, head_manifest_key)
-    base_manifest = _load_raw_manifest(session, base_manifest_key)
-    # A missing manifest yields a degraded categorization, so refuse to cache it.
+    head_manifest_key = (head_metrics.extras or {}).get("manifest_key") if head_metrics else None
+    base_manifest_key = (base_metrics.extras or {}).get("manifest_key") if base_metrics else None
+    head_manifest = _load_raw_manifest(session, head_manifest_key) if head_manifest_key else None
+    base_manifest = _load_raw_manifest(session, base_manifest_key) if base_manifest_key else None
+    # A missing manifest yields a degraded categorization, so refuse to cache it — and drop
+    # any blob a prior finalize wrote, so a recompare never serves the stale result.
     if head_manifest is None or base_manifest is None:
+        try:
+            session.delete(key)
+        except Exception:
+            logger.exception("finalize: failed to delete stale comparison response")
         return
     head_diff_threshold = head_manifest.get("diff_threshold")
     head_images_by_file_name = {
@@ -186,7 +188,7 @@ def _write_comparison_response_blob(
                 categorized, "diff", str(base_artifact_id), head_diff_threshold
             )
         ),
-        key=comparison_response_key(org_id, project_id, head_artifact_id, base_artifact_id),
+        key=key,
         content_type="application/json",
     )
 
@@ -1332,6 +1334,19 @@ def finalize_snapshot_comparison(
     comparison_key = _comparison_key(org_id, project_id, head_artifact_id, base_artifact_id)
     _put_json(session, comparison_key, comparison_manifest)
 
+    # Precompute the categorized comparison response so the details GET serves it from a
+    # single blob. Written before the SUCCESS swap so any request that observes SUCCESS
+    # sees a fresh blob (and never a prior recompare's result under the same key).
+    try:
+        _write_comparison_response_blob(
+            session, comparison_manifest, org_id, project_id, head_artifact_id, base_artifact_id
+        )
+    except Exception:
+        logger.exception(
+            "finalize: failed to write precomputed comparison response",
+            extra={"comparison_id": comparison.id},
+        )
+
     extras = comparison.extras or {}
     extras["comparison_key"] = comparison_key
     extras["diff_algorithm_version"] = DIFF_ALGORITHM_VERSION
@@ -1440,16 +1455,4 @@ def finalize_snapshot_comparison(
             logger.exception(
                 "compare_completion VCS update failed after successful comparison",
                 extra={"head_artifact_id": head_artifact_id, "comparison_id": comparison.id},
-            )
-
-        # Precompute the categorized comparison response so the details GET can serve
-        # it from a single blob instead of re-reading and re-categorizing the manifests.
-        try:
-            _write_comparison_response_blob(
-                session, comparison_manifest, org_id, project_id, head_artifact_id, base_artifact_id
-            )
-        except Exception:
-            logger.exception(
-                "finalize: failed to write precomputed comparison response",
-                extra={"comparison_id": comparison.id},
             )

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -22,6 +22,7 @@ from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.analytics import PreprodStatusCheckApprovalCreatedEvent
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.categorize import categorize_image_sets
+from sentry.preprod.snapshots.comparison_categorizer import categorize_comparison_images
 from sentry.preprod.snapshots.constants import (
     MISSING_BASE_GRACE_PERIOD_SECONDS,
     RECONSTRUCTION_RETRY_COUNTDOWN_SECONDS,
@@ -35,6 +36,7 @@ from sentry.preprod.snapshots.image_diff.compare import (
 )
 from sentry.preprod.snapshots.image_diff.odiff import OdiffServer
 from sentry.preprod.snapshots.image_diff.types import ImageSize
+from sentry.preprod.snapshots.image_serialization import build_head_image_list
 from sentry.preprod.snapshots.manifest import (
     ChunkAssignment,
     ChunkCandidate,
@@ -49,6 +51,7 @@ from sentry.preprod.snapshots.models import (
     PreprodSnapshotComparison,
     PreprodSnapshotMetrics,
 )
+from sentry.preprod.snapshots.precompute import build_comparison_payload, comparison_response_key
 from sentry.preprod.snapshots.reconstruction import reconstruct_base_manifest
 from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 from sentry.silo.base import SiloMode
@@ -131,6 +134,61 @@ def _put_json(session: Session, key: str, model: BaseModel) -> None:
 
 def _put_diff_mask(session: Session, key: str, data: bytes) -> None:
     _retry_objectstore(lambda: session.put(data, key=key, content_type="image/png"))
+
+
+def _load_raw_manifest(session: Session, key: str) -> dict[str, Any] | None:
+    response = session.get(key)
+    if response is None:
+        return None
+    return orjson.loads(response.payload.read())
+
+
+def _write_comparison_response_blob(
+    session: Session,
+    comparison_manifest: ComparisonManifest,
+    org_id: int,
+    project_id: int,
+    head_artifact_id: int,
+    base_artifact_id: int,
+) -> None:
+    metrics_by_artifact = {
+        m.preprod_artifact_id: m
+        for m in PreprodSnapshotMetrics.objects.filter(
+            preprod_artifact_id__in=(head_artifact_id, base_artifact_id)
+        )
+    }
+    head_metrics = metrics_by_artifact.get(head_artifact_id)
+    base_metrics = metrics_by_artifact.get(base_artifact_id)
+    if head_metrics is None or base_metrics is None:
+        return
+    head_manifest_key = (head_metrics.extras or {}).get("manifest_key")
+    base_manifest_key = (base_metrics.extras or {}).get("manifest_key")
+    if not head_manifest_key or not base_manifest_key:
+        return
+    head_manifest = _load_raw_manifest(session, head_manifest_key)
+    base_manifest = _load_raw_manifest(session, base_manifest_key)
+    # A missing manifest yields a degraded categorization, so refuse to cache it.
+    if head_manifest is None or base_manifest is None:
+        return
+    head_diff_threshold = head_manifest.get("diff_threshold")
+    head_images_by_file_name = {
+        img["image_file_name"]: img
+        for img in build_head_image_list(head_manifest.get("images", {}), head_diff_threshold)
+    }
+    categorized = categorize_comparison_images(
+        comparison_manifest.dict()["images"],
+        head_images_by_file_name,
+        base_manifest.get("images", {}),
+    )
+    session.put(
+        orjson.dumps(
+            build_comparison_payload(
+                categorized, "diff", str(base_artifact_id), head_diff_threshold
+            )
+        ),
+        key=comparison_response_key(org_id, project_id, head_artifact_id, base_artifact_id),
+        content_type="application/json",
+    )
 
 
 def _errored_result(candidate: ChunkCandidate, reason: str) -> ComparisonImageResult:
@@ -1382,4 +1440,16 @@ def finalize_snapshot_comparison(
             logger.exception(
                 "compare_completion VCS update failed after successful comparison",
                 extra={"head_artifact_id": head_artifact_id, "comparison_id": comparison.id},
+            )
+
+        # Precompute the categorized comparison response so the details GET can serve
+        # it from a single blob instead of re-reading and re-categorizing the manifests.
+        try:
+            _write_comparison_response_blob(
+                session, comparison_manifest, org_id, project_id, head_artifact_id, base_artifact_id
+            )
+        except Exception:
+            logger.exception(
+                "finalize: failed to write precomputed comparison response",
+                extra={"comparison_id": comparison.id},
             )

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -12,6 +12,8 @@ from sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot_latest_bas
     LATEST_BASE_SNAPSHOT_GET_QUERY_PARAMS,
 )
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
+from sentry.preprod.snapshots.comparison_categorizer import categorize_comparison_images
+from sentry.preprod.snapshots.image_serialization import build_head_image_list
 from sentry.preprod.snapshots.manifest import (
     ComparisonImageResult,
     ComparisonManifest,
@@ -19,7 +21,7 @@ from sentry.preprod.snapshots.manifest import (
     SnapshotManifest,
 )
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
-from sentry.preprod.snapshots.precompute import build_head_images_payload
+from sentry.preprod.snapshots.precompute import build_comparison_payload, build_head_images_payload
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.analytics import assert_last_analytics_event
 
@@ -1674,25 +1676,28 @@ class PreprodSnapshotGoldenResponseTest(APITestCase):
         self._mock_multi_session(mock_get_session, session_objects)
         return head_artifact, base_artifact
 
-    def _mock_rw_session(self, mock_get_session, initial):
-        store = dict(initial)
-
-        def _get(key):
-            if key not in store:
-                return None
-            result = MagicMock()
-            result.payload.read.return_value = store[key]
-            return result
-
-        def _put(data, key):
-            store[key] = data
-            return MagicMock()
-
-        session = MagicMock()
-        session.get.side_effect = _get
-        session.put.side_effect = _put
-        mock_get_session.return_value = session
-        return store
+    def _comparison_blob_bytes(self, head_artifact, base_artifact):
+        # Build the precomputed blob exactly as finalize does: same manifests, same
+        # categorizer inputs — so a fast-path hit is byte-identical to the live response.
+        head_manifest = orjson.loads(self._snapshot_manifest_bytes(self._head_images(), 0.2))
+        base_manifest = orjson.loads(self._snapshot_manifest_bytes(self._base_images()))
+        comparison_manifest = orjson.loads(
+            self._comparison_manifest_bytes(head_artifact, base_artifact)
+        )
+        head_images_by_file_name = {
+            img["image_file_name"]: img
+            for img in build_head_image_list(
+                head_manifest["images"], head_manifest.get("diff_threshold")
+            )
+        }
+        categorized = categorize_comparison_images(
+            comparison_manifest["images"], head_images_by_file_name, base_manifest["images"]
+        )
+        return orjson.dumps(
+            build_comparison_payload(
+                categorized, "diff", str(base_artifact.id), head_manifest.get("diff_threshold")
+            )
+        )
 
     @patch("sentry.analytics.record")
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
@@ -1707,47 +1712,31 @@ class PreprodSnapshotGoldenResponseTest(APITestCase):
             base_snapshot_metrics=base_metrics,
             state=PreprodSnapshotComparison.State.SUCCESS,
         )
-        comparison_key = (
-            f"{self.org.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}/comparison.json"
-        )
-        comparison.extras = {"comparison_key": comparison_key}
+        comparison.extras = {
+            "comparison_key": f"{self.org.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}/comparison.json"
+        }
         comparison.save(update_fields=["extras"])
 
-        manifest_objects = {
-            self._manifest_key(head_artifact): self._snapshot_manifest_bytes(head_images, 0.2),
-            self._manifest_key(base_artifact): self._snapshot_manifest_bytes(base_images),
-            comparison_key: self._comparison_manifest_bytes(head_artifact, base_artifact),
-        }
-        store = self._mock_rw_session(mock_get_session, manifest_objects)
-
-        dynamic_ids = {
-            "head_artifact_id": "<HEAD_ID>",
-            "base_artifact_id": "<BASE_ID>",
-            "project_id": "<PROJECT_ID>",
-        }
-
-        # First GET runs the live (miss) path and writes the comparison blob.
-        self._assert_golden(
-            "snapshot_diff.json",
-            self.client.get(self._get_detail_url(head_artifact.id)),
-            dynamic_ids,
-        )
-
-        comparison_blob_key = (
+        blob_key = (
             f"{self.org.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}"
             "/snapshot_comparison_response.json"
         )
-        assert comparison_blob_key in store
+        # Only the precomputed blob is available — every manifest is absent, so a fallback
+        # could not produce a diff. Matching the diff golden proves the fast path served it.
+        self._mock_multi_session(
+            mock_get_session, {blob_key: self._comparison_blob_bytes(head_artifact, base_artifact)}
+        )
 
-        # Drop every manifest so only the precomputed blob can answer; proves the fast
-        # path is byte-identical to the live response.
-        for key in manifest_objects:
-            del store[key]
+        response = self.client.get(self._get_detail_url(head_artifact.id))
 
         self._assert_golden(
             "snapshot_diff.json",
-            self.client.get(self._get_detail_url(head_artifact.id)),
-            dynamic_ids,
+            response,
+            {
+                "head_artifact_id": "<HEAD_ID>",
+                "base_artifact_id": "<BASE_ID>",
+                "project_id": "<PROJECT_ID>",
+            },
         )
 
     @patch("sentry.analytics.record")

--- a/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
+++ b/tests/sentry/preprod/api/endpoints/test_preprod_artifact_snapshot.py
@@ -1674,6 +1674,82 @@ class PreprodSnapshotGoldenResponseTest(APITestCase):
         self._mock_multi_session(mock_get_session, session_objects)
         return head_artifact, base_artifact
 
+    def _mock_rw_session(self, mock_get_session, initial):
+        store = dict(initial)
+
+        def _get(key):
+            if key not in store:
+                return None
+            result = MagicMock()
+            result.payload.read.return_value = store[key]
+            return result
+
+        def _put(data, key):
+            store[key] = data
+            return MagicMock()
+
+        session = MagicMock()
+        session.get.side_effect = _get
+        session.put.side_effect = _put
+        mock_get_session.return_value = session
+        return store
+
+    @patch("sentry.analytics.record")
+    @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
+    def test_golden_diff_precomputed_comparison(self, mock_get_session, mock_record):
+        head_images = self._head_images()
+        base_images = self._base_images()
+        head_artifact, head_metrics = self._create_artifact(image_count=len(head_images))
+        base_artifact, base_metrics = self._create_artifact(image_count=len(base_images))
+
+        comparison = self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+        )
+        comparison_key = (
+            f"{self.org.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}/comparison.json"
+        )
+        comparison.extras = {"comparison_key": comparison_key}
+        comparison.save(update_fields=["extras"])
+
+        manifest_objects = {
+            self._manifest_key(head_artifact): self._snapshot_manifest_bytes(head_images, 0.2),
+            self._manifest_key(base_artifact): self._snapshot_manifest_bytes(base_images),
+            comparison_key: self._comparison_manifest_bytes(head_artifact, base_artifact),
+        }
+        store = self._mock_rw_session(mock_get_session, manifest_objects)
+
+        dynamic_ids = {
+            "head_artifact_id": "<HEAD_ID>",
+            "base_artifact_id": "<BASE_ID>",
+            "project_id": "<PROJECT_ID>",
+        }
+
+        # First GET runs the live (miss) path and writes the comparison blob.
+        self._assert_golden(
+            "snapshot_diff.json",
+            self.client.get(self._get_detail_url(head_artifact.id)),
+            dynamic_ids,
+        )
+
+        comparison_blob_key = (
+            f"{self.org.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}"
+            "/snapshot_comparison_response.json"
+        )
+        assert comparison_blob_key in store
+
+        # Drop every manifest so only the precomputed blob can answer; proves the fast
+        # path is byte-identical to the live response.
+        for key in manifest_objects:
+            del store[key]
+
+        self._assert_golden(
+            "snapshot_diff.json",
+            self.client.get(self._get_detail_url(head_artifact.id)),
+            dynamic_ids,
+        )
+
     @patch("sentry.analytics.record")
     @patch("sentry.preprod.api.endpoints.snapshots.preprod_artifact_snapshot.get_session")
     def test_golden_diff(self, mock_get_session, mock_record):

--- a/tests/sentry/preprod/helpers/test_deletion.py
+++ b/tests/sentry/preprod/helpers/test_deletion.py
@@ -1,5 +1,6 @@
 from sentry.preprod.helpers.deletion import _collect_snapshot_objectstore_keys
 from sentry.preprod.models import PreprodArtifact
+from sentry.preprod.snapshots.models import PreprodSnapshotComparison
 from sentry.testutils.cases import TestCase
 
 
@@ -22,3 +23,38 @@ class CollectSnapshotObjectstoreKeysTest(TestCase):
 
         assert manifest_key in collected
         assert head_images_key in collected
+
+    def test_collects_comparison_response_key(self) -> None:
+        head_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADED,
+            app_id="com.example.app",
+        )
+        base_artifact = self.create_preprod_artifact(
+            project=self.project,
+            state=PreprodArtifact.ArtifactState.UPLOADED,
+            app_id="com.example.app",
+        )
+        head_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=head_artifact, image_count=0
+        )
+        base_metrics = self.create_preprod_snapshot_metrics(
+            preprod_artifact=base_artifact, image_count=0
+        )
+        comparison = self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head_metrics,
+            base_snapshot_metrics=base_metrics,
+            state=PreprodSnapshotComparison.State.SUCCESS,
+        )
+        comparison.extras = {
+            "comparison_key": f"{self.organization.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}/comparison.json"
+        }
+        comparison.save(update_fields=["extras"])
+
+        expected = (
+            f"{self.organization.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}"
+            "/snapshot_comparison_response.json"
+        )
+        collected = {key for _, _, key in _collect_snapshot_objectstore_keys([head_artifact])}
+
+        assert expected in collected

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -111,8 +111,12 @@ def _dict_backed_session(stored: dict[str, bytes]) -> MagicMock:
     def _put(contents, key, content_type):
         stored[key] = contents
 
+    def _delete(key):
+        stored.pop(key, None)
+
     session.get.side_effect = _get
     session.put.side_effect = _put
+    session.delete.side_effect = _delete
     return session
 
 
@@ -650,10 +654,14 @@ class FinalizeSnapshotComparisonTest(TestCase):
         assert payload["base_artifact_id"] == str(b.id)
         assert len(payload["changed"]) == 1
 
-    def test_finalize_skips_comparison_blob_when_base_manifest_missing(self):
+    def test_finalize_deletes_stale_comparison_blob_when_base_manifest_missing(self):
         from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
 
         comparison, h, b, prefix, stored = self._finalize_with_manifests(include_base=False)
+        blob_key = f"{prefix}/snapshot_comparison_response.json"
+        # A prior finalize left a blob under the same key; without a base manifest we can't
+        # rebuild it, so it must be dropped rather than served as the new result.
+        stored[blob_key] = orjson.dumps({"schema_version": 1, "stale": True})
         session = _dict_backed_session(stored)
         with (
             patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
@@ -663,7 +671,7 @@ class FinalizeSnapshotComparisonTest(TestCase):
 
         comparison.refresh_from_db()
         assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
-        assert f"{prefix}/snapshot_comparison_response.json" not in stored
+        assert blob_key not in stored
 
     def test_finalize_writes_images_errored_column(self):
         from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -610,6 +610,61 @@ class FinalizeSnapshotComparisonTest(TestCase):
         assert called_manifest.head_artifact_id == h.id
         assert called_session is session
 
+    def _finalize_with_manifests(self, include_base=True):
+        comparison, h, b = self._comparison(1, done_indices=[0])
+        prefix = f"{self.organization.id}/{self.project.id}/{h.id}/{b.id}"
+        head_key = f"{self.organization.id}/{self.project.id}/{h.id}/manifest.json"
+        base_key = f"{self.organization.id}/{self.project.id}/{b.id}/manifest.json"
+        comparison.head_snapshot_metrics.extras = {"manifest_key": head_key}
+        comparison.head_snapshot_metrics.save(update_fields=["extras"])
+        comparison.base_snapshot_metrics.extras = {"manifest_key": base_key}
+        comparison.base_snapshot_metrics.save(update_fields=["extras"])
+        stored = {
+            f"{prefix}/plan.json": orjson.dumps(self._single_chunk_plan(h, b).dict()),
+            f"{prefix}/chunks/0.json": orjson.dumps(self._changed_chunk_result().dict()),
+            head_key: orjson.dumps(
+                {"images": {"a.png": {"content_hash": "h", "width": 1, "height": 2}}},
+            ),
+        }
+        if include_base:
+            stored[base_key] = orjson.dumps(
+                {"images": {"a.png": {"content_hash": "b", "width": 1, "height": 2}}}
+            )
+        return comparison, h, b, prefix, stored
+
+    def test_finalize_writes_comparison_response_blob(self):
+        from sentry.preprod.snapshots.precompute import COMPARISON_SCHEMA_VERSION
+        from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
+
+        comparison, h, b, prefix, stored = self._finalize_with_manifests()
+        session = _dict_backed_session(stored)
+        with (
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks._try_auto_approve_snapshot"),
+        ):
+            finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
+
+        payload = orjson.loads(stored[f"{prefix}/snapshot_comparison_response.json"])
+        assert payload["schema_version"] == COMPARISON_SCHEMA_VERSION
+        assert payload["comparison_type"] == "diff"
+        assert payload["base_artifact_id"] == str(b.id)
+        assert len(payload["changed"]) == 1
+
+    def test_finalize_skips_comparison_blob_when_base_manifest_missing(self):
+        from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
+
+        comparison, h, b, prefix, stored = self._finalize_with_manifests(include_base=False)
+        session = _dict_backed_session(stored)
+        with (
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks._try_auto_approve_snapshot"),
+        ):
+            finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
+
+        comparison.refresh_from_db()
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
+        assert f"{prefix}/snapshot_comparison_response.json" not in stored
+
     def test_finalize_writes_images_errored_column(self):
         from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
 

--- a/tests/sentry/preprod/snapshots/test_precompute.py
+++ b/tests/sentry/preprod/snapshots/test_precompute.py
@@ -3,11 +3,17 @@ from unittest.mock import MagicMock
 
 import orjson
 
+from sentry.preprod.snapshots.comparison_categorizer import CategorizedComparison
 from sentry.preprod.snapshots.precompute import (
+    COMPARISON_SCHEMA_VERSION,
     HEAD_IMAGES_SCHEMA_VERSION,
+    build_comparison_payload,
     build_head_images_payload,
+    comparison_response_key,
     head_images_key,
+    load_precomputed_comparison,
     load_precomputed_head_images,
+    refresh_expiration,
     refresh_manifest_expiration,
 )
 
@@ -61,6 +67,98 @@ class TestRefreshManifestExpiration:
         session.head.side_effect = OSError("boom")
 
         refresh_manifest_expiration(session, "mk")
+
+
+class TestRefreshExpiration:
+    def test_heads_every_present_key(self) -> None:
+        session = MagicMock()
+
+        refresh_expiration(session, ("a", None, "b"))
+
+        assert [c.args[0] for c in session.head.call_args_list] == ["a", "b"]
+
+    def test_swallows_errors_and_continues(self) -> None:
+        session = MagicMock()
+        session.head.side_effect = [OSError("boom"), None]
+
+        refresh_expiration(session, ("a", "b"))
+
+        assert [c.args[0] for c in session.head.call_args_list] == ["a", "b"]
+
+
+_PAIR = {
+    "base_image": {"key": "b", "image_file_name": "x.png"},
+    "head_image": {"key": "h", "image_file_name": "x.png"},
+    "diff_image_key": "d",
+    "diff": 0.5,
+}
+_IMG = {"key": "k", "image_file_name": "y.png", "width": 1, "height": 2}
+
+
+def _categorized() -> CategorizedComparison:
+    return CategorizedComparison(
+        changed=[cast(Any, _PAIR)],
+        added=[cast(Any, _IMG)],
+        unchanged=[cast(Any, _IMG), cast(Any, _IMG)],
+    )
+
+
+class TestComparisonResponseKey:
+    def test_key_format(self) -> None:
+        assert comparison_response_key(1, 2, 3, 4) == "1/2/3/4/snapshot_comparison_response.json"
+
+
+class TestBuildComparisonPayload:
+    def test_carries_schema_metadata_and_buckets(self) -> None:
+        payload = build_comparison_payload(_categorized(), "diff", "4", 0.1)
+
+        assert payload["schema_version"] == COMPARISON_SCHEMA_VERSION
+        assert payload["comparison_type"] == "diff"
+        assert payload["base_artifact_id"] == "4"
+        assert payload["diff_threshold"] == 0.1
+        assert payload["changed"] == [_PAIR]
+        assert payload["added"] == [_IMG]
+        assert len(payload["unchanged"]) == 2
+        assert payload["removed"] == []
+
+
+class TestLoadPrecomputedComparison:
+    def test_returns_none_when_key_missing(self) -> None:
+        assert load_precomputed_comparison(_mock_session(b""), None) is None
+
+    def test_returns_none_when_object_missing(self) -> None:
+        assert load_precomputed_comparison(_mock_session(None), "k") is None
+
+    def test_returns_payload_on_hit(self) -> None:
+        raw = orjson.dumps(build_comparison_payload(_categorized(), "diff", "4", 0.1))
+
+        result = load_precomputed_comparison(_mock_session(raw), "k")
+
+        assert result is not None
+        assert result["comparison_type"] == "diff"
+        assert result["changed"] == [_PAIR]
+
+    def test_returns_none_on_schema_version_mismatch(self) -> None:
+        payload = build_comparison_payload(_categorized(), "diff", "4", 0.1)
+        payload["schema_version"] = COMPARISON_SCHEMA_VERSION + 999
+        raw = orjson.dumps(payload)
+
+        assert load_precomputed_comparison(_mock_session(raw), "k") is None
+
+    def test_returns_none_when_a_bucket_is_absent(self) -> None:
+        payload = build_comparison_payload(_categorized(), "diff", "4", 0.1)
+        del cast(dict[str, Any], payload)["unchanged"]
+        raw = orjson.dumps(payload)
+
+        assert load_precomputed_comparison(_mock_session(raw), "k") is None
+
+    def test_returns_none_on_read_error(self) -> None:
+        session = MagicMock()
+        result = MagicMock()
+        result.payload.read.side_effect = OSError("boom")
+        session.get.return_value = result
+
+        assert load_precomputed_comparison(session, "k") is None
 
 
 def _mock_session(raw: bytes | None) -> MagicMock:


### PR DESCRIPTION
## Summary

Stacked on #123344 (head-image blob). Precompute the **categorized comparison response** so the snapshot-details GET can serve a diff build from a single blob instead of reading + parsing the head, comparison, and base manifests and re-categorizing 30k–47k images on every request (pre-PR2 traces show that work at p95 ≈ 12s, dominated by `parse_base_manifest` ~2.3s + `serialize_response_body`).

**Precompute happens at finalize** — the direct analog of #123344 writing the head-image blob at upload. `finalize_snapshot_comparison` already has the diff results in hand; it additionally reads the head + raw base manifests and runs the existing categorizer to build a payload **byte-identical to the live GET response**, then writes it before the PROCESSING→SUCCESS side effects. This makes the **first** detail-page load fast — the load that matters — which a lazy read-path write could not.

On GET, a SUCCESS comparison loads the blob and skips the three manifest reads/parses + the categorizer, overlaying only the genuinely per-request fields (comparison/approval status, approvers) live. On a miss it falls back to the existing live compute.

Writing at finalize also means:
- **No staleness:** the blob is rewritten fresh on every (re)finalize, so a recompare can't leave a stale result behind.
- **No degraded cache:** finalize refuses to write when a manifest is missing, so an incomplete categorization is never persisted.

(These two were the Cursor Bugbot findings on the earlier read-path-write version; the finalize approach removes both classes of bug rather than guarding against them.)

## Byte-parity

`test_golden_diff_precomputed_comparison` populates the blob exactly as finalize does, drops every manifest, and asserts the GET still returns the diff golden — proving the fast path is byte-identical to the live response and that a fallback couldn't have produced it.

## Test plan

- `tests/sentry/preprod/snapshots/test_compare_snapshots.py` — finalize writes the blob; finalize skips the write when a base manifest is missing.
- `tests/.../test_preprod_artifact_snapshot.py::...::test_golden_diff_precomputed_comparison` — read fast-path golden byte-parity.
- `tests/sentry/preprod/snapshots/test_precompute.py`, `tests/sentry/preprod/helpers/test_deletion.py` — precompute helpers + deletion key collection.
- Full preprod snapshot + endpoint + deletion suites: 255 passed; mypy (incl. tests) + prek clean.

https://claude.ai/code/session_013SAxBGjuP4a7cxRx3WmZa4
