### PR TITLE
fix(jira): Accept a pasted Jira URL when linking an issue

### DIFF
--- a/src/sentry/integrations/jira/client.py
+++ b/src/sentry/integrations/jira/client.py
@@ -1,6 +1,5 @@
 import datetime
 import logging
-import re
 from typing import Any
 from urllib.parse import parse_qs, urlparse, urlsplit
 
@@ -11,6 +10,7 @@ from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.integrations.utils.atlassian_connect import get_query_hash
+from sentry.integrations.utils.jira import parse_jira_issue_key
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.utils import jwt
 from sentry.utils.http import absolute_uri
@@ -18,7 +18,6 @@ from sentry.utils.http import absolute_uri
 logger = logging.getLogger("sentry.integrations.jira")
 
 JIRA_KEY = f"{urlparse(absolute_uri()).hostname}.jira"
-ISSUE_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
 CUSTOMFIELD_PREFIX = "customfield_"
 
 STATUS_SEARCH_PAGE_SIZE = 200
@@ -118,11 +117,12 @@ class JiraCloudClient(ApiClient):
         return self.get(self.ISSUE_URL % (issue_id,))
 
     def search_issues(self, query):
-        q = query.replace('"', '\\"')
-        # check if it looks like an issue id
-        if ISSUE_KEY_RE.match(query):
-            jql = f'id="{q}"'
+        issue_key = parse_jira_issue_key(query, self.base_url)
+        if issue_key is not None:
+            # the key pattern cannot contain a quote, so it needs no escaping
+            jql = f'id="{issue_key}"'
         else:
+            q = query.replace('"', '\\"')
             jql = f'text ~ "{q}"'
         return self.get(self.SEARCH_URL, params={"jql": jql, "fields": "*all"})
 

--- a/src/sentry/integrations/jira_server/client.py
+++ b/src/sentry/integrations/jira_server/client.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-import re
 from typing import Any
 from urllib.parse import parse_qsl, urlparse
 
