### PR TITLE
perf(integrations): Avoid Jira status fetches for ticket actions

### DIFF
--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -140,32 +140,32 @@ class IntegrationConfigSerializer(IntegrationSerializer):
             return {**base, "configOrganization": []}
 
         try:
-            install = obj.get_installation(organization_id=self.organization_id)
+            installation = obj.get_installation(organization_id=self.organization_id)
         except NotImplementedError:
             # The integration may not implement a Installed Integration object
             # representation.
             return {**base, "configOrganization": []}
 
-        config_organization = install.get_organization_config()
-
-        # Query param "action" only attached in TicketRuleForm modal.
+        # TicketRuleModal only needs the ticket-creation form for this request.
         if self.params.get("action") == "create":
             return {
                 **base,
-                "configOrganization": config_organization,
+                "configOrganization": [],
                 # This method comes from IssueBasicIntegration within the integration's installation class
-                "createIssueConfig": install.get_create_issue_config(  # type: ignore[attr-defined]
-                    None, user, params=self.params
+                "createIssueConfig": installation.get_create_issue_config(  # type: ignore[attr-defined]
+                    None,
+                    user,
+                    params=self.params,
                 ),
             }
 
-        return {**base, "configOrganization": config_organization}
+        return {**base, "configOrganization": installation.get_organization_config()}
 
 
 @register(OrganizationIntegration)
 class OrganizationIntegrationSerializer(Serializer):
     def __init__(self, params: Mapping[str, Any] | None = None) -> None:
-        self.params = params
+        self.params = params or {}
 
     def get_attrs(
         self,
@@ -202,6 +202,16 @@ class OrganizationIntegrationSerializer(Serializer):
         )
         serialized_integration: MutableMapping[str, Any] = {**integration_config}
 
+        organization_integration_fields = {
+            "externalId": integration.external_id,
+            "organizationId": obj.organization_id,
+            "organizationIntegrationStatus": obj.get_status_display(),
+            "gracePeriodEnd": obj.grace_period_end,
+        }
+        if self.params.get("action") == "create":
+            serialized_integration.update({"configData": None, **organization_integration_fields})
+            return serialized_integration
+
         dynamic_display_information = None
         config_data = None
 
@@ -231,10 +241,7 @@ class OrganizationIntegrationSerializer(Serializer):
         serialized_integration.update(
             {
                 "configData": config_data,
-                "externalId": integration.external_id,
-                "organizationId": obj.organization_id,
-                "organizationIntegrationStatus": obj.get_status_display(),
-                "gracePeriodEnd": obj.grace_period_end,
+                **organization_integration_fields,
             }
         )
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import DEFAULT, patch
 
 import responses
 
@@ -54,25 +54,11 @@ class OrganizationIntegrationDetailsTest(APITestCase):
 @control_silo_test
 class OrganizationIntegrationDetailsGetTest(OrganizationIntegrationDetailsTest):
     def test_normal_request_serializes_configuration(self) -> None:
-        config_organization = [{"name": "organization-setting"}]
-        config_data = {"organization-setting": "value"}
-        with (
-            patch.object(
-                GitlabIntegration,
-                "get_organization_config",
-                return_value=config_organization,
-            ) as get_organization_config,
-            patch.object(
-                GitlabIntegration, "get_config_data", return_value=config_data
-            ) as get_config_data,
-        ):
-            response = self.get_success_response(self.organization.slug, self.integration.id)
+        response = self.get_success_response(self.organization.slug, self.integration.id)
 
         assert response.data["id"] == str(self.integration.id)
-        assert response.data["configOrganization"] == config_organization
-        assert response.data["configData"] == config_data
-        get_organization_config.assert_called_once()
-        get_config_data.assert_called_once()
+        assert response.data["configOrganization"]
+        assert response.data["configData"] == {"sync_status_forward": {}}
 
 
 @control_silo_test
@@ -306,21 +292,16 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
         )
 
         params = {"action": "create", "ignored": "Sprint"}
