### PR TITLE
ref: Enforce org flag column parity between rpc methods and models in control

### DIFF
--- a/src/sentry/organizations/services/organization/model.py
+++ b/src/sentry/organizations/services/organization/model.py
@@ -163,8 +163,8 @@ class RpcOrganizationMember(RpcOrganizationMemberSummary):
         }
 
 
-# Add new organization flags to RpcOrganizationFlags first, only add them here after
-# they have been replicated via Organization.handle_async_replication logic
+# Only flags that `serialize_organization_mapping_flags` populates belong here; anything else
+# silently reads as its default. Declare new organization flags on `RpcOrganizationFlags` below.
 class RpcOrganizationMappingFlags(RpcModel):
     early_adopter: bool = False
     require_2fa: bool = False
@@ -172,14 +172,15 @@ class RpcOrganizationMappingFlags(RpcModel):
     enhanced_privacy: bool = False
     disable_shared_issues: bool = False
     disable_new_visibility_features: bool = False
-    require_email_verification: bool = False
-    codecov_access: bool = False
     disable_member_project_creation: bool = False
     prevent_superuser_access: bool = False
     disable_member_invite: bool = False
 
 
 class RpcOrganizationFlags(RpcOrganizationMappingFlags):
+    require_email_verification: bool = False
+    codecov_access: bool = False
+
     def as_int(self) -> int:
         # Must maintain the same order as the ORM's `Organization.flags` fields
         return flags_to_bits(

--- a/tests/sentry/organizations/services/test_organization.py
+++ b/tests/sentry/organizations/services/test_organization.py
@@ -1,7 +1,12 @@
 from django.conf import settings
 
+from sentry.hybridcloud.services.organization_mapping.serial import (
+    serialize_organization_mapping_flags,
+)
 from sentry.models.options.organization_option import OrganizationOption
 from sentry.models.organization import Organization, OrganizationStatus
+from sentry.models.organizationmapping import OrganizationMapping
+from sentry.organizations.services.organization import RpcOrganizationMappingFlags
 from sentry.organizations.services.organization.service import organization_service
 from sentry.testutils.cases import TestCase
 from sentry.testutils.silo import all_silo_test, assume_test_silo_mode_of
@@ -163,3 +168,22 @@ class FindOrganizationIdByOptionValueTest(TestCase):
             )
             is None
         )
+
+
+def test_no_mapping_flag_silently_defaults() -> None:
+    control_flag_names = set(RpcOrganizationMappingFlags.get_field_names())
+
+    mapping_columns = {field.name for field in OrganizationMapping._meta.get_fields()}
+    assert control_flag_names <= mapping_columns, (
+        f"{sorted(control_flag_names - mapping_columns)} have no OrganizationMapping column. "
+        "Declare them on RpcOrganizationFlags instead."
+    )
+
+    control_flags = serialize_organization_mapping_flags(
+        OrganizationMapping(**{name: True for name in control_flag_names})
+    )
+    unpopulated = sorted(name for name in control_flag_names if not getattr(control_flags, name))
+    assert not unpopulated, (
+        f"serialize_organization_mapping_flags does not populate {unpopulated}, so they always "
+        "fall back to their default when flags are built from control silo data."
+    )


### PR DESCRIPTION
RpcOrganizationMappingFlags is meant to hold only the flags available from control-silo data, but codecov_access has no OrganizationMapping column and require_email_verification stopped being populated. This caused them to silently read as False on any organization built from a mapping. This moves them down to RpcOrganizationFlags, where they're only reachable with real cell data.

Adds a test so this is enforced for all fields going forward.