@@ -16,6 +15,7 @@ from sentry.integrations.client import ApiClient
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.types import IntegrationProviderSlug
+from sentry.integrations.utils.jira import parse_jira_issue_key
 from sentry.integrations.utils.metrics import (
     IntegrationPipelineViewEvent,
     IntegrationPipelineViewType,
@@ -28,7 +28,6 @@ from sentry.utils.http import absolute_uri
 logger = logging.getLogger(__name__)
 
 JIRA_KEY = f"{urlparse(absolute_uri()).hostname}.jira"
-ISSUE_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
 CUSTOMFIELD_PREFIX = "customfield_"
 
 
@@ -108,11 +107,12 @@ class JiraServerClient(ApiClient):
         return self.get(self.ISSUE_URL % (issue_id,))
 
     def search_issues(self, query):
-        q = query.replace('"', '\\"')
-        # check if it looks like an issue id
-        if ISSUE_KEY_RE.match(query):
-            jql = f'id="{q}"'
+        issue_key = parse_jira_issue_key(query, self.base_url)
+        if issue_key is not None:
+            # the key pattern cannot contain a quote, so it needs no escaping
+            jql = f'id="{issue_key}"'
         else:
+            q = query.replace('"', '\\"')
             jql = f'text ~ "{q}"'
         return self.get(self.SEARCH_URL, params={"jql": jql})
 

--- a/src/sentry/integrations/utils/jira.py
+++ b/src/sentry/integrations/utils/jira.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import re
+from urllib.parse import ParseResult, parse_qs, urlparse
+
+ISSUE_KEY_RE = re.compile(r"^[A-Za-z][A-Za-z0-9]*-\d+$")
+
+# The segment preceding the issue key in the link shapes Jira itself produces:
+#   /browse/ABC-123
+#   /projects/ABC/issues/ABC-123
+_ISSUE_PATH_PARENTS = frozenset({"browse", "issues"})
+
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def _origin(url: ParseResult) -> tuple[str, str, int] | None:
+    """Scheme, host and port, with the port defaulted so ``:443`` == implicit."""
+    if url.scheme not in _DEFAULT_PORTS or not url.hostname:
+        return None
+    try:
+        port = url.port
+    except ValueError:  # a non-numeric port
+        return None
+    return (url.scheme, url.hostname.lower(), port or _DEFAULT_PORTS[url.scheme])
+
+
+def _path_segments(path: str) -> list[str]:
+    return [segment for segment in path.split("/") if segment]
+
+
+def parse_jira_issue_key(query: str, base_url: str) -> str | None:
+    """
+    Resolve ``query`` to a Jira issue key, or None if it does not name one.
+
+    Accepts a bare key (``ABC-123``) and the links Jira's own "copy link"
+    shortcuts produce, so pasting one resolves to the issue instead of falling
+    through to a full-text search that can never match it:
+
+    - ``https://example.atlassian.net/browse/ABC-123``
+    - ``https://example.atlassian.net/jira/software/projects/ABC/boards/1?selectedIssue=ABC-123``
+    - ``https://jira.example.com/projects/ABC/issues/ABC-123``
+
+    A URL is unwrapped only when its origin and context path match ``base_url``
+    *and* it matches one of those shapes. Everything else returns None and stays a full-text
+    search, which matters in both directions: an arbitrary link that happens to
+    contain a key-shaped path segment is not an issue reference, and the same key
+    names a different issue in someone else's Jira.
+    """
+    query = query.strip()
+
+    if ISSUE_KEY_RE.match(query):
+        return query
+
+    try:
+        url = urlparse(query)
+        base = urlparse(base_url)
+    except ValueError:
+        # e.g. an unterminated IPv6 literal. Not something we can read as a URL,
+        # so leave it alone rather than raising out of a search request.
+        return None
+
+    origin = _origin(url)
+    if origin is None or origin != _origin(base):
+        return None
+
+    # Jira Server can be mounted under a context path, so the link has to sit
+    # beneath the configured one. Compared segment-wise so /jira does not match
+    # a sibling install at /jira-archive.
+    base_segments = _path_segments(base.path)
+    segments = _path_segments(url.path)
+    if segments[: len(base_segments)] != base_segments:
+        return None
+    segments = segments[len(base_segments) :]
+
+    # Board and backlog links carry the issue in a query param rather than the path.
+    for selected in parse_qs(url.query).get("selectedIssue", []):
+        if ISSUE_KEY_RE.match(selected):
+            return selected
+
+    if (
+        len(segments) >= 2
+        and segments[-2] in _ISSUE_PATH_PARENTS
+        and ISSUE_KEY_RE.match(segments[-1])
+    ):
+        return segments[-1]
+
+    return None

--- a/src/sentry/integrations/utils/jira.py
+++ b/src/sentry/integrations/utils/jira.py
@@ -78,6 +78,9 @@ def parse_jira_issue_key(query: str, base_url: str) -> str | None:
         if ISSUE_KEY_RE.match(selected):
             return selected
 
+    # The path shapes Jira's own links use: /browse/ABC-123 and
+    # /projects/ABC/issues/ABC-123. Checking the parent segment rather than
+    # scanning for anything key-shaped keeps /docs/ABC-123/archive a text search.
     if (
         len(segments) >= 2
         and segments[-2] in _ISSUE_PATH_PARENTS

--- a/tests/sentry/integrations/jira/test_client.py
+++ b/tests/sentry/integrations/jira/test_client.py
@@ -3,7 +3,7 @@ from unittest import mock
 import jwt
 import responses
 from requests import PreparedRequest, Request
-from responses.matchers import header_matcher, query_string_matcher
+from responses.matchers import header_matcher, query_param_matcher, query_string_matcher
 
 from sentry.integrations.jira.client import STATUS_SEARCH_MAX_PAGES, STATUS_SEARCH_PAGE_SIZE
 from sentry.integrations.utils.atlassian_connect import get_query_hash
@@ -229,3 +229,39 @@ class JiraClientTest(TestCase):
 
         assert result == {"values": short_page}
         assert len(responses.calls) == 1
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.jira.integration.JiraCloudClient.finalize_request",
+        side_effect=mock_finalize_request,
+    )
+    def test_search_issues_with_pasted_issue_url(self, mock_finalize: mock.MagicMock) -> None:
+        body = {"issues": [{"key": "ABC-123", "fields": {"summary": "My Issue"}}]}
+        responses.add(
+            method=responses.GET,
+            url="https://example.atlassian.net/rest/api/2/search/jql/",
+            match=[query_param_matcher({"jql": 'id="ABC-123"', "fields": "*all"})],
+            body=json.dumps(body),
+            status=200,
+            content_type="application/json",
+        )
+        res = self.jira_client.search_issues("https://example.atlassian.net/browse/ABC-123")
+        assert res == body
+
+    @responses.activate
+    @mock.patch(
+        "sentry.integrations.jira.integration.JiraCloudClient.finalize_request",
+        side_effect=mock_finalize_request,
+    )
+    def test_search_issues_with_free_text(self, mock_finalize: mock.MagicMock) -> None:
+        body: dict[str, list[str]] = {"issues": []}
+        responses.add(
+            method=responses.GET,
+            url="https://example.atlassian.net/rest/api/2/search/jql/",
+            match=[query_param_matcher({"jql": 'text ~ "login crash"', "fields": "*all"})],
+            body=json.dumps(body),
+            status=200,
+            content_type="application/json",
+        )
+        res = self.jira_client.search_issues("login crash")
+        assert res == body

--- a/tests/sentry/integrations/jira_server/test_client.py
+++ b/tests/sentry/integrations/jira_server/test_client.py
@@ -1,9 +1,12 @@
+import responses
 from django.test import override_settings
 from requests import Request
+from responses.matchers import query_param_matcher
 
 from sentry.integrations.jira_server.client import JiraServerClient
 from sentry.testutils.cases import BaseTestCase, TestCase
 from sentry.testutils.silo import control_silo_test
+from sentry.utils import json
 from tests.sentry.integrations.jira_server import EXAMPLE_PRIVATE_KEY
 
 control_address = "http://controlserver"
@@ -59,3 +62,31 @@ class JiraServerClientTest(TestCase, BaseTestCase):
         ]
         for hc in header_components:
             assert hc in str(request.headers["Authorization"])