-        with (
-            patch.object(
-                JiraIntegration,
-                "get_create_issue_config",
-                autospec=True,
-                side_effect=JiraIntegration.get_create_issue_config,
-            ) as get_create_issue_config,
-            patch.object(
-                JiraIntegration, "get_organization_config", autospec=True
-            ) as get_organization_config,
-            patch.object(JiraIntegration, "get_config_data", autospec=True) as get_config_data,
-            patch.object(
-                JiraIntegration, "get_dynamic_display_information", autospec=True
-            ) as get_dynamic_display_information,
-        ):
+        create_issue_config_impl = JiraIntegration.get_create_issue_config
+        with patch.multiple(
+            JiraIntegration,
+            autospec=True,
+            get_create_issue_config=DEFAULT,
+            get_organization_config=DEFAULT,
+            get_config_data=DEFAULT,
+            get_dynamic_display_information=DEFAULT,
+        ) as jira_methods:
+            jira_methods["get_create_issue_config"].side_effect = create_issue_config_impl
             response = self.get_success_response(
                 self.organization.slug,
                 self.integration.id,
@@ -328,11 +309,15 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
             )
         data = response.data
 
-        get_create_issue_config.assert_called_once()
-        get_organization_config.assert_not_called()
-        get_config_data.assert_not_called()
-        get_dynamic_display_information.assert_not_called()
-        create_issue_call = get_create_issue_config.call_args
+        jira_methods["get_create_issue_config"].assert_called_once()
+        for method_name in (
+            "get_organization_config",
+            "get_config_data",
+            "get_dynamic_display_information",
+        ):
+            jira_methods[method_name].assert_not_called()
+
+        create_issue_call = jira_methods["get_create_issue_config"].call_args
         assert create_issue_call.args[1] is None
         assert create_issue_call.args[2].id == self.user.id
         assert create_issue_call.kwargs["params"]["action"] == "create"

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -6,6 +6,7 @@ from sentry import audit_log
 from sentry.constants import ObjectStatus
 from sentry.deletions.models.scheduleddeletion import ScheduledDeletion
 from sentry.integrations.gitlab.integration import GitlabIntegration
+from sentry.integrations.jira.integration import JiraIntegration
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.models.auditlogentry import AuditLogEntry
@@ -52,9 +53,26 @@ class OrganizationIntegrationDetailsTest(APITestCase):
 
 @control_silo_test
 class OrganizationIntegrationDetailsGetTest(OrganizationIntegrationDetailsTest):
-    def test_simple(self) -> None:
-        response = self.get_success_response(self.organization.slug, self.integration.id)
+    def test_normal_request_serializes_configuration(self) -> None:
+        config_organization = [{"name": "organization-setting"}]
+        config_data = {"organization-setting": "value"}
+        with (
+            patch.object(
+                GitlabIntegration,
+                "get_organization_config",
+                return_value=config_organization,
+            ) as get_organization_config,
+            patch.object(
+                GitlabIntegration, "get_config_data", return_value=config_data
+            ) as get_config_data,
+        ):
+            response = self.get_success_response(self.organization.slug, self.integration.id)
+
         assert response.data["id"] == str(self.integration.id)
+        assert response.data["configOrganization"] == config_organization
+        assert response.data["configData"] == config_data
+        get_organization_config.assert_called_once()
+        get_config_data.assert_called_once()
 
 
 @control_silo_test
@@ -244,20 +262,7 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
         self.integration.add_organization(self.organization, self.user)
 
     @responses.activate
-    def test_serialize_organizationintegration_with_create_issue_config_for_jira(self) -> None:
-        """Test the flow of choosing ticket creation on alert rule fire action
-        then serializes the issue config correctly for Jira"""
-
-        # Mock the legacy projects response
-        responses.add(
-            responses.GET,
-            "https://example.atlassian.net/rest/api/2/project",
-            json=[
-                {"id": "10000", "key": "PROJ1", "name": "Project 1"},
-                {"id": "10001", "key": "PROJ2", "name": "Project 2"},
-            ],
-        )
-
+    def test_action_create_only_serializes_create_issue_config_for_jira(self) -> None:
         # Mock the paginated projects response
         responses.add(
             responses.GET,
@@ -300,16 +305,39 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
             },
         )
 
