### PR TITLE
fix(seer): Drop the duplicate failure reason field

### DIFF
--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -269,7 +269,6 @@ class SeerRunState(BaseModel):
     # plain str so a new Seer reason does not fail validation mid-deploy.
     failure_reason: str | None = None
     updated_at: str
-    failure_reason: str | None = None
     owner_user_id: int | None = None
     pending_user_input: PendingUserInput | None = None
     repo_pr_states: dict[str, RepoPRState] = Field(default_factory=dict)


### PR DESCRIPTION
#122969 and #123044 each added an optional `failure_reason` to
`SeerRunState` and both landed, so the class declared the field twice.
mypy flags the redefinition and pydantic silently keeps the last one.

This keeps the documented declaration and removes the bare duplicate.
No behavior change.
