### PR TITLE
chore(workflow-engine): Replace killswitch with rollout rate option for all projects detector

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3569,6 +3569,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
+    "workflow_engine.all_projects_detectors.rollout-rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
     "workflow_engine.auto_creation.pull_request_workflow",
     type=Bool,
     default=False,

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -11,6 +11,7 @@ from sentry.issues.issue_occurrence import IssueOccurrence
 from sentry.issues.producer import PayloadType, produce_occurrence_to_kafka
 from sentry.models.activity import Activity
 from sentry.models.group import Group
+from sentry.options.rollout import in_rollout_group
 from sentry.services.eventstore.models import GroupEvent
 from sentry.utils import metrics
 from sentry.utils.cache import cache
@@ -163,9 +164,10 @@ def get_detectors_for_event_data(
 
     if options.get("workflow_engine.all_projects_detectors_enabled"):
         organization_id = event_data.event.project.organization_id
-        all_projects_detector = get_all_projects_detector(organization_id)
-        if all_projects_detector:
-            issue_stream_detectors.append(all_projects_detector)
+        if in_rollout_group("workflow_engine.all_projects_detectors.rollout-rate", organization_id):
+            all_projects_detector = get_all_projects_detector(organization_id)
+            if all_projects_detector:
+                issue_stream_detectors.append(all_projects_detector)
 
     if detector is None and isinstance(event_data.event, GroupEvent):
         detector = _get_detector_for_event(event_data.event)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -162,12 +162,11 @@ def get_detectors_for_event_data(
             extra={"project_id": event_data.group.project_id, "group_id": event_data.group.id},
         )
 
-    if options.get("workflow_engine.all_projects_detectors_enabled"):
-        organization_id = event_data.event.project.organization_id
-        if in_rollout_group("workflow_engine.all_projects_detectors.rollout-rate", organization_id):
-            all_projects_detector = get_all_projects_detector(organization_id)
-            if all_projects_detector:
-                issue_stream_detectors.append(all_projects_detector)
+    organization_id = event_data.event.project.organization_id
+    if in_rollout_group("workflow_engine.all_projects_detectors.rollout-rate", organization_id):
+        all_projects_detector = get_all_projects_detector(organization_id)
+        if all_projects_detector:
+            issue_stream_detectors.append(all_projects_detector)
 
     if detector is None and isinstance(event_data.event, GroupEvent):
         detector = _get_detector_for_event(event_data.event)

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1349,7 +1349,7 @@ class TestGetDetectorsForEventAllProject(TestCase):
         assert self.all_projects_detector not in result.detectors
         assert result.preferred_detector == self.error_detector
 
-    @override_options({"workflow_engine.all_projects_detectors_enabled": True})
+    @override_options({"workflow_engine.all_projects_detectors.rollout-rate": 1.0})
     def test_includes_all_projects_detector_with_option(self) -> None:
         event_data = WorkflowEventData(event=self.group_event, group=self.group)
         result = get_detectors_for_event_data(event_data)
@@ -1357,7 +1357,7 @@ class TestGetDetectorsForEventAllProject(TestCase):
         assert self.all_projects_detector in result.detectors
         assert result.preferred_detector == self.error_detector
 
-    @override_options({"workflow_engine.all_projects_detectors_enabled": True})
+    @override_options({"workflow_engine.all_projects_detectors.rollout-rate": 1.0})
     def test_missing_all_projects_detector_no_effect(self) -> None:
         self.all_projects_detector.delete()
         event_data = WorkflowEventData(event=self.group_event, group=self.group)

--- a/tests/sentry/workflow_engine/processors/test_workflow.py
+++ b/tests/sentry/workflow_engine/processors/test_workflow.py
@@ -534,7 +534,7 @@ class TestProcessWorkflows(BaseWorkflowTest):
         result = process_workflows(self.batch_client, self.event_data, FROZEN_TIME)
         assert _triggered_workflow_ids(result) == {self.error_workflow.id}
 
-    @override_options({"workflow_engine.all_projects_detectors_enabled": True})
+    @override_options({"workflow_engine.all_projects_detectors.rollout-rate": 1.0})
     def test_all_projects_workflow_via_process_workflows(self) -> None:
         all_projects_detector = ensure_default_all_projects_detector(self.organization.id)
 


### PR DESCRIPTION
Replaces the existing option with a rollout rate, this will allow us to unregister the one in options-automator and slowly raise the rate we release to populate the cache.