-        params = {"action": "create"}
-        installation = self.integration.get_installation(self.organization.id)
-        response = self.get_success_response(
-            self.organization.slug,
-            self.integration.id,
-            qs_params=params,
-        )
+        params = {"action": "create", "ignored": "Sprint"}
+        with (
+            patch.object(
+                JiraIntegration,
+                "get_create_issue_config",
+                autospec=True,
+                side_effect=JiraIntegration.get_create_issue_config,
+            ) as get_create_issue_config,
+            patch.object(
+                JiraIntegration, "get_organization_config", autospec=True
+            ) as get_organization_config,
+            patch.object(JiraIntegration, "get_config_data", autospec=True) as get_config_data,
+            patch.object(
+                JiraIntegration, "get_dynamic_display_information", autospec=True
+            ) as get_dynamic_display_information,
+        ):
+            response = self.get_success_response(
+                self.organization.slug,
+                self.integration.id,
+                qs_params=params,
+            )
         data = response.data
 
-        # Check we serialized the integration correctly
+        get_create_issue_config.assert_called_once()
+        get_organization_config.assert_not_called()
+        get_config_data.assert_not_called()
+        get_dynamic_display_information.assert_not_called()
+        create_issue_call = get_create_issue_config.call_args
+        assert create_issue_call.args[1] is None
+        assert create_issue_call.args[2].id == self.user.id
+        assert create_issue_call.kwargs["params"]["action"] == "create"
+        assert create_issue_call.kwargs["params"]["ignored"] == "Sprint"
+
         assert data["id"] == str(self.integration.id)
         assert data["name"] == self.integration.name
         assert data["icon"] == self.integration.metadata.get("icon")
@@ -318,7 +346,6 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
         assert data["scopes"] == self.integration.metadata.get("scopes")
         assert data["status"] == self.integration.get_status_display()
 
-        # Check we serialized the provider correctly
         resp_provider = data["provider"]
         provider = self.integration.get_provider()
         assert resp_provider["key"] == provider.key
@@ -329,14 +356,13 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
         assert resp_provider["features"] == sorted(f.value for f in provider.features)
         assert resp_provider["aspects"] == getattr(provider.metadata, "aspects", {})
 
-        # Check we serialized the create issue config correctly
-        assert installation.get_create_issue_config(None, self.user) == data.get(
-            "createIssueConfig", {}
-        )
-        assert installation.get_organization_config() == data.get("configOrganization", {})
+        assert [field["name"] for field in data["createIssueConfig"]] == [
+            "project",
+            "issuetype",
+        ]
+        assert data["configOrganization"] == []
 
-        # Check we serialized the other organization integration details correctly
-        assert data["configData"] == installation.get_config_data()
+        assert data["configData"] is None
         assert data["externalId"] == self.integration.external_id
         assert data["organizationId"] == self.organization.id
         assert (
@@ -344,3 +370,9 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
             == self.organization_integration.get_status_display()
         )
         assert data["gracePeriodEnd"] == self.organization_integration.grace_period_end
+
+        jira_request_urls = [call.request.url for call in responses.calls]
+        assert len(jira_request_urls) == 2
+        assert "/rest/api/2/project/search" in jira_request_urls[0]
+        assert "/rest/api/2/issue/createmeta" in jira_request_urls[1]
+        assert all("/rest/api/2/statuses/search" not in url for url in jira_request_urls)

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -1,4 +1,4 @@
-from unittest.mock import create_autospec, patch
+from unittest.mock import MagicMock, patch
 
 import responses
 
@@ -54,9 +54,8 @@ class OrganizationIntegrationDetailsTest(APITestCase):
 
 @control_silo_test
 class OrganizationIntegrationDetailsGetTest(OrganizationIntegrationDetailsTest):
-    def test_normal_request_serializes_configuration(self) -> None:
+    def test_simple(self) -> None:
         response = self.get_success_response(self.organization.slug, self.integration.id)
-
         assert response.data["id"] == str(self.integration.id)
         assert response.data["configOrganization"]
         assert response.data["configData"] == {"sync_status_forward": {}}
@@ -248,63 +247,12 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
         self.login_as(self.user)
         self.integration.add_organization(self.organization, self.user)
 