+
+    @responses.activate
+    def test_search_issues_with_pasted_issue_url(self) -> None:
+        body = {"issues": [{"key": "ABC-123", "fields": {"summary": "My Issue"}}]}
+        responses.add(
+            method=responses.GET,
+            url="https://jira.example.com/rest/api/2/search/",
+            match=[query_param_matcher({"jql": 'id="ABC-123"'})],
+            body=json.dumps(body),
+            status=200,
+            content_type="application/json",
+        )
+        res = self.jira_server_client.search_issues("https://jira.example.com/browse/ABC-123")
+        assert res == body
+
+    @responses.activate
+    def test_search_issues_with_free_text(self) -> None:
+        body: dict[str, list[str]] = {"issues": []}
+        responses.add(
+            method=responses.GET,
+            url="https://jira.example.com/rest/api/2/search/",
+            match=[query_param_matcher({"jql": 'text ~ "login crash"'})],
+            body=json.dumps(body),
+            status=200,
+            content_type="application/json",
+        )
+        res = self.jira_server_client.search_issues("login crash")
+        assert res == body

--- a/tests/sentry/integrations/utils/test_jira.py
+++ b/tests/sentry/integrations/utils/test_jira.py
@@ -1,0 +1,84 @@
+import pytest
+
+from sentry.integrations.utils.jira import parse_jira_issue_key
+
+CLOUD = "https://example.atlassian.net"
+SERVER = "https://jira.example.com"
+
+
+@pytest.mark.parametrize(
+    "query,base_url,expected",
+    [
+        # bare keys, the pre-existing behavior
+        ("ABC-123", CLOUD, "ABC-123"),
+        ("abc-123", CLOUD, "abc-123"),
+        ("A1B2-9", CLOUD, "A1B2-9"),
+        ("  ABC-123  ", CLOUD, "ABC-123"),
+        # the links Jira's copy-link shortcuts produce
+        (f"{CLOUD}/browse/ABC-123", CLOUD, "ABC-123"),
+        (f"{CLOUD}/browse/ABC-123?filter=456", CLOUD, "ABC-123"),
+        (f"{CLOUD}/browse/ABC-123#comment-1", CLOUD, "ABC-123"),
+        (f"{CLOUD}/browse/ABC-123/", CLOUD, "ABC-123"),
+        (f"{SERVER}/projects/ABC/issues/ABC-123", SERVER, "ABC-123"),
+        (f"{CLOUD}/jira/software/projects/ABC/boards/1?selectedIssue=ABC-123", CLOUD, "ABC-123"),
+        (
+            f"{CLOUD}/jira/software/c/projects/ABC/boards/1/backlog?selectedIssue=ABC-123",
+            CLOUD,
+            "ABC-123",
+        ),
+        # host comparison is case-insensitive, and base_url may carry a path
+        ("https://EXAMPLE.atlassian.net/browse/ABC-123", CLOUD, "ABC-123"),
+        (f"{CLOUD}/browse/ABC-123", f"{CLOUD}/", "ABC-123"),
+        # not issue keys - these must stay full-text searches
+        ("", CLOUD, None),
+        ("some free text", CLOUD, None),
+        ("fix ABC-123 regression", CLOUD, None),
+        ("ABC-123-456", CLOUD, None),
+        ("123-ABC", CLOUD, None),
+        ("-123", CLOUD, None),
+        (f"{CLOUD}/browse/", CLOUD, None),
+        (f"{CLOUD}/jira/software/projects/ABC/boards/1", CLOUD, None),
+        # a key-shaped path segment in a URL that is not a Jira issue link
+        (f"{CLOUD}/docs/ABC-123/archive", CLOUD, None),
+        ("https://example.com/docs/ABC-123/archive", CLOUD, None),
+        # another tenant's Jira: the same key names a different issue there
+        ("https://other-tenant.atlassian.net/browse/ABC-123", CLOUD, None),
+        (f"{CLOUD}/browse/ABC-123", SERVER, None),
+        # only http(s) URLs are unwrapped
+        ("ftp://example.atlassian.net/browse/ABC-123", CLOUD, None),
+        ("javascript:alert(1)//browse/ABC-123", CLOUD, None),
+        ("/browse/ABC-123", CLOUD, None),
+        # a different install behind the same hostname
+        ("https://jira.example.com:8443/browse/ABC-123", SERVER, None),
+        ("https://jira.example.com/browse/ABC-123", "https://jira.example.com:8443", None),
+        ("http://jira.example.com/browse/ABC-123", SERVER, None),
+        # ...but an explicit default port is the same origin
+        ("https://jira.example.com:443/browse/ABC-123", SERVER, "ABC-123"),
+        (f"{CLOUD}/browse/ABC-123", "https://example.atlassian.net:443", "ABC-123"),
+        # context paths, as Jira Server is commonly mounted under one
+        ("https://jira.example.com/jira/browse/ABC-123", f"{SERVER}/jira", "ABC-123"),
+        (
+            "https://jira.example.com/jira/projects/ABC/issues/ABC-123",
+            f"{SERVER}/jira",
+            "ABC-123",
+        ),
+        ("https://jira.example.com/browse/ABC-123", f"{SERVER}/jira", None),
+        ("https://jira.example.com/jira-archive/browse/ABC-123", f"{SERVER}/jira", None),
+        ("https://jira.example.com/jira/browse/ABC-123", f"{SERVER}/other", None),
+        # a port we cannot read is not an origin we can match
+        ("https://jira.example.com:port/browse/ABC-123", SERVER, None),
+        # malformed URLs must not raise out of a search request
+        ("http://[", CLOUD, None),
+        ("http://[::1/browse/ABC-123", CLOUD, None),
+        ("https://", CLOUD, None),
+    ],
+)
+def test_parse_jira_issue_key(query: str, base_url: str, expected: str | None) -> None:
+    assert parse_jira_issue_key(query, base_url) == expected
+
+
+def test_unparseable_base_url_does_not_raise() -> None:
+    """A base_url we cannot read means we cannot vouch for the host, so don't unwrap."""
+    assert parse_jira_issue_key(f"{CLOUD}/browse/ABC-123", "http://[") is None
+    # a bare key still resolves, since it needs no host to validate against
+    assert parse_jira_issue_key("ABC-123", "http://[") == "ABC-123"


### PR DESCRIPTION
Resolves https://linear.app/getsentry/issue/IE-17/jira-integration-link-issue-accepting-full-jira-url.

Pasting a link copied out of Jira into "Link issue" returned no results, so you had to hand-edit it down to the bare key.

`search_issues` tested the query against the fully-anchored `ISSUE_KEY_RE`, so `https://acme.atlassian.net/browse/ABC-123` fell through to `text ~ "https://acme.atlassian.net/browse/ABC-123"` — a full-text search for the URL string, which can never match.

Adds `parse_jira_issue_key()` in `sentry/integrations/utils/jira.py`, which resolves a bare key or unwraps `/browse/KEY-1`, `/projects/ABC/issues/KEY-1`, and `?selectedIssue=KEY-1`. A URL is unwrapped only when its origin (scheme, host, port) and context path match the integration's `base_url` **and** it matches one of those shapes; malformed URLs are caught rather than raised. Everything else stays a text search — an arbitrary link containing a key-shaped segment isn't an issue reference, and the same key names a different issue in another Jira.