### PR TITLE
feat(investigations): Implement GET endpoint for investigation orchestration

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -331,6 +331,9 @@ from sentry.investigations.endpoints.organization_investigation_favorite import 
 from sentry.investigations.endpoints.organization_investigation_index import (
     OrganizationInvestigationsIndexEndpoint,
 )
+from sentry.investigations.endpoints.organization_investigation_orchestration import (
+    OrganizationInvestigationOrchestrationEndpoint,
+)
 from sentry.investigations.endpoints.organization_investigation_parameters import (
     OrganizationInvestigationParametersEndpoint,
 )
@@ -2465,6 +2468,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/investigations/(?P<investigation_id>[^/]+)/$",
         OrganizationInvestigationsDetailsEndpoint.as_view(),
         name="sentry-api-0-organization-investigation-details",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/investigations/(?P<investigation_id>[^/]+)/orchestration/$",
+        OrganizationInvestigationOrchestrationEndpoint.as_view(),
+        name="sentry-api-0-organization-investigation-orchestration",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/investigations/(?P<investigation_id>[^/]+)/blocks/$",

--- a/src/sentry/investigations/endpoints/organization_investigation_candidates.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_candidates.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from django.db.models import Q
 from drf_spectacular.utils import extend_schema
 from rest_framework import status