-    def test_action_create_only_calls_create_issue_config(self) -> None:
-        params = {"action": "create", "ignored": "Sprint"}
-        create_issue_config = [{"name": "project"}, {"name": "issuetype"}]
-        installation = create_autospec(JiraIntegration, instance=True)
-        installation.get_create_issue_config.return_value = create_issue_config
-
-        with patch.object(RpcIntegration, "get_installation", return_value=installation):
-            response = self.get_success_response(
-                self.organization.slug,
-                self.integration.id,
-                qs_params=params,
-            )
-        data = response.data
-
-        installation.get_create_issue_config.assert_called_once()
-        installation.get_organization_config.assert_not_called()
-        installation.get_config_data.assert_not_called()
-        installation.get_dynamic_display_information.assert_not_called()
-
-        create_issue_call = installation.get_create_issue_config.call_args
-        assert create_issue_call.args[0] is None
-        assert create_issue_call.args[1].id == self.user.id
-        assert create_issue_call.kwargs["params"]["action"] == "create"
-        assert create_issue_call.kwargs["params"]["ignored"] == "Sprint"
-
-        assert data["id"] == str(self.integration.id)
-        assert data["name"] == self.integration.name
-        assert data["icon"] == self.integration.metadata.get("icon")
-        assert data["domainName"] == self.integration.metadata.get("domain_name")
-        assert data["accountType"] == self.integration.metadata.get("account_type")
-        assert data["scopes"] == self.integration.metadata.get("scopes")
-        assert data["status"] == self.integration.get_status_display()
-
-        resp_provider = data["provider"]
-        provider = self.integration.get_provider()
-        assert resp_provider["key"] == provider.key
-        assert resp_provider["slug"] == provider.key
-        assert resp_provider["name"] == provider.name
-        assert resp_provider["canAdd"] == provider.can_add
-        assert resp_provider["canDisable"] == provider.can_disable
-        assert resp_provider["features"] == sorted(f.value for f in provider.features)
-        assert resp_provider["aspects"] == getattr(provider.metadata, "aspects", {})
-
-        assert data["createIssueConfig"] == create_issue_config
-        assert data["configOrganization"] == []
-
-        assert data["configData"] is None
-        assert data["externalId"] == self.integration.external_id
-        assert data["organizationId"] == self.organization.id
-        assert (
-            data["organizationIntegrationStatus"]
-            == self.organization_integration.get_status_display()
-        )
-        assert data["gracePeriodEnd"] == self.organization_integration.grace_period_end
-
     @responses.activate
-    def test_action_create_only_fetches_jira_create_issue_fields(self) -> None:
+    def test_serialize_organizationintegration_with_create_issue_config_for_jira(self) -> None:
+        """Test the flow of choosing ticket creation on alert rule fire action
+        then serializes the issue config correctly for Jira"""
+
+        # Mock the paginated projects response
         responses.add(
             responses.GET,
             "https://example.atlassian.net/rest/api/2/project/search",
@@ -316,6 +264,8 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
                 "total": 2,
             },
         )
+
+        # Mock the create issue metadata endpoint
         responses.add(
             responses.GET,
             "https://example.atlassian.net/rest/api/2/issue/createmeta",
@@ -344,16 +294,65 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
             },
         )
 
