### PR TITLE
feat(smart-assignment): Pass repos to SA prompt to the agent doesn't guess

### DIFF
--- a/src/sentry/seer/smart_assignment/models.py
+++ b/src/sentry/seer/smart_assignment/models.py
@@ -89,6 +89,7 @@ class SmartAssignmentScore(models.TextChoices):
 class SmartAssignmentPayload(BaseModel):
     group_id: int
     project_slug: str | None = None
+    connected_repos: list[str] = Field(default_factory=list)
 
 
 class RankedCandidate(BaseModel):

--- a/src/sentry/seer/smart_assignment/trigger.py
+++ b/src/sentry/seer/smart_assignment/trigger.py
@@ -9,6 +9,7 @@ from sentry.models.group import Group
 from sentry.models.organization import Organization
 from sentry.ratelimits import backend as ratelimiter
 from sentry.seer.agent.client import SeerAgentClient
+from sentry.seer.autofix.utils import bulk_read_preferences_from_sentry_db
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.models.run import SeerRun
 from sentry.seer.smart_assignment.models import (
@@ -180,7 +181,16 @@ def _dispatch(group: Group, activity_type: ActivityType, activity: Activity) -> 
         "triggering_activity_id": activity.id,
     }
 
-    payload = SmartAssignmentPayload(group_id=group.id, project_slug=group.project.slug)
+    preferences = bulk_read_preferences_from_sentry_db(organization.id, [group.project_id])
+    preference = preferences.get(group.project_id)
+    connected_repos = (
+        [f"{repo.owner}/{repo.name}" for repo in preference.repositories] if preference else []
+    )
+    payload = SmartAssignmentPayload(
+        group_id=group.id,
+        project_slug=group.project.slug,
+        connected_repos=connected_repos,
+    )
     title = f"Smart assignment for {group.qualified_short_id or group.id}"
     try:
         run = client.start_feature_run(

--- a/tests/sentry/seer/smart_assignment/test_trigger.py
+++ b/tests/sentry/seer/smart_assignment/test_trigger.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.utils import timezone
@@ -96,7 +97,20 @@ class TriggerSmartAssignmentTest(TestCase):
     @patch(CLIENT_PATH)
     def test_dispatch_creates_run_mirror(self, mock_client_cls: MagicMock) -> None:
         self._wire_client(mock_client_cls)
-        with self.feature(RUN_FEATURES):
+        with (
+            self.feature(RUN_FEATURES),
+            patch(
+                "sentry.seer.smart_assignment.trigger.bulk_read_preferences_from_sentry_db"
+            ) as mock_preferences,
+        ):
+            mock_preferences.return_value = {
+                self.group.project_id: SimpleNamespace(
+                    repositories=[
+                        SimpleNamespace(owner="getsentry", name="sentry"),
+                        SimpleNamespace(owner="getsentry", name="seer"),
+                    ]
+                )
+            }
             trigger_smart_assignment(
                 self.group, ActivityType.SEER_RCA_STARTED, self._seer_started()
             )
@@ -106,6 +120,9 @@ class TriggerSmartAssignmentTest(TestCase):
         # The dispatch trigger (raw ActivityType name) is seeded on the extras for scoring.
         assert mirrors[0].extras["trigger"] == ActivityType.SEER_RCA_STARTED.name
         assert "referrer" not in mock_client_cls.return_value.start_feature_run.call_args.kwargs
+        assert mock_client_cls.return_value.start_feature_run.call_args.kwargs["payload"][
+            "connected_repos"
+        ] == ["getsentry/sentry", "getsentry/seer"]
         # A Seer AI-step start carries no ground truth.
         assert "actual_assignee_user_id" not in mirrors[0].extras
 


### PR DESCRIPTION
Whoops, I forgot there was a `sentry` side of https://github.com/getsentry/seer/pull/7984