### PR TITLE
fix(autofix): Send user context with feature runs

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -550,6 +550,7 @@ class SeerAgentClient:
         on_run_created: Callable[[SeerRun], None] | None = None,
         referrer: str | None = None,
         agent_run_options: AgentRunOptions | None = None,
+        user_org_context: dict[str, Any] | None = None,
     ) -> SeerRun:
         """Dispatch a run to a registered Seer feature by feature_id via the
         SEER_RUN_CREATE outbox. The feature builds its own agent run from
@@ -592,15 +593,19 @@ class SeerAgentClient:
         if agent_run_options is not None:
             resolved_agent_run_options.update(agent_run_options)
 
+        body = SeerFeatureRunRequest(
+            feature_id=feature_id,
+            payload=payload,
+            agent_run_options=resolved_agent_run_options,
+        )
+        if user_org_context is not None:
+            body["user_org_context"] = user_org_context
+
         return enqueue_seer_run(
             organization=self.organization,
             run_type=SeerRunType.FEATURE_RUN,
             on_run_created=_create_agent_run,
-            body=SeerFeatureRunRequest(
-                feature_id=feature_id,
-                payload=payload,
-                agent_run_options=resolved_agent_run_options,
-            ),
+            body=body,
             viewer_context=self.viewer_context,
             user_id=user_id,
             referrer=referrer,

--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -32,6 +32,7 @@ from sentry.seer.agent.client_utils import (
     AgentRunOptions,
     AgentUpdateRequest,
     SeerFeatureRunRequest,
+    UserOrgContext,
     collect_user_org_context,
     enqueue_seer_run,
     fetch_run_status,
@@ -550,7 +551,7 @@ class SeerAgentClient:
         on_run_created: Callable[[SeerRun], None] | None = None,
         referrer: str | None = None,
         agent_run_options: AgentRunOptions | None = None,
-        user_org_context: dict[str, Any] | None = None,
+        user_org_context: UserOrgContext | None = None,
     ) -> SeerRun:
         """Dispatch a run to a registered Seer feature by feature_id via the
         SEER_RUN_CREATE outbox. The feature builds its own agent run from

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -123,6 +123,7 @@ class SeerFeatureRunRequest(TypedDict):
     feature_id: str
     payload: dict[str, Any]
     agent_run_options: NotRequired[AgentRunOptions]
+    user_org_context: NotRequired[dict[str, Any]]
 
 
 class SeerFeatureRunWireRequest(SeerFeatureRunRequest):
@@ -376,14 +377,16 @@ def collect_user_org_context(
     user: SentryUser | RpcUser | AnonymousUser | None,
     organization: Organization,
     request: Request | None = None,
+    project_ids: Sequence[int] | None = None,
 ) -> dict[str, Any]:
-    """Collect user and organization context for a new agent run."""
-    all_projects = Project.objects.filter(
-        organization=organization, status=ObjectStatus.ACTIVE
-    ).values("id", "slug")
+    """Collect user and organization context, optionally scoped to specific projects."""
+    all_projects = Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
+    if project_ids is not None:
+        all_projects = all_projects.filter(id__in=project_ids)
+    project_values = list(all_projects.values("id", "slug"))
 
     prefs_by_pid = bulk_read_preferences_from_sentry_db(
-        organization.id, [p["id"] for p in all_projects]
+        organization.id, [p["id"] for p in project_values]
     )
     repos_by_pid = {
         str(pid): [repo.dict() for repo in pref.repositories] for pid, pref in prefs_by_pid.items()
@@ -391,7 +394,7 @@ def collect_user_org_context(
 
     all_org_projects = [
         {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"])) or []}
-        for p in all_projects
+        for p in project_values
     ]
 
     if user is None or isinstance(user, AnonymousUser):
@@ -426,6 +429,8 @@ def collect_user_org_context(
         .distinct()
         .values("id", "slug")
     )
+    if project_ids is not None:
+        my_projects = my_projects.filter(id__in=project_ids)
     user_projects = [
         {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"])) or []}
         for p in my_projects

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -400,16 +400,17 @@ def collect_user_org_context(
     user: SentryUser | RpcUser | AnonymousUser | None,
     organization: Organization,
     request: Request | None = None,
-    project_ids: Sequence[int] | None = None,
+    project_id: int | None = None,
 ) -> UserOrgContext:
-    """Collect user and organization context, optionally scoped to specific projects."""
-    all_projects = Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
-    if project_ids is not None:
-        all_projects = all_projects.filter(id__in=project_ids)
-    project_values = list(all_projects.values("id", "slug"))
+    """Collect user and organization context, optionally scoped to a project."""
+    all_projects = Project.objects.filter(
+        organization=organization, status=ObjectStatus.ACTIVE
+    ).values("id", "slug")
+    if project_id is not None:
+        all_projects = all_projects.filter(id=project_id)
 
     prefs_by_pid = bulk_read_preferences_from_sentry_db(
-        organization.id, [p["id"] for p in project_values]
+        organization.id, [p["id"] for p in all_projects]
     )
     repos_by_pid = {
         str(pid): [repo.dict() for repo in pref.repositories] for pid, pref in prefs_by_pid.items()
@@ -417,7 +418,7 @@ def collect_user_org_context(
 
     all_org_projects: list[UserOrgContextProject] = [
         {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"])) or []}
-        for p in project_values
+        for p in all_projects
     ]
 
     if user is None or isinstance(user, AnonymousUser):
@@ -454,8 +455,8 @@ def collect_user_org_context(
         .distinct()
         .values("id", "slug")
     )
-    if project_ids is not None:
-        my_projects = my_projects.filter(id__in=project_ids)
+    if project_id is not None:
+        my_projects = my_projects.filter(id=project_id)
     user_projects: list[UserOrgContextProject] = [
         {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"])) or []}
         for p in my_projects

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -482,49 +482,6 @@ def collect_user_org_context(
     }
 
 
-def collect_project_org_context(
-    user: SentryUser | RpcUser | AnonymousUser | None,
-    organization: Organization,
-    project: Project,
-) -> UserOrgContext:
-    preferences = bulk_read_preferences_from_sentry_db(organization.id, [project.id])
-    preference = preferences.get(project.id)
-    project_context = UserOrgContextProject(
-        id=project.id,
-        slug=project.slug,
-        repos=[repo.dict() for repo in preference.repositories] if preference else [],
-    )
-    context = UserOrgContext(
-        org_slug=organization.slug,
-        all_org_projects=[project_context],
-    )
-
-    if user is None or isinstance(user, AnonymousUser):
-        return context
-
-    try:
-        member = OrganizationMember.objects.get(organization=organization, user_id=user.id)
-    except OrganizationMember.DoesNotExist:
-        return context
-
-    user_options = user_option_service.get_many(filter={"user_ids": [user.id], "key": "timezone"})
-    context["user_id"] = user.id
-    context["user_name"] = user.name
-    context["user_email"] = user.email
-    context["user_timezone"] = get_option_from_list(user_options, key="timezone")
-    context["user_teams"] = [{"id": team.id, "slug": team.slug} for team in member.get_teams()]
-    context["user_projects"] = (
-        [project_context]
-        if Project.objects.filter(
-            id=project.id,
-            organization=organization,
-            teams__organizationmember__user_id=user.id,
-        ).exists()
-        else []
-    )
-    return context
-
-
 def get_proxy_headers() -> dict[str, str] | None:
     """Build auth headers for Seer to echo back to Sentry on callbacks.
 

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -400,14 +400,11 @@ def collect_user_org_context(
     user: SentryUser | RpcUser | AnonymousUser | None,
     organization: Organization,
     request: Request | None = None,
-    project_id: int | None = None,
 ) -> UserOrgContext:
-    """Collect user and organization context, optionally scoped to a project."""
+    """Collect user and organization context for a new agent run."""
     all_projects = Project.objects.filter(
         organization=organization, status=ObjectStatus.ACTIVE
     ).values("id", "slug")
-    if project_id is not None:
-        all_projects = all_projects.filter(id=project_id)
 
     prefs_by_pid = bulk_read_preferences_from_sentry_db(
         organization.id, [p["id"] for p in all_projects]
@@ -455,8 +452,6 @@ def collect_user_org_context(
         .distinct()
         .values("id", "slug")
     )
-    if project_id is not None:
-        my_projects = my_projects.filter(id=project_id)
     user_projects: list[UserOrgContextProject] = [
         {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"])) or []}
         for p in my_projects
@@ -485,6 +480,49 @@ def collect_user_org_context(
         "user_projects": user_projects,
         "all_org_projects": all_org_projects,
     }
+
+
+def collect_project_org_context(
+    user: SentryUser | RpcUser | AnonymousUser | None,
+    organization: Organization,
+    project: Project,
+) -> UserOrgContext:
+    preferences = bulk_read_preferences_from_sentry_db(organization.id, [project.id])
+    preference = preferences.get(project.id)
+    project_context = UserOrgContextProject(
+        id=project.id,
+        slug=project.slug,
+        repos=[repo.dict() for repo in preference.repositories] if preference else [],
+    )
+    context = UserOrgContext(
+        org_slug=organization.slug,
+        all_org_projects=[project_context],
+    )
+
+    if user is None or isinstance(user, AnonymousUser):
+        return context
+
+    try:
+        member = OrganizationMember.objects.get(organization=organization, user_id=user.id)
+    except OrganizationMember.DoesNotExist:
+        return context
+
+    user_options = user_option_service.get_many(filter={"user_ids": [user.id], "key": "timezone"})
+    context["user_id"] = user.id
+    context["user_name"] = user.name
+    context["user_email"] = user.email
+    context["user_timezone"] = get_option_from_list(user_options, key="timezone")
+    context["user_teams"] = [{"id": team.id, "slug": team.slug} for team in member.get_teams()]
+    context["user_projects"] = (
+        [project_context]
+        if Project.objects.filter(
+            id=project.id,
+            organization=organization,
+            teams__organizationmember__user_id=user.id,
+        ).exists()
+        else []
+    )
+    return context
 
 
 def get_proxy_headers() -> dict[str, str] | None:

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -65,6 +65,29 @@ class RunsByIdsRequest(TypedDict):
     run_ids: list[int]
 
 
+class UserOrgContextTeam(TypedDict):
+    id: int
+    slug: str
+
+
+class UserOrgContextProject(TypedDict):
+    id: int
+    slug: str
+    repos: list[dict[str, Any]]
+
+
+class UserOrgContext(TypedDict):
+    org_slug: str
+    user_id: NotRequired[int]
+    user_ip: NotRequired[str | None]
+    user_name: NotRequired[str | None]
+    user_email: NotRequired[str | None]
+    user_timezone: NotRequired[str | None]
+    user_teams: NotRequired[list[UserOrgContextTeam]]
+    user_projects: NotRequired[list[UserOrgContextProject]]
+    all_org_projects: NotRequired[list[UserOrgContextProject]]
+
+
 class AgentChatRequest(TypedDict):
     organization_id: int
     query: str
@@ -75,7 +98,7 @@ class AgentChatRequest(TypedDict):
     page_name: NotRequired[str | None]
     page_location: NotRequired[dict[str, Any] | None]
     sent_at: NotRequired[list[str] | None]
-    user_org_context: NotRequired[dict[str, Any] | None]
+    user_org_context: NotRequired[UserOrgContext | None]
     intelligence_level: NotRequired[str]
     reasoning_effort: NotRequired[str]
     is_interactive: NotRequired[bool]
@@ -123,7 +146,7 @@ class SeerFeatureRunRequest(TypedDict):
     feature_id: str
     payload: dict[str, Any]
     agent_run_options: NotRequired[AgentRunOptions]
-    user_org_context: NotRequired[dict[str, Any]]
+    user_org_context: NotRequired[UserOrgContext]
 
 
 class SeerFeatureRunWireRequest(SeerFeatureRunRequest):
@@ -378,7 +401,7 @@ def collect_user_org_context(
     organization: Organization,
     request: Request | None = None,
     project_ids: Sequence[int] | None = None,
-) -> dict[str, Any]:
+) -> UserOrgContext:
     """Collect user and organization context, optionally scoped to specific projects."""
     all_projects = Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
     if project_ids is not None:
@@ -392,7 +415,7 @@ def collect_user_org_context(
         str(pid): [repo.dict() for repo in pref.repositories] for pid, pref in prefs_by_pid.items()
     }
 
-    all_org_projects = [
+    all_org_projects: list[UserOrgContextProject] = [
         {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"])) or []}
         for p in project_values
     ]
@@ -419,7 +442,9 @@ def collect_user_org_context(
             "org_slug": organization.slug,
             "all_org_projects": all_org_projects,
         }
-    user_teams = [{"id": t.id, "slug": t.slug} for t in member.get_teams()]
+    user_teams: list[UserOrgContextTeam] = [
+        {"id": t.id, "slug": t.slug} for t in member.get_teams()
+    ]
     my_projects = (
         Project.objects.filter(
             organization=organization,
@@ -431,7 +456,7 @@ def collect_user_org_context(
     )
     if project_ids is not None:
         my_projects = my_projects.filter(id__in=project_ids)
-    user_projects = [
+    user_projects: list[UserOrgContextProject] = [
         {"id": p["id"], "slug": p["slug"], "repos": repos_by_pid.get(str(p["id"])) or []}
         for p in my_projects
     ]

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -9,7 +9,7 @@ from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.models.group import Group
 from sentry.seer.agent.client import SeerAgentClient
-from sentry.seer.agent.client_utils import AgentRunOptions, collect_project_org_context
+from sentry.seer.agent.client_utils import AgentRunOptions, collect_user_org_context
 from sentry.seer.agent.on_completion_hook import extract_hook_definition
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -83,11 +83,7 @@ def trigger_autofix_rca_feature(
         flush=flush,
         extras=extras,
         referrer=referrer.value,
-        user_org_context=collect_project_org_context(
-            user,
-            group.organization,
-            group.project,
-        ),
+        user_org_context=collect_user_org_context(user, group.organization),
         agent_run_options=AgentRunOptions(
             is_context_engine_enabled=False,
             enable_frontend_code_search=False,

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -9,7 +9,7 @@ from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.models.group import Group
 from sentry.seer.agent.client import SeerAgentClient
-from sentry.seer.agent.client_utils import AgentRunOptions, collect_user_org_context
+from sentry.seer.agent.client_utils import AgentRunOptions, collect_project_org_context
 from sentry.seer.agent.on_completion_hook import extract_hook_definition
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -83,10 +83,10 @@ def trigger_autofix_rca_feature(
         flush=flush,
         extras=extras,
         referrer=referrer.value,
-        user_org_context=collect_user_org_context(
+        user_org_context=collect_project_org_context(
             user,
             group.organization,
-            project_id=group.project_id,
+            group.project,
         ),
         agent_run_options=AgentRunOptions(
             is_context_engine_enabled=False,

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -9,7 +9,7 @@ from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.models.group import Group
 from sentry.seer.agent.client import SeerAgentClient
-from sentry.seer.agent.client_utils import AgentRunOptions
+from sentry.seer.agent.client_utils import AgentRunOptions, collect_user_org_context
 from sentry.seer.agent.on_completion_hook import extract_hook_definition
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -83,6 +83,11 @@ def trigger_autofix_rca_feature(
         flush=flush,
         extras=extras,
         referrer=referrer.value,
+        user_org_context=collect_user_org_context(
+            user,
+            group.organization,
+            project_ids=[group.project_id],
+        ),
         agent_run_options=AgentRunOptions(
             is_context_engine_enabled=False,
             enable_frontend_code_search=False,

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -86,7 +86,7 @@ def trigger_autofix_rca_feature(
         user_org_context=collect_user_org_context(
             user,
             group.organization,
-            project_ids=[group.project_id],
+            project_id=group.project_id,
         ),
         agent_run_options=AgentRunOptions(
             is_context_engine_enabled=False,

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1455,12 +1455,17 @@ class TestStartFeatureRun(TestCase):
     @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
     @patch("sentry.receivers.outbox.cell.make_feature_run_request")
     def test_flush_false_enqueues_without_dispatch(self, mock_request, _mock_access) -> None:
+        context = {
+            "org_slug": self.organization.slug,
+            "all_org_projects": [{"id": 1, "slug": "project", "repos": []}],
+        }
         client = SeerAgentClient(self.organization, self.user)
         run = client.start_feature_run(
             feature_id="night_shift",
             payload={"candidates": [1, 2]},
             title="Agentic triage (2 candidates)",
             flush=False,
+            user_org_context=context,
         )
 
         mock_request.assert_not_called()
@@ -1474,30 +1479,10 @@ class TestStartFeatureRun(TestCase):
         assert outbox.payload is not None
         body = outbox.payload["body"]
         assert body["feature_id"] == "night_shift"
+        assert body["user_org_context"] == context
         # ref/external_idempotency_key are stamped by the handler at dispatch, not enqueue.
         assert "ref" not in body
         assert outbox.payload["viewer_context"]["organization_id"] == self.organization.id
-
-    @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
-    @patch("sentry.receivers.outbox.cell.make_feature_run_request")
-    def test_forwards_user_org_context(self, mock_request, _mock_access) -> None:
-        context = {
-            "org_slug": self.organization.slug,
-            "all_org_projects": [{"id": 1, "slug": "project", "repos": []}],
-        }
-        client = SeerAgentClient(self.organization, self.user)
-
-        run = client.start_feature_run(
-            feature_id="autofix",
-            payload={"group_id": 1},
-            title="Autofix RCA",
-            flush=False,
-            user_org_context=context,
-        )
-
-        outbox = self._outbox_for(run)
-        assert outbox is not None and outbox.payload is not None
-        assert outbox.payload["body"]["user_org_context"] == context
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
     @patch("sentry.receivers.outbox.cell.make_feature_run_request")

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1480,6 +1480,27 @@ class TestStartFeatureRun(TestCase):
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
     @patch("sentry.receivers.outbox.cell.make_feature_run_request")
+    def test_forwards_user_org_context(self, mock_request, _mock_access) -> None:
+        context = {
+            "org_slug": self.organization.slug,
+            "all_org_projects": [{"id": 1, "slug": "project", "repos": []}],
+        }
+        client = SeerAgentClient(self.organization, self.user)
+
+        run = client.start_feature_run(
+            feature_id="autofix",
+            payload={"group_id": 1},
+            title="Autofix RCA",
+            flush=False,
+            user_org_context=context,
+        )
+
+        outbox = self._outbox_for(run)
+        assert outbox is not None and outbox.payload is not None
+        assert outbox.payload["body"]["user_org_context"] == context
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
+    @patch("sentry.receivers.outbox.cell.make_feature_run_request")
     def test_creates_agent_run_mirror(self, mock_request, _mock_access) -> None:
         client = SeerAgentClient(self.organization, self.user)
         run = client.start_feature_run(

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -20,6 +20,7 @@ from sentry.seer.agent.client_models import (
     RepoPRState,
     SeerRunState,
 )
+from sentry.seer.agent.client_utils import UserOrgContext
 from sentry.seer.autofix.commit_author import SeerCommitAuthor
 from sentry.seer.models import SeerApiError, SeerPermissionError
 from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunMirrorStatus, SeerRunType
@@ -1455,7 +1456,7 @@ class TestStartFeatureRun(TestCase):
     @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
     @patch("sentry.receivers.outbox.cell.make_feature_run_request")
     def test_flush_false_enqueues_without_dispatch(self, mock_request, _mock_access) -> None:
-        context = {
+        context: UserOrgContext = {
             "org_slug": self.organization.slug,
             "all_org_projects": [{"id": 1, "slug": "project", "repos": []}],
         }

--- a/tests/sentry/seer/agent/test_client_utils.py
+++ b/tests/sentry/seer/agent/test_client_utils.py
@@ -11,6 +11,7 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.agent.client_utils import (
     _normalize_wildcard_operators,
     _sanitize_json_strings,
+    collect_project_org_context,
     collect_user_org_context,
     enqueue_seer_run,
     fetch_run_statuses,
@@ -213,34 +214,41 @@ class CollectUserOrgContextTest(TestCase):
         assert [r["external_id"] for r in user_by_id[self.project1.id]["repos"]] == ["ext-1"]
         assert [r["external_id"] for r in user_by_id[self.project2.id]["repos"]] == ["ext-2"]
 
-    def test_collect_context_scopes_projects(self) -> None:
+
+class CollectProjectOrgContextTest(TestCase):
+    def test_collects_only_requested_project(self) -> None:
+        other_project = self.create_project(organization=self.organization)
         repo = self.create_repo(
-            project=self.project1,
-            name="acme/project-1-repo",
+            project=self.project,
+            name="acme/project-repo",
             provider="integrations:github",
             integration_id=999,
             external_id="ext-1",
         )
-        self.create_seer_project_repository(project=self.project1, repository=repo)
+        self.create_seer_project_repository(project=self.project, repository=repo)
 
-        context = collect_user_org_context(
+        context = collect_project_org_context(
             self.user,
             self.organization,
-            project_id=self.project1.id,
+            self.project,
         )
 
-        assert [project["id"] for project in context["all_org_projects"]] == [self.project1.id]
-        assert [project["id"] for project in context["user_projects"]] == [self.project1.id]
+        assert [project["id"] for project in context["all_org_projects"]] == [self.project.id]
+        assert [project["id"] for project in context["user_projects"]] == [self.project.id]
         assert context["all_org_projects"][0]["repos"][0]["external_id"] == "ext-1"
+        assert other_project.id not in {project["id"] for project in context["all_org_projects"]}
 
-        context_without_user = collect_user_org_context(
+    def test_collects_project_without_user(self) -> None:
+        context = collect_project_org_context(
             None,
             self.organization,
-            project_id=self.project1.id,
+            self.project,
         )
-        assert [project["id"] for project in context_without_user["all_org_projects"]] == [
-            self.project1.id
-        ]
+
+        assert context == {
+            "org_slug": self.organization.slug,
+            "all_org_projects": [{"id": self.project.id, "slug": self.project.slug, "repos": []}],
+        }
 
 
 class SnapshotToMarkdownTest(TestCase):

--- a/tests/sentry/seer/agent/test_client_utils.py
+++ b/tests/sentry/seer/agent/test_client_utils.py
@@ -226,7 +226,7 @@ class CollectUserOrgContextTest(TestCase):
         context = collect_user_org_context(
             self.user,
             self.organization,
-            project_ids=[self.project1.id],
+            project_id=self.project1.id,
         )
 
         assert [project["id"] for project in context["all_org_projects"]] == [self.project1.id]
@@ -236,7 +236,7 @@ class CollectUserOrgContextTest(TestCase):
         context_without_user = collect_user_org_context(
             None,
             self.organization,
-            project_ids=[self.project1.id],
+            project_id=self.project1.id,
         )
         assert [project["id"] for project in context_without_user["all_org_projects"]] == [
             self.project1.id

--- a/tests/sentry/seer/agent/test_client_utils.py
+++ b/tests/sentry/seer/agent/test_client_utils.py
@@ -11,7 +11,6 @@ from sentry.models.organizationmember import OrganizationMember
 from sentry.seer.agent.client_utils import (
     _normalize_wildcard_operators,
     _sanitize_json_strings,
-    collect_project_org_context,
     collect_user_org_context,
     enqueue_seer_run,
     fetch_run_statuses,
@@ -213,42 +212,6 @@ class CollectUserOrgContextTest(TestCase):
         user_by_id = {p["id"]: p for p in context["user_projects"]}
         assert [r["external_id"] for r in user_by_id[self.project1.id]["repos"]] == ["ext-1"]
         assert [r["external_id"] for r in user_by_id[self.project2.id]["repos"]] == ["ext-2"]
-
-
-class CollectProjectOrgContextTest(TestCase):
-    def test_collects_only_requested_project(self) -> None:
-        other_project = self.create_project(organization=self.organization)
-        repo = self.create_repo(
-            project=self.project,
-            name="acme/project-repo",
-            provider="integrations:github",
-            integration_id=999,
-            external_id="ext-1",
-        )
-        self.create_seer_project_repository(project=self.project, repository=repo)
-
-        context = collect_project_org_context(
-            self.user,
-            self.organization,
-            self.project,
-        )
-
-        assert [project["id"] for project in context["all_org_projects"]] == [self.project.id]
-        assert [project["id"] for project in context["user_projects"]] == [self.project.id]
-        assert context["all_org_projects"][0]["repos"][0]["external_id"] == "ext-1"
-        assert other_project.id not in {project["id"] for project in context["all_org_projects"]}
-
-    def test_collects_project_without_user(self) -> None:
-        context = collect_project_org_context(
-            None,
-            self.organization,
-            self.project,
-        )
-
-        assert context == {
-            "org_slug": self.organization.slug,
-            "all_org_projects": [{"id": self.project.id, "slug": self.project.slug, "repos": []}],
-        }
 
 
 class SnapshotToMarkdownTest(TestCase):

--- a/tests/sentry/seer/agent/test_client_utils.py
+++ b/tests/sentry/seer/agent/test_client_utils.py
@@ -213,6 +213,35 @@ class CollectUserOrgContextTest(TestCase):
         assert [r["external_id"] for r in user_by_id[self.project1.id]["repos"]] == ["ext-1"]
         assert [r["external_id"] for r in user_by_id[self.project2.id]["repos"]] == ["ext-2"]
 
+    def test_collect_context_scopes_projects(self) -> None:
+        repo = self.create_repo(
+            project=self.project1,
+            name="acme/project-1-repo",
+            provider="integrations:github",
+            integration_id=999,
+            external_id="ext-1",
+        )
+        self.create_seer_project_repository(project=self.project1, repository=repo)
+
+        context = collect_user_org_context(
+            self.user,
+            self.organization,
+            project_ids=[self.project1.id],
+        )
+
+        assert [project["id"] for project in context["all_org_projects"]] == [self.project1.id]
+        assert [project["id"] for project in context["user_projects"]] == [self.project1.id]
+        assert context["all_org_projects"][0]["repos"][0]["external_id"] == "ext-1"
+
+        context_without_user = collect_user_org_context(
+            None,
+            self.organization,
+            project_ids=[self.project1.id],
+        )
+        assert [project["id"] for project in context_without_user["all_org_projects"]] == [
+            self.project1.id
+        ]
+
 
 class SnapshotToMarkdownTest(TestCase):
     def test_single_node(self) -> None:

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -24,7 +24,7 @@ class TestTriggerAutofixRCAFeature(TestCase):
         with (
             patch("sentry.seer.autofix_rca.dispatch.SeerAgentClient") as MockClient,
             patch(
-                "sentry.seer.autofix_rca.dispatch.collect_project_org_context",
+                "sentry.seer.autofix_rca.dispatch.collect_user_org_context",
                 return_value=expected_context,
             ) as mock_collect_context,
             patch("sentry.seer.autofix_rca.dispatch.quotas") as mock_quotas,
@@ -70,11 +70,7 @@ class TestTriggerAutofixRCAFeature(TestCase):
         }
         assert run_kwargs["referrer"] == AutofixReferrer.NIGHT_SHIFT.value
         assert run_kwargs["user_org_context"] == expected_context
-        mock_collect_context.assert_called_once_with(
-            None,
-            self.group.organization,
-            self.group.project,
-        )
+        mock_collect_context.assert_called_once_with(None, self.group.organization)
 
         # A new run consumes Seer autofix budget.
         mock_quotas.backend.record_seer_run.assert_called_once()

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -24,7 +24,7 @@ class TestTriggerAutofixRCAFeature(TestCase):
         with (
             patch("sentry.seer.autofix_rca.dispatch.SeerAgentClient") as MockClient,
             patch(
-                "sentry.seer.autofix_rca.dispatch.collect_user_org_context",
+                "sentry.seer.autofix_rca.dispatch.collect_project_org_context",
                 return_value=expected_context,
             ) as mock_collect_context,
             patch("sentry.seer.autofix_rca.dispatch.quotas") as mock_quotas,
@@ -73,7 +73,7 @@ class TestTriggerAutofixRCAFeature(TestCase):
         mock_collect_context.assert_called_once_with(
             None,
             self.group.organization,
-            project_id=self.group.project_id,
+            self.group.project,
         )
 
         # A new run consumes Seer autofix budget.

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -19,9 +19,14 @@ class TestTriggerAutofixRCAFeature(TestCase):
 
     def test_dispatches_feature_run(self) -> None:
         fake_run = self.create_seer_run(organization=self.organization, type="feature_run")
+        expected_context = {"org_slug": self.organization.slug, "all_org_projects": []}
 
         with (
             patch("sentry.seer.autofix_rca.dispatch.SeerAgentClient") as MockClient,
+            patch(
+                "sentry.seer.autofix_rca.dispatch.collect_user_org_context",
+                return_value=expected_context,
+            ) as mock_collect_context,
             patch("sentry.seer.autofix_rca.dispatch.quotas") as mock_quotas,
         ):
             mock_quotas.backend.check_seer_quota.return_value = True
@@ -64,6 +69,12 @@ class TestTriggerAutofixRCAFeature(TestCase):
             "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
         }
         assert run_kwargs["referrer"] == AutofixReferrer.NIGHT_SHIFT.value
+        assert run_kwargs["user_org_context"] == expected_context
+        mock_collect_context.assert_called_once_with(
+            None,
+            self.group.organization,
+            project_ids=[self.group.project_id],
+        )
 
         # A new run consumes Seer autofix budget.
         mock_quotas.backend.record_seer_run.assert_called_once()

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -73,7 +73,7 @@ class TestTriggerAutofixRCAFeature(TestCase):
         mock_collect_context.assert_called_once_with(
             None,
             self.group.organization,
-            project_ids=[self.group.project_id],
+            project_id=self.group.project_id,
         )
 
         # A new run consumes Seer autofix budget.


### PR DESCRIPTION
Autofix RCA feature runs now send Seer the same user and organization context as existing agent-based Autofix runs. This lets the underlying Explorer run identify connected repositories and attribute human-triggered runs correctly, while preserving the established behavior for automated runs without a user.

The feature-run request accepts this context explicitly and forwards it through the existing outbox path. This is the Sentry counterpart to getsentry/seer#7988, which already accepts and forwards the optional feature-run context.