-        response = self.get_success_response(
-            self.organization.slug,
-            self.integration.id,
-            qs_params={"action": "create", "ignored": "Sprint"},
+        params = {"action": "create", "ignored": "Sprint"}
+        installation = MagicMock(
+            spec=JiraIntegration,
+            wraps=self.integration.get_installation(self.organization.id),
         )
+        with patch.object(RpcIntegration, "get_installation", return_value=installation):
+            response = self.get_success_response(
+                self.organization.slug,
+                self.integration.id,
+                qs_params=params,
+            )
+        data = response.data
 
-        assert [field["name"] for field in response.data["createIssueConfig"]] == [
+        installation.get_create_issue_config.assert_called_once()
+        installation.get_organization_config.assert_not_called()
+        installation.get_config_data.assert_not_called()
+        installation.get_dynamic_display_information.assert_not_called()
+
+        create_issue_call = installation.get_create_issue_config.call_args
+        assert create_issue_call.args[0] is None
+        assert create_issue_call.args[1].id == self.user.id
+        assert create_issue_call.kwargs["params"].dict() == params
+
+        # Check we serialized the integration correctly
+        assert data["id"] == str(self.integration.id)
+        assert data["name"] == self.integration.name
+        assert data["icon"] == self.integration.metadata.get("icon")
+        assert data["domainName"] == self.integration.metadata.get("domain_name")
+        assert data["accountType"] == self.integration.metadata.get("account_type")
+        assert data["scopes"] == self.integration.metadata.get("scopes")
+        assert data["status"] == self.integration.get_status_display()
+
+        # Check we serialized the provider correctly
+        resp_provider = data["provider"]
+        provider = self.integration.get_provider()
+        assert resp_provider["key"] == provider.key
+        assert resp_provider["slug"] == provider.key
+        assert resp_provider["name"] == provider.name
+        assert resp_provider["canAdd"] == provider.can_add
+        assert resp_provider["canDisable"] == provider.can_disable
+        assert resp_provider["features"] == sorted(f.value for f in provider.features)
+        assert resp_provider["aspects"] == getattr(provider.metadata, "aspects", {})
+
+        # Check we serialized the create issue config correctly
+        assert [field["name"] for field in data["createIssueConfig"]] == [
             "project",
             "issuetype",
         ]
+        assert data["configOrganization"] == []
+
+        # Check we serialized the other organization integration details correctly
+        assert data["configData"] is None
+        assert data["externalId"] == self.integration.external_id
+        assert data["organizationId"] == self.organization.id
+        assert (
+            data["organizationIntegrationStatus"]
+            == self.organization_integration.get_status_display()
+        )
+        assert data["gracePeriodEnd"] == self.organization_integration.grace_period_end
 
         jira_request_urls = [call.request.url for call in responses.calls]
         assert len(jira_request_urls) == 2

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_details.py
@@ -1,4 +1,4 @@
-from unittest.mock import DEFAULT, patch
+from unittest.mock import create_autospec, patch
 
 import responses
 
@@ -9,6 +9,7 @@ from sentry.integrations.gitlab.integration import GitlabIntegration
 from sentry.integrations.jira.integration import JiraIntegration
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.repository import Repository
 from sentry.shared_integrations.exceptions import ApiError, IntegrationError
@@ -247,9 +248,63 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
         self.login_as(self.user)
         self.integration.add_organization(self.organization, self.user)
 
+    def test_action_create_only_calls_create_issue_config(self) -> None:
+        params = {"action": "create", "ignored": "Sprint"}
+        create_issue_config = [{"name": "project"}, {"name": "issuetype"}]
+        installation = create_autospec(JiraIntegration, instance=True)
+        installation.get_create_issue_config.return_value = create_issue_config
+
+        with patch.object(RpcIntegration, "get_installation", return_value=installation):
+            response = self.get_success_response(
+                self.organization.slug,
+                self.integration.id,
+                qs_params=params,
+            )
+        data = response.data
+
+        installation.get_create_issue_config.assert_called_once()
+        installation.get_organization_config.assert_not_called()
+        installation.get_config_data.assert_not_called()
+        installation.get_dynamic_display_information.assert_not_called()
+
+        create_issue_call = installation.get_create_issue_config.call_args
+        assert create_issue_call.args[0] is None
+        assert create_issue_call.args[1].id == self.user.id
+        assert create_issue_call.kwargs["params"]["action"] == "create"
+        assert create_issue_call.kwargs["params"]["ignored"] == "Sprint"
+
+        assert data["id"] == str(self.integration.id)
+        assert data["name"] == self.integration.name
+        assert data["icon"] == self.integration.metadata.get("icon")
+        assert data["domainName"] == self.integration.metadata.get("domain_name")
+        assert data["accountType"] == self.integration.metadata.get("account_type")
+        assert data["scopes"] == self.integration.metadata.get("scopes")
+        assert data["status"] == self.integration.get_status_display()
+
+        resp_provider = data["provider"]
+        provider = self.integration.get_provider()
+        assert resp_provider["key"] == provider.key
+        assert resp_provider["slug"] == provider.key
+        assert resp_provider["name"] == provider.name
+        assert resp_provider["canAdd"] == provider.can_add
+        assert resp_provider["canDisable"] == provider.can_disable
+        assert resp_provider["features"] == sorted(f.value for f in provider.features)
+        assert resp_provider["aspects"] == getattr(provider.metadata, "aspects", {})
+
+        assert data["createIssueConfig"] == create_issue_config
+        assert data["configOrganization"] == []
+
+        assert data["configData"] is None
+        assert data["externalId"] == self.integration.external_id
+        assert data["organizationId"] == self.organization.id
+        assert (
+            data["organizationIntegrationStatus"]
+            == self.organization_integration.get_status_display()
+        )
+        assert data["gracePeriodEnd"] == self.organization_integration.grace_period_end
+
     @responses.activate
-    def test_action_create_only_serializes_create_issue_config_for_jira(self) -> None:
-        # Mock the paginated projects response
+    def test_action_create_only_fetches_jira_create_issue_fields(self) -> None:
         responses.add(
             responses.GET,
             "https://example.atlassian.net/rest/api/2/project/search",
@@ -261,8 +316,6 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
                 "total": 2,
             },
         )
-
-        # Mock the create issue metadata endpoint
         responses.add(
             responses.GET,
             "https://example.atlassian.net/rest/api/2/issue/createmeta",
@@ -291,70 +344,16 @@ class IssueOrganizationIntegrationDetailsGetTest(APITestCase):
             },
         )
 
