### PR TITLE
feat(smart-assignment): Resolve unverified user emails when delivering results

### DIFF
--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -126,7 +126,7 @@ def _validate_resolve_verdict(
 
         if candidate.identifier_kind == "email":
             users = user_service.get_many_by_email(
-                emails=[value], organization_id=organization_id, is_verified=True
+                emails=[value], organization_id=organization_id, is_verified=False
             )
             resolved.append(users[0].id if users else None)
             continue

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -183,6 +183,27 @@ class DeliverSmartAssignmentResultTest(TestCase):
         self._assert_outcome(mock_metrics, "resolved")
 
     @patch(METRICS_PATH)
+    def test_email_kind_resolves_by_unverified_email(self, mock_metrics: MagicMock) -> None:
+        carol = self.create_user(email="carol@example.com")
+        self.create_member(user=carol, organization=self.organization)
+        self.create_useremail(user=carol, email="carol-secondary@example.com", is_verified=False)
+        result = {
+            "candidates": [
+                {
+                    "identifier": "carol-secondary@example.com",
+                    "identifier_kind": "email",
+                    "reason": "unlinked commit author",
+                    "confidence": "low",
+                },
+            ]
+        }
+
+        self._deliver(result)
+
+        assert self._extras()["predicted_assignee_user_ids"] == [carol.id]
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
     def test_unresolvable_identifier_records_no_user(self, mock_metrics: MagicMock) -> None:
         result = {
             "candidates": [


### PR DESCRIPTION
We're just trying to guess a user, and we already make sure the user is a member of the given org. This may fix ~10% of unmapped-user abstentions.