### PR TITLE
feat(release): use spans dataset for release comparison table

### DIFF
--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -9,9 +9,10 @@ import {
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import type {RouterConfig} from 'sentry-test/reactTestingLibrary';
 
-import type {ReleaseProject} from 'sentry/types/release';
+import {type ReleaseProject, ReleaseComparisonChartType} from 'sentry/types/release';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ReleaseComparisonChart} from 'sentry/views/explore/releases/detail/overview/releaseComparisonChart';
+import {ReleaseEventsChart} from 'sentry/views/explore/releases/detail/overview/releaseComparisonChart/releaseEventsChart';
 
 describe('Releases > Detail > Overview > ReleaseComparison', () => {
   const organization = OrganizationFixture();
@@ -233,5 +234,45 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
         })
       );
     });
+  });
+
+  it.each([
+    [ReleaseComparisonChartType.FAILURE_RATE, 2],
+    [ReleaseComparisonChartType.TRANSACTION_COUNT, 1],
+  ])('queries the spans dataset for the %s timeseries', async (chartType, callCount) => {
+    const eventsStatsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-stats/`,
+      body: {data: []},
+    });
+
+    render(
+      <ReleaseEventsChart
+        release={release}
+        project={project}
+        chartType={chartType}
+        value={null}
+        diff={null}
+        period="14d"
+      />,
+      {
+        organization,
+        initialRouterConfig,
+      }
+    );
+
+    await waitFor(() => {
+      expect(eventsStatsRequest).toHaveBeenCalledTimes(callCount);
+    });
+
+    for (const [, options] of eventsStatsRequest.mock.calls) {
+      expect(options).toEqual(
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.SPANS,
+            query: expect.stringContaining('is_transaction:true'),
+          }),
+        })
+      );
+    }
   });
 });

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.spec.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.spec.tsx
@@ -6,10 +6,11 @@ import {
   SessionUserCountByStatusFixture,
 } from 'sentry-fixture/sessions';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import type {RouterConfig} from 'sentry-test/reactTestingLibrary';
 
 import type {ReleaseProject} from 'sentry/types/release';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {ReleaseComparisonChart} from 'sentry/views/explore/releases/detail/overview/releaseComparisonChart';
 
 describe('Releases > Detail > Overview > ReleaseComparison', () => {
@@ -180,5 +181,57 @@ describe('Releases > Detail > Overview > ReleaseComparison', () => {
     expect(await screen.findAllByRole('radio')).toHaveLength(1);
     expect(screen.queryByLabelText(/toggle chart/i)).not.toBeInTheDocument();
     expect(screen.queryByLabelText(/toggle additional/i)).not.toBeInTheDocument();
+  });
+
+  it('queries the spans dataset for transaction totals', async () => {
+    const performanceOrganization = OrganizationFixture({
+      features: [...organization.features, 'performance-view'],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${performanceOrganization.slug}/events-stats/`,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${performanceOrganization.slug}/issues-count/`,
+      body: {},
+    });
+    const eventsRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${performanceOrganization.slug}/events/`,
+      body: {
+        data: [{'failure_rate()': 0.1, 'count()': 100}],
+        meta: {fields: {'failure_rate()': 'percentage', 'count()': 'integer'}},
+      },
+    });
+
+    render(
+      <ReleaseComparisonChart
+        release={release}
+        releaseSessions={releaseSessions}
+        allSessions={allSessions}
+        loading={false}
+        reloading={false}
+        errored={false}
+        project={project}
+        api={api}
+        hasHealthData
+      />,
+      {
+        organization: performanceOrganization,
+        initialRouterConfig,
+      }
+    );
+
+    await waitFor(() => {
+      expect(eventsRequest).toHaveBeenCalledWith(
+        `/organizations/${performanceOrganization.slug}/events/`,
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: DiscoverDatasets.SPANS,
+            query: expect.stringContaining('is_transaction:true'),
+          }),
+        })
+      );
+    });
   });
 });

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/index.tsx
@@ -193,18 +193,18 @@ export function ReleaseComparisonChart({
           query: {
             field: ['failure_rate()', 'count()'],
             query: new MutableSearch([
-              'event.type:transaction',
+              'is_transaction:true',
               `release:${release.version}`,
             ]).formatString(),
-            dataset: DiscoverDatasets.METRICS_ENHANCED,
+            dataset: DiscoverDatasets.SPANS,
             ...commonQuery,
           },
         }),
         api.requestPromise(url, {
           query: {
             field: ['failure_rate()', 'count()'],
-            query: new MutableSearch(['event.type:transaction']).formatString(),
-            dataset: DiscoverDatasets.METRICS_ENHANCED,
+            query: new MutableSearch(['is_transaction:true']).formatString(),
+            dataset: DiscoverDatasets.SPANS,
             ...commonQuery,
           },
         }),

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -74,15 +74,9 @@ export function ReleaseEventsChart({
       case ReleaseComparisonChartType.ERROR_COUNT:
         return new MutableSearch(['event.type:error', releaseFilter]).formatString();
       case ReleaseComparisonChartType.TRANSACTION_COUNT:
-        return new MutableSearch([
-          'event.type:transaction',
-          releaseFilter,
-        ]).formatString();
+        return new MutableSearch(['is_transaction:true', releaseFilter]).formatString();
       case ReleaseComparisonChartType.FAILURE_RATE:
-        return new MutableSearch([
-          'event.type:transaction',
-          releaseFilter,
-        ]).formatString();
+        return new MutableSearch(['is_transaction:true', releaseFilter]).formatString();
       default:
         return '';
     }
@@ -144,11 +138,12 @@ export function ReleaseEventsChart({
       start={start}
       end={end}
       interval={getInterval({start, end, period, utc}, 'high')}
-      query="event.type:transaction"
+      query="is_transaction:true"
       includePrevious={false}
       currentSeriesNames={[t('All Releases')]}
       yAxis={getYAxis()}
       field={getField()}
+      dataset={DiscoverDatasets.SPANS}
       confirmedQuery={chartType === ReleaseComparisonChartType.FAILURE_RATE}
       partial
       referrer="api.releases.release-details-chart"
@@ -169,7 +164,7 @@ export function ReleaseEventsChart({
           dataset={
             chartType === ReleaseComparisonChartType.ERROR_COUNT
               ? DiscoverDatasets.ERRORS
-              : DiscoverDatasets.METRICS_ENHANCED
+              : DiscoverDatasets.SPANS
           }
           environments={environments}
           start={start ?? null}


### PR DESCRIPTION
This PR replaces the `metricsEnhanced` dataset with the `spans` dataset with `is_transaction:true` for the release comparison table. 

<img width="976" height="274" alt="Screenshot 2026-09-01 at 5 47 40 PM" src="https://github.com/user-attachments/assets/464f4a31-7448-4f99-9949-091711c4807b" />

More details in the tickets.

Closes BROWSE-679
Closes BROWSE-722