### PR TITLE
fix(derived data): Refine promote_to_live logic

### DIFF
--- a/src/sentry/issues/derived/promote.py
+++ b/src/sentry/issues/derived/promote.py
@@ -86,7 +86,7 @@ def _read_live_generated_at(group_id: int) -> datetime | None:
     return (
         GroupDerivedData.objects.filter(group_id=group_id)
         .values_list("generated_at", flat=True)
-        .first()
+        .get_or_none()
     )
 
 
@@ -297,7 +297,7 @@ def _log_if_live_cursor_orphaned(group_id: int, derived: GroupDerivedData) -> No
     live_cursor = (
         GroupDerivedData.objects.filter(group_id=group_id)
         .values_list("cursor_date", "cursor_id")
-        .first()
+        .get_or_none()
     )
     if live_cursor is None:
         return

--- a/src/sentry/issues/derived/promote.py
+++ b/src/sentry/issues/derived/promote.py
@@ -1,3 +1,15 @@
+"""Promote a fully-computed GroupDerivedData generation into the live row.
+
+Strategy: bring our candidate up to date against the log, attempt an
+atomic CAS against the current live row, and if the CAS fails, retry
+unless post-hoc classification shows a retry can't help. After
+``MAX_PROMOTION_ATTEMPTS`` failed attempts we give up with
+``PromotionFailed``.
+
+The UPDATE is the canonical decision point; the follow-up reads only
+decide whether another attempt is worthwhile.
+"""
+
 from __future__ import annotations
 
 import enum

--- a/src/sentry/issues/derived/promote.py
+++ b/src/sentry/issues/derived/promote.py
@@ -81,17 +81,13 @@ class PromotionFailed(Exception):
         super().__init__(f"group {group_id}: {result.value} after {attempts} attempts")
 
 
