### PR TITLE
ref(pr-iter): Gate PR iteration once, at ingestion

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -353,14 +353,6 @@ class SeerAgentClient:
 
         self.enable_coding = enable_coding
 
-        # PR context tools back both the automated CI and the manual iteration flows,
-        # so either flag grants them.
-        if enable_pr_context_tools and not (
-            features.has("organizations:autofix-pr-iteration", organization, actor=user)
-            or features.has("organizations:autofix-pr-iteration-manual", organization, actor=user)
-        ):
-            raise SeerPermissionError("PR context tools are not enabled for this organization")
-
         self.enable_pr_context_tools = enable_pr_context_tools
 
         self.viewer_context = self._build_viewer_context()

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -37,7 +37,6 @@ from sentry.seer.autofix.artifact_schemas import (
 from sentry.seer.autofix.commit_author import SeerCommitAuthor
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.constants import (
-    ITERATION_FLAG,
     MANUAL_FLAG,
     REVIEW_REQUEST_FLAG,
 )
@@ -87,10 +86,6 @@ class NoSeerQuotaException(Exception):
 
 
 class PrIterationNoPullRequestException(Exception):
-    pass
-
-
-class PrIterationNotEnabledException(Exception):
     pass
 
 
@@ -586,12 +581,6 @@ def trigger_autofix_agent(
 
     config = STEP_CONFIGS[step]
 
-    # Either flag enables the PR_ITERATION step itself: automated CI iteration runs
-    # under `autofix-pr-iteration`, human-triggered iteration under the `-manual`
-    # variant. Both reach this function via `trigger_autofix_agent`.
-    pr_iteration_enabled = features.has(ITERATION_FLAG, group.organization) or features.has(
-        MANUAL_FLAG, group.organization
-    )
     is_iteration_step = step == AutofixStep.PR_ITERATION
 
     client = get_autofix_agent_client(
@@ -608,9 +597,6 @@ def trigger_autofix_agent(
 
     iteration_index: int | None = None
     if is_iteration_step:
-        if not pr_iteration_enabled:
-            raise PrIterationNotEnabledException()
-
         if run_state is None or not run_state.repo_pr_states:
             raise PrIterationNoPullRequestException()
 

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -55,7 +55,6 @@ from sentry.seer.agent.client_utils import fetch_run_status, get_agent_state_fro
 from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
     PrIterationNoPullRequestException,
-    PrIterationNotEnabledException,
     trigger_autofix_agent,
 )
 from sentry.seer.autofix.commit_author import commit_author_for_feedback
@@ -545,11 +544,7 @@ def _drain_queued_autofix_feedback(
             actor_user_id=actor_user_id,
             commit_author=commit_author_for_feedback(feedback_items, organization_id),
         )
-    except (
-        PrIterationNoPullRequestException,
-        PrIterationNotEnabledException,
-        SeerPermissionError,
-    ) as error:
+    except (PrIterationNoPullRequestException, SeerPermissionError) as error:
         log_ctx.info(
             "autofix.pr_iteration.consume_feedback.trigger_agent",
             outcome="skipped",

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -237,24 +237,8 @@ class TestSeerAgentClient(TestCase):
         assert body["agent_run_options"]["code_review_enabled"] is True
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    def test_client_init_raises_when_pr_ctx_tools_flag_disabled(self, mock_access):
-        mock_access.return_value = (True, None)
-
-        with pytest.raises(SeerPermissionError):
-            SeerAgentClient(self.organization, self.user, enable_pr_context_tools=True)
-
-    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @with_feature("organizations:autofix-pr-iteration")
-    def test_client_init_succeeds_when_pr_ctx_tools_flag_enabled(self, mock_access):
-        mock_access.return_value = (True, None)
-
-        client = SeerAgentClient(self.organization, self.user, enable_pr_context_tools=True)
-        assert client.enable_pr_context_tools is True
-
-    @patch("sentry.seer.agent.client.has_seer_access_with_detail")
-    @with_feature("organizations:autofix-pr-iteration-manual")
-    def test_client_init_succeeds_when_manual_pr_ctx_tools_flag_enabled(self, mock_access):
-        """PR context tools back both iteration flows, so the manual flag alone grants them."""
+    def test_client_init_leaves_pr_ctx_tools_gate_to_the_caller(self, mock_access):
+        """No iteration flag is set: the client still honours what it was passed."""
         mock_access.return_value = (True, None)
 
         client = SeerAgentClient(self.organization, self.user, enable_pr_context_tools=True)
@@ -279,7 +263,6 @@ class TestSeerAgentClient(TestCase):
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.receivers.outbox.cell.make_agent_chat_request")
     @patch("sentry.seer.agent.client.collect_user_org_context")
-    @with_feature("organizations:autofix-pr-iteration")
     def test_start_run_passes_enable_pr_context_tools(
         self, mock_collect_context, mock_post, mock_access
     ):
@@ -580,7 +563,6 @@ class TestSeerAgentClient(TestCase):
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail")
     @patch("sentry.seer.agent.client.make_agent_chat_request")
-    @with_feature("organizations:autofix-pr-iteration")
     def test_continue_run_passes_enable_pr_context_tools(self, mock_post, mock_access):
         mock_access.return_value = (True, None)
         mock_post.return_value = self._mock_run_response(run_id=789)

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -17,7 +17,6 @@ from sentry.seer.autofix.autofix_agent import (
     AutofixStep,
     NoSeerQuotaException,
     PrIterationNoPullRequestException,
-    PrIterationNotEnabledException,
     _build_base_shas_metadata,
     build_step_prompt,
     generate_autofix_handoff_prompt,
@@ -823,14 +822,14 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
-    def test_pr_iteration_enabled_by_either_flag(
+    def test_pr_iteration_does_not_gate_on_flags(
         self, mock_client_class, mock_broadcast, mock_check_quota, mock_record_run
     ):
-        """Automated CI iteration and manual iteration each enable the PR_ITERATION step.
+        """The PR_ITERATION step is gated by its callers, not here.
 
         Automated CI iteration runs under ``autofix-pr-iteration`` and manual
-        iteration under the ``-manual`` variant, so either flag alone is enough and
-        neither flag rejects the step.
+        iteration under the ``-manual`` variant; whichever caller checked its flag
+        is what decides, so the step itself runs with neither flag set.
         """
         mock_client = MagicMock()
         mock_client_class.return_value = mock_client
@@ -855,17 +854,16 @@ class TestTriggerAutofixAgent(TestCase):
                 run_id=67890,
             )
 
-        with pytest.raises(PrIterationNotEnabledException):
-            trigger()
-        mock_client.continue_run.assert_not_called()
+        trigger()
+        assert mock_client.continue_run.call_count == 1
 
         with self.feature("organizations:autofix-pr-iteration"):
             trigger()
-        assert mock_client.continue_run.call_count == 1
+        assert mock_client.continue_run.call_count == 2
 
         with self.feature("organizations:autofix-pr-iteration-manual"):
             trigger()
-        assert mock_client.continue_run.call_count == 2
+        assert mock_client.continue_run.call_count == 3
 
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)


### PR DESCRIPTION
The agent client and the trigger both re-checked the PR iteration
flags that every ingestion path had already checked. The innermost
check won, so an org whose flag went dark between queueing feedback
and draining it failed with a permission error naming tools nobody
had asked about. Callers decide now, and pass what they decided.