### PR TITLE
fix(seer): Align inline resource link icons

### DIFF
--- a/static/app/components/seer/markdown/embeds/components/resourceLink.tsx
+++ b/static/app/components/seer/markdown/embeds/components/resourceLink.tsx
@@ -1,5 +1,7 @@
 import type {ComponentType, ReactNode} from 'react';
+import {css} from '@emotion/react';
 
+import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 
 import {
@@ -65,7 +67,19 @@ export function ResourceLink({
   icon: ComponentType<SVGIconProps>;
   title: string;
 }): ReactNode {
-  const icon = <Icon size="xs" style={{verticalAlign: 'middle'}} />;
+  const icon = (
+    <Flex
+      as="span"
+      align="center"
+      display="inline-flex"
+      height="1em"
+      css={css`
+        vertical-align: text-bottom;
+      `}
+    >
+      <Icon size="xs" />
+    </Flex>
+  );
 
   if (/^https?:\/\//.test(href) && isSafeHref(href)) {
     try {


### PR DESCRIPTION
Inline Seer markdown resource links now keep the anchor on the surrounding text baseline while centering the icon within a font-sized wrapper. This prevents inherited line height from making the link taller than adjacent text and keeps the icon and label aligned consistently.

<img width="385" height="39" alt="image" src="https://github.com/user-attachments/assets/aeacd60d-2157-4dac-a966-6f44ea2abedc" />
