### PR TITLE
fix(preprod): Use itms-services URL scheme for iOS app installs

### DIFF
--- a/static/app/views/preprod/components/installDetailsContent.spec.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.spec.tsx
@@ -1,8 +1,9 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {
+  getDeviceInstallUrl,
   getDistributionErrorTooltip,
   InstallDetailsContent,
 } from 'sentry/views/preprod/components/installDetailsContent';
@@ -36,12 +37,31 @@ describe('getDistributionErrorTooltip', () => {
   });
 });
 
+describe('getDeviceInstallUrl', () => {
+  it('wraps apple install URLs with the itms-services scheme', () => {
+    expect(getDeviceInstallUrl('apple', 'https://example.com/install')).toBe(
+      'itms-services://?action=download-manifest&url=https%3A%2F%2Fexample.com%2Finstall'
+    );
+  });
+
+  it('returns android install URLs unchanged', () => {
+    expect(getDeviceInstallUrl('android', 'https://example.com/install')).toBe(
+      'https://example.com/install'
+    );
+  });
+});
+
 describe('InstallDetailsContent', () => {
   const organization = OrganizationFixture();
   const INSTALL_DETAILS_URL = `/organizations/${organization.slug}/preprodartifacts/artifact-1/private-install-details/`;
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: jest.fn().mockResolvedValue(''),
+      },
+    });
   });
 
   it('shows settings link on 404 when distribution is disabled', async () => {
@@ -217,7 +237,59 @@ describe('InstallDetailsContent', () => {
     });
 
     expect(await screen.findByText('5 downloads')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Download'})).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Download'})).toHaveAttribute(
+      'href',
+      'itms-services://?action=download-manifest&url=https%3A%2F%2Fexample.com%2Finstall'
+    );
+  });
+
+  it('copies the itms-services URL for apple builds', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      body: {
+        platform: 'apple',
+        install_url: 'https://example.com/install',
+        is_code_signature_valid: true,
+      },
+    });
+
+    render(<InstallDetailsContent artifactId="artifact-1" projectSlug="my-project" />, {
+      organization,
+    });
+
+    const copyButtons = await screen.findAllByRole('button', {
+      name: 'Copy Download Link',
+    });
+    await userEvent.click(copyButtons[0]!);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'itms-services://?action=download-manifest&url=https%3A%2F%2Fexample.com%2Finstall'
+    );
+  });
+
+  it('opens the raw install URL for android downloads', async () => {
+    MockApiClient.addMockResponse({
+      url: INSTALL_DETAILS_URL,
+      body: {
+        platform: 'android',
+        install_url: 'https://example.com/install',
+      },
+    });
+
+    render(<InstallDetailsContent artifactId="artifact-1" projectSlug="my-project" />, {
+      organization,
+    });
+
+    expect(await screen.findByRole('button', {name: 'Download'})).not.toHaveAttribute(
+      'href'
+    );
+
+    const copyButtons = screen.getAllByRole('button', {name: 'Copy Download Link'});
+    await userEvent.click(copyButtons[0]!);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      'https://example.com/install'
+    );
   });
 
   it('renders install groups when provided', async () => {

--- a/static/app/views/preprod/components/installDetailsContent.tsx
+++ b/static/app/views/preprod/components/installDetailsContent.tsx
@@ -2,7 +2,7 @@ import {Fragment, type ReactNode} from 'react';
 import {useTheme} from '@emotion/react';
 
 import {Tag} from '@sentry/scraps/badge';
-import {Button} from '@sentry/scraps/button';
+import {Button, LinkButton} from '@sentry/scraps/button';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {Separator} from '@sentry/scraps/separator';
@@ -20,6 +20,7 @@ import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {InstallDetailsApiResponse} from 'sentry/views/preprod/types/installDetailsTypes';
+import type {Platform} from 'sentry/views/preprod/types/sharedTypes';
 
 export function getDistributionErrorTooltip(
   errorCode?: string | null,
@@ -39,6 +40,13 @@ export function getDistributionErrorTooltip(
   }
 
   return errorMessage || t('Not installable');
+}
+
+export function getDeviceInstallUrl(platform: Platform, installUrl: string): string {
+  if (platform === 'apple') {
+    return `itms-services://?action=download-manifest&url=${encodeURIComponent(installUrl)}`;
+  }
+  return installUrl;
 }
 
 interface InstallDetailsContentProps {
@@ -165,6 +173,10 @@ export function InstallDetailsContent({
       </Stack>
     );
   } else if (installDetails.install_url) {
+    const deviceInstallUrl = getDeviceInstallUrl(
+      installDetails.platform,
+      installDetails.install_url
+    );
     const details = installDetails.is_code_signature_valid !== undefined && (
       <CodeSignatureInfo>
         {installDetails.profile_name && (
@@ -194,11 +206,7 @@ export function InstallDetailsContent({
             <Container display={{sm: 'none', xl: 'block'}}>
               <QuietZoneQRCode
                 aria-label={t('Install QR Code')}
-                value={
-                  installDetails.platform === 'apple'
-                    ? `itms-services://?action=download-manifest&url=${encodeURIComponent(installDetails.install_url)}`
-                    : installDetails.install_url
-                }
+                value={deviceInstallUrl}
                 size={qrSize}
               />
             </Container>
@@ -239,14 +247,25 @@ export function InstallDetailsContent({
               align={{zero: 'stretch', sm: 'center'}}
             >
               <Flex width={{sm: '100%', xl: 'auto'}}>
-                <Button
-                  onClick={() => window.open(installDetails.install_url, '_blank')}
-                  variant="primary"
-                  size="md"
-                  style={{width: '100%'}}
-                >
-                  {t('Download')}
-                </Button>
+                {installDetails.platform === 'apple' ? (
+                  <LinkButton
+                    href={deviceInstallUrl}
+                    variant="primary"
+                    size="md"
+                    style={{width: '100%'}}
+                  >
+                    {t('Download')}
+                  </LinkButton>
+                ) : (
+                  <Button
+                    onClick={() => window.open(deviceInstallUrl, '_blank')}
+                    variant="primary"
+                    size="md"
+                    style={{width: '100%'}}
+                  >
+                    {t('Download')}
+                  </Button>
+                )}
               </Flex>
               {installDetails.install_url && (
                 <Flex
@@ -256,7 +275,7 @@ export function InstallDetailsContent({
                   <Container display={{zero: 'block', sm: 'none'}} width="100%">
                     <Button
                       onClick={() =>
-                        copy(installDetails.install_url!, {
+                        copy(deviceInstallUrl, {
                           successMessage: t('Copied Download Link'),
                         })
                       }
@@ -274,7 +293,7 @@ export function InstallDetailsContent({
                         icon={<IconLink />}
                         size="md"
                         onClick={() =>
-                          copy(installDetails.install_url!, {
+                          copy(deviceInstallUrl, {
                             successMessage: t('Copied Download Link'),
                           })
                         }


### PR DESCRIPTION
## Summary
- Extract `getDeviceInstallUrl` helper to centralize `itms-services://` URL wrapping for Apple OTA installs
- Use `LinkButton` with `href` for Apple downloads instead of `window.open`, enabling native iOS install flow
- Copy the device-specific URL (with `itms-services://` for Apple, raw URL for Android) to clipboard

## Test plan
- [x] Added unit tests for `getDeviceInstallUrl` (Apple wrapping and Android passthrough)
- [x] Added test for clipboard copy with `itms-services://` URL on Apple builds
- [x] Added test verifying Android download button has no `href` and copies raw URL
- [x] Updated existing test to verify Download button `href` attribute for Apple builds