### PR TITLE
feat(auth): Animate Auth V2 login transitions

### DIFF
--- a/static/app/components/animatedActivity.tsx
+++ b/static/app/components/animatedActivity.tsx
@@ -1,0 +1,88 @@
+import {Activity, type ReactNode, useEffect, useState} from 'react';
+import {
+  motion,
+  type TargetAndTransition,
+  type Transition,
+  useAnimationControls,
+} from 'framer-motion';
+
+import {Container} from '@sentry/scraps/layout';
+
+type ActivityMode = 'hidden' | 'visible';
+
+interface AnimatedActivityProps {
+  animate: TargetAndTransition;
+  children: ReactNode;
+  exit: TargetAndTransition;
+  initial: TargetAndTransition;
+  mode: ActivityMode;
+  transition: Transition;
+  elementRef?: (element: HTMLDivElement | null) => void;
+  layoutMode?: 'normal' | 'pop';
+}
+
+// This compatibility component can be replaced with Motion's AnimateActivity once
+// it is available in the main package: https://motion.dev/docs/react-animate-activity
+export function AnimatedActivity({
+  animate,
+  children,
+  elementRef,
+  exit,
+  initial,
+  layoutMode = 'normal',
+  mode,
+  transition,
+}: AnimatedActivityProps) {
+  const controls = useAnimationControls();
+  const [activityMode, setActivityMode] = useState<ActivityMode>(mode);
+
+  useEffect(() => {
+    if (mode === 'visible') {
+      if (activityMode === 'hidden') {
+        controls.set(initial);
+        setActivityMode('visible');
+        return;
+      }
+
+      void controls.start({...animate, transition});
+      return;
+    }
+
+    if (activityMode === 'hidden') {
+      return;
+    }
+
+    let cancelled = false;
+    void controls.start({...exit, transition}).then(() => {
+      if (cancelled) {
+        return;
+      }
+
+      controls.set(initial);
+      setActivityMode('hidden');
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [activityMode, animate, controls, exit, initial, mode, transition]);
+
+  const isExiting = mode === 'hidden' && activityMode === 'visible';
+
+  return (
+    <Activity mode={activityMode}>
+      <MotionContainer
+        ref={element => elementRef?.(element as HTMLDivElement | null)}
+        area="1 / 1"
+        position={layoutMode === 'pop' && isExiting ? 'absolute' : 'relative'}
+        width="100%"
+        initial={mode === 'visible' ? false : initial}
+        animate={controls}
+      >
+        {children}
+      </MotionContainer>
+    </Activity>
+  );
+}
+
+const MotionContainer = motion.create(Container);

--- a/static/app/views/authV2/authLogin/components/emailAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/emailAuth.spec.tsx
@@ -1,6 +1,12 @@
 import {UserFixture} from 'sentry-fixture/user';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  waitForElementToBeRemoved,
+} from 'sentry-test/reactTestingLibrary';
 
 import {EmailAuth} from './emailAuth';
 
@@ -15,12 +21,18 @@ describe('EmailAuth', () => {
     });
     render(<EmailAuth onAuthResult={onAuthResult} />);
 
+    expect(
+      screen.queryByRole('button', {name: 'Log in to Sentry'})
+    ).not.toBeInTheDocument();
     await userEvent.type(
       screen.getByRole('textbox', {name: 'Email'}),
       'user@example.com'
     );
+    expect(
+      screen.queryByRole('button', {name: 'Log in to Sentry'})
+    ).not.toBeInTheDocument();
     await userEvent.type(screen.getByLabelText('Password'), 'secret');
-    await userEvent.click(screen.getByRole('button', {name: 'Log in to Sentry'}));
+    await userEvent.click(await screen.findByRole('button', {name: 'Log in to Sentry'}));
 
     await waitFor(() =>
       expect(request).toHaveBeenCalledWith(
@@ -40,38 +52,7 @@ describe('EmailAuth', () => {
     );
   });
 
-  it('submits credentials populated without change events', async () => {
-    const request = MockApiClient.addMockResponse({
-      url: '/auth/login/',
-      method: 'POST',
-      body: {nextUri: '/organizations/', user: UserFixture()},
-    });
-    render(<EmailAuth onAuthResult={jest.fn()} />);
-
-    const email = screen.getByRole('textbox', {name: 'Email'});
-    const password = screen.getByLabelText('Password');
-    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
-      email,
-      'user@example.com'
-    );
-    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
-      password,
-      'secret'
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: 'Log in to Sentry'}));
-
-    await waitFor(() =>
-      expect(request).toHaveBeenCalledWith(
-        '/auth/login/',
-        expect.objectContaining({
-          data: {username: 'user@example.com', password: 'secret', orgSlug: null},
-        })
-      )
-    );
-  });
-
-  it('preserves credentials populated without change events after an error', async () => {
+  it('preserves credentials after an error', async () => {
     MockApiClient.addMockResponse({
       url: '/auth/login/',
       method: 'POST',
@@ -83,24 +64,18 @@ describe('EmailAuth', () => {
     });
     render(<EmailAuth onAuthResult={jest.fn()} />);
 
-    const email = screen.getByRole('textbox', {name: 'Email'});
-    const password = screen.getByLabelText('Password');
-    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
-      email,
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Email'}),
       'user@example.com'
     );
-    Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(
-      password,
-      'wrong'
-    );
-
-    await userEvent.click(screen.getByRole('button', {name: 'Log in to Sentry'}));
+    await userEvent.type(screen.getByLabelText('Password'), 'wrong');
+    await userEvent.click(await screen.findByRole('button', {name: 'Log in to Sentry'}));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
       'Invalid email or password'
     );
-    expect(email).toHaveValue('user@example.com');
-    expect(password).toHaveValue('wrong');
+    expect(screen.getByRole('textbox', {name: 'Email'})).toHaveValue('user@example.com');
+    expect(screen.getByLabelText('Password')).toHaveValue('wrong');
   });
 
   it('reports required MFA methods', async () => {
@@ -131,7 +106,7 @@ describe('EmailAuth', () => {
     );
   });
 
-  it('shows login errors and clears them when credentials change', async () => {
+  it('clears login errors when entering password recovery', async () => {
     MockApiClient.addMockResponse({
       url: '/auth/login/',
       method: 'POST',
@@ -163,11 +138,6 @@ describe('EmailAuth', () => {
     );
 
     await userEvent.click(screen.getByRole('button', {name: 'Forgot password?'}));
-    expect(screen.getByRole('alert')).toHaveTextContent('Invalid email or password');
-
-    await userEvent.click(screen.getByRole('button', {name: 'Back to Login'}));
-
-    await userEvent.type(screen.getByLabelText('Password'), '!');
 
     expect(screen.queryByText('Invalid email or password')).not.toBeInTheDocument();
   });
@@ -249,9 +219,9 @@ describe('EmailAuth', () => {
     );
     expect(screen.getByText('user@example.com')).toBeInTheDocument();
     expect(screen.queryByRole('textbox', {name: 'Email'})).not.toBeInTheDocument();
-    expect(
+    await waitForElementToBeRemoved(() =>
       screen.queryByRole('button', {name: 'Reset Password'})
-    ).not.toBeInTheDocument();
+    );
     expect(
       screen.queryByRole('button', {name: 'Use a different email'})
     ).not.toBeInTheDocument();

--- a/static/app/views/authV2/authLogin/components/emailAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/emailAuth.tsx
@@ -1,6 +1,8 @@
 import {useEffect, useId, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {VisuallyHidden} from '@react-aria/visually-hidden';
+import {AnimatePresence, motion} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
@@ -27,6 +29,7 @@ interface EmailAuthProps {
 }
 
 export function EmailAuth({onAuthResult, organizationSlug}: EmailAuthProps) {
+  const theme = useTheme();
   const authErrorDescriptionId = useId();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -39,7 +42,8 @@ export function EmailAuth({onAuthResult, organizationSlug}: EmailAuthProps) {
     ? t('Hide password')
     : t('Show password');
   const authError = emailAuth.errorMessage;
-  const isPending = emailAuth.isPending || passwordReset.isPending;
+  const isEmailAuthTransitioning = emailAuth.isPending || Boolean(emailAuth.result);
+  const isPending = isEmailAuthTransitioning || passwordReset.isPending;
 
   function handleEmailChange(event: React.ChangeEvent<HTMLInputElement>) {
     setEmail(event.currentTarget.value);
@@ -53,6 +57,7 @@ export function EmailAuth({onAuthResult, organizationSlug}: EmailAuthProps) {
   }
 
   function setPasswordRecoveryMode(enabled: boolean) {
+    emailAuth.reset();
     passwordReset.reset();
     setIsPasswordRecovery(enabled);
   }
@@ -138,60 +143,51 @@ export function EmailAuth({onAuthResult, organizationSlug}: EmailAuthProps) {
             )}
           </InputGroup>
         )}
-        {!isPasswordRecovery && (
-          <Container paddingTop="md">
-            <InputGroup>
-              <InputGroup.Input
-                type={isPasswordVisible ? 'text' : 'password'}
-                name="password"
-                value={password}
-                autoComplete="current-password"
-                disabled={isPending}
-                placeholder={t('Password')}
-                aria-label={t('Password')}
-                aria-invalid={Boolean(authError)}
-                required
-                onChange={handlePasswordChange}
-              />
-              <InputGroup.TrailingItems>
-                {password && (
-                  <Button
-                    aria-label={passwordVisibilityLabel}
-                    icon={isPasswordVisible ? <IconHide /> : <IconShow />}
-                    size="zero"
-                    tooltipProps={{title: passwordVisibilityLabel}}
-                    variant="transparent"
-                    onClick={() => setIsPasswordVisible(visible => !visible)}
+        <AnimatePresence initial={false}>
+          {!isPasswordRecovery && (
+            <motion.div
+              initial={{height: 0, overflow: 'hidden'}}
+              animate={{
+                height: 'auto',
+                overflow: 'hidden',
+                transitionEnd: {overflow: 'visible'},
+              }}
+              exit={{height: 0, overflow: 'hidden'}}
+              transition={theme.motion.framer.smooth.moderate}
+            >
+              <Container paddingTop="md">
+                <InputGroup>
+                  <InputGroup.Input
+                    type={isPasswordVisible ? 'text' : 'password'}
+                    name="password"
+                    value={password}
+                    autoComplete="current-password"
+                    disabled={isPending}
+                    placeholder={t('Password')}
+                    aria-label={t('Password')}
+                    aria-invalid={Boolean(authError)}
+                    required
+                    onChange={handlePasswordChange}
                   />
-                )}
-              </InputGroup.TrailingItems>
-            </InputGroup>
-          </Container>
-        )}
+                  <InputGroup.TrailingItems>
+                    {password && (
+                      <Button
+                        aria-label={passwordVisibilityLabel}
+                        icon={isPasswordVisible ? <IconHide /> : <IconShow />}
+                        size="zero"
+                        tooltipProps={{title: passwordVisibilityLabel}}
+                        variant="transparent"
+                        onClick={() => setIsPasswordVisible(visible => !visible)}
+                      />
+                    )}
+                  </InputGroup.TrailingItems>
+                </InputGroup>
+              </Container>
+            </motion.div>
+          )}
+        </AnimatePresence>
         <Flex paddingTop="md">
-          <Container flex="1" paddingTop="sm">
-            {!passwordReset.result && !isPasswordRecovery && (
-              <Button
-                type="submit"
-                variant="primary"
-                size="sm"
-                busy={emailAuth.isPending}
-              >
-                {t('Log in to Sentry')}
-              </Button>
-            )}
-            {!passwordReset.result && isPasswordRecovery && (
-              <Button
-                type="submit"
-                variant="primary"
-                size="sm"
-                busy={passwordReset.isPending}
-              >
-                {t('Reset Password')}
-              </Button>
-            )}
-          </Container>
-          <Flex flex="1" justify="end">
+          <Flex flex="1">
             {isPasswordRecovery ? (
               <ForgotPasswordButton
                 disabled={isPending}
@@ -213,6 +209,42 @@ export function EmailAuth({onAuthResult, organizationSlug}: EmailAuthProps) {
               </ForgotPasswordButton>
             )}
           </Flex>
+          <Flex flex="1" justify="end" paddingTop="sm">
+            <AnimatePresence initial={false} mode="wait">
+              {!passwordReset.result &&
+                !isPasswordRecovery &&
+                Boolean(email && password) && (
+                  <MotionButton
+                    key="login"
+                    type="submit"
+                    variant="primary"
+                    size="sm"
+                    busy={isEmailAuthTransitioning}
+                    initial={{opacity: 0, y: 5}}
+                    animate={{opacity: 1, y: 0}}
+                    exit={{opacity: 0, scale: 0.96}}
+                    transition={theme.motion.framer.smooth.moderate}
+                  >
+                    {t('Log in to Sentry')}
+                  </MotionButton>
+                )}
+              {!passwordReset.result && isPasswordRecovery && Boolean(email) && (
+                <MotionButton
+                  key="password-reset"
+                  type="submit"
+                  variant="primary"
+                  size="sm"
+                  busy={passwordReset.isPending}
+                  initial={{opacity: 0, y: 5}}
+                  animate={{opacity: 1, y: 0}}
+                  exit={{opacity: 0, scale: 0.96}}
+                  transition={theme.motion.framer.smooth.moderate}
+                >
+                  {t('Reset Password')}
+                </MotionButton>
+              )}
+            </AnimatePresence>
+          </Flex>
         </Flex>
         {authError && (
           <VisuallyHidden id={authErrorDescriptionId} role="alert">
@@ -228,3 +260,5 @@ const ForgotPasswordButton = styled(Button)`
   color: ${p => p.theme.tokens.content.secondary};
   font-weight: ${p => p.theme.font.weight.sans.regular};
 `;
+
+const MotionButton = motion.create(Button);

--- a/static/app/views/authV2/authLogin/components/organizationSwitcher.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationSwitcher.tsx
@@ -1,0 +1,94 @@
+import {useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import {AnimatePresence, motion} from 'framer-motion';
+
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
+
+import {t} from 'sentry/locale';
+import {useDimensions} from 'sentry/utils/useDimensions';
+import type {AuthOrganization} from 'sentry/views/authV2/authLogin/hooks/useAuthOrganization';
+
+import {OrganizationAuth} from './organizationAuth';
+import {OrganizationSlugInput} from './organizationSlugInput';
+
+interface OrganizationSwitcherProps {
+  authOrganization: AuthOrganization | undefined;
+  isInputVisible: boolean;
+  onCancel: () => void;
+  onClear: (() => void) | undefined;
+  onOpen: () => void;
+  onSelect: (organizationSlug: string) => void;
+}
+
+export function OrganizationSwitcher({
+  authOrganization,
+  isInputVisible,
+  onCancel,
+  onClear,
+  onOpen,
+  onSelect,
+}: OrganizationSwitcherProps) {
+  const theme = useTheme();
+  const [element, setElement] = useState<HTMLDivElement | null>(null);
+  // The callback ref triggers a render when the grid mounts, while this stable
+  // ref-shaped object lets useDimensions attach its observer to that grid.
+  const elementRef = useMemo(() => ({current: element}), [element]);
+  const {height} = useDimensions({elementRef});
+
+  return (
+    <MotionContainer
+      initial={false}
+      animate={height ? {height} : undefined}
+      transition={theme.motion.framer.spring.moderate}
+    >
+      <MotionGrid
+        ref={gridElement => setElement(gridElement as HTMLDivElement | null)}
+        columns="1fr"
+      >
+        <AnimatePresence initial={false} mode="popLayout">
+          {authOrganization ? (
+            <MotionContainer
+              key="organization"
+              area="1 / 1"
+              initial={{opacity: 0, y: -5}}
+              animate={{opacity: 1, y: 0}}
+              exit={{opacity: 0, y: 5}}
+              transition={theme.motion.framer.smooth.moderate}
+            >
+              <OrganizationAuth authOrganization={authOrganization} onClear={onClear} />
+            </MotionContainer>
+          ) : isInputVisible ? (
+            <MotionContainer
+              key="organization-input"
+              area="1 / 1"
+              initial={{opacity: 0, y: -10}}
+              animate={{opacity: 1, y: 0}}
+              exit={{opacity: 0, y: 10}}
+              transition={theme.motion.framer.smooth.moderate}
+            >
+              <OrganizationSlugInput onCancel={onCancel} onSelect={onSelect} />
+            </MotionContainer>
+          ) : (
+            <MotionFlex
+              key="organization-button"
+              area="1 / 1"
+              direction="column"
+              width="100%"
+              initial={{opacity: 0, y: -10}}
+              animate={{opacity: 1, y: 0}}
+              exit={{opacity: 0, y: 10}}
+              transition={theme.motion.framer.smooth.moderate}
+            >
+              <Button onClick={onOpen}>{t('Organization SSO')}</Button>
+            </MotionFlex>
+          )}
+        </AnimatePresence>
+      </MotionGrid>
+    </MotionContainer>
+  );
+}
+
+const MotionContainer = motion.create(Container);
+const MotionFlex = motion.create(Flex);
+const MotionGrid = motion.create(Grid);

--- a/static/app/views/authV2/authLogin/components/requiredOrganizationSso.tsx
+++ b/static/app/views/authV2/authLogin/components/requiredOrganizationSso.tsx
@@ -1,0 +1,44 @@
+import {Button} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+
+import {QuestionTooltip} from 'sentry/components/questionTooltip';
+import {IconArrow} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {AuthOrganization} from 'sentry/views/authV2/authLogin/hooks/useAuthOrganization';
+
+import {OrganizationAuth} from './organizationAuth';
+
+interface RequiredOrganizationSsoProps {
+  authOrganization: AuthOrganization;
+  onClear: () => void;
+}
+
+export function RequiredOrganizationSso({
+  authOrganization,
+  onClear,
+}: RequiredOrganizationSsoProps) {
+  return (
+    <Stack align="center" gap="md">
+      <Container width="100%">
+        <OrganizationAuth authOrganization={authOrganization} onClear={onClear} />
+      </Container>
+      <Flex width="100%" align="center" justify="between">
+        <Button
+          icon={<IconArrow direction="left" />}
+          size="zero"
+          variant="transparent"
+          onClick={onClear}
+        >
+          {t('Wrong organization')}
+        </Button>
+        <QuestionTooltip
+          position="bottom"
+          size="xs"
+          title={t(
+            'This organization requires SSO authentication. You may still log in with an email and password to access other organizations and account settings.'
+          )}
+        />
+      </Flex>
+    </Stack>
+  );
+}

--- a/static/app/views/authV2/authLogin/components/secondFactorAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/secondFactorAuth.tsx
@@ -1,13 +1,17 @@
-import {Activity, useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
+import {useTheme} from '@emotion/react';
+import {motion} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
-import {Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
+import {AnimatedActivity} from 'sentry/components/animatedActivity';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {useDimensions} from 'sentry/utils/useDimensions';
 import {
   type SecondFactorAuthResult,
   type SecondFactorCredentials,
@@ -49,11 +53,19 @@ const USE_METHOD_LABELS: Record<MfaMethod['id'], string> = {
   recovery: t('Use recovery code'),
 };
 
+const METHOD_INITIAL = {opacity: 0, x: -10};
+const METHOD_ANIMATE = {opacity: 1, x: 0};
+const METHOD_EXIT = {opacity: 0, x: 10};
+
 export function SecondFactorAuth({
   methods: providedMethods,
   onBack,
   onComplete,
 }: SecondFactorAuthProps) {
+  const theme = useTheme();
+  const [methodElement, setMethodElement] = useState<HTMLDivElement | null>(null);
+  const methodElementRef = useMemo(() => ({current: methodElement}), [methodElement]);
+  const {height: methodHeight} = useDimensions({elementRef: methodElementRef});
   const methodsQuery = useSecondFactorMethods(providedMethods === undefined);
   const methods = providedMethods ?? methodsQuery.data?.mfaMethods ?? [];
   const sortedMethods = SECOND_FACTOR_PRIORITY.flatMap(id =>
@@ -108,23 +120,41 @@ export function SecondFactorAuth({
         </Alert.Container>
       )}
 
-      {/* Preserve each method's local state across switches. Remounting the SMS
-          method would automatically request another challenge. */}
-      {sortedMethods.map(method => (
-        <Activity
-          key={method.id}
-          mode={method.id === activeMethod ? 'visible' : 'hidden'}
-        >
-          <MethodInput
-            method={method.id}
-            isActive={method.id === activeMethod}
-            isProcessing={isProcessing}
-            resetKey={auth.errorMessage}
-            onAuthenticate={authenticate}
-            onResetAuthentication={auth.reset}
-          />
-        </Activity>
-      ))}
+      <MotionContainer
+        initial={false}
+        animate={methodHeight ? {height: methodHeight} : undefined}
+        transition={theme.motion.framer.spring.moderate}
+      >
+        <Grid columns="1fr" position="relative">
+          {/* Preserve each method's local state across switches. Remounting the SMS
+              method would automatically request another challenge. */}
+          {sortedMethods.map(method => {
+            const isActive = method.id === activeMethod;
+
+            return (
+              <AnimatedActivity
+                key={method.id}
+                mode={isActive ? 'visible' : 'hidden'}
+                layoutMode="pop"
+                elementRef={isActive ? setMethodElement : undefined}
+                initial={METHOD_INITIAL}
+                animate={METHOD_ANIMATE}
+                exit={METHOD_EXIT}
+                transition={theme.motion.framer.smooth.moderate}
+              >
+                <MethodInput
+                  method={method.id}
+                  isActive={isActive}
+                  isProcessing={isProcessing}
+                  resetKey={auth.errorMessage}
+                  onAuthenticate={authenticate}
+                  onResetAuthentication={auth.reset}
+                />
+              </AnimatedActivity>
+            );
+          })}
+        </Grid>
+      </MotionContainer>
 
       <Flex align="center" justify="between">
         <Button
@@ -222,3 +252,5 @@ function MethodInput({
       );
   }
 }
+
+const MotionContainer = motion.create(Container);

--- a/static/app/views/authV2/authLogin/index.spec.tsx
+++ b/static/app/views/authV2/authLogin/index.spec.tsx
@@ -139,6 +139,10 @@ describe('AuthLogin', () => {
     expect(screen.getByRole('button', {name: 'SSO'})).toBeInTheDocument();
     expect(screen.queryByRole('textbox', {name: 'Email'})).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Account Settings'})).toHaveAttribute(
+      'href',
+      'https://sentry.io/settings/account/'
+    );
     expect(
       screen.queryByRole('button', {name: 'Clear organization login context'})
     ).not.toBeInTheDocument();
@@ -344,6 +348,7 @@ describe('AuthLogin', () => {
     expect(await screen.findByRole('heading', {name: 'Sign in to Sentry'})).toBeVisible();
     expect(screen.queryByRole('link', {name: 'Learn more'})).not.toBeInTheDocument();
   });
+
   it('replaces organization lookup with the organization context', async () => {
     MockApiClient.addMockResponse({
       url: '/auth/config/',
@@ -371,24 +376,43 @@ describe('AuthLogin', () => {
         warnings: [],
       },
     });
-
     const {router} = render(<AuthLogin />, {
       initialRouterConfig: {
-        location: {pathname: '/auth/login/acme/'},
+        location: {pathname: '/auth/login/'},
         route: '/auth/login/:orgSlug?/',
       },
     });
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Organization SSO'}));
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'Organization Slug'}),
+      'acme'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Locate'}));
 
     expect(await screen.findByText('Acme')).toBeInTheDocument();
     expect(
       screen.queryByRole('button', {name: 'Organization SSO'})
     ).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'SSO'})).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', {name: 'Email'})).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
+    expect(screen.queryByText('or')).not.toBeInTheDocument();
+    await userEvent.hover(screen.getByTestId('more-information'));
+    expect(
+      await screen.findByText(
+        'This organization requires SSO authentication. You may still log in with an email and password to access other organizations and account settings.'
+      )
+    ).toBeVisible();
 
-    await userEvent.click(
-      screen.getByRole('button', {name: 'Clear organization login context'})
-    );
+    await userEvent.click(screen.getByRole('button', {name: 'Wrong organization'}));
     expect(router.location.pathname).toBe('/auth/login/');
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Organization SSO'})).toBeVisible()
+    );
+    expect(
+      screen.queryByRole('textbox', {name: 'Organization Slug'})
+    ).not.toBeInTheDocument();
   });
 
   it('performs a full-page navigation after password authentication', async () => {
@@ -585,7 +609,9 @@ describe('AuthLogin', () => {
     });
     await userEvent.click(await screen.findByRole('button', {name: 'Back to Login'}));
     await waitFor(() => expect(cancelRequest).toHaveBeenCalledTimes(1));
-    expect(await screen.findByRole('textbox', {name: 'Email'})).toBeVisible();
+    await waitFor(() =>
+      expect(screen.getByRole('textbox', {name: 'Email'})).toBeVisible()
+    );
     await waitFor(() => expect(configRefetch).toHaveBeenCalledTimes(1));
     await userEvent.click(screen.getByRole('button', {name: 'Organization SSO'}));
     await userEvent.type(

--- a/static/app/views/authV2/authLogin/index.tsx
+++ b/static/app/views/authV2/authLogin/index.tsx
@@ -1,5 +1,7 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
+import {AnimatePresence, motion} from 'framer-motion';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Tag} from '@sentry/scraps/badge';
@@ -10,6 +12,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 import {BrandPageLayout} from 'sentry/components/brandPageLayout';
 import {IconGithub, IconGoogle, IconLab, IconSentry, IconVsts} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
+import {ConfigStore} from 'sentry/stores/configStore';
 import type {AuthConfig} from 'sentry/types/auth';
 import {isNotFoundError} from 'sentry/utils/requestError/requestError';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
@@ -19,8 +22,8 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
 
 import {EmailAuth} from './components/emailAuth';
-import {OrganizationAuth} from './components/organizationAuth';
-import {OrganizationSlugInput} from './components/organizationSlugInput';
+import {OrganizationSwitcher} from './components/organizationSwitcher';
+import {RequiredOrganizationSso} from './components/requiredOrganizationSso';
 import {SecondFactorAuth} from './components/secondFactorAuth';
 import {useAuthConfig} from './hooks/useAuthConfig';
 import {useAuthOrganization} from './hooks/useAuthOrganization';
@@ -39,8 +42,10 @@ const AUTH_PROVIDER_CONFIG = {
 } satisfies Record<AuthProviderLinkKey, {icon: React.ReactNode; label: string}>;
 
 export default function AuthLogin() {
+  const theme = useTheme();
   const {orgSlug} = useParams<{orgSlug?: string}>();
   const location = useLocation();
+  const sentryUrl = ConfigStore.get('links').sentryUrl;
   const {setAuthV2CookieState} = useEnableAuthV2();
 
   const returnToLegacyLogin = () => {
@@ -105,6 +110,10 @@ export default function AuthLogin() {
     : [];
   const [mfaMethods, setMfaMethods] = useState<MfaMethod[]>();
   const pendingMfaMethods = mfaMethods ?? loginConfig?.pendingMfa?.mfaMethods;
+  const organizationSsoOnly =
+    authOrganization?.ssoRequired && !authOrganization.authenticated
+      ? authOrganization
+      : null;
   const [isOrganizationSlugInputVisible, setIsOrganizationSlugInputVisible] =
     useState(false);
 
@@ -114,10 +123,17 @@ export default function AuthLogin() {
 
   const handleSelectOrganization = useCallback(
     (organizationSlug: string) => {
-      navigate({pathname: `/auth/login/${encodeURIComponent(organizationSlug)}/`});
+      navigate({
+        pathname: `/auth/login/${encodeURIComponent(organizationSlug)}/`,
+      });
     },
     [navigate]
   );
+
+  const handleClearOrganization = useCallback(() => {
+    setIsOrganizationSlugInputVisible(false);
+    navigate({pathname: '/auth/login/'});
+  }, [navigate]);
 
   const handleAuthResult = useCallback(
     (result: EmailAuthResult) => {
@@ -131,6 +147,16 @@ export default function AuthLogin() {
     },
     [completeAuthentication, location, navigate]
   );
+
+  const mainState = hasInitialAuthConfigError
+    ? 'auth-config-error'
+    : hasAuthOrganizationError
+      ? 'organization-error'
+      : pendingMfaMethods
+        ? 'mfa'
+        : organizationSsoOnly
+          ? 'organization-sso'
+          : 'login';
 
   if (
     isAuthConfigPending ||
@@ -169,90 +195,107 @@ export default function AuthLogin() {
             {t('Sign in to Sentry')}
           </Heading>
 
-          <Stack gap="lg">
-            {hasInitialAuthConfigError ? (
-              <Stack gap="md">
-                <Alert variant="danger">
-                  {t('Unable to load the login page. Try again.')}
-                </Alert>
-                <Button busy={isAuthConfigFetching} onClick={() => refetchAuthConfig()}>
-                  {t('Retry')}
-                </Button>
-              </Stack>
-            ) : hasAuthOrganizationError ? (
-              <Stack gap="md">
-                <Alert variant="danger">
-                  {t('Unable to load organization authentication. Please try again.')}
-                </Alert>
-                <Button
-                  busy={isAuthOrganizationFetching}
-                  onClick={() => refetchAuthOrganization()}
-                >
-                  {t('Retry')}
-                </Button>
-              </Stack>
-            ) : pendingMfaMethods ? (
-              <SecondFactorAuth
-                methods={pendingMfaMethods}
-                onBack={() => {
-                  setMfaMethods(undefined);
-                }}
-                onComplete={completeAuthentication}
-              />
-            ) : (
-              <Fragment>
+          <AnimatePresence initial={false} mode="wait">
+            <MotionStack
+              key={mainState}
+              width="100%"
+              gap="lg"
+              initial={{opacity: 0, y: -10}}
+              animate={{opacity: 1, y: 0}}
+              exit={{opacity: 0, y: 10}}
+              transition={theme.motion.framer.smooth.moderate}
+            >
+              {hasInitialAuthConfigError ? (
                 <Stack gap="md">
-                  {!focusedOrgAuth && authProviderButtons.length > 0 && (
-                    <Grid
-                      columns={`repeat(${authProviderButtons.length}, minmax(0, 1fr))`}
-                      gap="sm"
-                    >
-                      {authProviderButtons.map(button => (
-                        <LinkButton
-                          key={button.id}
-                          href={button.href}
-                          icon={button.icon}
-                          size="sm"
-                        >
-                          {button.label}
-                        </LinkButton>
-                      ))}
-                    </Grid>
-                  )}
-                  {authOrganization ? (
-                    <OrganizationAuth
+                  <Alert variant="danger">
+                    {t('Unable to load the login page. Try again.')}
+                  </Alert>
+                  <Button busy={isAuthConfigFetching} onClick={() => refetchAuthConfig()}>
+                    {t('Retry')}
+                  </Button>
+                </Stack>
+              ) : hasAuthOrganizationError ? (
+                <Stack gap="md">
+                  <Alert variant="danger">
+                    {t('Unable to load organization authentication. Please try again.')}
+                  </Alert>
+                  <Button
+                    busy={isAuthOrganizationFetching}
+                    onClick={() => refetchAuthOrganization()}
+                  >
+                    {t('Retry')}
+                  </Button>
+                </Stack>
+              ) : pendingMfaMethods ? (
+                <SecondFactorAuth
+                  methods={pendingMfaMethods}
+                  onBack={() => {
+                    setMfaMethods(undefined);
+                  }}
+                  onComplete={completeAuthentication}
+                />
+              ) : organizationSsoOnly ? (
+                <RequiredOrganizationSso
+                  authOrganization={organizationSsoOnly}
+                  onClear={handleClearOrganization}
+                />
+              ) : (
+                <Fragment>
+                  <Stack gap="md">
+                    {!focusedOrgAuth && authProviderButtons.length > 0 && (
+                      <Grid
+                        columns={`repeat(${authProviderButtons.length}, minmax(0, 1fr))`}
+                        gap="sm"
+                      >
+                        {authProviderButtons.map(button => (
+                          <LinkButton
+                            key={button.id}
+                            href={button.href}
+                            icon={button.icon}
+                            size="sm"
+                          >
+                            {button.label}
+                          </LinkButton>
+                        ))}
+                      </Grid>
+                    )}
+                    <OrganizationSwitcher
                       authOrganization={authOrganization}
-                      onClear={
-                        focusedOrgAuth
-                          ? undefined
-                          : () => navigate({pathname: '/auth/login/'})
-                      }
-                    />
-                  ) : isOrganizationSlugInputVisible ? (
-                    <OrganizationSlugInput
+                      isInputVisible={isOrganizationSlugInputVisible}
                       onCancel={() => setIsOrganizationSlugInputVisible(false)}
+                      onClear={focusedOrgAuth ? undefined : handleClearOrganization}
+                      onOpen={() => setIsOrganizationSlugInputVisible(true)}
                       onSelect={handleSelectOrganization}
                     />
+                  </Stack>
+
+                  {focusedOrgAuth ? (
+                    <Stack gap="md">
+                      <Grid columns="1fr max-content 1fr" align="center" gap="md">
+                        <Container borderTop="secondary" />
+                        <Text as="div" align="center" variant="muted" size="lg">
+                          {t('or')}
+                        </Text>
+                        <Container borderTop="secondary" />
+                      </Grid>
+                      <LinkButton href={`${sentryUrl}/settings/account/`}>
+                        {t('Account Settings')}
+                      </LinkButton>
+                    </Stack>
                   ) : (
-                    <Button onClick={() => setIsOrganizationSlugInputVisible(true)}>
-                      {t('Organization SSO')}
-                    </Button>
+                    <Fragment>
+                      <AuthDivider />
+
+                      <EmailAuth
+                        organizationSlug={orgSlug}
+                        onAuthResult={handleAuthResult}
+                      />
+                    </Fragment>
                   )}
-                </Stack>
-
-                {!focusedOrgAuth && (
-                  <Fragment>
-                    <AuthDivider />
-
-                    <EmailAuth
-                      organizationSlug={orgSlug}
-                      onAuthResult={handleAuthResult}
-                    />
-                  </Fragment>
-                )}
-              </Fragment>
-            )}
-          </Stack>
+                </Fragment>
+              )}
+            </MotionStack>
+          </AnimatePresence>
         </LoginContainer>
 
         {loginConfig?.loginBanner && (
@@ -283,3 +326,5 @@ function AuthDivider() {
 const LoginContainer = styled(Stack)`
   padding-top: 18vh;
 `;
+
+const MotionStack = motion.create(Stack);

--- a/static/app/views/authV2/brandedAuthLayout.tsx
+++ b/static/app/views/authV2/brandedAuthLayout.tsx
@@ -5,12 +5,13 @@ import {BrandPageLayout} from 'sentry/components/brandPageLayout';
 
 export default function BrandedAuthLayout() {
   const location = useLocation();
+  const pageKey = location.pathname.split('/').slice(0, 3).join('/');
 
   return (
     <BrandPageLayout>
       <BrandPageLayout.Content>
         <AnimatePresence initial={false} mode="wait">
-          <Outlet key={location.pathname} />
+          <Outlet key={pageKey} />
         </AnimatePresence>
       </BrandPageLayout.Content>
     </BrandPageLayout>

--- a/tests/acceptance/test_auth_react.py
+++ b/tests/acceptance/test_auth_react.py
@@ -84,6 +84,10 @@ class ReactAuthTest(AcceptanceTestCase):
             xpath="//*[contains(normalize-space(.), 'Requires sign in with Dummy')]"
         )
 
+    def leave_organization_sso(self) -> None:
+        self.browser.click_when_visible(xpath="//button[normalize-space(.)='Wrong organization']")
+        self.browser.wait_until('[aria-label="Email"]')
+
     def begin_organization_sso(self, organization_slug: str) -> None:
         self.select_organization_sso(organization_slug)
         self.browser.click_when_visible(xpath="//button[normalize-space(.)='SSO']")
@@ -297,13 +301,17 @@ class ReactAuthTest(AcceptanceTestCase):
         self.create_member(organization=organization, user=user)
         self.create_auth_provider(organization_id=organization.id, provider="dummy")
 
-        # Selecting an SSO-required organization does not force the user to start SSO.
+        # Leaving the SSO-required organization makes password authentication available.
         self.select_organization_sso(organization.slug)
+        self.leave_organization_sso()
         self.submit_visible_credentials(user.email, PASSWORD)
 
-        # Password authentication succeeds, but it does not grant access to the organization.
+        # Password authentication succeeds without granting access to the organization.
         self.browser.wait_until_script_execution(
-            "return window.location.pathname === '/settings/account/'"
+            f"return window.location.pathname === '/auth/login/{organization.slug}/'"
+        )
+        self.browser.wait_until(
+            xpath="//*[contains(normalize-space(.), 'Requires sign in with Dummy')]"
         )
 
     def test_password_login_uses_organization_without_sso(self) -> None:
@@ -315,14 +323,15 @@ class ReactAuthTest(AcceptanceTestCase):
         self.create_auth_provider(organization_id=sso_organization.id, provider="dummy")
         password_organization = self.create_organization(owner=user, slug="password-org")
 
-        # Password login cannot enter the selected organization because it requires SSO.
+        # Leaving the SSO-required organization allows login to a password-capable one.
         self.select_organization_sso(sso_organization.slug)
+        self.leave_organization_sso()
         self.submit_visible_credentials(user.email, PASSWORD)
 
         # The authenticated user lands in an accessible organization instead.
         self.wait_for_authenticated_organization(password_organization.slug)
 
-    def test_password_login_preserves_sso_organization_destination(self) -> None:
+    def test_sso_login_preserves_organization_destination(self) -> None:
         user = self.create_user(email="preserved-sso-destination@example.com")
         user.set_password(PASSWORD)
         user.save()
@@ -341,12 +350,6 @@ class ReactAuthTest(AcceptanceTestCase):
             expires="Tue, 20 Jun 2035 19:07:44 GMT",
         )
         self.browser.get(f"/organizations/{sso_organization.slug}/issues/")
-        self.browser.wait_until('[aria-label="Email"]')
-
-        # Password authentication establishes the account session, but the protected
-        # destination takes precedence over the password-capable fallback organization.
-        self.submit_visible_credentials(user.email, PASSWORD)
-        self.browser.wait_until_not('[aria-label="Email"]')
         self.browser.wait_until_script_execution(
             f"return window.location.pathname === '/auth/login/{sso_organization.slug}/'"
         )
@@ -354,6 +357,7 @@ class ReactAuthTest(AcceptanceTestCase):
             xpath="//*[contains(normalize-space(.), 'Requires sign in with Dummy')]"
         )
 
+        # SSO authentication returns to the protected organization destination.
         self.browser.click_when_visible(xpath="//button[normalize-space(.)='SSO']")
         self.browser.wait_until('form > input[type="email"][name="email"]:only-child')
         self.complete_dummy_sso(user.email)


### PR DESCRIPTION
Auth V2 switches abruptly between login states, making organization selection, password recovery, and MFA changes feel disconnected.

This adds coordinated transitions across the main login states, organization selection, password recovery, conditional submit actions, and MFA methods. Organizations requiring SSO receive a focused state that hides unrelated authentication options and provides a clear path back.

MFA methods preserve their React state through exit animations so switching methods does not restart challenges. The organization states and animation lifecycle logic are extracted into focused components, including a temporary `AnimatedActivity` compatibility component.

Tests: 38 tests across the Auth V2 login, email authentication, organization authentication, and second-factor authentication suites.