### PR TITLE
fix(ourlogs): copy and filter full log values, not truncated ones

### DIFF
--- a/static/app/views/explore/hooks/useTraceItemDetails.tsx
+++ b/static/app/views/explore/hooks/useTraceItemDetails.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useRef, useState} from 'react';
 import {useHover} from '@react-aria/interactions';
 import {captureException} from '@sentry/react';
-import {skipToken, useQuery} from '@tanstack/react-query';
+import {skipToken, useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -214,26 +214,38 @@ function useTraceItemDetailsPrefetch({
   const organization = useOrganization();
   const {selection} = usePageFilters();
   const project = useProjectFromId({project_id: projectId});
+  const queryClient = useQueryClient();
   const [shouldFetch, setShouldFetch] = useState(false);
 
+  const detailsApiOptions = traceItemDetailsApiOptions({
+    organizationSlug: organization.slug,
+    projectSlug: project?.slug ?? '',
+    traceItemId,
+    traceItemType,
+    referrer,
+    traceId,
+    ...(timestamp
+      ? {timestamp: normalizeTimestampToSeconds(timestamp)}
+      : normalizeDateTimeParams(selection.datetime)),
+  });
+
   const {data, isFetching} = useQuery({
-    ...traceItemDetailsApiOptions({
-      organizationSlug: organization.slug,
-      projectSlug: project?.slug ?? '',
-      traceItemId,
-      traceItemType,
-      referrer,
-      traceId,
-      ...(timestamp
-        ? {timestamp: normalizeTimestampToSeconds(timestamp)}
-        : normalizeDateTimeParams(selection.datetime)),
-    }),
+    ...detailsApiOptions,
     enabled: shouldFetch && !!project?.slug,
   });
 
   const prefetch = useCallback(() => setShouldFetch(true), []);
 
+  const fetchDetails = async () => {
+    if (!project?.slug) {
+      return;
+    }
+    const response = await queryClient.fetchQuery(detailsApiOptions);
+    return response.json;
+  };
+
   return {
+    fetchDetails,
     prefetch,
     project,
     traceItemMeta: data?.meta,
@@ -267,7 +279,7 @@ export function usePrefetchTraceItemDetailsOnHover({
    */
   hoverPrefetchDisabled?: boolean;
 }) {
-  const {prefetch, project, traceItemMeta, traceItemAttributes, isPending} =
+  const {fetchDetails, prefetch, project, traceItemMeta, traceItemAttributes, isPending} =
     useTraceItemDetailsPrefetch({
       traceItemId,
       projectId,
@@ -312,6 +324,7 @@ export function usePrefetchTraceItemDetailsOnHover({
   );
 
   return {
+    fetchTraceItemDetails: fetchDetails,
     hoverProps,
     prefetch,
     isProjectReady: Boolean(project?.slug),

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -634,6 +634,39 @@ describe('logsTableRow', () => {
     });
   });
 
+  it('navigates with the truncated message when similar spans cannot load the details', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${rowDataWithTruncatedMessage[OurLogKnownFieldKey.ID]}/`,
+      method: 'GET',
+      statusCode: 500,
+    });
+
+    const {router} = render(
+      <LogRowContent
+        dataRow={rowDataWithTruncatedMessage}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithTruncatedMessage)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+        showExploreSimilarSpansLink
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow, {delay: null});
+    const messageCell = await screen.findByTestId('log-table-cell-message');
+    await userEvent.click(within(messageCell).getByRole('button', {name: 'Actions'}));
+    await userEvent.click(await screen.findByText('Explore similar spans'));
+
+    await waitFor(() => {
+      expect(JSON.parse(router.location.query.crossEvents as string)).toEqual([
+        {type: 'logs', query: `message:"${truncatedMessage}"`},
+      ]);
+    });
+  });
+
   it('does not show string filter actions for numeric fields', async () => {
     const numericField = 'custom.duration';
     const numericRowData = LogFixture({

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -112,6 +112,16 @@ describe('logsTableRow', () => {
     [OurLogKnownFieldKey.RELEASE]: release.version, // Needed otherwise stacktrace link will also not load
   });
 
+  const truncatedMessage = `${'a'.repeat(128)}...`;
+  const fullMessage = 'a'.repeat(300);
+
+  const rowDataWithTruncatedMessage = LogFixture({
+    [OurLogKnownFieldKey.ID]: '9',
+    [OurLogKnownFieldKey.PROJECT_ID]: project.id,
+    [OurLogKnownFieldKey.ORGANIZATION_ID]: Number(organization.id),
+    [OurLogKnownFieldKey.MESSAGE]: truncatedMessage,
+  });
+
   const rowDataWithScrubbedFields = LogFixture({
     [OurLogKnownFieldKey.ID]: '3',
     [OurLogKnownFieldKey.PROJECT_ID]: project.id,
@@ -212,6 +222,28 @@ describe('logsTableRow', () => {
         meta: {},
         timestamp: rowDataWithCodeFilePath[OurLogKnownFieldKey.TIMESTAMP],
         attributes: Object.entries(rowDataWithCodeFilePath).map(
+          ([k, v]) =>
+            ({
+              name: k,
+              value: v,
+              type: typeof v === 'string' ? 'str' : 'float',
+            }) as TraceItemResponseAttribute
+        ),
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${rowDataWithTruncatedMessage[OurLogKnownFieldKey.ID]}/`,
+      method: 'GET',
+      body: {
+        itemId: rowDataWithTruncatedMessage[OurLogKnownFieldKey.ID],
+        links: null,
+        meta: {},
+        timestamp: rowDataWithTruncatedMessage[OurLogKnownFieldKey.TIMESTAMP],
+        attributes: Object.entries({
+          ...rowDataWithTruncatedMessage,
+          [OurLogKnownFieldKey.MESSAGE]: fullMessage,
+        }).map(
           ([k, v]) =>
             ({
               name: k,
@@ -1032,6 +1064,44 @@ describe('logsTableRow', () => {
 
     // Row should still be expanded - the cell action should not toggle visibility
     expect(screen.getByRole('button', {name: 'Copy as JSON'})).toBeInTheDocument();
+  });
+
+  it('copies the untruncated value when the table value was truncated', async () => {
+    const mockWriteText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+    });
+
+    render(
+      <LogRowContent
+        dataRow={rowDataWithTruncatedMessage}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithTruncatedMessage)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow, {delay: null});
+
+    await userEvent.click(
+      within(screen.getByTestId('log-table-cell-message')).getByRole('button', {
+        name: 'Actions',
+      })
+    );
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Copy to clipboard'})
+    );
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith(fullMessage);
+    });
   });
 
   it('renders fields with data scrubbing meta information', async () => {

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -608,6 +608,35 @@ describe('logsTableRow', () => {
   });
 
   it('resolves the untruncated message when similar spans is clicked before the details load', async () => {
+    // Hold the details response open so the item is still unresolved when clicked,
+    // rather than racing the hover prefetch for that window.
+    let releaseDetails = () => {};
+    const detailsHeld = new Promise<void>(resolve => {
+      releaseDetails = resolve;
+    });
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${rowDataWithTruncatedMessage[OurLogKnownFieldKey.ID]}/`,
+      method: 'GET',
+      asyncDelay: detailsHeld,
+      body: {
+        itemId: rowDataWithTruncatedMessage[OurLogKnownFieldKey.ID],
+        links: null,
+        meta: {},
+        timestamp: rowDataWithTruncatedMessage[OurLogKnownFieldKey.TIMESTAMP],
+        attributes: Object.entries({
+          ...rowDataWithTruncatedMessage,
+          [OurLogKnownFieldKey.MESSAGE]: fullMessage,
+        }).map(
+          ([k, v]) =>
+            ({
+              name: k,
+              value: v,
+              type: typeof v === 'string' ? 'str' : 'float',
+            }) as TraceItemResponseAttribute
+        ),
+      },
+    });
+
     const {router} = render(
       <LogRowContent
         dataRow={rowDataWithTruncatedMessage}
@@ -626,6 +655,8 @@ describe('logsTableRow', () => {
     const messageCell = await screen.findByTestId('log-table-cell-message');
     await userEvent.click(within(messageCell).getByRole('button', {name: 'Actions'}));
     await userEvent.click(await screen.findByText('Explore similar spans'));
+
+    releaseDetails();
 
     await waitFor(() => {
       expect(JSON.parse(router.location.query.crossEvents as string)).toEqual([

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -1120,6 +1120,49 @@ describe('logsTableRow', () => {
     expect(screen.getByRole('button', {name: 'Copy as JSON'})).toBeInTheDocument();
   });
 
+  it('copies the truncated value when the details request fails', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${rowDataWithTruncatedMessage[OurLogKnownFieldKey.ID]}/`,
+      method: 'GET',
+      statusCode: 500,
+    });
+    const mockWriteText = jest.fn().mockResolvedValue(undefined);
+    Object.defineProperty(window.navigator, 'clipboard', {
+      value: {
+        writeText: mockWriteText,
+      },
+      writable: true,
+    });
+
+    render(
+      <LogRowContent
+        dataRow={rowDataWithTruncatedMessage}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithTruncatedMessage)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow, {delay: null});
+
+    await userEvent.click(
+      within(screen.getByTestId('log-table-cell-message')).getByRole('button', {
+        name: 'Actions',
+      })
+    );
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Copy to clipboard'})
+    );
+
+    await waitFor(() => {
+      expect(mockWriteText).toHaveBeenCalledWith(truncatedMessage);
+    });
+  });
+
   it('copies the untruncated value when the table value was truncated', async () => {
     const mockWriteText = jest.fn().mockResolvedValue(undefined);
     Object.defineProperty(window.navigator, 'clipboard', {

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -555,6 +555,36 @@ describe('logsTableRow', () => {
     ]);
   });
 
+  it('uses the untruncated message for the similar spans link when the table value was truncated', async () => {
+    render(
+      <LogRowContent
+        dataRow={rowDataWithTruncatedMessage}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithTruncatedMessage)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+        showExploreSimilarSpansLink
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow);
+    const messageCell = await screen.findByTestId('log-table-cell-message');
+    await userEvent.click(within(messageCell).getByRole('button', {name: 'Actions'}));
+
+    await waitFor(() => {
+      const href = screen
+        .getByText('Explore similar spans')
+        .closest('a')!
+        .getAttribute('href')!;
+      expect(JSON.parse(qs.parse(href.split('?')[1]!).crossEvents as string)).toEqual([
+        {type: 'logs', query: `message:"${fullMessage}"`},
+      ]);
+    });
+  });
+
   it('does not show string filter actions for numeric fields', async () => {
     const numericField = 'custom.duration';
     const numericRowData = LogFixture({

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -506,6 +506,24 @@ describe('logsTableRow', () => {
       ...rowData,
       [OurLogKnownFieldKey.MESSAGE]: 'test "quoted" log body',
     };
+    MockApiClient.addMockResponse({
+      url: `/projects/${organization.slug}/${project.slug}/trace-items/${rowDataWithQuotedMessage[OurLogKnownFieldKey.ID]}/`,
+      method: 'GET',
+      body: {
+        itemId: rowDataWithQuotedMessage[OurLogKnownFieldKey.ID],
+        links: null,
+        meta: {},
+        timestamp: rowDataWithQuotedMessage[OurLogKnownFieldKey.TIMESTAMP],
+        attributes: Object.entries(rowDataWithQuotedMessage).map(
+          ([k, v]) =>
+            ({
+              name: k,
+              value: v,
+              type: typeof v === 'string' ? 'str' : 'float',
+            }) as TraceItemResponseAttribute
+        ),
+      },
+    });
 
     render(
       <LogRowContent
@@ -525,7 +543,11 @@ describe('logsTableRow', () => {
     const messageCell = await screen.findByTestId('log-table-cell-message');
     await userEvent.click(within(messageCell).getByRole('button', {name: 'Actions'}));
 
-    const link = (await screen.findByText('Explore similar spans')).closest('a')!;
+    const link = await waitFor(() => {
+      const anchor = screen.getByText('Explore similar spans').closest('a');
+      expect(anchor).not.toBeNull();
+      return anchor!;
+    });
     for (const label of ['Copy to clipboard', 'Add to filter', 'Exclude from filter']) {
       const menuItem = await screen.findByText(label);
       expect(menuItem.compareDocumentPosition(link)).toBe(
@@ -580,6 +602,33 @@ describe('logsTableRow', () => {
         .closest('a')!
         .getAttribute('href')!;
       expect(JSON.parse(qs.parse(href.split('?')[1]!).crossEvents as string)).toEqual([
+        {type: 'logs', query: `message:"${fullMessage}"`},
+      ]);
+    });
+  });
+
+  it('resolves the untruncated message when similar spans is clicked before the details load', async () => {
+    const {router} = render(
+      <LogRowContent
+        dataRow={rowDataWithTruncatedMessage}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithTruncatedMessage)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+        showExploreSimilarSpansLink
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow, {delay: null});
+    const messageCell = await screen.findByTestId('log-table-cell-message');
+    await userEvent.click(within(messageCell).getByRole('button', {name: 'Actions'}));
+    await userEvent.click(await screen.findByText('Explore similar spans'));
+
+    await waitFor(() => {
+      expect(JSON.parse(router.location.query.crossEvents as string)).toEqual([
         {type: 'logs', query: `message:"${fullMessage}"`},
       ]);
     });

--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -651,6 +651,30 @@ describe('logsTableRow', () => {
     });
   });
 
+  it('filters on the untruncated value when the table value was truncated', async () => {
+    const {router} = render(
+      <LogRowContent
+        dataRow={rowDataWithTruncatedMessage}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithTruncatedMessage)}
+        sharedHoverTimeoutRef={{current: null}}
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow, {delay: null});
+    const messageCell = await screen.findByTestId('log-table-cell-message');
+    await userEvent.click(within(messageCell).getByRole('button', {name: 'Actions'}));
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Add to filter'})
+    );
+
+    await waitFor(() => {
+      expect(router.location.query[LOGS_QUERY_KEY]).toBe(`message:${fullMessage}`);
+    });
+  });
+
   it('shows a link when hovering over code file path in the table', async () => {
     render(
       <LogRowContent

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -427,6 +427,12 @@ export const LogRowContent = memo(function LogRowContentImpl({
     addSearchFilter({key: filter.key, value: filter.value, negated});
   }
 
+  function exploreSimilarSpansFor(message: string | number) {
+    navigate(
+      getExploreSimilarSpansUrl({message: String(message), organization, selection})
+    );
+  }
+
   const copyCellValue = useMutation({
     mutationFn: ({cellValue, field}: {cellValue: string | number; field: string}) =>
       resolveFullCellValue(field, cellValue),
@@ -437,14 +443,8 @@ export const LogRowContent = memo(function LogRowContentImpl({
   const exploreSimilarSpans = useMutation({
     mutationFn: ({cellValue, field}: {cellValue: string | number; field: string}) =>
       resolveFullCellValue(field, cellValue),
-    onSuccess: value =>
-      navigate(
-        getExploreSimilarSpansUrl({
-          message: String(value),
-          organization,
-          selection,
-        })
-      ),
+    onSuccess: value => exploreSimilarSpansFor(value),
+    onError: (_error, {cellValue}) => exploreSimilarSpansFor(cellValue),
   });
 
   const filterOnCellValue = useMutation({

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -358,6 +358,7 @@ export const LogRowContent = memo(function LogRowContentImpl({
     ? getLogRowTimestampMillis(dataRow) / 1000
     : null;
   const {
+    fetchTraceItemDetails,
     hoverProps,
     prefetch,
     isProjectReady,
@@ -380,6 +381,26 @@ export const LogRowContent = memo(function LogRowContentImpl({
     isProjectReady,
   });
   const [caseInsensitivity] = useCaseInsensitivity();
+
+  // The table asks the API to truncate long strings for display, so the rendered
+  // cell value can be cut short. Trace item details come back untruncated.
+  async function copyFullCellValue(field: string, cellValue: string | number) {
+    if (typeof cellValue !== 'string') {
+      copyToClipboard(cellValue);
+      return;
+    }
+
+    let fullValue: TraceItemResponseAttribute['value'] | undefined;
+    try {
+      const attributes =
+        traceItemAttributes ?? (await fetchTraceItemDetails())?.attributes;
+      fullValue = attributes?.find(attribute => attribute.name === field)?.value;
+    } catch {
+      // Falling back to the truncated value beats copying nothing.
+    }
+
+    copyToClipboard(typeof fullValue === 'string' ? fullValue : cellValue);
+  }
 
   const observedTimestamp = traceItemAttributes?.find(
     a => a.name === OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS
@@ -629,7 +650,7 @@ export const LogRowContent = memo(function LogRowContentImpl({
                           });
                           break;
                         case Actions.COPY_TO_CLIPBOARD:
-                          copyToClipboard(cellValue);
+                          copyFullCellValue(field, cellValue);
                           break;
                         case Actions.COPY_LINK: {
                           const logId = String(dataRow[OurLogKnownFieldKey.ID]);

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -166,13 +166,51 @@ const ALLOWED_CELL_ACTIONS: Actions[] = [
 ];
 const EXPLORE_SIMILAR_SPANS_REFERRER = 'trace-logs-table-similar-spans';
 
+function getExploreSimilarSpansUrl({
+  message,
+  organization,
+  selection,
+}: {
+  message: string;
+  organization: Organization;
+  selection: PageFilters;
+}) {
+  return getExploreUrl({
+    organization,
+    selection: {
+      ...selection,
+      datetime: {
+        period: '24h',
+        start: null,
+        end: null,
+        utc: selection.datetime.utc,
+      },
+    },
+    mode: Mode.SAMPLES,
+    referrer: EXPLORE_SIMILAR_SPANS_REFERRER,
+    crossEvents: [
+      {
+        type: 'logs',
+        query: `${OurLogKnownFieldKey.MESSAGE}:"${escapeDoubleQuotes(message)}"`,
+      },
+    ],
+  });
+}
+
 function getExploreSimilarSpansMenuItems({
   message,
+  onResolveMessage,
   organization,
   selection,
   showExploreSimilarSpansLink,
 }: {
   message: string | number | null | undefined;
+  /**
+   * Set while the untruncated message has not loaded. The item resolves the
+   * message on click rather than linking to a query built from a shortened one,
+   * so it trades the href for correctness only for as long as that lasts.
+   */
+  onResolveMessage: (() => void) | undefined;
   organization: Organization;
   selection: PageFilters;
   showExploreSimilarSpansLink?: boolean;
@@ -187,26 +225,15 @@ function getExploreSimilarSpansMenuItems({
     {
       key: 'explore-similar-spans',
       label: t('Explore similar spans'),
-      to: getExploreUrl({
-        organization,
-        selection: {
-          ...selection,
-          datetime: {
-            period: '24h',
-            start: null,
-            end: null,
-            utc: selection.datetime.utc,
-          },
-        },
-        mode: Mode.SAMPLES,
-        referrer: EXPLORE_SIMILAR_SPANS_REFERRER,
-        crossEvents: [
-          {
-            type: 'logs',
-            query: `${OurLogKnownFieldKey.MESSAGE}:"${escapeDoubleQuotes(messageString)}"`,
-          },
-        ],
-      }),
+      ...(onResolveMessage
+        ? {onAction: onResolveMessage}
+        : {
+            to: getExploreSimilarSpansUrl({
+              message: messageString,
+              organization,
+              selection,
+            }),
+          }),
     },
   ];
 }
@@ -405,6 +432,19 @@ export const LogRowContent = memo(function LogRowContentImpl({
       resolveFullCellValue(field, cellValue),
     onSuccess: value => copyToClipboard(value),
     onError: (_error, {cellValue}) => copyToClipboard(cellValue),
+  });
+
+  const exploreSimilarSpans = useMutation({
+    mutationFn: ({cellValue, field}: {cellValue: string | number; field: string}) =>
+      resolveFullCellValue(field, cellValue),
+    onSuccess: value =>
+      navigate(
+        getExploreSimilarSpansUrl({
+          message: String(value),
+          organization,
+          selection,
+        })
+      ),
   });
 
   const filterOnCellValue = useMutation({
@@ -608,6 +648,11 @@ export const LogRowContent = memo(function LogRowContentImpl({
               field === OurLogKnownFieldKey.MESSAGE
                 ? getExploreSimilarSpansMenuItems({
                     message: typeof fullMessage === 'string' ? fullMessage : value,
+                    onResolveMessage:
+                      typeof fullMessage === 'string'
+                        ? undefined
+                        : () =>
+                            exploreSimilarSpans.mutate({cellValue: value ?? '', field}),
                     organization,
                     selection,
                     showExploreSimilarSpansLink,

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -1,7 +1,7 @@
 import type {ComponentProps, SyntheticEvent} from 'react';
 import {Fragment, memo, useCallback, useMemo, useState} from 'react';
 import {useTheme} from '@emotion/react';
-import type {UseQueryResult} from '@tanstack/react-query';
+import {useMutation, type UseQueryResult} from '@tanstack/react-query';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
 
@@ -389,34 +389,37 @@ export const LogRowContent = memo(function LogRowContentImpl({
       return cellValue;
     }
 
-    let fullValue: TraceItemResponseAttribute['value'] | undefined;
-    try {
-      const attributes =
-        traceItemAttributes ?? (await fetchTraceItemDetails())?.attributes;
-      fullValue = attributes?.find(attribute => attribute.name === field)?.value;
-    } catch {
-      // Falling back to the truncated value beats doing nothing.
-    }
+    const attributes = traceItemAttributes ?? (await fetchTraceItemDetails())?.attributes;
+    const fullValue = attributes?.find(attribute => attribute.name === field)?.value;
 
     return typeof fullValue === 'string' ? fullValue : cellValue;
   }
 
-  async function copyFullCellValue(field: string, cellValue: string | number) {
-    copyToClipboard(await resolveFullCellValue(field, cellValue));
-  }
-
-  async function addFullCellValueFilter(
-    field: string,
-    cellValue: string | number,
-    negated: boolean
-  ) {
-    const filter = getMessageFilter(
-      field,
-      dataRow,
-      await resolveFullCellValue(field, cellValue)
-    );
+  function filterOnValue(field: string, value: string | number, negated: boolean) {
+    const filter = getMessageFilter(field, dataRow, value);
     addSearchFilter({key: filter.key, value: filter.value, negated});
   }
+
+  const copyCellValue = useMutation({
+    mutationFn: ({cellValue, field}: {cellValue: string | number; field: string}) =>
+      resolveFullCellValue(field, cellValue),
+    onSuccess: value => copyToClipboard(value),
+    onError: (_error, {cellValue}) => copyToClipboard(cellValue),
+  });
+
+  const filterOnCellValue = useMutation({
+    mutationFn: ({
+      cellValue,
+      field,
+    }: {
+      cellValue: string | number;
+      field: string;
+      negated: boolean;
+    }) => resolveFullCellValue(field, cellValue),
+    onSuccess: (value, {field, negated}) => filterOnValue(field, value, negated),
+    onError: (_error, {cellValue, field, negated}) =>
+      filterOnValue(field, cellValue, negated),
+  });
 
   const observedTimestamp = traceItemAttributes?.find(
     a => a.name === OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS
@@ -659,13 +662,13 @@ export const LogRowContent = memo(function LogRowContentImpl({
                     handleCellAction={(actions, cellValue) => {
                       switch (actions) {
                         case Actions.ADD:
-                          addFullCellValueFilter(field, cellValue, false);
+                          filterOnCellValue.mutate({cellValue, field, negated: false});
                           break;
                         case Actions.EXCLUDE:
-                          addFullCellValueFilter(field, cellValue, true);
+                          filterOnCellValue.mutate({cellValue, field, negated: true});
                           break;
                         case Actions.COPY_TO_CLIPBOARD:
-                          copyFullCellValue(field, cellValue);
+                          copyCellValue.mutate({cellValue, field});
                           break;
                         case Actions.COPY_LINK: {
                           const logId = String(dataRow[OurLogKnownFieldKey.ID]);

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -384,10 +384,9 @@ export const LogRowContent = memo(function LogRowContentImpl({
 
   // The table asks the API to truncate long strings for display, so the rendered
   // cell value can be cut short. Trace item details come back untruncated.
-  async function copyFullCellValue(field: string, cellValue: string | number) {
+  async function resolveFullCellValue(field: string, cellValue: string | number) {
     if (typeof cellValue !== 'string') {
-      copyToClipboard(cellValue);
-      return;
+      return cellValue;
     }
 
     let fullValue: TraceItemResponseAttribute['value'] | undefined;
@@ -396,10 +395,27 @@ export const LogRowContent = memo(function LogRowContentImpl({
         traceItemAttributes ?? (await fetchTraceItemDetails())?.attributes;
       fullValue = attributes?.find(attribute => attribute.name === field)?.value;
     } catch {
-      // Falling back to the truncated value beats copying nothing.
+      // Falling back to the truncated value beats doing nothing.
     }
 
-    copyToClipboard(typeof fullValue === 'string' ? fullValue : cellValue);
+    return typeof fullValue === 'string' ? fullValue : cellValue;
+  }
+
+  async function copyFullCellValue(field: string, cellValue: string | number) {
+    copyToClipboard(await resolveFullCellValue(field, cellValue));
+  }
+
+  async function addFullCellValueFilter(
+    field: string,
+    cellValue: string | number,
+    negated: boolean
+  ) {
+    const filter = getMessageFilter(
+      field,
+      dataRow,
+      await resolveFullCellValue(field, cellValue)
+    );
+    addSearchFilter({key: filter.key, value: filter.value, negated});
   }
 
   const observedTimestamp = traceItemAttributes?.find(
@@ -634,20 +650,12 @@ export const LogRowContent = memo(function LogRowContentImpl({
                     column={discoverColumn}
                     dataRow={dataRow}
                     handleCellAction={(actions, cellValue) => {
-                      const filter = getMessageFilter(field, dataRow, cellValue);
                       switch (actions) {
                         case Actions.ADD:
-                          addSearchFilter({
-                            key: filter.key,
-                            value: filter.value,
-                          });
+                          addFullCellValueFilter(field, cellValue, false);
                           break;
                         case Actions.EXCLUDE:
-                          addSearchFilter({
-                            key: filter.key,
-                            value: filter.value,
-                            negated: true,
-                          });
+                          addFullCellValueFilter(field, cellValue, true);
                           break;
                         case Actions.COPY_TO_CLIPBOARD:
                           copyFullCellValue(field, cellValue);

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -422,6 +422,13 @@ export const LogRowContent = memo(function LogRowContentImpl({
     a => a.name === OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS
   );
 
+  // The table asks the API to truncate long strings for display, so the row's
+  // message can be cut short. Trace item details come back untruncated, and
+  // hovering the row prefetches them before the cell actions are reachable.
+  const fullMessage = traceItemAttributes?.find(
+    a => a.name === OurLogKnownFieldKey.MESSAGE
+  )?.value;
+
   const rendererExtra: RendererExtra = {
     highlightTerms,
     caseSensitiveHighlighting: !caseInsensitivity,
@@ -597,7 +604,7 @@ export const LogRowContent = memo(function LogRowContentImpl({
             const extraMenuItems =
               field === OurLogKnownFieldKey.MESSAGE
                 ? getExploreSimilarSpansMenuItems({
-                    message: value,
+                    message: typeof fullMessage === 'string' ? fullMessage : value,
                     organization,
                     selection,
                     showExploreSimilarSpansLink,


### PR DESCRIPTION
The logs samples table asks the API to truncate long strings for display (`useLogsQueryTruncate` → `useLogsApiOptions`), and the backend cuts each string to that length and appends `...`. Anything reading a cell straight off the row therefore gets the shortened value, not the log's real one.

Two cell actions were doing that:

- **Copy to clipboard** copied the truncated string, so pasting a long log message gave back only the first ~128 characters. This is the reported bug.
- **Add to filter / Exclude from filter** built the filter from the same value, so filtering on a long string produced a query that silently matched nothing. `message` mostly escaped this because `getMessageFilter` prefers `message.template`, but any other long string column was affected.

Both now resolve the value from the row's trace item details, which come back untruncated. Hovering a row already prefetches those details, so the lookup is a cache hit in practice; `usePrefetchTraceItemDetailsOnHover` gains a promise-returning `fetchTraceItemDetails` for the case where the click beats the prefetch, and both actions fall back to the rendered value if the fetch fails.

The resolution is keyed on the cell's field name rather than special-casing `message`, so tags and custom string attributes are covered too, in the standalone logs table and in the embedded ones (trace drawer, replay) alike.

Closes LOGS-951.