-class _RowVersion(NamedTuple):
-    id: int
-    generated_at: datetime
-
-
-def _read_row_version(group_id: int) -> _RowVersion | None:
-    """Read the live row's ``(id, generated_at)``, or None if absent."""
-    row = (
-        GroupDerivedData.objects.filter(group_id=group_id).values_list("id", "generated_at").first()
+def _read_live_generated_at(group_id: int) -> datetime | None:
+    """Return the live row's ``generated_at``, or None if the row is absent."""
+    return (
+        GroupDerivedData.objects.filter(group_id=group_id)
+        .values_list("generated_at", flat=True)
+        .first()
     )
-    return _RowVersion(*row) if row is not None else None
 
 
 def _classify_failed_create(group_id: int, generated_at: datetime) -> PromotionResult:
@@ -101,8 +97,8 @@ def _classify_failed_create(group_id: int, generated_at: datetime) -> PromotionR
     Group, so the error is either a concurrent writer winning the create
     race or the group having been deleted underneath us.
     """
-    live_row = _read_row_version(group_id)
-    if live_row is None:
+    live_generated_at = _read_live_generated_at(group_id)
+    if live_generated_at is None:
         # No visible winner. If the group is gone, that's the FK
         # violation. Otherwise we lost to some other race (e.g. a
         # concurrent GDD delete between our INSERT and this read);
@@ -111,7 +107,7 @@ def _classify_failed_create(group_id: int, generated_at: datetime) -> PromotionR
             return PromotionResult.GROUP_MISSING
         return PromotionResult.RACE_LOST
 
-    if live_row.generated_at > generated_at:
+    if live_generated_at > generated_at:
         return PromotionResult.SUPERSEDED
     # The winner is same-or-older generation, so its cursor position
     # tells us nothing about the log tail. Not CURSOR_BEHIND: that name
@@ -154,9 +150,9 @@ def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
         return PromotionResult.PROMOTED
 
     # Check why we failed: row missing or newer generation?
-    live_row = _read_row_version(candidate.group_id)
+    live_generated_at = _read_live_generated_at(candidate.group_id)
 
-    if live_row is None:
+    if live_generated_at is None:
         # Row doesn't exist — try to create it. enforce_constraints so a
         # violation surfaces here instead of floating up to an
         # enclosing transaction's commit.
@@ -172,7 +168,7 @@ def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
             return _classify_failed_create(candidate.group_id, generated_at)
         return PromotionResult.PROMOTED
 
-    if live_row.generated_at > generated_at:
+    if live_generated_at > generated_at:
         return PromotionResult.SUPERSEDED
     return PromotionResult.CURSOR_BEHIND
 

--- a/src/sentry/issues/derived/promote.py
+++ b/src/sentry/issues/derived/promote.py
@@ -237,82 +237,79 @@ def build_and_promote_derived_data(
 
         result = promote_to_live(derived)
         metrics.incr("issues.derived.promote_to_live", tags={"result": result.value})
-        if result is PromotionResult.PROMOTED:
-            logger.info(
-                "issues.derived.promoted",
-                extra={
-                    "group_id": group_id,
-                    "cursor_date": str(derived.cursor_date),
-                    "cursor_id": derived.cursor_id,
-                    "attempts": attempt + 1,
-                },
-            )
-            _generation_cache.delete(current_gen_id)
-            return
-
-        if result is PromotionResult.SUPERSEDED:
-            # A newer generation already won — not an error.
-            _generation_cache.delete(current_gen_id)
-            return
-
-        if result is PromotionResult.GROUP_MISSING:
-            _generation_cache.delete(current_gen_id)
-            raise Group.DoesNotExist(f"Group {group_id} does not exist")
-
-        if result is PromotionResult.RACE_LOST:
-            # Concurrent same-or-older-generation writer beat us to the
-            # create. Their cursor position is not necessarily ahead of
-            # ours, so we must not apply the "give up if no new entries"
-            # heuristic — just retry. The next attempt will normally
-            # promote via the UPDATE path (cursor guard permitting).
-            continue
-
-        # CURSOR_BEHIND: the live row's cursor is ahead of ours.
-        # If new entries exist past our cursor, the next drain will pick
-        # them up. If not, the log was modified (e.g. merge deleted
-        # entries) and our replay is incomplete — give up.
-        if not _entries_after_cursor(group_id, derived.cursor_date, derived.cursor_id, 1):
-            # We're up-to-date with the log, but the live row is ahead.
-            # If the live row's cursor references an entry that no longer
-            # exists, the log was mutated (e.g. merge/unmerge deleted the
-            # referenced entry). Note that in the log so filtering on
-            # PromotionFailed can distinguish this cause.
-            #
-            # TODO: when we detect an orphaned live cursor, the safer
-            # response is probably to retry promotion without the cursor
-            # guard — our replay is complete against the current log, so
-            # forcing our state over the live row (still gated on
-            # generated_at) would leave the group in a consistent state
-            # instead of stuck at PromotionFailed until the next regen.
-            live_cursor = (
-                GroupDerivedData.objects.filter(group_id=group_id)
-                .values_list("cursor_date", "cursor_id")
-                .first()
-            )
-            if live_cursor is not None:
-                live_cursor_date, live_cursor_id = live_cursor
-                if (
-                    # Should be unreachable: a live cursor at cursor_id=0
-                    # is at EPOCH and can't be ahead of any candidate.
-                    live_cursor_id != 0
-                    and not GroupActionLogEntry.objects.filter(
-                        group_id=group_id, id=live_cursor_id
-                    ).exists()
-                ):
-                    logger.info(
-                        "issues.derived.promote.live_cursor_orphaned",
-                        extra={
-                            "group_id": group_id,
-                            "live_cursor_date": str(live_cursor_date),
-                            "live_cursor_id": live_cursor_id,
-                            "candidate_cursor_date": str(derived.cursor_date),
-                            "candidate_cursor_id": derived.cursor_id,
-                        },
-                    )
-            break
+        match result:
+            case PromotionResult.PROMOTED:
+                logger.info(
+                    "issues.derived.promoted",
+                    extra={
+                        "group_id": group_id,
+                        "cursor_date": str(derived.cursor_date),
+                        "cursor_id": derived.cursor_id,
+                        "attempts": attempt + 1,
+                    },
+                )
+                _generation_cache.delete(current_gen_id)
+                return
+            case PromotionResult.SUPERSEDED:
+                # A newer generation already won — not an error.
+                _generation_cache.delete(current_gen_id)
+                return
+            case PromotionResult.GROUP_MISSING:
+                _generation_cache.delete(current_gen_id)
+                raise Group.DoesNotExist(f"Group {group_id} does not exist")
+            case PromotionResult.RACE_LOST:
+                # Didn't fail, but didn't succeed due to a race.
+                # Assuming there's not ongoing messy contention, the next attempt
+                # should succeed or fail cleanly, so we retry.
+                continue
+            case PromotionResult.CURSOR_BEHIND:
+                # The live row's cursor is ahead of ours. If new entries
+                # exist past our cursor, the next drain will pick them up.
+                if _entries_after_cursor(group_id, derived.cursor_date, derived.cursor_id, 1):
+                    continue
+                # If not, the log was modified (e.g. merge deleted entries)
+                # and our replay is incomplete — give up.
+                _log_if_live_cursor_orphaned(group_id, derived)
+                break
 
     _generation_cache.delete(current_gen_id)
     raise PromotionFailed(group_id, result, attempt + 1)
+
+
+def _log_if_live_cursor_orphaned(group_id: int, derived: GroupDerivedData) -> None:
+    """Log if the live row's cursor points at a deleted log entry.
+
+    Called on the terminal CURSOR_BEHIND give-up path so operators can
+    distinguish log-mutation causes (merge/unmerge deleted the referenced
+    entry) from lost races.
+
+    TODO: when we detect an orphaned live cursor, the safer response is
+    probably to retry promotion without the cursor guard.
+    """
+    live_cursor = (
+        GroupDerivedData.objects.filter(group_id=group_id)
+        .values_list("cursor_date", "cursor_id")
+        .first()
+    )
+    if live_cursor is None:
+        return
+    live_cursor_date, live_cursor_id = live_cursor
+    if live_cursor_id == 0:
+        # 0 is the "no actions yet" state; unexpected in this context, but doesn't suggest an
+        # orphaned cursor.
+        return
+    if GroupActionLogEntry.objects.filter(group_id=group_id, id=live_cursor_id).exists():
+        return
+    logger.info(
+        "issues.derived.promote.live_cursor_orphaned",
+        extra={
+            "group_id": group_id,
+            "live_cursor_date": str(live_cursor_date),
+            "live_cursor_id": live_cursor_id,
+            "candidate_cursor_date": str(derived.cursor_date),
+            "candidate_cursor_id": derived.cursor_id,
+        },
+    )
 
 
 class BatchRunResult(NamedTuple):

--- a/src/sentry/issues/derived/promote.py
+++ b/src/sentry/issues/derived/promote.py
@@ -11,6 +11,7 @@ from django.db import IntegrityError, router, transaction
 from django.db.models import Q
 from django.utils import timezone
 
+from sentry.db.postgres.transactions import enforce_constraints
 from sentry.issues.derived.processing import (
     DEFAULT_BATCH_SIZE,
     PIPELINE,
@@ -21,6 +22,7 @@ from sentry.issues.derived.processing import (
     _drain_log,
     _entries_after_cursor,
 )
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
 from sentry.models.group import Group
 from sentry.utils import metrics
@@ -49,6 +51,12 @@ class PromotionResult(enum.Enum):
     PROMOTED = "promoted"
     SUPERSEDED = "superseded"  # a newer generation already promoted
     CURSOR_BEHIND = "cursor_behind"  # same generation, but cursor is more advanced
+    # Lost a create race to a same/older-generation writer whose cursor
+    # is not necessarily ahead. Returned instead of looping internally
+    # to keep promote_to_live a single CAS attempt; the caller owns the
+    # retry budget.
+    RACE_LOST = "race_lost"
+    GROUP_MISSING = "group_missing"  # the group was deleted; nothing to promote onto
 
 
 class PromotionFailed(Exception):
@@ -61,6 +69,45 @@ class PromotionFailed(Exception):
         super().__init__(f"group {group_id}: {result.value} after {attempts} attempts")
 
 
+class _RowVersion(NamedTuple):
+    id: int
+    generated_at: datetime
+
+
+def _read_row_version(group_id: int) -> _RowVersion | None:
+    """Read the live row's ``(id, generated_at)``, or None if absent."""
+    row = (
+        GroupDerivedData.objects.filter(group_id=group_id).values_list("id", "generated_at").first()
+    )
+    return _RowVersion(*row) if row is not None else None
+
+
+def _classify_failed_create(group_id: int, generated_at: datetime) -> PromotionResult:
+    """Explain an IntegrityError from the promote INSERT.
+
+    The model constrains ``group`` to be unique and to reference a live
+    Group, so the error is either a concurrent writer winning the create
+    race or the group having been deleted underneath us.
+    """
+    live_row = _read_row_version(group_id)
+    if live_row is None:
+        # No visible winner. If the group is gone, that's the FK
+        # violation. Otherwise we lost to some other race (e.g. a
+        # concurrent GDD delete between our INSERT and this read);
+        # retry rather than guess at the exact sequence.
+        if not Group.objects.filter(id=group_id).exists():
+            return PromotionResult.GROUP_MISSING
+        return PromotionResult.RACE_LOST
+
+    if live_row.generated_at > generated_at:
+        return PromotionResult.SUPERSEDED
+    # The winner is same-or-older generation, so its cursor position
+    # tells us nothing about the log tail. Not CURSOR_BEHIND: that name
+    # implies the winner is genuinely ahead, and the caller uses it to
+    # decide to give up.
+    return PromotionResult.RACE_LOST
+
+
 def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
     """Upsert the candidate's state into the row for its group.
 
@@ -69,7 +116,12 @@ def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
     success, all state fields (including ``generated_at``) are stamped.
 
     Returns SUPERSEDED if the row has a newer ``generated_at``.
-    Returns CURSOR_BEHIND if the cursor guard failed.
+    Returns CURSOR_BEHIND if the cursor guard failed against a same or
+    older generation whose cursor is genuinely ahead.
+    Returns RACE_LOST if we lost a create race to a same-or-older
+    generation whose cursor may not be ahead — the caller should retry
+    unconditionally rather than treating "no new log entries" as fatal.
+    Returns GROUP_MISSING if the group has been deleted.
 
     The candidate object itself is not persisted — it may be an unsaved
     in-memory instance used only to carry the computed state.
@@ -90,30 +142,25 @@ def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
         return PromotionResult.PROMOTED
 
     # Check why we failed: row missing or newer generation?
-    row = (
-        GroupDerivedData.objects.filter(group_id=candidate.group_id)
-        .values_list("id", "generated_at")
-        .get_or_none()
-    )
+    live_row = _read_row_version(candidate.group_id)
 
-    if row is None:
-        # Row doesn't exist — try to create it.
+    if live_row is None:
+        # Row doesn't exist — try to create it. enforce_constraints so a
+        # violation surfaces here instead of floating up to an
+        # enclosing transaction's commit.
         try:
-            with transaction.atomic(using=router.db_for_write(GroupDerivedData)):
+            with enforce_constraints(
+                transaction.atomic(using=router.db_for_write(GroupDerivedData))
+            ):
                 GroupDerivedData.objects.create(
                     group_id=candidate.group_id,
                     **values,
                 )
         except IntegrityError:
-            # A concurrent writer created the row first. This could be
-            # SUPERSEDED (if their generated_at is newer) but we'd need
-            # another query to distinguish. CURSOR_BEHIND triggers a
-            # retry which will resolve it on the UPDATE path.
-            return PromotionResult.CURSOR_BEHIND
+            return _classify_failed_create(candidate.group_id, generated_at)
         return PromotionResult.PROMOTED
 
-    _row_id, current_generated_at = row
-    if current_generated_at > generated_at:
+    if live_row.generated_at > generated_at:
         return PromotionResult.SUPERSEDED
     return PromotionResult.CURSOR_BEHIND
 
@@ -208,11 +255,60 @@ def build_and_promote_derived_data(
             _generation_cache.delete(current_gen_id)
             return
 
+        if result is PromotionResult.GROUP_MISSING:
+            _generation_cache.delete(current_gen_id)
+            raise Group.DoesNotExist(f"Group {group_id} does not exist")
+
+        if result is PromotionResult.RACE_LOST:
+            # Concurrent same-or-older-generation writer beat us to the
+            # create. Their cursor position is not necessarily ahead of
+            # ours, so we must not apply the "give up if no new entries"
+            # heuristic — just retry. The next attempt will normally
+            # promote via the UPDATE path (cursor guard permitting).
+            continue
+
         # CURSOR_BEHIND: the live row's cursor is ahead of ours.
         # If new entries exist past our cursor, the next drain will pick
         # them up. If not, the log was modified (e.g. merge deleted
         # entries) and our replay is incomplete — give up.
         if not _entries_after_cursor(group_id, derived.cursor_date, derived.cursor_id, 1):
+            # We're up-to-date with the log, but the live row is ahead.
+            # If the live row's cursor references an entry that no longer
+            # exists, the log was mutated (e.g. merge/unmerge deleted the
+            # referenced entry). Note that in the log so filtering on
+            # PromotionFailed can distinguish this cause.
+            #
+            # TODO: when we detect an orphaned live cursor, the safer
+            # response is probably to retry promotion without the cursor
+            # guard — our replay is complete against the current log, so
+            # forcing our state over the live row (still gated on
+            # generated_at) would leave the group in a consistent state
+            # instead of stuck at PromotionFailed until the next regen.
+            live_cursor = (
+                GroupDerivedData.objects.filter(group_id=group_id)
+                .values_list("cursor_date", "cursor_id")
+                .first()
+            )
+            if live_cursor is not None:
+                live_cursor_date, live_cursor_id = live_cursor
+                if (
+                    # Should be unreachable: a live cursor at cursor_id=0
+                    # is at EPOCH and can't be ahead of any candidate.
+                    live_cursor_id != 0
+                    and not GroupActionLogEntry.objects.filter(
+                        group_id=group_id, id=live_cursor_id
+                    ).exists()
+                ):
+                    logger.info(
+                        "issues.derived.promote.live_cursor_orphaned",
+                        extra={
+                            "group_id": group_id,
+                            "live_cursor_date": str(live_cursor_date),
+                            "live_cursor_id": live_cursor_id,
+                            "candidate_cursor_date": str(derived.cursor_date),
+                            "candidate_cursor_id": derived.cursor_id,
+                        },
+                    )
             break
 
     _generation_cache.delete(current_gen_id)
@@ -270,7 +366,10 @@ def build_and_promote_batch(
             )
         except PromotionFailed as e:
             processed[e.result] = processed.get(e.result, 0) + 1
-            logger.exception(f"{log_key}.promotion_failed")
+            logger.exception(
+                f"{log_key}.promotion_failed",
+                extra={"group_id": e.group_id},
+            )
         except GroupLogTimeout as e:
             return BatchRunResult(
                 processed=processed,

--- a/tests/sentry/issues/derived/test_promote.py
+++ b/tests/sentry/issues/derived/test_promote.py
@@ -1,3 +1,5 @@
+from collections.abc import Generator
+from contextlib import contextmanager
 from datetime import timedelta
 from unittest.mock import patch
 
@@ -21,6 +23,9 @@ from sentry.issues.derived.promote import (
     PromotionFailed,
     PromotionResult,
     _generation_cache,
+    _read_row_version,
+    _RowVersion,
+    build_and_promote_batch,
     build_and_promote_derived_data,
     promote_to_live,
 )
@@ -43,6 +48,24 @@ def _publish(*, group: Group, action: GroupAction, actor: GroupActionActor = SYS
             project=group.project,
             actor=actor,
         )
+
+
+@contextmanager
+def _hide_first_row_read() -> Generator[None]:
+    """Hide the live row from promote_to_live's first existence probe.
+
+    Opens the TOCTOU window between that probe and the INSERT, so the
+    INSERT loses the create race and raises IntegrityError.
+    """
+    seen = iter([True])
+
+    def hide_once(group_id: int) -> _RowVersion | None:
+        if next(seen, False):
+            return None
+        return _read_row_version(group_id)
+
+    with patch("sentry.issues.derived.promote._read_row_version", hide_once):
+        yield
 
 
 @with_feature("projects:issue-action-log-write-to-db")
@@ -142,6 +165,70 @@ class PromoteToLiveTest(TestCase):
         )
         processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
         assert promote_to_live(candidate) is PromotionResult.SUPERSEDED
+
+    def test_promote_create_race_returns_superseded_when_winner_is_newer(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        gen_time = django_timezone.now()
+        candidate = GroupDerivedData(
+            group_id=group.id,
+            generated_at=gen_time,
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+        processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
+
+        newer_time = gen_time + timedelta(seconds=10)
+        GroupDerivedData.objects.filter(group_id=group.id).update(
+            generated_at=newer_time,
+            cursor_date=candidate.cursor_date,
+            cursor_id=candidate.cursor_id,
+        )
+
+        with _hide_first_row_read():
+            assert promote_to_live(candidate) is PromotionResult.SUPERSEDED
+
+    def test_promote_create_race_returns_race_lost_when_winner_same_generation(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        gen_time = django_timezone.now()
+        candidate = GroupDerivedData(
+            group_id=group.id,
+            generated_at=gen_time,
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+        # Only process one entry so candidate's cursor is behind the log tip.
+        processing._process_batch(PIPELINE, candidate, batch_size=1, persist=False)
+
+        last = GroupActionLogEntry.objects.filter(group_id=group.id).order_by("id").last()
+        assert last is not None
+        GroupDerivedData.objects.filter(group_id=group.id).update(
+            generated_at=gen_time - timedelta(seconds=10),
+            cursor_date=last.date_added,
+            cursor_id=last.id,
+        )
+
+        with _hide_first_row_read():
+            assert promote_to_live(candidate) is PromotionResult.RACE_LOST
+
+    def test_promote_returns_group_missing_when_group_deleted(self) -> None:
+        candidate = GroupDerivedData(
+            group_id=999999999,
+            generated_at=django_timezone.now(),
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+        assert promote_to_live(candidate) is PromotionResult.GROUP_MISSING
 
     def test_generation_prevents_stale_incremental_write(self) -> None:
         """End-to-end ABA test: incremental write computed from pre-generation
@@ -272,6 +359,55 @@ class PromoteToLiveTest(TestCase):
         with pytest.raises(PromotionFailed):
             build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
 
+    def test_build_and_promote_logs_when_live_cursor_orphaned(self) -> None:
+        group = self.create_group()
+
+        # Live row references a cursor_id that has no matching log entry.
+        self.create_group_derived_data(
+            group,
+            cursor_date=django_timezone.now(),
+            cursor_id=99999,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+
+        with patch("sentry.issues.derived.promote.logger") as mock_logger:
+            with pytest.raises(PromotionFailed):
+                build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+
+        orphan_calls = [
+            call
+            for call in mock_logger.info.call_args_list
+            if call.args and call.args[0] == "issues.derived.promote.live_cursor_orphaned"
+        ]
+        assert len(orphan_calls) == 1
+        assert orphan_calls[0].kwargs["extra"]["group_id"] == group.id
+        assert orphan_calls[0].kwargs["extra"]["live_cursor_id"] == 99999
+
+    def test_build_and_promote_does_not_log_orphan_when_live_cursor_exists(self) -> None:
+        group = self.create_group()
+        entry = self.create_group_action_log_entry(group)
+
+        # cursor_date in the future so a fresh candidate's replay lands behind it.
+        self.create_group_derived_data(
+            group,
+            cursor_date=django_timezone.now() + timedelta(hours=1),
+            cursor_id=entry.id,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+
+        with patch("sentry.issues.derived.promote.logger") as mock_logger:
+            with pytest.raises(PromotionFailed):
+                build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+
+        orphan_calls = [
+            call
+            for call in mock_logger.info.call_args_list
+            if call.args and call.args[0] == "issues.derived.promote.live_cursor_orphaned"
+        ]
+        assert orphan_calls == []
+
     def test_build_and_promote_superseded_returns_cleanly(self) -> None:
         group = self.create_group()
         _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
@@ -306,6 +442,41 @@ class PromoteToLiveTest(TestCase):
         build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
         derived = GroupDerivedData.objects.get(group_id=group.id)
         assert derived.view_count == 2
+
+    def test_build_and_promote_retries_on_race_lost_without_new_entries(self) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        # Had RACE_LOST been treated as CURSOR_BEHIND, the caller would give
+        # up here: the drain leaves no entries past the cursor.
+        real_promote = promote_to_live
+        attempts = []
+
+        def flaky_promote(candidate: GroupDerivedData) -> PromotionResult:
+            attempts.append(candidate)
+            if len(attempts) == 1:
+                return PromotionResult.RACE_LOST
+            return real_promote(candidate)
+
+        with patch("sentry.issues.derived.promote.promote_to_live", side_effect=flaky_promote):
+            build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
+
+        assert len(attempts) == 2
+        derived = GroupDerivedData.objects.get(group_id=group.id)
+        assert derived.view_count == 1
+
+    def test_build_and_promote_raises_group_does_not_exist_on_mid_loop_group_missing(
+        self,
+    ) -> None:
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        def missing_then_real(candidate: GroupDerivedData) -> PromotionResult:
+            return PromotionResult.GROUP_MISSING
+
+        with patch("sentry.issues.derived.promote.promote_to_live", side_effect=missing_then_real):
+            with pytest.raises(Group.DoesNotExist):
+                build_and_promote_derived_data(group.id, time_limit=timedelta(minutes=5))
 
     def test_build_and_promote_prevents_stale_incremental_write(self) -> None:
         """End-to-end ABA test: incremental write computed from pre-generation
@@ -397,3 +568,31 @@ class PromoteToLiveTest(TestCase):
         state = _generation_cache.get(gen_id2)
         assert state is not None
         assert state.cursor_id > first_cursor
+
+    def test_build_and_promote_batch_logs_group_id_on_promotion_failed(self) -> None:
+        group = self.create_group()
+
+        # Cursor ahead of anything a fresh candidate could replay, forcing failure.
+        self.create_group_derived_data(
+            group,
+            cursor_date=django_timezone.now(),
+            cursor_id=99999,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+
+        with patch("sentry.issues.derived.promote.logger") as mock_logger:
+            result = build_and_promote_batch(
+                [group.id],
+                timeout=timedelta(minutes=5),
+                log_key="test.batch",
+            )
+
+        assert result.processed.get(PromotionResult.CURSOR_BEHIND) == 1
+        failed_calls = [
+            call
+            for call in mock_logger.exception.call_args_list
+            if call.args and call.args[0] == "test.batch.promotion_failed"
+        ]
+        assert len(failed_calls) == 1
+        assert failed_calls[0].kwargs["extra"]["group_id"] == group.id

--- a/tests/sentry/issues/derived/test_promote.py
+++ b/tests/sentry/issues/derived/test_promote.py
@@ -1,6 +1,6 @@
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import timedelta
+from datetime import datetime, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -23,8 +23,7 @@ from sentry.issues.derived.promote import (
     PromotionFailed,
     PromotionResult,
     _generation_cache,
-    _read_row_version,
-    _RowVersion,
+    _read_live_generated_at,
     build_and_promote_batch,
     build_and_promote_derived_data,
     promote_to_live,
@@ -59,12 +58,12 @@ def _hide_first_row_read() -> Generator[None]:
     """
     seen = iter([True])
 
-    def hide_once(group_id: int) -> _RowVersion | None:
+    def hide_once(group_id: int) -> datetime | None:
         if next(seen, False):
             return None
-        return _read_row_version(group_id)
+        return _read_live_generated_at(group_id)
 
-    with patch("sentry.issues.derived.promote._read_row_version", hide_once):
+    with patch("sentry.issues.derived.promote._read_live_generated_at", hide_once):
         yield
 
 


### PR DESCRIPTION
This refines promotion logic in a few ways.

1. Previously, a creation race would be interpreted falsely as a CURSOR_BEHIND (we don't know that). This introduces a new "RACE_LOST" result that signals "we didn't succeed or fail due to state weirdness, try again" to help address that case.
2. When we hit a CURSOR_BEHIND and there isn't actually more log data available for us to process, check if the live row references a log entry that doesn't exist for this group and log.
3. Handle Group deletion a bit more accurately.
4. Include Group ID in PromotionError exception logging just for ease of filtering.

The unfortunate complexity continues.