-        params = {"action": "create", "ignored": "Sprint"}
-        create_issue_config_impl = JiraIntegration.get_create_issue_config
-        with patch.multiple(
-            JiraIntegration,
-            autospec=True,
-            get_create_issue_config=DEFAULT,
-            get_organization_config=DEFAULT,
-            get_config_data=DEFAULT,
-            get_dynamic_display_information=DEFAULT,
-        ) as jira_methods:
-            jira_methods["get_create_issue_config"].side_effect = create_issue_config_impl
-            response = self.get_success_response(
-                self.organization.slug,
-                self.integration.id,
-                qs_params=params,
-            )
-        data = response.data
+        response = self.get_success_response(
+            self.organization.slug,
+            self.integration.id,
+            qs_params={"action": "create", "ignored": "Sprint"},
+        )
 
-        jira_methods["get_create_issue_config"].assert_called_once()
-        for method_name in (
-            "get_organization_config",
-            "get_config_data",
-            "get_dynamic_display_information",
-        ):
-            jira_methods[method_name].assert_not_called()
-
-        create_issue_call = jira_methods["get_create_issue_config"].call_args
-        assert create_issue_call.args[1] is None
-        assert create_issue_call.args[2].id == self.user.id
-        assert create_issue_call.kwargs["params"]["action"] == "create"
-        assert create_issue_call.kwargs["params"]["ignored"] == "Sprint"
-
-        assert data["id"] == str(self.integration.id)
-        assert data["name"] == self.integration.name
-        assert data["icon"] == self.integration.metadata.get("icon")
-        assert data["domainName"] == self.integration.metadata.get("domain_name")
-        assert data["accountType"] == self.integration.metadata.get("account_type")
-        assert data["scopes"] == self.integration.metadata.get("scopes")
-        assert data["status"] == self.integration.get_status_display()
-
-        resp_provider = data["provider"]
-        provider = self.integration.get_provider()
-        assert resp_provider["key"] == provider.key
-        assert resp_provider["slug"] == provider.key
-        assert resp_provider["name"] == provider.name
-        assert resp_provider["canAdd"] == provider.can_add
-        assert resp_provider["canDisable"] == provider.can_disable
-        assert resp_provider["features"] == sorted(f.value for f in provider.features)
-        assert resp_provider["aspects"] == getattr(provider.metadata, "aspects", {})
-
-        assert [field["name"] for field in data["createIssueConfig"]] == [
+        assert [field["name"] for field in response.data["createIssueConfig"]] == [
             "project",
             "issuetype",
         ]
-        assert data["configOrganization"] == []
-
-        assert data["configData"] is None
-        assert data["externalId"] == self.integration.external_id
-        assert data["organizationId"] == self.organization.id
-        assert (
-            data["organizationIntegrationStatus"]
-            == self.organization_integration.get_status_display()
-        )
-        assert data["gracePeriodEnd"] == self.organization_integration.grace_period_end
 
         jira_request_urls = [call.request.url for call in responses.calls]
         assert len(jira_request_urls) == 2


### PR DESCRIPTION
Ticket action settings only use `createIssueConfig`, but the endpoint also built the full integration settings response. [This trace](https://sentry.sentry.io/explore/traces/trace/9958e574157240bcae4569f0d9640ec0/?node=span-a4c2ce602e6e43fb) shows that triggering 187 Jira `/statuses/search` requests per request and taking 80-100 seconds.

`action=create` now only builds `createIssueConfig` plus locally available integration fields. `configOrganization` and `configData` are empty/null for this path, and normal integration detail requests are unchanged.