@@ -13,6 +15,9 @@ from sentry.investigations.endpoints.base import (
     can_request_actor_create_investigation,
     investigation_ids_with_project_access,
     service_error,
+)
+from sentry.investigations.endpoints.serializers import (
+    orchestration_summaries_by_investigation,
 )
 from sentry.investigations.endpoints.validators import InvestigationCandidatesValidator
 from sentry.investigations.models import (
@@ -105,8 +110,9 @@ class OrganizationInvestigationCandidatesEndpoint(OrganizationInvestigationsBase
         viewable_ids = investigation_ids_with_project_access(
             existing, request.access.accessible_project_ids
         )
+        orchestration_by_investigation = orchestration_summaries_by_investigation(existing)
         can_create = can_request_actor_create_investigation(request)
-        items: list[dict[str, str]] = []
+        items: list[dict[str, Any]] = []
         for source in resolved_sources:
             if source is None:
                 items.append({"status": "unavailable"})
@@ -120,7 +126,14 @@ class OrganizationInvestigationCandidatesEndpoint(OrganizationInvestigationsBase
             )
             if investigation is not None:
                 if investigation.id in viewable_ids:
-                    items.append({"status": "view", "investigationId": str(investigation.id)})
+                    item: dict[str, Any] = {
+                        "status": "view",
+                        "investigationId": str(investigation.id),
+                    }
+                    orchestration = orchestration_by_investigation.get(investigation.id)
+                    if orchestration is not None:
+                        item["orchestration"] = orchestration
+                    items.append(item)
                 else:
                     items.append({"status": "unavailable"})
             elif can_create:

--- a/src/sentry/investigations/endpoints/organization_investigation_orchestration.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_orchestration.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.investigations.endpoints.base import (
+    OrganizationInvestigationEndpoint,
+    service_error,
+)
+from sentry.investigations.models import Investigation
+from sentry.investigations.services.investigations import InvestigationServiceError
+from sentry.investigations.services.orchestration import get_orchestration_projection
+from sentry.models.organization import Organization
+
+
+@extend_schema(tags=["Investigations"])
+@cell_silo_endpoint
+class OrganizationInvestigationOrchestrationEndpoint(OrganizationInvestigationEndpoint):
+    publish_status = {"GET": ApiPublishStatus.PRIVATE}
+
+    def get(
+        self, request: Request, organization: Organization, investigation: Investigation
+    ) -> Response:
+        try:
+            projection = get_orchestration_projection(investigation)
+        except InvestigationServiceError as error:
+            response = service_error(error)
+            if response is not None:
+                return response
+            raise
+        return Response(projection)

--- a/src/sentry/investigations/endpoints/serializers/__init__.py
+++ b/src/sentry/investigations/endpoints/serializers/__init__.py
@@ -7,6 +7,7 @@ __all__ = (
     "InvestigationParameterSerializerResponse",
     "InvestigationSerializer",
     "InvestigationSerializerResponse",
+    "orchestration_summaries_by_investigation",
 )
 
 
@@ -16,6 +17,7 @@ from .investigation import (
     InvestigationDetailsSerializerResponse,
     InvestigationSerializer,
     InvestigationSerializerResponse,
+    orchestration_summaries_by_investigation,
 )
 from .parameter import (
     InvestigationParameterSerializer,

--- a/src/sentry/investigations/endpoints/serializers/investigation.py
+++ b/src/sentry/investigations/endpoints/serializers/investigation.py
@@ -23,6 +23,7 @@ from sentry.investigations.models import (
     Investigation,
     InvestigationBlock,
     InvestigationFavoriteUser,
+    InvestigationOrchestrationRun,
     InvestigationParameter,
     InvestigationProject,
     InvestigationSourceType,
@@ -51,6 +52,37 @@ class InvestigationTitleGenerationSerializerResponse(TypedDict):
     status: str | None
 
 
+class InvestigationOrchestrationSerializerResponse(TypedDict):
+    phase: str
+    status: str
+    heartbeatAt: datetime | None
+    notebookRevision: int
+
+
+def orchestration_summaries_by_investigation(
+    investigations: Sequence[Investigation],
+) -> dict[int, InvestigationOrchestrationSerializerResponse]:
+    return {
+        investigation_id: {
+            "phase": phase,
+            "status": status,
+            "heartbeatAt": heartbeat_at,
+            "notebookRevision": notebook_revision,
+        }
+        for investigation_id, phase, status, heartbeat_at, notebook_revision in (
+            InvestigationOrchestrationRun.objects.filter(
+                investigation_id__in=[investigation.id for investigation in investigations]
+            ).values_list(
+                "investigation_id",
+                "phase",
+                "status",
+                "heartbeat_at",
+                "notebook_revision",
+            )
+        )
+    }
+
+
 class InvestigationSerializerResponse(TypedDict):
     id: str
     title: str
@@ -65,6 +97,7 @@ class InvestigationSerializerResponse(TypedDict):
     blockCount: int
     isFavorited: bool
     titleGeneration: InvestigationTitleGenerationSerializerResponse
+    orchestration: InvestigationOrchestrationSerializerResponse | None
 
 
 class InvestigationDetailsSerializerResponse(InvestigationSerializerResponse):
@@ -109,11 +142,14 @@ class InvestigationSerializer(Serializer):
             else set()
         )
 
+        orchestration_by_investigation = orchestration_summaries_by_investigation(item_list)
+
         return {
             investigation: {
                 "block_count": block_counts.get(investigation.id, 0),
                 "is_favorited": investigation.id in favorited_ids,
                 "summary_visible": investigation.id in summary_visible_ids,
+                "orchestration": orchestration_by_investigation.get(investigation.id),
             }
             for investigation in item_list
         }
@@ -142,6 +178,7 @@ class InvestigationSerializer(Serializer):
             "blockCount": attrs["block_count"],
             "isFavorited": attrs["is_favorited"],
             "titleGeneration": {"status": obj.title_generation_status},
+            "orchestration": attrs["orchestration"],
         }
 
 

--- a/src/sentry/investigations/services/orchestration.py
+++ b/src/sentry/investigations/services/orchestration.py
@@ -16,6 +16,7 @@ from sentry.investigations.models import (
 from sentry.investigations.services.breached_metrics import BreachedMetricSource
 from sentry.investigations.services.investigations import (
     DEFAULT_INVESTIGATION_TITLE,
+    InvestigationSourceNotFound,
     _create_project_links,
     _legacy_storage_filters,
     investigation_lineage_key,
@@ -26,6 +27,7 @@ __all__ = [
     "agentic_breached_metric_lineage_key",
     "create_agentic_breached_metric_investigation",
     "create_agentic_manual_investigation",
+    "get_orchestration_projection",
 ]
 
 
@@ -274,3 +276,38 @@ def create_agentic_breached_metric_investigation(
                     return active, False
                 raise
     raise AssertionError("unreachable")
+
+
+def _serialize_orchestration_run(run: InvestigationOrchestrationRun) -> dict[str, Any]:
+    """Overlay projection JSON with the run's authoritative scalar fields."""
+
+    projection = deepcopy(run.projection)
+    projection.update(
+        {
+            "runId": (
+                str(run.seer_run.seer_run_state_id)
+                if run.seer_run is not None and run.seer_run.seer_run_state_id is not None
+                else None
+            ),
+            "investigationId": str(run.investigation_id),
+            "workflowVersion": run.workflow_version,
+            "generation": run.generation,
+            "phase": run.phase,
+            "status": run.status,
+            "notebookRevision": run.notebook_revision,
+            "heartbeatAt": run.heartbeat_at,
+            "updatedAt": run.date_updated,
+        }
+    )
+    projection["report"]["notebookRevision"] = run.notebook_revision
+    return projection
+
+
+def get_orchestration_projection(investigation: Investigation) -> dict[str, Any]:
+    try:
+        run = InvestigationOrchestrationRun.objects.select_related("seer_run").get(
+            investigation=investigation
+        )
+    except InvestigationOrchestrationRun.DoesNotExist:
+        raise InvestigationSourceNotFound
+    return _serialize_orchestration_run(run)

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -210,6 +210,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/blocks/order/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/duplicate/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/favorite/'
+  | '/organizations/$organizationIdOrSlug/investigations/$investigationId/orchestration/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/parameters/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/title-generation/'
   | '/organizations/$organizationIdOrSlug/investigations/candidates/'

--- a/tests/sentry/investigations/endpoints/serializers/test_investigation.py
+++ b/tests/sentry/investigations/endpoints/serializers/test_investigation.py
@@ -4,6 +4,7 @@ from typing import Any
 
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from django.utils import timezone
 
 from sentry.api.serializers import serialize
 from sentry.investigations.endpoints.serializers import (
@@ -39,6 +40,27 @@ class InvestigationSerializerTest(TestCase):
             "blockCount": 0,
             "isFavorited": False,
             "titleGeneration": {"status": None},
+            "orchestration": None,
+        }
+
+    def test_serializes_compact_orchestration_state_without_a_mode(self) -> None:
+        heartbeat = timezone.now()
+        self.create_investigation_orchestration_run(
+            investigation=self.investigation,
+            phase="investigating",
+            status="processing",
+            notebook_revision=4,
+            heartbeat_at=heartbeat,
+        )
+
+        result = serialize(self.investigation, self.user, InvestigationSerializer())
+
+        assert "mode" not in result
+        assert result["orchestration"] == {
+            "phase": "investigating",
+            "status": "processing",
+            "heartbeatAt": heartbeat,
+            "notebookRevision": 4,
         }
 
     def test_counts_only_active_blocks(self) -> None:
@@ -71,6 +93,7 @@ class InvestigationSerializerTest(TestCase):
             )
             self.create_investigation_block(investigation=investigation, position=0)
             self.create_investigation_favorite(investigation=investigation, user=self.user)
+            self.create_investigation_orchestration_run(investigation=investigation)
 
         first_batch = list(Investigation.objects.filter(organization=self.organization))
         serialize(
@@ -91,6 +114,7 @@ class InvestigationSerializerTest(TestCase):
             )
             self.create_investigation_block(investigation=investigation, position=0)
             self.create_investigation_favorite(investigation=investigation, user=self.user)
+            self.create_investigation_orchestration_run(investigation=investigation)
 
         second_batch = list(Investigation.objects.filter(organization=self.organization))
         with CaptureQueriesContext(connection) as second_queries:
@@ -105,6 +129,9 @@ class InvestigationSerializerTest(TestCase):
         counts = sorted(result["blockCount"] for result in results)
         # Only the setUp investigation has no blocks; every created one has exactly one.
         assert counts == [0] + [1] * (len(second_batch) - 1)
+        assert (
+            sum(result["orchestration"] is not None for result in results) == len(second_batch) - 1
+        )
 
 
 class InvestigationDetailsSerializerTest(TestCase):

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_base.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_base.py
@@ -50,6 +50,21 @@ class OrganizationInvestigationBaseTest(APITestCase):
         )
         assert response.status_code == 404
 
+    def test_feature_is_required_for_orchestration(self) -> None:
+        investigation = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Agentic"
+        )
+        self.create_investigation_orchestration_run(investigation=investigation)
+        url = reverse(
+            "sentry-api-0-organization-investigation-orchestration",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": investigation.id,
+            },
+        )
+
+        assert self.client.get(url).status_code == 404
+
 
 @with_feature(FEATURE)
 class OrganizationInvestigationsEndpointTest(APITestCase):
@@ -66,6 +81,45 @@ class OrganizationInvestigationsEndpointTest(APITestCase):
             self.client.logout()
         response = self.client.get(self.collection_url)
         assert response.status_code in {401, 403}
+
+    def test_orchestration_routes_reject_an_investigation_from_another_organization(self) -> None:
+        other_organization = self.create_organization()
+        investigation = self.create_investigation(
+            organization=other_organization, created_by=self.user, title="Other tenant"
+        )
+        self.create_investigation_orchestration_run(investigation=investigation)
+        url = reverse(
+            "sentry-api-0-organization-investigation-orchestration",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": investigation.id,
+            },
+        )
+
+        assert self.client.get(url).status_code == 404
+
+    def test_orchestration_routes_require_every_selected_project(self) -> None:
+        restricted_team = self.create_team(organization=self.organization)
+        restricted_project = self.create_project(
+            organization=self.organization, teams=[restricted_team]
+        )
+        investigation = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Restricted"
+        )
+        self.create_investigation_project(investigation=investigation, project=restricted_project)
+        self.create_investigation_orchestration_run(investigation=investigation)
+        viewer = self.create_user()
+        self.create_member(organization=self.organization, user=viewer, role="member", teams=[])
+        self.login_as(viewer)
+        orchestration_url = reverse(
+            "sentry-api-0-organization-investigation-orchestration",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": investigation.id,
+            },
+        )
+
+        assert self.client.get(orchestration_url).status_code == 403
 
     def test_empty_project_scope_does_not_require_every_organization_project(self) -> None:
         investigation = self.create_investigation(

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_candidates.py
@@ -195,6 +195,12 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
         assert launched.data["id"] != template_investigation.data["id"]
         assert launched.data["template"] is None
         assert launched.data["source"]["ref"] == source["ref"]
+        assert launched.data["orchestration"] == {
+            "phase": "broad_scan",
+            "status": "pending",
+            "heartbeatAt": None,
+            "notebookRevision": 0,
+        }
         investigation = Investigation.objects.get(id=launched.data["id"])
         assert investigation.source_type == InvestigationSourceType.METRIC_OPEN_PERIOD
         run = InvestigationOrchestrationRun.objects.get(investigation=investigation)
@@ -217,7 +223,13 @@ class OrganizationInvestigationCandidatesTest(APITestCase):
 
         assert candidate.status_code == 200, candidate.data
         assert candidate.data == {
-            "items": [{"status": "view", "investigationId": launched.data["id"]}]
+            "items": [
+                {
+                    "status": "view",
+                    "investigationId": launched.data["id"],
+                    "orchestration": launched.data["orchestration"],
+                }
+            ]
         }
 
         duplicate = self.client.post(self.collection_url, {"source": source}, format="json")

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_index.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from unittest import mock
 
 from django.urls import reverse
+from django.utils import timezone
 
 from sentry.investigations.models import (
     Investigation,
@@ -75,6 +76,12 @@ class OrganizationInvestigationIndexTest(APITestCase):
 
         assert response.status_code == 201, response.data
         assert "mode" not in response.data
+        assert response.data["orchestration"] == {
+            "phase": "intake",
+            "status": "awaiting_input",
+            "heartbeatAt": None,
+            "notebookRevision": 0,
+        }
         run = InvestigationOrchestrationRun.objects.get(investigation_id=response.data["id"])
         assert run.source == {
             "type": "manual",
@@ -136,6 +143,34 @@ class OrganizationInvestigationIndexTest(APITestCase):
         assert listed["summaryDescription"] == (
             "Checkout errors increased.\nReview the latest release."
         )
+
+    def test_list_includes_orchestration_state_only_for_agentic_investigations(self) -> None:
+        heartbeat = timezone.now()
+        agentic = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Agentic"
+        )
+        self.create_investigation_orchestration_run(
+            investigation=agentic,
+            phase="judging",
+            status="processing",
+            notebook_revision=2,
+            heartbeat_at=heartbeat,
+        )
+        manual = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Manual"
+        )
+
+        response = self.client.get(self.collection_url)
+
+        assert response.status_code == 200
+        listed = {item["id"]: item for item in response.data}
+        assert listed[str(agentic.id)]["orchestration"] == {
+            "phase": "judging",
+            "status": "processing",
+            "heartbeatAt": heartbeat,
+            "notebookRevision": 2,
+        }
+        assert listed[str(manual.id)]["orchestration"] is None
 
     def test_regular_member_can_create_an_investigation(self) -> None:
         member_user = self.create_user()

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_orchestration.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_orchestration.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from django.urls import reverse
+from django.utils import timezone
+
+from sentry.investigations.models import Investigation, InvestigationOrchestrationRun
+from sentry.investigations.services.orchestration import create_agentic_manual_investigation
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.helpers.features import with_feature
+
+FEATURE = "organizations:investigations"
+
+
+@with_feature(FEATURE)
+class OrganizationInvestigationOrchestrationTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+
+    def create_agentic(self) -> tuple[Investigation, InvestigationOrchestrationRun]:
+        return create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Agentic",
+            source={"type": "manual", "prompt": "Investigate checkout latency"},
+            project_ids=[self.project.id],
+            filters={},
+        )
+
+    def orchestration_url(self, investigation_id: int | str) -> str:
+        return reverse(
+            "sentry-api-0-organization-investigation-orchestration",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": investigation_id,
+            },
+        )
+
+    def test_returns_the_projection_written_at_creation(self) -> None:
+        investigation, run = self.create_agentic()
+
+        response = self.client.get(self.orchestration_url(investigation.id))
+
+        assert response.status_code == 200, response.data
+        assert response.data["investigationId"] == str(investigation.id)
+        assert response.data["runId"] is None
+        assert response.data["sourceType"] == "manual"
+        assert response.data["phase"] == "broad_scan"
+        assert response.data["status"] == "pending"
+        assert response.data["workflowVersion"] == 1
+        assert response.data["generation"] == 1
+        assert response.data["notebookRevision"] == 0
+        assert response.data["heartbeatAt"] is None
+        assert response.data["updatedAt"] == run.date_updated
+        assert response.data["hypotheses"] == []
+        assert response.data["broadScan"]["status"] == "queued"
+        assert response.data["pendingInput"] is None
+        assert response.data["report"]["revision"] == 0
+        assert response.data["report"]["notebookRevision"] == 0
+
+    def test_prefers_the_run_columns_over_the_stored_projection(self) -> None:
+        investigation, run = self.create_agentic()
+        heartbeat = timezone.now()
+        # The stored projection keeps its creation-time scalars; the columns move on.
+        run.update(
+            phase="investigating",
+            status="processing",
+            workflow_version=3,
+            generation=2,
+            notebook_revision=7,
+            heartbeat_at=heartbeat,
+        )
+        assert run.projection["phase"] == "broad_scan"
+        assert run.projection["workflowVersion"] == 1
+
+        response = self.client.get(self.orchestration_url(investigation.id))
+
+        assert response.status_code == 200, response.data
+        assert response.data["phase"] == "investigating"
+        assert response.data["status"] == "processing"
+        assert response.data["workflowVersion"] == 3
+        assert response.data["generation"] == 2
+        assert response.data["notebookRevision"] == 7
+        assert response.data["heartbeatAt"] == heartbeat
+        # The report's notebook revision is overlaid too, not just the top-level one.
+        assert response.data["report"]["notebookRevision"] == 7
+
+    def test_awaiting_input_run_reports_its_missing_fields(self) -> None:
+        investigation, _ = create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Agentic",
+            source={"type": "manual"},
+            project_ids=[self.project.id],
+            filters={},
+        )
+
+        response = self.client.get(self.orchestration_url(investigation.id))
+
+        assert response.status_code == 200, response.data
+        assert response.data["phase"] == "intake"
+        assert response.data["status"] == "awaiting_input"
+        assert response.data["pendingInput"]["missingFields"] == ["prompt"]
+        assert response.data["broadScan"]["status"] == "blocked"
+
+    def test_reports_seers_run_id_once_seer_accepts_the_run(self) -> None:
+        investigation, run = self.create_agentic()
+        seer_run = self.create_seer_run(organization=self.organization, seer_run_state_id=4242)
+        run.update(seer_run=seer_run)
+
+        response = self.client.get(self.orchestration_url(investigation.id))
+
+        assert response.status_code == 200, response.data
+        assert response.data["runId"] == "4242"
+        assert response.data["runId"] != str(seer_run.id)
+
+    def test_reports_no_run_id_while_the_seer_run_is_still_mirroring(self) -> None:
+        investigation, run = self.create_agentic()
+        run.update(seer_run=self.create_seer_run(organization=self.organization))
+
+        response = self.client.get(self.orchestration_url(investigation.id))
+
+        assert response.status_code == 200, response.data
+        assert response.data["runId"] is None
+
+    def test_returns_not_found_for_an_investigation_without_a_run(self) -> None:
+        investigation = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Manual"
+        )
+
+        assert self.client.get(self.orchestration_url(investigation.id)).status_code == 404
+
+    def test_returns_not_found_for_an_unknown_investigation(self) -> None:
+        assert self.client.get(self.orchestration_url(2**32)).status_code == 404


### PR DESCRIPTION
Adds `GET /organizations/{org}/investigations/{id}/orchestration/`. It returns the run's stored projection overlaid with its authoritative columns (phase, status, workflow version, generation, notebook revision, heartbeat), so a stale projection never masks live state. Investigations without an orchestration run 404.

The list, detail, and candidate responses gain a compact `orchestration` summary (phase, status, `heartbeatAt`, `notebookRevision`), resolved in one bulk query and `null` for non-agentic investigations.

Read-only. No commands, dispatch, event reduction, or migrations. The command API follows separately.
