### PR TITLE
ref(insights): give each table its own sortable-fields list

### DIFF
--- a/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/renderHeadCell.tsx
@@ -17,83 +17,17 @@ import {
   parseFunction,
 } from 'sentry/utils/discover/fields';
 import type {QueryParameterNames} from 'sentry/views/insights/common/views/queryParameters';
-import {SpanFields, SpanFunction} from 'sentry/views/insights/types';
+import {SpanFields} from 'sentry/views/insights/types';
 
 type Options = {
   column: GridColumnHeader<string>;
+  sortableFields: readonly string[];
   location?: Location;
   sort?: Sort;
   sortParameterName?: QueryParameterNames | typeof DEFAULT_SORT_PARAMETER_NAME;
 };
 
 const DEFAULT_SORT_PARAMETER_NAME = 'sort';
-
-const {SPAN_SELF_TIME, SPAN_DURATION, HTTP_RESPONSE_CONTENT_LENGTH, CACHE_ITEM_SIZE} =
-  SpanFields;
-const {
-  TIME_SPENT_PERCENTAGE,
-  EPM,
-  TPM,
-  HTTP_RESPONSE_COUNT,
-  HTTP_RESPONSE_RATE,
-  CACHE_HIT_RATE,
-  CACHE_MISS_RATE,
-} = SpanFunction;
-
-const SORTABLE_FIELDS = new Set([
-  `avg(${SPAN_SELF_TIME})`,
-  `avg(${SPAN_DURATION})`,
-  `sum(${SPAN_DURATION})`,
-  `sum(${SPAN_SELF_TIME})`,
-  `p95(${SPAN_SELF_TIME})`,
-  'p75(transaction.duration)',
-  'transaction.duration',
-  'transaction',
-  'count()',
-  `${EPM}()`,
-  `${TPM}()`,
-  `${TIME_SPENT_PERCENTAGE}()`,
-  `${HTTP_RESPONSE_COUNT}(5)`,
-  `${HTTP_RESPONSE_COUNT}(4)`,
-  `${HTTP_RESPONSE_COUNT}(3)`,
-  `${HTTP_RESPONSE_COUNT}(2)`,
-  `${HTTP_RESPONSE_RATE}(5)`,
-  `${HTTP_RESPONSE_RATE}(4)`,
-  `${HTTP_RESPONSE_RATE}(3)`,
-  `${HTTP_RESPONSE_RATE}(2)`,
-  `avg(${HTTP_RESPONSE_CONTENT_LENGTH})`,
-  `${CACHE_HIT_RATE}()`,
-  `${CACHE_MISS_RATE}()`,
-  SpanFields.TIMESTAMP,
-  SpanFields.SPAN_DURATION,
-  `avg(${CACHE_ITEM_SIZE})`,
-  SpanFields.MESSAGING_MESSAGE_DESTINATION_NAME,
-  'count_op(queue.publish)',
-  'count_op(queue.process)',
-  'avg_if(span.duration,span.op,equals,queue.process)',
-  'avg(messaging.message.receive.latency)',
-  'time_spent_percentage(span.duration)',
-  'transaction',
-  'request.method',
-  'span.op',
-  'project',
-  'epm()',
-  'p50(span.duration)',
-  'p95(span.duration)',
-  'failure_rate()',
-  'performance_score(measurements.score.total)',
-  'count_unique(user)',
-  'p50_if(span.duration,is_transaction,equals,true)',
-  'p75_if(span.duration,is_transaction,equals,true)',
-  'p90_if(span.duration,is_transaction,equals,true)',
-  'p95_if(span.duration,is_transaction,equals,true)',
-  'p99_if(span.duration,is_transaction,equals,true)',
-  'failure_rate_if(is_transaction,equals,true)',
-  'sum_if(span.duration,is_transaction,equals,true)',
-  'p75(measurements.frames_slow_rate)',
-  'p75(measurements.frames_frozen_rate)',
-  'trace_status_rate(ok)',
-]);
 
 const NUMERIC_FIELDS = new Set([
   'transaction.duration',
@@ -109,10 +43,11 @@ export const getColumnSort = ({
   column,
   location,
   sort,
+  sortableFields,
   sortParameterName,
 }: Options): GridColumnSort => {
   const {key} = column;
-  const canSort = Boolean(location && sort && SORTABLE_FIELDS.has(key));
+  const canSort = Boolean(location && sort && sortableFields.includes(key));
 
   return {
     align: getAlignment(key),
@@ -140,7 +75,7 @@ export const renderHeadCell = ({column}: Pick<Options, 'column'>) =>
     column.name
   );
 
-const getAlignment = (key: string): ColumnAlign => {
+export const getAlignment = (key: string): ColumnAlign => {
   const result = parseFunction(key);
 
   if (result) {

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.spec.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.spec.tsx
@@ -1,0 +1,48 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {MobileOverviewTable} from 'sentry/views/insights/pages/mobile/mobileOverviewTable';
+import {DEFAULT_SORT} from 'sentry/views/insights/pages/mobile/settings';
+
+const EMPTY_RESPONSE = {
+  data: [],
+  isLoading: false,
+  meta: {fields: {}, units: {}},
+};
+
+describe('MobileOverviewTable', () => {
+  it('links the Time Spent header to the ascending sort when it is the active sort', () => {
+    render(<MobileOverviewTable response={EMPTY_RESPONSE} sort={DEFAULT_SORT} />, {
+      organization: OrganizationFixture(),
+    });
+
+    const header = screen.getByRole('columnheader', {name: /time spent/i});
+    const link = screen.getByRole('link', {name: /time spent/i});
+
+    expect(header).toHaveAttribute('aria-sort', 'descending');
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringContaining('sort=sum%28span.duration%29')
+    );
+  });
+
+  it('links the Time Spent header to the descending sort when another column is sorted', () => {
+    render(
+      <MobileOverviewTable
+        response={EMPTY_RESPONSE}
+        sort={{field: 'count_unique(user)', kind: 'desc'}}
+      />,
+      {organization: OrganizationFixture()}
+    );
+
+    const header = screen.getByRole('columnheader', {name: /time spent/i});
+    const link = screen.getByRole('link', {name: /time spent/i});
+
+    expect(header).not.toHaveAttribute('aria-sort');
+    expect(link).toHaveAttribute(
+      'href',
+      expect.stringContaining('sort=-sum%28span.duration%29')
+    );
+  });
+});

--- a/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
+++ b/static/app/views/insights/pages/mobile/mobileOverviewTable.tsx
@@ -116,7 +116,7 @@ export type ValidSort = Sort & {
 };
 
 export function isAValidSort(sort: Sort): sort is ValidSort {
-  return (SORTABLE_FIELDS as unknown as string[]).includes(sort.field);
+  return (SORTABLE_FIELDS as readonly string[]).includes(sort.field);
 }
 
 interface Props {
@@ -161,7 +161,8 @@ export function MobileOverviewTable({response, sort}: Props) {
         grid={{
           prependColumnWidths: ['max-content'],
           renderPrependColumns,
-          getColumnSort: column => getColumnSort({column, location, sort}),
+          getColumnSort: column =>
+            getColumnSort({column, location, sort, sortableFields: SORTABLE_FIELDS}),
           renderHeadCell: column => renderHeadCell({column}),
           renderBodyCell: (column, row) =>
             renderBodyCell(column, row, meta, location, navigate, organization, theme),

--- a/static/app/views/performance/eap/segmentSpansTable.tsx
+++ b/static/app/views/performance/eap/segmentSpansTable.tsx
@@ -24,7 +24,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
 import {
-  getColumnSort,
+  getAlignment,
   renderHeadCell,
 } from 'sentry/views/insights/common/components/tableCells/renderHeadCell';
 import {SpanIdCell} from 'sentry/views/insights/common/components/tableCells/spanIdCell';
@@ -159,7 +159,7 @@ export function SegmentSpansTable({
         data={consolidatedData}
         columnOrder={SEGMENT_SPANS_COLUMN_ORDER}
         grid={{
-          getColumnSort: column => getColumnSort({column}),
+          getColumnSort: column => ({align: getAlignment(column.key)}),
           renderHeadCell: column => renderHeadCell({column}),
           renderBodyCell: (column, row) =>
             renderBodyCell(

--- a/static/app/views/performance/transactionSummary/transactionEvents/eapSampledEventsTable.tsx
+++ b/static/app/views/performance/transactionSummary/transactionEvents/eapSampledEventsTable.tsx
@@ -115,6 +115,8 @@ const COLUMN_ORDER: SampledEventsColumn[] = [
   {key: 'profile.id', name: t('Profile'), width: COL_WIDTH_UNDEFINED},
 ];
 
+const SORTABLE_FIELDS = ['request.method', 'span.duration', 'timestamp'] as const;
+
 type Props = {
   eventView: EventView;
   isMaxDurationLoading: boolean;
@@ -237,6 +239,7 @@ export function SampledEventsTable({
               column,
               location,
               sort,
+              sortableFields: SORTABLE_FIELDS,
               sortParameterName: QueryParameterNames.SPANS_SORT,
             }),
           renderHeadCell: column => {


### PR DESCRIPTION
Deduplicates a bunch of sortable fields from the insights `tableCells.tsx`. Three call sites with no intended behavior change:

- **Mobile overview** ([`/organizations/<org-slug>/insights/mobile`](https://sentry-git-joshgoldberg-de-1571-mobile-overviews-time-sp-6a37ce.sentry.dev/organizations/sentry/insights/mobile/?project=-1&statsPeriod=30d)): passes the tuple that already derives its `ValidSort` type and backs `isAValidSort`. This is the case the divergence was actually reachable in, so it now has coverage.
- **Sampled events** ([`/organizations/<org-slug>/insights/backend/summary/events/?transaction=<name>&project=<id>`](https://sentry-git-joshgoldberg-de-1571-mobile-overviews-time-sp-6a37ce.sentry.dev/insights/summary/events/?transaction=MainActivity&statsPeriod=30d&project=4510398352719872)): declares `request.method`, `span.duration`, and `timestamp`. That's what the shared set matched against its columns.
- **Segment spans** ([`/organizations/<org-slug>/insights/backend/summary/?transaction=<name>&project=<id>`](https://sentry-git-joshgoldberg-de-1571-mobile-overviews-time-sp-6a37ce.sentry.dev/insights/summary/?transaction=MainActivity&statsPeriod=30d&project=4510398352719872)): passed neither `location` nor `sort`, so `canSort` was always `false` and it was only ever using the helper for alignment. It now calls the newly exported `getAlignment` directly.

Closes DE-1571.