### PR TITLE
fix(action-log): Hash dedicated outbox rollout key

### DIFF
--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -144,7 +144,7 @@ def publish_action(
         return
 
     use_dedicated_outbox = in_rollout_group(
-        "issues.action_log.dedicated_outbox_rollout_rate", group_id
+        "issues.action_log.dedicated_outbox_rollout_rate", str(group_id)
     )
     outbox_model = GroupActionLogOutbox if use_dedicated_outbox else CellOutbox
     metrics.incr(

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -692,7 +692,7 @@ class TestPublishActionWrite(TestCase):
         ).exists()
         assert GroupActionLogOutbox.objects.count() == 1
         mock_in_rollout_group.assert_called_once_with(
-            "issues.action_log.dedicated_outbox_rollout_rate", self.group.id
+            "issues.action_log.dedicated_outbox_rollout_rate", str(self.group.id)
         )
         mock_incr.assert_any_call("issues.action_log.outbox_write", tags={"route": "dedicated"})
 


### PR DESCRIPTION
We currently use `group_id` as the key for `in_rollout_group` for this options rollout. I didn't realize at the time that `in_rollout_group` will mod the key if it is an int to determine whether it should be part of the rollout group — in this case, since `group_id` are not distributed evenly, we should not mod this. Stringifying it will get us to the expected even distribution