### PR TITLE
feat(seer): Record prompt version on night shift deliveries

### DIFF
--- a/src/sentry/seer/agent/feature_delivery.py
+++ b/src/sentry/seer/agent/feature_delivery.py
@@ -21,6 +21,7 @@ class FeatureDeliveryFn(Protocol):
         status: FeatureRunStatus,
         result: dict[str, Any] | None,
         error: str | None,
+        prompt_version: str | None = None,
     ) -> None: ...
 
 

--- a/src/sentry/seer/autofix_rca/delivery.py
+++ b/src/sentry/seer/autofix_rca/delivery.py
@@ -20,6 +20,7 @@ def deliver_autofix_rca_result(
     status: FeatureRunStatus,
     result: dict[str, Any] | None,
     error: str | None,
+    prompt_version: str | None = None,
 ) -> None:
     logger.info(
         "autofix_rca.delivery.received",

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -844,6 +844,7 @@ def deliver_feature_result(
     status: FeatureRunStatus,
     result: dict[str, Any] | None = None,
     error: str | None = None,
+    prompt_version: str | None = None,
 ) -> None:
     """Dispatch a feature result from Seer to the registered handler."""
     handler = DELIVERY_HANDLERS.get(feature_id)
@@ -859,7 +860,7 @@ def deliver_feature_result(
     except (TypeError, ValueError):
         raise ParseError("Invalid run uuid")
 
-    handler(organization_id, parsed_run_uuid, status, result, error)
+    handler(organization_id, parsed_run_uuid, status, result, error, prompt_version)
 
 
 def get_monitoring_provider_connections(

--- a/src/sentry/seer/night_shift/delivery.py
+++ b/src/sentry/seer/night_shift/delivery.py
@@ -49,6 +49,7 @@ def deliver_night_shift_result(
     status: FeatureRunStatus,
     result: dict[str, Any] | None,
     error: str | None,
+    prompt_version: str | None = None,
 ) -> None:
     """Process a night_shift result from Seer."""
     shard = (
@@ -68,16 +69,17 @@ def deliver_night_shift_result(
     # Guaranteed by the seer_run__uuid filter above: a null FK can't match a uuid.
     assert shard.seer_run is not None
 
-    # Per-delivery error_message lives on the shard so a sibling shard's success
-    # can't clear it.
-    if error:
-        shard.update(
-            extras={
-                **(shard.extras or {}),
-                "error_type": SeerNightShiftRunErrorType.SHARD_DELIVERY_FAILED.value,
-                "error_message": error,
-            }
-        )
+    # Per-delivery metadata lives on the shard so a sibling shard's success
+    # can't clear it. prompt_version is written even on error deliveries,
+    # which have no result rows to carry it.
+    if prompt_version or error:
+        extras = {**(shard.extras or {})}
+        if prompt_version:
+            extras["prompt_version"] = prompt_version
+        if error:
+            extras["error_type"] = SeerNightShiftRunErrorType.SHARD_DELIVERY_FAILED.value
+            extras["error_message"] = error
+        shard.update(extras=extras)
 
     log_extra: dict[str, object] = {
         "organization_id": run.organization_id,
@@ -119,6 +121,7 @@ def deliver_night_shift_result(
         organization=run.organization,
         triage_response=triage_response,
         dry_run=dry_run,
+        prompt_version=prompt_version,
         log_extra=log_extra,
     )
 
@@ -129,6 +132,7 @@ def _process_verdicts(
     organization: Organization,
     triage_response: TriageResponse,
     dry_run: bool,
+    prompt_version: str | None,
     log_extra: Mapping[str, object],
 ) -> None:
     """Mark SKIPs, fire autofix for fixable verdicts, and persist one result row
@@ -267,6 +271,9 @@ def _process_verdicts(
     rows: list[SeerNightShiftRunResult] = []
     for v in verdicts:
         extras: dict[str, Any] = {"action": str(v.action)}
+        # Denormalized onto each row so by-prompt-version analysis needs no join.
+        if prompt_version:
+            extras["prompt_version"] = prompt_version
         if v.reason:
             extras["reason"] = v.reason[:REASON_MAX_CHARS]
         if v.action == TriageAction.SKIP and v.skip_reason:

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -217,6 +217,7 @@ def deliver_smart_assignment_result(
     status: FeatureRunStatus,
     result: dict[str, Any] | None,
     error: str | None,
+    prompt_version: str | None = None,
 ) -> None:
     """Resolve a delivered smart_assignment verdict's ranked picks and record them.
 

--- a/tests/sentry/seer/night_shift/test_delivery.py
+++ b/tests/sentry/seer/night_shift/test_delivery.py
@@ -845,3 +845,82 @@ class TestDeliverNightShiftResult(TestCase):
             )
 
             assert mock_trigger.call_args.kwargs["user_context"] is None
+
+    def test_prompt_version_recorded_on_shard_and_result_rows(self) -> None:
+        """prompt_version is recorded on the shard and denormalized onto every verdict row."""
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        group = self.create_group(project=project)
+        run = self._create_night_shift_run(organization=org)
+
+        result = {
+            "verdicts": [
+                {"group_id": group.id, "action": TriageAction.SKIP.value, "reason": "not fixable"}
+            ]
+        }
+
+        with patch("sentry.seer.night_shift.delivery.trigger_autofix_agent"):
+            deliver_night_shift_result(
+                organization_id=org.id,
+                run_uuid=self._run_uuid(run),
+                status="completed",
+                result=result,
+                error=None,
+                prompt_version="2026-09-02.1",
+            )
+
+        redis = redis_clusters.get("default")
+        redis.delete(skip_cache_key(group.id))
+
+        shard = run.shards.get()
+        assert shard.extras["prompt_version"] == "2026-09-02.1"
+        result_row = SeerNightShiftRunResult.objects.get(run=run)
+        assert result_row.extras["prompt_version"] == "2026-09-02.1"
+
+    def test_prompt_version_recorded_on_error_delivery(self) -> None:
+        """Errored deliveries write no verdict rows, so prompt_version lands only on the shard."""
+        run = self._create_night_shift_run()
+
+        deliver_night_shift_result(
+            organization_id=run.organization_id,
+            run_uuid=self._run_uuid(run),
+            status="error",
+            result=None,
+            error="Seer exploded",
+            prompt_version="2026-09-02.1",
+        )
+
+        shard = run.shards.get()
+        assert shard.extras["prompt_version"] == "2026-09-02.1"
+        assert shard.extras["error_message"] == "Seer exploded"
+        assert not SeerNightShiftRunResult.objects.filter(run=run).exists()
+
+    def test_absent_prompt_version_leaves_extras_clean(self) -> None:
+        """Deliveries without a prompt_version (older Seer) must not write the key."""
+        org = self.create_organization()
+        project = self.create_project(organization=org)
+        group = self.create_group(project=project)
+        run = self._create_night_shift_run(organization=org)
+
+        result = {
+            "verdicts": [
+                {"group_id": group.id, "action": TriageAction.SKIP.value, "reason": "not fixable"}
+            ]
+        }
+
+        with patch("sentry.seer.night_shift.delivery.trigger_autofix_agent"):
+            deliver_night_shift_result(
+                organization_id=org.id,
+                run_uuid=self._run_uuid(run),
+                status="completed",
+                result=result,
+                error=None,
+            )
+
+        redis = redis_clusters.get("default")
+        redis.delete(skip_cache_key(group.id))
+
+        shard = run.shards.get()
+        assert "prompt_version" not in shard.extras
+        result_row = SeerNightShiftRunResult.objects.get(run=run)
+        assert "prompt_version" not in result_row.extras


### PR DESCRIPTION
Night shift triage results can now be attributed to the prompt revision that produced them. `deliver_feature_result` accepts an optional Seer-reported `prompt_version` string, and the night shift handler records it in the shard's `extras` — on every delivery, errors included, since failed runs write no result rows — and denormalized onto each `SeerNightShiftRunResult` row, so verdict quality and error rates can be grouped by prompt version without a join. The smart_assignment and autofix handlers accept the kwarg and ignore it for now.

This ships ahead of the Seer-side change, which will add a `PROMPT_VERSION` constant to the night shift feature and pass it on result push. Deploy order matters: Seer must not send the kwarg until this is deployed, as the RPC dispatch would reject the unknown argument and lose the delivered result. Older Seer versions simply omit it and nothing is recorded.
