### PR TITLE
fix(metrics): stop the metrics table header from stretching to center its content

### DIFF
--- a/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
+++ b/static/app/views/explore/metrics/metricInfoTabs/metricInfoTabStyles.tsx
@@ -22,6 +22,7 @@ export const StyledSimpleTable = styled(SimpleTable)`
   position: relative;
   height: 100%;
   min-height: 0;
+  grid-template-rows: auto minmax(0, 1fr);
 
   > tbody {
     overflow-x: hidden;


### PR DESCRIPTION
`StyledSimpleTable` sets `height: 100%` but never declares `grid-template-rows`. The underlying `TableGrid` is `display: grid` with no row template, so `<thead>` and `<tbody>` land in implicit `auto` rows. Declaring `grid-template-rows` explicitly fixes it.

From `/explore/metrics/?metric=%7B"metric"%3A%7B"name"%3A"assisted_query.outcome"%2C"type"%3A"distribution"%2C"unit"%3A"none"%7D%2C"query"%3A""%2C"aggregateFields"%3A%5B%7B"yAxes"%3A%5B"sum%28value%2Cassisted_query.outcome%2Cdistribution%2Cnone%29"%5D%7D%5D%2C"aggregateSortBys"%3A%5B%7B"field"%3A"sum%28value%2Cautofix_rca.delivery_error%2Ccounter%2Cnone%29"%2C"kind"%3A"desc"%7D%5D%2C"sortBys"%3A%5B%7B"field"%3A"timestamp"%2C"kind"%3A"desc"%7D%5D%2C"mode"%3A"samples"%7D&project=11276&statsPeriod=1h` per DE-1588:

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="814" height="375" alt="Screenshot 2026-09-02 at 10 20 26 AM" src="https://github.com/user-attachments/assets/9d999560-7533-4de0-81b4-64d2cf3bc798" />
</td>
<td>
<img width="814" height="375" alt="Screenshot 2026-09-02 at 10 20 30 AM" src="https://github.com/user-attachments/assets/27eac1ed-17cf-4bf7-9c90-3987d1209c67" />
</td>
</tr>
</tbody>
</table>

Closes DE-1588.