### PR TITLE
fix(ourlogs): build the similar spans link from the untruncated message

### DIFF
--- a/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.spec.tsx
@@ -555,6 +555,36 @@ describe('logsTableRow', () => {
     ]);
   });
 
+  it('uses the untruncated message for the similar spans link when the table value was truncated', async () => {
+    render(
+      <LogRowContent
+        dataRow={rowDataWithTruncatedMessage}
+        highlightTerms={[]}
+        meta={LogFixtureMeta(rowDataWithTruncatedMessage)}
+        sharedHoverTimeoutRef={{
+          current: null,
+        }}
+        showExploreSimilarSpansLink
+      />,
+      {organization, initialRouterConfig, additionalWrapper: ProviderWrapper}
+    );
+
+    const logTableRow = await screen.findByTestId('log-table-row');
+    await userEvent.hover(logTableRow);
+    const messageCell = await screen.findByTestId('log-table-cell-message');
+    await userEvent.click(within(messageCell).getByRole('button', {name: 'Actions'}));
+
+    await waitFor(() => {
+      const href = screen
+        .getByText('Explore similar spans')
+        .closest('a')!
+        .getAttribute('href')!;
+      expect(JSON.parse(qs.parse(href.split('?')[1]!).crossEvents as string)).toEqual([
+        {type: 'logs', query: `message:"${fullMessage}"`},
+      ]);
+    });
+  });
+
   it('does not show string filter actions for numeric fields', async () => {
     const numericField = 'custom.duration';
     const numericRowData = LogFixture({

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -422,6 +422,13 @@ export const LogRowContent = memo(function LogRowContentImpl({
     a => a.name === OurLogKnownFieldKey.OBSERVED_TIMESTAMP_NANOS
   );
 
+  // The table asks the API to truncate long strings for display, so the row's
+  // message can be cut short. Trace item details come back untruncated, and
+  // hovering the row prefetches them before the cell actions are reachable.
+  const fullMessage = traceItemAttributes?.find(
+    a => a.name === OurLogKnownFieldKey.MESSAGE
+  )?.value;
+
   const rendererExtra: RendererExtra = {
     highlightTerms,
     caseSensitiveHighlighting: !caseInsensitivity,
@@ -597,7 +604,7 @@ export const LogRowContent = memo(function LogRowContentImpl({
             const extraMenuItems =
               field === OurLogKnownFieldKey.MESSAGE
                 ? getExploreSimilarSpansMenuItems({
-                    message: value,
+                    message: typeof fullMessage === 'string' ? fullMessage : value,
                     organization,
                     selection,
                     showExploreSimilarSpansLink,


### PR DESCRIPTION
Same root cause as #123377: the logs samples table asks the API to truncate long strings for display, so anything reading a value straight off the row gets the shortened string. `getExploreSimilarSpansMenuItems` built the "Explore similar spans" Explore query from `dataRow[message]`, so for a long message the generated query was `message:"<first N chars>..."` and silently matched nothing. It is live in the trace drawer's embedded logs table, which enables both `showCellActions` and `showExploreSimilarSpansLink`.

This one needed a different approach than the copy and filter actions. Those are click handlers, so they can await the trace item details fetch; this is a `to` href computed during render. It instead reads the message from the row's prefetched `traceItemAttributes` when they have landed and falls back to the row value until then. Hovering a row prefetches the details before the cell actions are reachable, so in practice the link is built from the full message; if the details arrive later, the row re-renders and the href upgrades in place.

Closes LOGS-952.
