### PR TITLE
feat(investigations): Accept orchestration commands

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -332,6 +332,7 @@ from sentry.investigations.endpoints.organization_investigation_index import (
     OrganizationInvestigationsIndexEndpoint,
 )
 from sentry.investigations.endpoints.organization_investigation_orchestration import (
+    OrganizationInvestigationOrchestrationCommandsEndpoint,
     OrganizationInvestigationOrchestrationEndpoint,
 )
 from sentry.investigations.endpoints.organization_investigation_parameters import (
@@ -2485,6 +2486,11 @@ ORGANIZATION_URLS: list[URLPattern | URLResolver] = [
         r"^(?P<organization_id_or_slug>[^/]+)/investigations/(?P<investigation_id>[^/]+)/orchestration/$",
         OrganizationInvestigationOrchestrationEndpoint.as_view(),
         name="sentry-api-0-organization-investigation-orchestration",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/investigations/(?P<investigation_id>[^/]+)/orchestration/commands/$",
+        OrganizationInvestigationOrchestrationCommandsEndpoint.as_view(),
+        name="sentry-api-0-organization-investigation-orchestration-commands",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/investigations/(?P<investigation_id>[^/]+)/blocks/$",

--- a/src/sentry/investigations/endpoints/organization_investigation_orchestration.py
+++ b/src/sentry/investigations/endpoints/organization_investigation_orchestration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from drf_spectacular.utils import extend_schema
+from rest_framework import status
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -8,11 +9,18 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.investigations.endpoints.base import (
     OrganizationInvestigationEndpoint,
+    require_authenticated_user,
     service_error,
+)
+from sentry.investigations.endpoints.validators import (
+    InvestigationOrchestrationCommandValidator,
 )
 from sentry.investigations.models import Investigation
 from sentry.investigations.services.investigations import InvestigationServiceError
-from sentry.investigations.services.orchestration import get_orchestration_projection
+from sentry.investigations.services.orchestration import (
+    accept_orchestration_command,
+    get_orchestration_projection,
+)
 from sentry.models.organization import Organization
 
 
@@ -32,3 +40,47 @@ class OrganizationInvestigationOrchestrationEndpoint(OrganizationInvestigationEn
                 return response
             raise
         return Response(projection)
+
+
+@extend_schema(tags=["Investigations"])
+@cell_silo_endpoint
+class OrganizationInvestigationOrchestrationCommandsEndpoint(OrganizationInvestigationEndpoint):
+    publish_status = {"POST": ApiPublishStatus.PRIVATE}
+
+    def post(
+        self, request: Request, organization: Organization, investigation: Investigation
+    ) -> Response:
+        actor_id = require_authenticated_user(request)
+        validator = InvestigationOrchestrationCommandValidator(data=request.data)
+        if not validator.is_valid():
+            return Response(validator.errors, status=status.HTTP_400_BAD_REQUEST)
+
+        values = validator.validated_data
+        command = dict(values["command"])
+        command_type = command.pop("type")
+        try:
+            accepted = accept_orchestration_command(
+                investigation=investigation,
+                request_id=values["request_id"],
+                expected_workflow_version=values["expected_workflow_version"],
+                command_type=command_type,
+                payload=command,
+                actor_id=actor_id,
+            )
+        except InvestigationServiceError as error:
+            response = service_error(error)
+            if response is not None:
+                return response
+            raise
+
+        return Response(
+            {
+                "runId": (str(accepted.run_id) if accepted.run_id is not None else None),
+                "requestId": str(accepted.request_id),
+                "accepted": True,
+                "duplicate": accepted.duplicate,
+                "workflowVersion": accepted.workflow_version,
+                "projection": accepted.projection,
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/src/sentry/investigations/endpoints/validators/__init__.py
+++ b/src/sentry/investigations/endpoints/validators/__init__.py
@@ -9,6 +9,7 @@ __all__ = (
     "InvestigationCreateValidator",
     "InvestigationCandidatesValidator",
     "InvestigationDeleteValidator",
+    "InvestigationOrchestrationCommandValidator",
     "InvestigationUpdateValidator",
     "ParameterValuesValidator",
     "PermissionsUpdateValidator",
@@ -37,4 +38,5 @@ from .investigation import (
     InvestigationUpdateValidator,
     PermissionsUpdateValidator,
 )
+from .orchestration import InvestigationOrchestrationCommandValidator
 from .parameter import ParameterValuesValidator

--- a/src/sentry/investigations/endpoints/validators/orchestration.py
+++ b/src/sentry/investigations/endpoints/validators/orchestration.py
@@ -7,6 +7,7 @@ from django.utils.dateparse import parse_datetime
 from rest_framework import serializers
 
 from sentry.investigations.contracts import StrictContractSerializer
+from sentry.investigations.endpoints.validators.base import StrictCamelSnakeValidator
 from sentry.utils import json
 
 MAX_AGENTIC_SOURCE_BYTES = 200_000
@@ -77,3 +78,89 @@ def validate_agentic_source(source: Any) -> dict[str, Any]:
     if not validator.is_valid():
         raise serializers.ValidationError({"source": validator.errors})
     return source
+
+
+class ProvideInputCommandValidator(StrictContractSerializer):
+    type = serializers.ChoiceField(choices=["provide_input"])
+    prompt = serializers.CharField(required=False, max_length=20_000)
+    timeRange = serializers.JSONField(required=False)
+
+    def validate_timeRange(self, value: Any) -> dict[str, str]:
+        return _validate_time_range(value)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if "prompt" not in attrs and "timeRange" not in attrs:
+            raise serializers.ValidationError("prompt or timeRange is required.")
+        return attrs
+
+
+class AddHypothesisCommandValidator(StrictContractSerializer):
+    type = serializers.ChoiceField(choices=["add_hypothesis"])
+    statement = serializers.CharField(max_length=300)
+    rationale = serializers.CharField(required=False, allow_null=True, max_length=1_000)
+
+
+class SetHypothesisDispositionCommandValidator(StrictContractSerializer):
+    type = serializers.ChoiceField(choices=["set_hypothesis_disposition"])
+    hypothesisId = serializers.CharField(max_length=128)
+    disposition = serializers.ChoiceField(
+        choices=["accepted", "rejected"], required=False, allow_null=True
+    )
+
+
+class SteerCommandValidator(StrictContractSerializer):
+    type = serializers.ChoiceField(choices=["steer"])
+    target = serializers.ChoiceField(choices=["workflow", "hypothesis", "report", "block"])
+    targetId = serializers.CharField(required=False, allow_null=True, max_length=128)
+    instruction = serializers.CharField(max_length=4_000)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs["target"] in {"hypothesis", "block"} and not attrs.get("targetId"):
+            raise serializers.ValidationError("hypothesis and block steering require targetId.")
+        return attrs
+
+
+class RetryCommandValidator(StrictContractSerializer):
+    type = serializers.ChoiceField(choices=["retry"])
+    target = serializers.ChoiceField(choices=["run", "hypothesis", "report"])
+    targetId = serializers.CharField(required=False, allow_null=True, max_length=128)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs["target"] == "hypothesis" and not attrs.get("targetId"):
+            raise serializers.ValidationError("hypothesis retry requires targetId.")
+        return attrs
+
+
+class CancelCommandValidator(StrictContractSerializer):
+    type = serializers.ChoiceField(choices=["cancel"])
+    reason = serializers.CharField(required=False, allow_null=True, max_length=1_000)
+
+
+COMMAND_VALIDATORS: dict[str, type[StrictContractSerializer]] = {
+    "provide_input": ProvideInputCommandValidator,
+    "add_hypothesis": AddHypothesisCommandValidator,
+    "set_hypothesis_disposition": SetHypothesisDispositionCommandValidator,
+    "steer": SteerCommandValidator,
+    "retry": RetryCommandValidator,
+    "cancel": CancelCommandValidator,
+}
+
+
+class InvestigationOrchestrationCommandValidator(StrictCamelSnakeValidator):
+    request_id = serializers.UUIDField()
+    expected_workflow_version = serializers.IntegerField(min_value=1)
+    command = serializers.JSONField()
+
+    def validate_command(self, value: Any) -> dict[str, Any]:
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("Must be an object.")
+        command_type = value.get("type")
+        if not isinstance(command_type, str):
+            raise serializers.ValidationError("type is required.")
+        validator_type = COMMAND_VALIDATORS.get(command_type)
+        if validator_type is None:
+            raise serializers.ValidationError("Unsupported command type.")
+        validator = validator_type(data=value)
+        if not validator.is_valid():
+            raise serializers.ValidationError(validator.errors)
+        return dict(validator.validated_data)

--- a/src/sentry/investigations/services/orchestration.py
+++ b/src/sentry/investigations/services/orchestration.py
@@ -1,13 +1,17 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any
+from uuid import UUID
 
 from django.db import IntegrityError, router, transaction
 from django.db.models import Max
+from django.utils import timezone
 
 from sentry.investigations.models import (
     Investigation,
+    InvestigationOrchestrationCommand,
     InvestigationOrchestrationRun,
     InvestigationOrchestrationStatus,
     InvestigationSourceType,
@@ -16,14 +20,28 @@ from sentry.investigations.models import (
 from sentry.investigations.services.breached_metrics import BreachedMetricSource
 from sentry.investigations.services.investigations import (
     DEFAULT_INVESTIGATION_TITLE,
+    InvestigationConflictError,
     InvestigationSourceNotFound,
+    InvestigationValidationError,
     _create_project_links,
     _legacy_storage_filters,
     investigation_lineage_key,
 )
 from sentry.models.organization import Organization
 
+
+@dataclass(frozen=True)
+class AcceptedOrchestrationCommand:
+    run_id: int | None
+    request_id: UUID
+    duplicate: bool
+    workflow_version: int
+    projection: dict[str, Any]
+
+
 __all__ = [
+    "AcceptedOrchestrationCommand",
+    "accept_orchestration_command",
     "agentic_breached_metric_lineage_key",
     "create_agentic_breached_metric_investigation",
     "create_agentic_manual_investigation",
@@ -311,3 +329,85 @@ def get_orchestration_projection(investigation: Investigation) -> dict[str, Any]
     except InvestigationOrchestrationRun.DoesNotExist:
         raise InvestigationSourceNotFound
     return _serialize_orchestration_run(run)
+
+
+def _command_acceptance(
+    run: InvestigationOrchestrationRun,
+    command: InvestigationOrchestrationCommand,
+    *,
+    duplicate: bool,
+) -> AcceptedOrchestrationCommand:
+    return AcceptedOrchestrationCommand(
+        run_id=(
+            run.seer_run.seer_run_state_id
+            if run.seer_run is not None and run.seer_run.seer_run_state_id is not None
+            else None
+        ),
+        request_id=command.request_id,
+        duplicate=duplicate,
+        workflow_version=run.workflow_version,
+        projection=_serialize_orchestration_run(run),
+    )
+
+
+def accept_orchestration_command(
+    *,
+    investigation: Investigation,
+    request_id: UUID,
+    expected_workflow_version: int,
+    command_type: str,
+    payload: dict[str, Any],
+    actor_id: int,
+) -> AcceptedOrchestrationCommand:
+    with transaction.atomic(using=router.db_for_write(InvestigationOrchestrationRun)):
+        try:
+            locked_investigation = Investigation.objects.select_for_update().get(
+                id=investigation.id
+            )
+        except Investigation.DoesNotExist:
+            raise InvestigationSourceNotFound
+        if locked_investigation.status == InvestigationStatus.ARCHIVED:
+            raise InvestigationValidationError(
+                {"detail": "Archived investigations do not accept commands."}
+            )
+        try:
+            run = InvestigationOrchestrationRun.objects.select_for_update().get(
+                investigation=locked_investigation
+            )
+        except InvestigationOrchestrationRun.DoesNotExist:
+            raise InvestigationSourceNotFound
+
+        existing = InvestigationOrchestrationCommand.objects.filter(
+            orchestration_run=run, request_id=request_id
+        ).first()
+        if existing is not None:
+            if (
+                existing.expected_workflow_version != expected_workflow_version
+                or existing.type != command_type
+                or existing.payload != payload
+            ):
+                raise InvestigationConflictError(
+                    "Request ID was already used for a different command."
+                )
+            return _command_acceptance(run, existing, duplicate=True)
+
+        if run.workflow_version != expected_workflow_version:
+            raise InvestigationConflictError("Workflow version does not match.")
+
+        resulting_version = run.workflow_version + 1
+        command = InvestigationOrchestrationCommand.objects.create(
+            orchestration_run=run,
+            request_id=request_id,
+            actor_id=actor_id,
+            expected_workflow_version=expected_workflow_version,
+            resulting_workflow_version=resulting_version,
+            type=command_type,
+            payload=deepcopy(payload),
+        )
+        projection = deepcopy(run.projection)
+        projection["workflowVersion"] = resulting_version
+        run.workflow_version = resulting_version
+        run.projection = projection
+        run.date_updated = timezone.now()
+        run.save(update_fields=["workflow_version", "projection", "date_updated"])
+        return _command_acceptance(run, command, duplicate=False)

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -211,6 +211,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/duplicate/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/favorite/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/orchestration/'
+  | '/organizations/$organizationIdOrSlug/investigations/$investigationId/orchestration/commands/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/parameters/'
   | '/organizations/$organizationIdOrSlug/investigations/$investigationId/title-generation/'
   | '/organizations/$organizationIdOrSlug/investigations/candidates/'

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_base.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_base.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from uuid import uuid4
+
 from django.urls import reverse
 
 from sentry.investigations.models import (
@@ -119,7 +121,25 @@ class OrganizationInvestigationsEndpointTest(APITestCase):
             },
         )
 
+        command_url = reverse(
+            "sentry-api-0-organization-investigation-orchestration-commands",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": investigation.id,
+            },
+        )
+
         assert self.client.get(orchestration_url).status_code == 403
+        response = self.client.post(
+            command_url,
+            data={
+                "requestId": str(uuid4()),
+                "expectedWorkflowVersion": 1,
+                "command": {"type": "cancel"},
+            },
+            format="json",
+        )
+        assert response.status_code == 403
 
     def test_empty_project_scope_does_not_require_every_organization_project(self) -> None:
         investigation = self.create_investigation(

--- a/tests/sentry/investigations/endpoints/test_organization_investigation_orchestration.py
+++ b/tests/sentry/investigations/endpoints/test_organization_investigation_orchestration.py
@@ -1,12 +1,23 @@
 from __future__ import annotations
 
+from typing import Any
+from uuid import uuid4
+
 from django.urls import reverse
 from django.utils import timezone
 
-from sentry.investigations.models import Investigation, InvestigationOrchestrationRun
+from sentry.investigations.models import (
+    Investigation,
+    InvestigationOrchestrationCommand,
+    InvestigationOrchestrationCommandStatus,
+    InvestigationOrchestrationRun,
+    InvestigationStatus,
+)
 from sentry.investigations.services.orchestration import create_agentic_manual_investigation
+from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
+from sentry.testutils.silo import assume_test_silo_mode
 
 FEATURE = "organizations:investigations"
 
@@ -132,3 +143,151 @@ class OrganizationInvestigationOrchestrationTest(APITestCase):
 
     def test_returns_not_found_for_an_unknown_investigation(self) -> None:
         assert self.client.get(self.orchestration_url(2**32)).status_code == 404
+
+
+@with_feature(FEATURE)
+class OrganizationInvestigationOrchestrationCommandsTest(APITestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(self.user)
+        self.investigation, self.orchestration_run = create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title="Agentic",
+            source={"type": "manual", "prompt": "Investigate checkout latency"},
+            project_ids=[self.project.id],
+            filters={},
+        )
+        self.command_url = self.commands_url(self.investigation.id)
+
+    def commands_url(self, investigation_id: int | str) -> str:
+        return reverse(
+            "sentry-api-0-organization-investigation-orchestration-commands",
+            kwargs={
+                "organization_id_or_slug": self.organization.slug,
+                "investigation_id": investigation_id,
+            },
+        )
+
+    def command(self, **overrides: Any) -> dict[str, Any]:
+        body: dict[str, Any] = {
+            "requestId": str(uuid4()),
+            "expectedWorkflowVersion": 1,
+            "command": {
+                "type": "add_hypothesis",
+                "statement": "A recent release caused the regression",
+                "rationale": "The timing overlaps",
+            },
+        }
+        body.update(overrides)
+        return body
+
+    def test_accepts_a_command_and_advances_the_workflow_version(self) -> None:
+        body = self.command()
+
+        response = self.client.post(self.command_url, data=body, format="json")
+
+        assert response.status_code == 200, response.data
+        assert response.data["requestId"] == body["requestId"]
+        assert response.data["accepted"] is True
+        assert response.data["duplicate"] is False
+        assert response.data["workflowVersion"] == 2
+        assert response.data["projection"]["workflowVersion"] == 2
+        stored = InvestigationOrchestrationCommand.objects.get(request_id=body["requestId"])
+        assert stored.type == "add_hypothesis"
+        assert stored.actor_id == self.user.id
+        assert stored.status == InvestigationOrchestrationCommandStatus.ACCEPTED
+        assert stored.expected_workflow_version == 1
+        assert stored.resulting_workflow_version == 2
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 2
+        # Persisting a command must not touch the notebook.
+        assert not self.investigation.blocks.exists()
+
+    def test_stores_the_payload_with_its_wire_casing(self) -> None:
+        body = self.command(
+            command={"type": "steer", "target": "block", "targetId": "b-1", "instruction": "Focus"}
+        )
+
+        response = self.client.post(self.command_url, data=body, format="json")
+
+        assert response.status_code == 200, response.data
+        stored = InvestigationOrchestrationCommand.objects.get(request_id=body["requestId"])
+        # The payload is forwarded to Seer verbatim, so its keys must not be rewritten.
+        assert stored.payload == {"target": "block", "targetId": "b-1", "instruction": "Focus"}
+
+    def test_replaying_a_request_id_returns_the_original_acceptance(self) -> None:
+        body = self.command()
+        first = self.client.post(self.command_url, data=body, format="json")
+        assert first.status_code == 200, first.data
+
+        replay = self.client.post(self.command_url, data=body, format="json")
+
+        assert replay.status_code == 200, replay.data
+        assert replay.data["duplicate"] is True
+        assert replay.data["workflowVersion"] == 2
+        assert InvestigationOrchestrationCommand.objects.count() == 1
+
+    def test_reusing_a_request_id_for_a_different_command_conflicts(self) -> None:
+        body = self.command()
+        assert self.client.post(self.command_url, data=body, format="json").status_code == 200
+        changed = self.command(requestId=body["requestId"])
+        changed["command"]["statement"] = "A database lock caused the regression"
+
+        response = self.client.post(self.command_url, data=changed, format="json")
+
+        assert response.status_code == 409
+        assert InvestigationOrchestrationCommand.objects.count() == 1
+
+    def test_rejects_a_stale_workflow_version(self) -> None:
+        assert (
+            self.client.post(self.command_url, data=self.command(), format="json").status_code
+            == 200
+        )
+
+        response = self.client.post(
+            self.command_url, data=self.command(expectedWorkflowVersion=1), format="json"
+        )
+
+        assert response.status_code == 409
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 2
+        assert InvestigationOrchestrationCommand.objects.count() == 1
+
+    def test_rejects_an_unsupported_command_type(self) -> None:
+        response = self.client.post(
+            self.command_url, data=self.command(command={"type": "explode"}), format="json"
+        )
+
+        assert response.status_code == 400
+        assert not InvestigationOrchestrationCommand.objects.exists()
+
+    def test_archived_investigation_rejects_commands_without_advancing_the_run(self) -> None:
+        self.investigation.update(status=InvestigationStatus.ARCHIVED)
+
+        response = self.client.post(self.command_url, data=self.command(), format="json")
+
+        assert response.status_code == 400
+        self.orchestration_run.refresh_from_db()
+        assert self.orchestration_run.workflow_version == 1
+        assert not self.orchestration_run.commands.exists()
+
+    def test_returns_not_found_for_an_investigation_without_a_run(self) -> None:
+        investigation = self.create_investigation(
+            organization=self.organization, created_by=self.user, title="Manual"
+        )
+
+        response = self.client.post(
+            self.commands_url(investigation.id), data=self.command(), format="json"
+        )
+
+        assert response.status_code == 404
+
+    def test_requires_an_authenticated_user(self) -> None:
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            self.client.logout()
+
+        response = self.client.post(self.command_url, data=self.command(), format="json")
+
+        assert response.status_code in {401, 403}
+        assert not InvestigationOrchestrationCommand.objects.exists()

--- a/tests/sentry/investigations/endpoints/validators/test_investigation.py
+++ b/tests/sentry/investigations/endpoints/validators/test_investigation.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 from typing import Any
+from uuid import uuid4
 
+import pytest
 from rest_framework import serializers
 
 from sentry.investigations.endpoints.validators import (
     InvestigationCreateValidator,
+    InvestigationOrchestrationCommandValidator,
     InvestigationUpdateValidator,
 )
 
@@ -229,3 +232,146 @@ class TestInvestigationUpdateValidator:
 
         assert not validator.is_valid()
         assert "projectIds" in validator.errors
+
+
+class TestInvestigationOrchestrationCommandValidator:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            {"type": "provide_input", "prompt": "Investigate latency"},
+            {"type": "add_hypothesis", "statement": "A release caused the regression"},
+            {
+                "type": "set_hypothesis_disposition",
+                "hypothesisId": "hypothesis-1",
+                "disposition": "accepted",
+            },
+            {
+                "type": "steer",
+                "target": "block",
+                "targetId": "block-1",
+                "instruction": "Focus on the latest release",
+            },
+            {"type": "retry", "target": "hypothesis", "targetId": "hypothesis-1"},
+            {"type": "cancel", "reason": "No longer needed"},
+        ],
+    )
+    def test_accepts_each_supported_command(self, command: dict[str, Any]) -> None:
+        validator = InvestigationOrchestrationCommandValidator(
+            data={
+                "requestId": str(uuid4()),
+                "expectedWorkflowVersion": 1,
+                "command": command,
+            }
+        )
+
+        assert validator.is_valid(), validator.errors
+
+    def test_normalizes_a_discriminated_command(self) -> None:
+        request_id = uuid4()
+        data = assert_valid(
+            InvestigationOrchestrationCommandValidator(
+                data={
+                    "requestId": str(request_id),
+                    "expectedWorkflowVersion": 3,
+                    "command": {
+                        "type": "set_hypothesis_disposition",
+                        "hypothesisId": "hypothesis-1",
+                        "disposition": None,
+                    },
+                }
+            )
+        )
+
+        assert data == {
+            "request_id": request_id,
+            "expected_workflow_version": 3,
+            # The command payload is a wire object bound for Seer, so its keys
+            # survive untouched while the envelope is snake_cased.
+            "command": {
+                "type": "set_hypothesis_disposition",
+                "hypothesisId": "hypothesis-1",
+                "disposition": None,
+            },
+        }
+
+    def test_rejects_unknown_nested_fields(self) -> None:
+        validator = InvestigationOrchestrationCommandValidator(
+            data={
+                "requestId": str(uuid4()),
+                "expectedWorkflowVersion": 1,
+                "command": {"type": "cancel", "unexpected": True},
+            }
+        )
+
+        assert not validator.is_valid()
+        assert "command" in validator.errors
+
+    def test_provide_input_requires_at_least_one_value(self) -> None:
+        validator = InvestigationOrchestrationCommandValidator(
+            data={
+                "requestId": str(uuid4()),
+                "expectedWorkflowVersion": 1,
+                "command": {"type": "provide_input"},
+            }
+        )
+
+        assert not validator.is_valid()
+        assert "command" in validator.errors
+
+    def test_rejects_a_naive_provide_input_time_range(self) -> None:
+        validator = InvestigationOrchestrationCommandValidator(
+            data={
+                "requestId": str(uuid4()),
+                "expectedWorkflowVersion": 1,
+                "command": {
+                    "type": "provide_input",
+                    "timeRange": {
+                        "start": "2025-01-01T00:00:00",
+                        "end": "2025-01-01T01:00:00",
+                    },
+                },
+            }
+        )
+
+        assert not validator.is_valid()
+        assert "command" in validator.errors
+
+    def test_targeted_commands_require_their_target_id(self) -> None:
+        validator = InvestigationOrchestrationCommandValidator(
+            data={
+                "requestId": str(uuid4()),
+                "expectedWorkflowVersion": 1,
+                "command": {
+                    "type": "steer",
+                    "target": "hypothesis",
+                    "instruction": "Check the region split",
+                },
+            }
+        )
+
+        assert not validator.is_valid()
+        assert "command" in validator.errors
+
+    def test_rejects_an_invalid_target(self) -> None:
+        validator = InvestigationOrchestrationCommandValidator(
+            data={
+                "requestId": str(uuid4()),
+                "expectedWorkflowVersion": 1,
+                "command": {"type": "retry", "target": "block"},
+            }
+        )
+
+        assert not validator.is_valid()
+        assert "command" in validator.errors
+
+    def test_rejects_oversized_command_content(self) -> None:
+        validator = InvestigationOrchestrationCommandValidator(
+            data={
+                "requestId": str(uuid4()),
+                "expectedWorkflowVersion": 1,
+                "command": {"type": "add_hypothesis", "statement": "x" * 301},
+            }
+        )
+
+        assert not validator.is_valid()
+        assert "command" in validator.errors

--- a/tests/sentry/investigations/services/test_investigations.py
+++ b/tests/sentry/investigations/services/test_investigations.py
@@ -1,20 +1,24 @@
 from __future__ import annotations
 
+import threading
 from unittest import mock
+from uuid import UUID, uuid4
 
 import pytest
-from django.db import IntegrityError
+from django.db import IntegrityError, close_old_connections
 
 from sentry.db.models.fields.bounded import I64_MAX
 from sentry.investigations.models import (
     Investigation,
     InvestigationBlockDependency,
+    InvestigationOrchestrationCommand,
     InvestigationOrchestrationRun,
     InvestigationProject,
     InvestigationSourceType,
 )
 from sentry.investigations.services.breached_metrics import BreachedMetricSource
 from sentry.investigations.services.investigations import (
+    InvestigationConflictError,
     InvestigationSourceNotFound,
     InvestigationValidationError,
     create_block,
@@ -28,9 +32,11 @@ from sentry.investigations.services.investigations import (
     update_investigation,
 )
 from sentry.investigations.services.orchestration import (
+    accept_orchestration_command,
     create_agentic_manual_investigation,
 )
-from sentry.testutils.cases import TestCase
+from sentry.testutils.cases import TestCase, TransactionTestCase
+from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
 TEMPLATE_KWARGS = {
     "organization": mock.sentinel.organization,
@@ -386,3 +392,75 @@ class OrchestrationControlServiceTest(TestCase):
         assert Investigation.objects.count() == investigation_count
         assert InvestigationProject.objects.count() == project_link_count
         assert not InvestigationOrchestrationRun.objects.exists()
+
+    def test_command_acceptance_rolls_back_command_and_version_together(self) -> None:
+        investigation, run = create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title=None,
+            source={"type": "manual", "prompt": "Investigate latency"},
+            project_ids=[],
+            filters={},
+        )
+
+        with (
+            mock.patch.object(InvestigationOrchestrationRun, "save", side_effect=RuntimeError),
+            pytest.raises(RuntimeError),
+        ):
+            accept_orchestration_command(
+                investigation=investigation,
+                request_id=uuid4(),
+                expected_workflow_version=1,
+                command_type="cancel",
+                payload={},
+                actor_id=self.user.id,
+            )
+
+        run.refresh_from_db()
+        assert run.workflow_version == 1
+        assert not InvestigationOrchestrationCommand.objects.filter(orchestration_run=run).exists()
+
+
+class OrchestrationCommandConcurrencyTest(TransactionTestCase):
+    def test_only_one_command_is_accepted_for_a_workflow_version(self) -> None:
+        investigation, run = create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title=None,
+            source={"type": "manual", "prompt": "Investigate latency"},
+            project_ids=[],
+            filters={},
+        )
+        barrier = threading.Barrier(2, timeout=10)
+
+        def submit(request_id: UUID, reason: str) -> str:
+            close_old_connections()
+            barrier.wait()
+            try:
+                accept_orchestration_command(
+                    investigation=investigation,
+                    request_id=request_id,
+                    expected_workflow_version=1,
+                    command_type="cancel",
+                    payload={"reason": reason},
+                    actor_id=self.user.id,
+                )
+                return "accepted"
+            except InvestigationConflictError:
+                return "conflict"
+            finally:
+                close_old_connections()
+
+        with ContextPropagatingThreadPoolExecutor(max_workers=2) as executor:
+            outcomes = [
+                future.result(timeout=15)
+                for future in (
+                    executor.submit(submit, uuid4(), "first"),
+                    executor.submit(submit, uuid4(), "second"),
+                )
+            ]
+
+        run.refresh_from_db()
+        assert sorted(outcomes) == ["accepted", "conflict"]
+        assert run.workflow_version == 2
+        assert InvestigationOrchestrationCommand.objects.filter(orchestration_run=run).count() == 1


### PR DESCRIPTION
Adds `POST /organizations/{org}/investigations/{id}/orchestration/commands/`. Six command types (`provide_input`, `add_hypothesis`, `set_hypothesis_disposition`, `steer`, `retry`, `cancel`) are validated against per-type schemas, then persisted idempotently under row locking with workflow-version fencing.

Replaying a request id returns the original acceptance. Reusing one for a different command conflicts, as does a stale expected version. Archived investigations are rejected without advancing the run.

Command payloads are validated without key-case conversion, so their camelCase keys survive into storage and on to Seer. Only the envelope is snake_cased.

Commands are persisted only. No Seer dispatch, event reduction, or migrations.
