### PR TITLE
fix(seer): Keep investigation runs out of the Explorer chat history

### DIFF
--- a/static/app/views/seerExplorer/seerExplorerSessionContext.spec.tsx
+++ b/static/app/views/seerExplorer/seerExplorerSessionContext.spec.tsx
@@ -1,33 +1,41 @@
 import {buildRunsSearchQuery} from 'sentry/views/seerExplorer/seerExplorerSessionContext';
 
 describe('buildRunsSearchQuery', () => {
-  it('scopes to the current user and Explorer sessions when there is no search', () => {
-    expect(buildRunsSearchQuery()).toBe('is:mine type:explorer');
-    expect(buildRunsSearchQuery('')).toBe('is:mine type:explorer');
-    expect(buildRunsSearchQuery('   ')).toBe('is:mine type:explorer');
+  it('scopes to the current user and recorded Explorer sessions when there is no search', () => {
+    expect(buildRunsSearchQuery()).toBe('is:mine is:agent type:explorer');
+    expect(buildRunsSearchQuery('')).toBe('is:mine is:agent type:explorer');
+    expect(buildRunsSearchQuery('   ')).toBe('is:mine is:agent type:explorer');
+  });
+
+  it('excludes runs with no history mirror, such as investigation blocks', () => {
+    expect(buildRunsSearchQuery()).toContain('is:agent');
   });
 
   it('wraps free-text search in quotes so it stays a title filter', () => {
     expect(buildRunsSearchQuery('database error')).toBe(
-      'is:mine type:explorer "database error"'
+      'is:mine is:agent type:explorer "database error"'
     );
   });
 
   it('trims the search before quoting', () => {
-    expect(buildRunsSearchQuery('  padded  ')).toBe('is:mine type:explorer "padded"');
+    expect(buildRunsSearchQuery('  padded  ')).toBe(
+      'is:mine is:agent type:explorer "padded"'
+    );
   });
 
   it('quotes input that looks like structured search instead of parsing it', () => {
     // Without quoting these would be parsed by the runs search grammar and 400.
     expect(buildRunsSearchQuery('unknownkey:value')).toBe(
-      'is:mine type:explorer "unknownkey:value"'
+      'is:mine is:agent type:explorer "unknownkey:value"'
     );
     expect(buildRunsSearchQuery('type:not-a-real-type')).toBe(
-      'is:mine type:explorer "type:not-a-real-type"'
+      'is:mine is:agent type:explorer "type:not-a-real-type"'
     );
   });
 
   it('escapes embedded double quotes', () => {
-    expect(buildRunsSearchQuery('say "hi"')).toBe('is:mine type:explorer "say \\"hi\\""');
+    expect(buildRunsSearchQuery('say "hi"')).toBe(
+      'is:mine is:agent type:explorer "say \\"hi\\""'
+    );
   });
 });

--- a/static/app/views/seerExplorer/seerExplorerSessionContext.tsx
+++ b/static/app/views/seerExplorer/seerExplorerSessionContext.tsx
@@ -13,6 +13,7 @@ export function buildRunsSearchQuery(searchQuery?: string) {
   const trimmed = searchQuery?.trim();
   return [
     'is:mine',
+    'is:agent',
     'type:explorer',
     trimmed ? `"${escapeDoubleQuotes(trimmed)}"` : undefined,
   ]


### PR DESCRIPTION
Investigation runs start with `record_in_history=False`, so they create no `SeerAgentRun` mirror row, but the Explorer chat history query only filters `is:mine type:explorer`, so they still list as untitled sessions the user never started. Scope the query to `is:agent` so the sidebar shows only runs that were recorded in history.

<!-- Describe your PR here. -->