### PR TITLE
feat(pr-iter): Pause PR iteration when the run errors

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -46,6 +46,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewCommentFeedbackSource,
 )
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
+from sentry.seer.autofix.pr_iteration.pause import PauseReason, pause_pr_iteration
 from sentry.seer.autofix.pr_ready_for_review import (
     emit_pr_ready_for_review,
     format_pull_requests_payload,
@@ -833,6 +834,21 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         # the hook re-fire after the push doesn't loop.
         if current_step == AutofixStep.PR_ITERATION:
             log_ctx = cls._iteration_log_context(organization, group, state)
+
+            if state.status == "error":
+                paused = pause_pr_iteration(
+                    run_id=run_id,
+                    organization_id=organization.id,
+                    reason=PauseReason.RUN_ERRORED,
+                )
+                log_ctx.info(
+                    "autofix.pr_iteration.paused_on_error",
+                    run_status=state.status,
+                    paused=paused,
+                    failure_reason=state.failure_reason,
+                )
+                return
+
             pushed = cls._push_iteration_changes(
                 log_ctx,
                 group,

--- a/src/sentry/seer/autofix/pr_iteration/pause.py
+++ b/src/sentry/seer/autofix/pr_iteration/pause.py
@@ -8,6 +8,7 @@ name, so a per-repo pause cannot find its own entries.
 from __future__ import annotations
 
 import logging
+from enum import StrEnum
 
 from django.utils import timezone
 
@@ -20,6 +21,11 @@ logger = logging.getLogger(__name__)
 
 # Run-level SeerRun.extras key. No key means that the run iterates.
 PAUSED_EXTRA = "pr_iteration_paused"
+
+
+class PauseReason(StrEnum):
+    USER_STOP = "user_stop"
+    RUN_ERRORED = "run_errored"
 
 
 def _get_seer_run(run_id: int, organization_id: int) -> SeerRun | None:
@@ -38,8 +44,27 @@ def is_pr_iteration_paused(*, run_id: int, organization_id: int) -> bool:
     return get_run_extra(seer_run, PAUSED_EXTRA) is not None
 
 
+def get_pause_reason(*, run_id: int, organization_id: int) -> PauseReason | None:
+    seer_run = _get_seer_run(run_id, organization_id)
+    if seer_run is None:
+        return None
+
+    marker = get_run_extra(seer_run, PAUSED_EXTRA)
+    if marker is None:
+        return None
+
+    try:
+        return PauseReason(marker.get("reason", PauseReason.USER_STOP))
+    except ValueError:
+        return None
+
+
 def pause_pr_iteration(
-    *, run_id: int, organization_id: int, actor_user_id: int | None = None
+    *,
+    run_id: int,
+    organization_id: int,
+    reason: PauseReason,
+    actor_user_id: int | None = None,
 ) -> bool:
     seer_run = _get_seer_run(run_id, organization_id)
     if seer_run is None:
@@ -52,18 +77,21 @@ def pause_pr_iteration(
                 extras[PAUSED_EXTRA] = {
                     "paused_at": timezone.now().isoformat(),
                     "actor_user_id": actor_user_id,
+                    "reason": reason.value,
                 }
     except SeerRun.DoesNotExist:
         # The run was deleted between the lookup and the marker write.
         return False
     clear_queued_autofix_feedback(run_id)
 
+    metrics.incr("autofix.pr_iteration.paused", tags={"reason": reason.value})
     logger.info(
         "autofix.pr_iteration.paused",
         extra={
             "run_id": run_id,
             "organization_id": organization_id,
             "actor_user_id": actor_user_id,
+            "reason": reason.value,
         },
     )
     return True

--- a/src/sentry/seer/autofix/pr_iteration/pause.py
+++ b/src/sentry/seer/autofix/pr_iteration/pause.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import logging
 from enum import StrEnum
+from typing import Any
 
 from django.utils import timezone
 
@@ -44,12 +45,11 @@ def is_pr_iteration_paused(*, run_id: int, organization_id: int) -> bool:
     return get_run_extra(seer_run, PAUSED_EXTRA) is not None
 
 
-def get_pause_reason(*, run_id: int, organization_id: int) -> PauseReason | None:
-    seer_run = _get_seer_run(run_id, organization_id)
-    if seer_run is None:
-        return None
+def pause_reason_from_marker(marker: Any | None) -> PauseReason | None:
+    """Read the reason off a marker a caller already holds, sparing the query.
 
-    marker = get_run_extra(seer_run, PAUSED_EXTRA)
+    Markers written before the reason existed record a user stop.
+    """
     if marker is None:
         return None
 
@@ -57,6 +57,14 @@ def get_pause_reason(*, run_id: int, organization_id: int) -> PauseReason | None
         return PauseReason(marker.get("reason", PauseReason.USER_STOP))
     except ValueError:
         return None
+
+
+def get_pause_reason(*, run_id: int, organization_id: int) -> PauseReason | None:
+    seer_run = _get_seer_run(run_id, organization_id)
+    if seer_run is None:
+        return None
+
+    return pause_reason_from_marker(get_run_extra(seer_run, PAUSED_EXTRA))
 
 
 def pause_pr_iteration(

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -64,7 +64,11 @@ from sentry.seer.autofix.github_perms import (
 )
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
-from sentry.seer.autofix.pr_iteration.pause import PAUSED_EXTRA
+from sentry.seer.autofix.pr_iteration.pause import (
+    PAUSED_EXTRA,
+    PauseReason,
+    get_pause_reason,
+)
 from sentry.seer.autofix.pr_iteration.queue import (
     peek_queued_autofix_feedback,
     try_enqueue_autofix_feedback,
@@ -91,6 +95,11 @@ from sentry.utils.http import is_mcp_request
 logger = logging.getLogger(__name__)
 
 SEER_PERMISSION_DENIED = "You are not authorized to perform this action"
+
+PAUSED_PR_ITERATION_DETAIL = {
+    PauseReason.USER_STOP: "Iteration was stopped for this pull request",
+    PauseReason.RUN_ERRORED: "Seer can no longer iterate on this pull request",
+}
 
 
 def _is_unknown_run_id_error(error: SeerPermissionError) -> bool:
@@ -389,6 +398,15 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
                     return Response(
                         {"detail": "Cannot iterate on a PR before one has been created"},
                         status=status.HTTP_400_BAD_REQUEST,
+                    )
+
+                pause_reason = get_pause_reason(
+                    run_id=resolved_run_id, organization_id=group.organization.id
+                )
+                if pause_reason is not None:
+                    return Response(
+                        {"detail": PAUSED_PR_ITERATION_DETAIL[pause_reason]},
+                        status=status.HTTP_409_CONFLICT,
                     )
 
                 serialized_users = user_service.serialize_many(

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -68,6 +68,7 @@ from sentry.seer.autofix.pr_iteration.pause import (
     PAUSED_EXTRA,
     PauseReason,
     get_pause_reason,
+    pause_reason_from_marker,
 )
 from sentry.seer.autofix.pr_iteration.queue import (
     peek_queued_autofix_feedback,
@@ -612,6 +613,9 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
             for repo_name, info in missing_perms.items()
         ]
         queued_feedback = [item.feedback.dict() for item in queued_items]
+        # Off the fetched row, not is_pr_iteration_paused: polled every second.
+        paused_marker = get_run_extra(run, PAUSED_EXTRA) if run is not None else None
+        pause_reason = pause_reason_from_marker(paused_marker)
         return Response(
             {
                 "autofix": {
@@ -636,10 +640,8 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
                         "organizations:autofix-pr-iteration-manual", group.organization
                     ),
                     "queued_feedback": queued_feedback,
-                    # Off the fetched row, not is_pr_iteration_paused: polled every second.
-                    "pr_iteration_paused": (
-                        run is not None and get_run_extra(run, PAUSED_EXTRA) is not None
-                    ),
+                    "pr_iteration_paused": paused_marker is not None,
+                    "pr_iteration_pause_reason": pause_reason.value if pause_reason else None,
                     "warnings": warnings,
                 }
             }

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -82,6 +82,7 @@ from sentry.seer.autofix.pr_iteration.missing_permissions import (
     post_missing_permissions_comment,
 )
 from sentry.seer.autofix.pr_iteration.pause import (
+    PauseReason,
     is_pr_iteration_paused,
     pause_pr_iteration,
     record_pause_blocked,
@@ -440,11 +441,11 @@ def _drain_queued_autofix_feedback(
         log_ctx.error("autofix.pr_iteration.consume_feedback.group_not_found", exc_info=False)
         return
 
-    if state.status == "processing":
+    if state.status in ("processing", "error"):
         log_ctx.info(
             "autofix.pr_iteration.consume_feedback.drain",
             outcome="skipped",
-            reason="run_processing",
+            reason="run_processing" if state.status == "processing" else "run_errored",
             run_status=state.status,
             trigger_id=trigger_id,
             trigger_source=trigger_source,
@@ -1236,6 +1237,7 @@ def pause_pr_iteration_from_comment(
     paused = pause_pr_iteration(
         run_id=run_id,
         organization_id=organization_id,
+        reason=PauseReason.USER_STOP,
         actor_user_id=resolved.actor_user.id if resolved.actor_user else None,
     )
     reaction: Reaction = "+1"

--- a/tests/sentry/seer/autofix/pr_iteration/test_cap_exhausted.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_cap_exhausted.py
@@ -10,7 +10,7 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     GithubCheckSuiteEvent,
 )
 from sentry.seer.autofix.pr_iteration.constants import CAP_ASSIGN_FLAG
-from sentry.seer.autofix.pr_iteration.pause import pause_pr_iteration
+from sentry.seer.autofix.pr_iteration.pause import PauseReason, pause_pr_iteration
 from sentry.seer.models.run import SeerRun
 from sentry.testutils.cases import TestCase
 
@@ -158,7 +158,11 @@ class AssignUserForExhaustedCapTest(TestCase):
 
     @patch(f"{CAP_EXHAUSTED_PATH}.scm_actions")
     def test_skips_paused_run(self, mock_actions: MagicMock, _mock_cap: MagicMock) -> None:
-        pause_pr_iteration(run_id=RUN_ID, organization_id=self.organization.id)
+        pause_pr_iteration(
+            run_id=RUN_ID,
+            organization_id=self.organization.id,
+            reason=PauseReason.USER_STOP,
+        )
 
         with self.feature(FLAG), patch(f"{PAUSE_PATH}.metrics") as mock_metrics:
             assign_user_for_exhausted_cap(_event(), self._resolved())

--- a/tests/sentry/seer/autofix/pr_iteration/test_pause.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_pause.py
@@ -7,6 +7,8 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeed
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
 from sentry.seer.autofix.pr_iteration.pause import (
     PAUSED_EXTRA,
+    PauseReason,
+    get_pause_reason,
     is_pr_iteration_paused,
     pause_pr_iteration,
 )
@@ -62,6 +64,7 @@ class PausePrIterationTest(TestCase):
             pause_pr_iteration(
                 run_id=RUN_ID,
                 organization_id=self.organization.id,
+                reason=PauseReason.USER_STOP,
                 actor_user_id=self.user.id,
             )
             is True
@@ -71,18 +74,25 @@ class PausePrIterationTest(TestCase):
         assert marker is not None
         assert marker["actor_user_id"] == self.user.id
         assert marker["paused_at"]
+        assert marker["reason"] == PauseReason.USER_STOP.value
         assert peek_queued_autofix_feedback(RUN_ID) == []
         assert self._is_paused() is True
 
     def test_second_pause_changes_nothing(self) -> None:
         pause_pr_iteration(
-            run_id=RUN_ID, organization_id=self.organization.id, actor_user_id=self.user.id
+            run_id=RUN_ID,
+            organization_id=self.organization.id,
+            reason=PauseReason.USER_STOP,
+            actor_user_id=self.user.id,
         )
         first_marker = self._marker()
 
         assert (
             pause_pr_iteration(
-                run_id=RUN_ID, organization_id=self.organization.id, actor_user_id=99
+                run_id=RUN_ID,
+                organization_id=self.organization.id,
+                reason=PauseReason.RUN_ERRORED,
+                actor_user_id=99,
             )
             is True
         )
@@ -93,7 +103,14 @@ class PausePrIterationTest(TestCase):
     def test_returns_false_without_seer_run_row(self) -> None:
         self.seer_run.delete()
 
-        assert pause_pr_iteration(run_id=RUN_ID, organization_id=self.organization.id) is False
+        assert (
+            pause_pr_iteration(
+                run_id=RUN_ID,
+                organization_id=self.organization.id,
+                reason=PauseReason.USER_STOP,
+            )
+            is False
+        )
         assert self._is_paused() is False
 
     def test_returns_false_when_run_deleted_before_write(self) -> None:
@@ -103,7 +120,14 @@ class PausePrIterationTest(TestCase):
         assert self._enqueue() is True
 
         with patch("sentry.seer.autofix.pr_iteration.pause.get_run_extra", side_effect=delete_run):
-            assert pause_pr_iteration(run_id=RUN_ID, organization_id=self.organization.id) is False
+            assert (
+                pause_pr_iteration(
+                    run_id=RUN_ID,
+                    organization_id=self.organization.id,
+                    reason=PauseReason.USER_STOP,
+                )
+                is False
+            )
 
         # The queue survives a failed marker write, so the marker is written first.
         assert len(peek_queued_autofix_feedback(RUN_ID)) == 1
@@ -111,7 +135,12 @@ class PausePrIterationTest(TestCase):
     def test_returns_false_for_another_organization(self) -> None:
         other_org = self.create_organization()
 
-        assert pause_pr_iteration(run_id=RUN_ID, organization_id=other_org.id) is False
+        assert (
+            pause_pr_iteration(
+                run_id=RUN_ID, organization_id=other_org.id, reason=PauseReason.USER_STOP
+            )
+            is False
+        )
 
     def test_pause_leaves_other_run_alone(self) -> None:
         other_run = self.create_seer_run(
@@ -119,9 +148,31 @@ class PausePrIterationTest(TestCase):
         )
         assert self._enqueue(OTHER_RUN_ID) is True
 
-        pause_pr_iteration(run_id=RUN_ID, organization_id=self.organization.id)
+        pause_pr_iteration(
+            run_id=RUN_ID, organization_id=self.organization.id, reason=PauseReason.USER_STOP
+        )
 
         other_run.refresh_from_db()
         assert (other_run.extras or {}).get(PAUSED_EXTRA) is None
         assert len(peek_queued_autofix_feedback(OTHER_RUN_ID)) == 1
         assert self._is_paused(OTHER_RUN_ID) is False
+
+    def test_pause_reason_round_trips(self) -> None:
+        assert get_pause_reason(run_id=RUN_ID, organization_id=self.organization.id) is None
+
+        pause_pr_iteration(
+            run_id=RUN_ID, organization_id=self.organization.id, reason=PauseReason.RUN_ERRORED
+        )
+
+        assert (
+            get_pause_reason(run_id=RUN_ID, organization_id=self.organization.id)
+            == PauseReason.RUN_ERRORED
+        )
+
+    def test_pause_reason_defaults_to_user_stop_for_legacy_markers(self) -> None:
+        self.seer_run.update(extras={PAUSED_EXTRA: {"paused_at": "2024-01-01T00:00:00Z"}})
+
+        assert (
+            get_pause_reason(run_id=RUN_ID, organization_id=self.organization.id)
+            == PauseReason.USER_STOP
+        )

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -30,6 +30,11 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewCommentFeedbackSource,
     GithubPullRequestReviewComment,
 )
+from sentry.seer.autofix.pr_iteration.pause import (
+    PauseReason,
+    get_pause_reason,
+    is_pr_iteration_paused,
+)
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import AutofixHandoffPoint, SeerAutomationHandoffConfiguration
 from sentry.seer.models.run import SeerRunMilestone, SeerRunMilestoneType
@@ -741,6 +746,36 @@ class TestPrIterationCompletionHook(TestCase):
 
         mock_consume.assert_called_once()
         assert mock_consume.call_args.args[1:] == (self.organization, 123)
+
+    @patch(f"{HOOK_PATH}.AutofixOnCompletionHook._consume_queued_feedback")
+    @patch(f"{HOOK_PATH}.trigger_push_changes")
+    def test_an_errored_iteration_pauses_instead_of_pushing(self, mock_push, mock_consume):
+        self.create_seer_run(
+            organization=self.organization, seer_run_state_id=123, user_id=self.user.id
+        )
+        state = self._unsynced()
+        state.status = "error"
+
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+
+        mock_push.assert_not_called()
+        mock_consume.assert_not_called()
+        assert is_pr_iteration_paused(run_id=123, organization_id=self.organization.id) is True
+        assert (
+            get_pause_reason(run_id=123, organization_id=self.organization.id)
+            == PauseReason.RUN_ERRORED
+        )
+
+    @patch(f"{HOOK_PATH}.AutofixOnCompletionHook._consume_queued_feedback")
+    @patch(f"{HOOK_PATH}.trigger_push_changes")
+    def test_an_errored_iteration_without_a_run_row_still_stops(self, mock_push, mock_consume):
+        state = self._unsynced()
+        state.status = "error"
+
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+
+        mock_push.assert_not_called()
+        mock_consume.assert_not_called()
 
     @patch(f"{HOOK_PATH}.consume_queued_autofix_feedback.apply_async")
     def test_the_hand_back_to_the_queue_schedules_the_drain(self, mock_apply):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -99,6 +99,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(self._get_url(group.id), format="json")
         assert response.status_code == 200, response.data
         assert response.data["autofix"]["pr_iteration_paused"] is False
+        assert response.data["autofix"]["pr_iteration_pause_reason"] is None
 
         pause_pr_iteration(
             run_id=888, organization_id=self.organization.id, reason=PauseReason.USER_STOP
@@ -109,6 +110,48 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         response = self.client.get(self._get_url(group.id), format="json")
         assert response.status_code == 200, response.data
         assert response.data["autofix"]["pr_iteration_paused"] is True
+        assert response.data["autofix"]["pr_iteration_pause_reason"] == "user_stop"
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    def test_get_reports_an_errored_pause_apart_from_a_user_stop(self, mock_get_explorer_state):
+        group = self.create_group()
+        self.create_seer_run(organization=self.organization, seer_run_state_id=888)
+        mock_get_explorer_state.return_value = SeerRunState(
+            run_id=888,
+            blocks=[],
+            status="completed",
+            updated_at="2023-07-18T12:00:00Z",
+        )
+        pause_pr_iteration(
+            run_id=888, organization_id=self.organization.id, reason=PauseReason.RUN_ERRORED
+        )
+        self.login_as(user=self.user)
+
+        response = self.client.get(self._get_url(group.id), format="json")
+
+        assert response.status_code == 200, response.data
+        assert response.data["autofix"]["pr_iteration_paused"] is True
+        assert response.data["autofix"]["pr_iteration_pause_reason"] == "run_errored"
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    def test_get_reads_a_reasonless_marker_as_a_user_stop(self, mock_get_explorer_state):
+        """Markers written before the reason existed came from `@sentry` stop."""
+        group = self.create_group()
+        run = self.create_seer_run(organization=self.organization, seer_run_state_id=888)
+        run.update(extras={PAUSED_EXTRA: {"paused_at": "2024-01-01T00:00:00Z"}})
+        mock_get_explorer_state.return_value = SeerRunState(
+            run_id=888,
+            blocks=[],
+            status="completed",
+            updated_at="2023-07-18T12:00:00Z",
+        )
+        self.login_as(user=self.user)
+
+        response = self.client.get(self._get_url(group.id), format="json")
+
+        assert response.status_code == 200, response.data
+        assert response.data["autofix"]["pr_iteration_paused"] is True
+        assert response.data["autofix"]["pr_iteration_pause_reason"] == "user_stop"
 
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
     def test_get_reports_pr_iteration_not_paused_without_mirror_row(self, mock_get_explorer_state):

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -21,7 +21,11 @@ from sentry.seer.autofix.github_perms import MissingGithubPermissions
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import Decision
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
-from sentry.seer.autofix.pr_iteration.pause import PAUSED_EXTRA, pause_pr_iteration
+from sentry.seer.autofix.pr_iteration.pause import (
+    PAUSED_EXTRA,
+    PauseReason,
+    pause_pr_iteration,
+)
 from sentry.seer.autofix.pr_iteration.queue import QueuedAutofixFeedback
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import SeerPermissionError
@@ -96,7 +100,9 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.data
         assert response.data["autofix"]["pr_iteration_paused"] is False
 
-        pause_pr_iteration(run_id=888, organization_id=self.organization.id)
+        pause_pr_iteration(
+            run_id=888, organization_id=self.organization.id, reason=PauseReason.USER_STOP
+        )
         run.refresh_from_db()
         assert run.extras is not None and PAUSED_EXTRA in run.extras
 
@@ -863,6 +869,38 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
 
         assert response.status_code == 400, response.data
         assert response.data["detail"] == "Cannot iterate on a PR before one has been created"
+        mock_try_enqueue.assert_not_called()
+
+    @with_feature("organizations:autofix-pr-iteration-manual")
+    @patch("sentry.seer.endpoints.group_ai_autofix.try_enqueue_autofix_feedback")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
+    def test_pr_iteration_rejected_when_paused(self, mock_run_state, mock_try_enqueue):
+        group = self.create_group()
+        self.create_seer_run(
+            organization=group.organization, seer_run_state_id=123, user_id=self.user.id
+        )
+        mock_run_state.return_value = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo", pr_number=7)},
+        )
+        pause_pr_iteration(
+            run_id=123,
+            organization_id=group.organization.id,
+            reason=PauseReason.RUN_ERRORED,
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={"step": "pr_iteration", "run_id": 123, "user_context": "please fix this"},
+            format="json",
+        )
+
+        assert response.status_code == 409, response.data
+        assert response.data["detail"] == "Seer can no longer iterate on this pull request"
         mock_try_enqueue.assert_not_called()
 
     @with_feature("organizations:autofix-pr-iteration-manual")

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -32,6 +32,7 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeed
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
 from sentry.seer.autofix.pr_iteration.pause import (
     PAUSED_EXTRA,
+    PauseReason,
     is_pr_iteration_paused,
     pause_pr_iteration,
 )
@@ -457,7 +458,11 @@ class TriggerPrIterationFromCommentTest(TestCase):
         self.create_seer_run(
             organization=self.organization, seer_run_state_id=67890, user_id=self.user.id
         )
-        pause_pr_iteration(run_id=67890, organization_id=self.organization.id)
+        pause_pr_iteration(
+            run_id=67890,
+            organization_id=self.organization.id,
+            reason=PauseReason.USER_STOP,
+        )
         mock_get_state.return_value = self._agent_state()
 
         self._call()
@@ -1027,6 +1032,22 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
         mock_trigger.assert_not_called()
 
     @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_returns_when_errored(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = self._state(status="error")
+
+        self._call()
+
+        mock_pop.assert_not_called()
+        mock_trigger.assert_not_called()
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
     @patch(f"{TASK_PATH}.fetch_run_status", side_effect=SeerApiError("nope", 500))
     def test_returns_when_run_state_not_found(
         self,
@@ -1565,7 +1586,11 @@ class TriggerConsumePrIterationFeedbackTest(TestCase):
         self.create_seer_run(
             organization=self.organization, seer_run_state_id=67890, user_id=self.user.id
         )
-        pause_pr_iteration(run_id=67890, organization_id=self.organization.id)
+        pause_pr_iteration(
+            run_id=67890,
+            organization_id=self.organization.id,
+            reason=PauseReason.USER_STOP,
+        )
 
         with patch(f"{PAUSE_PATH}.metrics") as mock_metrics:
             self._trigger(bypass=True)


### PR DESCRIPTION
A run that ended in error left the iteration loop live, so the
completion hook kept pushing and queued feedback kept draining into
the same failure. An errored run now pauses itself and records why,
and the state payload carries that reason, so the drawer can stop
telling people a run that broke was stopped by hand.
