### PR TITLE
perf(hybridcloud): Reuse cell HTTP connections across webhook deliveries

### DIFF
--- a/src/sentry/hybridcloud/apigateway/proxy.py
+++ b/src/sentry/hybridcloud/apigateway/proxy.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Generator
-from http.cookiejar import Cookie
 from threading import local
-from typing import Any
 from urllib.parse import urljoin
 from wsgiref.util import is_hop_by_hop
 
@@ -18,10 +16,10 @@ from django.http.response import HttpResponseBase
 from requests import Response as ExternalResponse
 from requests import Session
 from requests import request as external_request
-from requests.cookies import RequestsCookieJar
 from requests.exceptions import ConnectionError, Timeout
 
 from sentry import options
+from sentry.net.http import StatelessCookieJar
 from sentry.objectstore.endpoints.organization import ChunkedEncodingDecoder, get_raw_body
 from sentry.options.rollout import in_random_rollout
 from sentry.silo.util import (
@@ -63,18 +61,10 @@ PROXY_CHUNK_SIZE = 512 * 1024
 _connection = local()
 
 
-class _StatelessCookieJar(RequestsCookieJar):
-    def set_cookie(self, cookie: Cookie, *args: Any, **kwargs: Any) -> None:
-        return None
-
-    def extract_cookies(self, response: Any, request: Any) -> None:
-        return None
-
-
 def _get_connection() -> Session:
     if not hasattr(_connection, "session"):
         session = Session()
-        session.cookies = _StatelessCookieJar()
+        session.cookies = StatelessCookieJar()
         _connection.session = session
     return _connection.session
 

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import socket
 from collections.abc import Callable
 from functools import partial
+from http.cookiejar import Cookie
 from typing import Any, Optional, cast
 
 from requests import Session as _Session
@@ -13,6 +14,7 @@ from requests.adapters import (
     HTTPAdapter,
     Retry,
 )
+from requests.cookies import RequestsCookieJar
 from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.connectionpool import connection_from_url as _connection_from_url
@@ -206,6 +208,20 @@ class TimeoutAdapter(HTTPAdapter):
 
 
 USER_AGENT = f"sentry/{SENTRY_VERSION} (https://sentry.io)"
+
+
+class StatelessCookieJar(RequestsCookieJar):
+    """
+    A cookie jar that keeps nothing, for sessions shared across unrelated
+    requests: a `Set-Cookie` from one response must not ride along on the
+    next request or a redirect.
+    """
+
+    def set_cookie(self, cookie: Cookie, *args: Any, **kwargs: Any) -> None:
+        return None
+
+    def extract_cookies(self, response: Any, request: Any) -> None:
+        return None
 
 
 class Session(_Session):

--- a/src/sentry/net/http.py
+++ b/src/sentry/net/http.py
@@ -6,7 +6,13 @@ from functools import partial
 from typing import Any, Optional, cast
 
 from requests import Session as _Session
-from requests.adapters import DEFAULT_POOLBLOCK, DEFAULT_RETRIES, HTTPAdapter, Retry
+from requests.adapters import (
+    DEFAULT_POOLBLOCK,
+    DEFAULT_POOLSIZE,
+    DEFAULT_RETRIES,
+    HTTPAdapter,
+    Retry,
+)
 from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib3.connectionpool import HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.connectionpool import connection_from_url as _connection_from_url
@@ -161,11 +167,12 @@ class BlacklistAdapter(HTTPAdapter):
         self,
         is_ipaddress_permitted: IsIpAddressPermitted = None,
         max_retries: Retry | None | int = DEFAULT_RETRIES,
+        pool_maxsize: int = DEFAULT_POOLSIZE,
     ) -> None:
         # If is_ipaddress_permitted is defined, then we pass it as an additional parameter to freshly created
         # `urllib3.connectionpool.ConnectionPool` instances managed by `SafePoolManager`.
         self.is_ipaddress_permitted = is_ipaddress_permitted
-        super().__init__(max_retries=max_retries)
+        super().__init__(max_retries=max_retries, pool_maxsize=pool_maxsize)
 
     def init_poolmanager(
         self, connections: int, maxsize: int, block: bool = DEFAULT_POOLBLOCK, **pool_kwargs: Any
@@ -217,11 +224,19 @@ class SafeSession(Session):
         self,
         is_ipaddress_permitted: IsIpAddressPermitted = None,
         max_retries: Retry | None = None,
+        pool_maxsize: int = DEFAULT_POOLSIZE,
     ) -> None:
+        """
+        `pool_maxsize` caps the idle connections kept per host. Pools never
+        block, so more concurrent requests than that still go out, but each
+        surplus one opens a connection that is closed instead of pooled.
+        """
         Session.__init__(self)
         self.headers.update({"User-Agent": USER_AGENT})
         adapter = BlacklistAdapter(
-            is_ipaddress_permitted=is_ipaddress_permitted, max_retries=max_retries
+            is_ipaddress_permitted=is_ipaddress_permitted,
+            max_retries=max_retries,
+            pool_maxsize=pool_maxsize,
         )
         self.mount("https://", adapter)
         self.mount("http://", adapter)

--- a/src/sentry/shared_integrations/client/base.py
+++ b/src/sentry/shared_integrations/client/base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping, MutableMapping, Sequence
+from contextlib import AbstractContextManager
 from types import TracebackType
 from typing import Any, Literal, NotRequired, Self, TypedDict, TypeVar, overload
 
@@ -188,6 +189,15 @@ class BaseApiClient:
         """
         return build_session()
 
+    def borrow_session(self) -> AbstractContextManager[SafeSession]:
+        """
+        The session one `_request` call sends on. By default that is a fresh
+        `build_session()` closed when the call ends, so its connection pool
+        never outlives the request. Clients that keep a session across calls
+        override this to hand out the shared one without closing it.
+        """
+        return self.build_session()
+
     @staticmethod
     def _normalize_cert_setting(cert_setting: object) -> str | tuple[str, str] | None:
         # ``requests`` accepts cert as None, a single cert path, or a
@@ -346,7 +356,7 @@ class BaseApiClient:
             extra["api_request_type"] = api_request_type_tag
 
         try:
-            with self.build_session() as session:
+            with self.borrow_session() as session:
                 finalized_request = self.finalize_request(_prepared_request)
                 self.set_proxy_request_options(finalized_request, timeout)
                 environment_settings = session.merge_environment_settings(

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import ipaddress
 import logging
 import socket
+import threading
 from collections.abc import Mapping
+from contextlib import AbstractContextManager, nullcontext
 from hashlib import sha256
 from typing import Any
 
@@ -36,6 +38,12 @@ from sentry.utils import metrics
 
 REQUEST_ATTEMPTS_LIMIT = 10
 CACHE_TIMEOUT = 43200  # 12 hours = 60 * 60 * 12 seconds
+
+# Idle connections a process keeps open per cell. Slots are only taken when a
+# connection is returned, so an oversized pool costs nothing; an undersized one
+# makes every thread past the cap reconnect on each request. Sized above the
+# concurrent deliveries a webhook drain runs.
+CELL_SESSION_POOL_MAXSIZE = 32
 
 
 class SiloClientError(Exception):
@@ -94,6 +102,55 @@ def validate_cell_ip_address(ip: str) -> bool:
     if not result:
         sentry_sdk.capture_exception(CellResolutionError(f"Disallowed Cell Silo IP address: {ip}"))
     return result
+
+
+def _new_cell_session(retries: int | None) -> SafeSession:
+    max_retries = None
+    if retries is not None:
+        max_retries = Retry(
+            total=retries,
+            backoff_factor=0.1,
+            status_forcelist=[503],
+            allowed_methods=["PATCH", "HEAD", "PUT", "GET", "DELETE", "POST"],
+        )
+    return build_session(
+        is_ipaddress_permitted=validate_cell_ip_address,
+        max_retries=max_retries,
+        pool_maxsize=CELL_SESSION_POOL_MAXSIZE,
+    )
+
+
+_cell_sessions: dict[tuple[str, int | None], SafeSession] = {}
+_cell_sessions_lock = threading.Lock()
+
+
+def get_cell_session(cell: Cell, retries: int | None) -> SafeSession:
+    """
+    The process-wide session for requests to `cell`, created on first use.
+
+    Sharing it across `CellSiloClient` instances is what lets connections be
+    reused: a session closed after one request pools nothing. Threads are
+    free to send on it concurrently; urllib3 pools hand out one connection
+    per in-flight request. The retry policy is baked into a session's
+    adapter, so each policy gets its own. Cells get their own too, rather than
+    sharing one session's host pools, so a `PoolManager` LRU-evicting a
+    cell's pool cannot quietly bring back per-request connections.
+    """
+    key = (cell.name, retries)
+    with _cell_sessions_lock:
+        session = _cell_sessions.get(key)
+        if session is None:
+            session = _cell_sessions[key] = _new_cell_session(retries)
+    return session
+
+
+def close_cell_sessions() -> None:
+    """Close and forget every shared cell session. Tests reset with this."""
+    with _cell_sessions_lock:
+        sessions = list(_cell_sessions.values())
+        _cell_sessions.clear()
+    for session in sessions:
+        session.close()
 
 
 class CellSiloClient(BaseApiClient):
@@ -192,25 +249,26 @@ class CellSiloClient(BaseApiClient):
             timeout=timeout,
         )
 
+    def _retries(self) -> int | None:
+        if not self.retry:
+            return None
+        return options.get("hybridcloud.regionsiloclient.retries")
+
     def build_session(self) -> SafeSession:
         """
         Generates a safe Requests session for the API client to use.
         This injects a custom is_ipaddress_permitted function to allow only connections to Cell Silo IP addresses.
         """
-        if not self.retry:
-            return build_session(
-                is_ipaddress_permitted=validate_cell_ip_address,
-            )
+        return _new_cell_session(self._retries())
 
-        return build_session(
-            is_ipaddress_permitted=validate_cell_ip_address,
-            max_retries=Retry(
-                total=options.get("hybridcloud.regionsiloclient.retries"),
-                backoff_factor=0.1,
-                status_forcelist=[503],
-                allowed_methods=["PATCH", "HEAD", "PUT", "GET", "DELETE", "POST"],
-            ),
-        )
+    def borrow_session(self) -> AbstractContextManager[SafeSession]:
+        """
+        Send on the process-wide session for this cell instead of a fresh one
+        per request, and leave it open afterwards so its connections are there
+        for the next request. The cell IP check is bound to the session's
+        pools and runs on every new connection, reused session or not.
+        """
+        return nullcontext(get_cell_session(self.cell, self._retries()))
 
     def _get_hash_cache_key(self, hash: str) -> str:
         return f"region_silo_client:request_attempts:{hash}"

--- a/src/sentry/silo/client.py
+++ b/src/sentry/silo/client.py
@@ -20,7 +20,7 @@ from requests.adapters import Retry
 
 from sentry import options
 from sentry.http import build_session
-from sentry.net.http import SafeSession
+from sentry.net.http import SafeSession, StatelessCookieJar
 from sentry.shared_integrations.client.base import BaseApiClient
 from sentry.silo.base import SiloMode
 from sentry.silo.util import (
@@ -39,11 +39,11 @@ from sentry.utils import metrics
 REQUEST_ATTEMPTS_LIMIT = 10
 CACHE_TIMEOUT = 43200  # 12 hours = 60 * 60 * 12 seconds
 
-# Idle connections a process keeps open per cell. Slots are only taken when a
-# connection is returned, so an oversized pool costs nothing; an undersized one
-# makes every thread past the cap reconnect on each request. Sized above the
-# concurrent deliveries a webhook drain runs.
-CELL_SESSION_POOL_MAXSIZE = 32
+# Idle connections a process keeps open per cell. A thread past the cap still
+# connects, but its connection is closed after use instead of pooled, so this
+# mirrors the most requests one process has in flight to a cell: a webhook
+# drain's `hybridcloud.webhookpayload.worker_threads`.
+CELL_SESSION_POOL_MAXSIZE = 16
 
 
 class SiloClientError(Exception):
@@ -113,14 +113,19 @@ def _new_cell_session(retries: int | None) -> SafeSession:
             status_forcelist=[503],
             allowed_methods=["PATCH", "HEAD", "PUT", "GET", "DELETE", "POST"],
         )
-    return build_session(
+    session = build_session(
         is_ipaddress_permitted=validate_cell_ip_address,
         max_retries=max_retries,
         pool_maxsize=CELL_SESSION_POOL_MAXSIZE,
     )
+    session.cookies = StatelessCookieJar()
+    return session
 
 
-_cell_sessions: dict[tuple[str, int | None], SafeSession] = {}
+# Keyed by cell name and whether the session retries; the value records the
+# retry count the session was built with, so a live change to the retries
+# option replaces the session instead of stranding the old one.
+_cell_sessions: dict[tuple[str, bool], tuple[int | None, SafeSession]] = {}
 _cell_sessions_lock = threading.Lock()
 
 
@@ -132,22 +137,34 @@ def get_cell_session(cell: Cell, retries: int | None) -> SafeSession:
     reused: a session closed after one request pools nothing. Threads are
     free to send on it concurrently; urllib3 pools hand out one connection
     per in-flight request. The retry policy is baked into a session's
-    adapter, so each policy gets its own. Cells get their own too, rather than
-    sharing one session's host pools, so a `PoolManager` LRU-evicting a
-    cell's pool cannot quietly bring back per-request connections.
+    adapter, so the retrying and non-retrying clients get separate sessions,
+    and a session built with a stale retry count is closed and rebuilt. Cells
+    get their own too, rather than sharing one session's host pools, so a
+    `PoolManager` LRU-evicting a cell's pool cannot quietly bring back
+    per-request connections.
     """
-    key = (cell.name, retries)
+    key = (cell.name, retries is not None)
+    stale: SafeSession | None = None
     with _cell_sessions_lock:
-        session = _cell_sessions.get(key)
-        if session is None:
-            session = _cell_sessions[key] = _new_cell_session(retries)
+        entry = _cell_sessions.get(key)
+        if entry is None or entry[0] != retries:
+            if entry is not None:
+                stale = entry[1]
+            session = _new_cell_session(retries)
+            _cell_sessions[key] = (retries, session)
+        else:
+            session = entry[1]
+    if stale is not None:
+        # Requests already running on it keep their connection; closing only
+        # empties its pool so nothing new is handed out.
+        stale.close()
     return session
 
 
 def close_cell_sessions() -> None:
     """Close and forget every shared cell session. Tests reset with this."""
     with _cell_sessions_lock:
-        sessions = list(_cell_sessions.values())
+        sessions = [session for _, session in _cell_sessions.values()]
         _cell_sessions.clear()
     for session in sessions:
         session.close()

--- a/src/sentry/testutils/pytest/sentry.py
+++ b/src/sentry/testutils/pytest/sentry.py
@@ -451,6 +451,12 @@ def pytest_runtest_teardown(item: pytest.Item) -> None:
     ProjectOption.objects.clear_local_cache()
     UserOption.objects.clear_local_cache()
 
+    # Shared cell sessions bind the IP check and cell set they were built
+    # under; a later test that patches either must get a fresh one.
+    from sentry.silo.client import close_cell_sessions
+
+    close_cell_sessions()
+
     sentry_sdk.get_global_scope().set_client(None)
 
 

--- a/tests/sentry/net/test_http.py
+++ b/tests/sentry/net/test_http.py
@@ -1,0 +1,21 @@
+from requests.adapters import DEFAULT_POOLSIZE
+
+from sentry.net.http import SafeSession
+
+
+def _pool(session: SafeSession):
+    return session.get_adapter("https://example.com").poolmanager.connection_from_url(
+        "https://example.com"
+    )
+
+
+def test_safe_session_default_pool_size() -> None:
+    pool = _pool(SafeSession())
+    assert pool.pool is not None
+    assert pool.pool.maxsize == DEFAULT_POOLSIZE
+
+
+def test_safe_session_pool_maxsize_reaches_the_connection_pool() -> None:
+    pool = _pool(SafeSession(pool_maxsize=40))
+    assert pool.pool is not None
+    assert pool.pool.maxsize == 40

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -563,6 +563,34 @@ class CellSessionTest(TestCase):
             assert plain_policy.allowed_methods is not None
             assert "POST" not in plain_policy.allowed_methods
 
+    def test_changing_the_retries_option_replaces_the_session(self) -> None:
+        with override_cells(self.cell_config):
+            with override_options({"hybridcloud.regionsiloclient.retries": 3}):
+                before = get_cell_session(self.cell, 3)
+            with (
+                override_options({"hybridcloud.regionsiloclient.retries": 5}),
+                patch.object(before, "close", wraps=before.close) as mock_close,
+            ):
+                with CellSiloClient(self.cell, retry=True).borrow_session() as after:
+                    pass
+            assert after is not before
+            assert mock_close.call_count == 1
+            assert _cell_adapter(after, "http://na.testserver").max_retries.total == 5
+            # The non-retrying session is untouched by the option.
+            assert get_cell_session(self.cell, None) is get_cell_session(self.cell, None)
+
+    @responses.activate
+    def test_shared_session_keeps_no_cookies(self) -> None:
+        with override_cells(self.cell_config):
+            responses.add(
+                responses.GET,
+                "http://na.testserver/api/0/imaginary/",
+                json={},
+                headers={"Set-Cookie": "session=abc; Path=/"},
+            )
+            CellSiloClient(self.cell).request("GET", "/api/0/imaginary/")
+            assert not get_cell_session(self.cell, None).cookies
+
     def test_session_pool_is_sized_for_concurrent_deliveries(self) -> None:
         with override_cells(self.cell_config):
             session = get_cell_session(self.cell, None)

--- a/tests/sentry/silo/test_client.py
+++ b/tests/sentry/silo/test_client.py
@@ -8,21 +8,27 @@ import responses
 from django.test import RequestFactory, override_settings
 from pytest import raises
 
+from sentry.net.http import BlacklistAdapter, SafeSession
 from sentry.shared_integrations.exceptions import ApiError, ApiHostError
 from sentry.shared_integrations.response.base import BaseApiResponse
 from sentry.silo.base import SiloMode
 from sentry.silo.client import (
     CACHE_TIMEOUT,
+    CELL_SESSION_POOL_MAXSIZE,
     REQUEST_ATTEMPTS_LIMIT,
     CellSiloClient,
     SiloClientError,
+    close_cell_sessions,
     get_cell_ip_addresses,
+    get_cell_session,
     validate_cell_ip_address,
 )
 from sentry.silo.util import PROXY_DIRECT_LOCATION_HEADER, PROXY_SIGNATURE_HEADER
 from sentry.testutils.cases import TestCase
 from sentry.testutils.cell import override_cells
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.hybrid_cloud import override_allowed_cell_silo_ip_addresses
+from sentry.testutils.silo import control_silo_test
 from sentry.types.cell import Cell, CellResolutionError
 from sentry.utils import json
 
@@ -510,3 +516,77 @@ def test_get_cell_ip_addresses_when_single_host_invalid(mock_incr: MagicMock) ->
         # Ensure we log a single metric when IP resolution fails
         assert mock_incr.call_count == 1
         assert mock_incr.call_args.args[0] == "hybrid_cloud.silo_client.ip_address_resolution_error"
+
+
+def _cell_adapter(session: SafeSession, url: str) -> BlacklistAdapter:
+    adapter = session.get_adapter(url)
+    assert isinstance(adapter, BlacklistAdapter)
+    return adapter
+
+
+@control_silo_test
+class CellSessionTest(TestCase):
+    """Cell clients send on one process-wide session per cell and retry policy."""
+
+    def setUp(self) -> None:
+        self.cell = Cell("na", 1, "http://na.testserver")
+        self.other_cell = Cell("eu", 2, "http://eu.testserver")
+        self.cell_config = (self.cell, self.other_cell)
+
+    def test_clients_for_a_cell_share_one_session(self) -> None:
+        with override_cells(self.cell_config):
+            with CellSiloClient(self.cell).borrow_session() as first:
+                pass
+            with CellSiloClient(self.cell).borrow_session() as second:
+                pass
+            assert first is second
+            assert first is get_cell_session(self.cell, None)
+
+    def test_sessions_are_keyed_by_cell_and_retry_policy(self) -> None:
+        with (
+            override_cells(self.cell_config),
+            override_options({"hybridcloud.regionsiloclient.retries": 3}),
+        ):
+            plain = get_cell_session(self.cell, None)
+            assert get_cell_session(self.other_cell, None) is not plain
+
+            with CellSiloClient(self.cell, retry=True).borrow_session() as retrying:
+                pass
+            assert retrying is not plain
+            assert retrying is get_cell_session(self.cell, 3)
+            # requests' default policy never retries a POST; the cell policy does.
+            retrying_policy = _cell_adapter(retrying, "http://na.testserver").max_retries
+            assert retrying_policy.total == 3
+            assert retrying_policy.allowed_methods is not None
+            assert "POST" in retrying_policy.allowed_methods
+            plain_policy = _cell_adapter(plain, "http://na.testserver").max_retries
+            assert plain_policy.allowed_methods is not None
+            assert "POST" not in plain_policy.allowed_methods
+
+    def test_session_pool_is_sized_for_concurrent_deliveries(self) -> None:
+        with override_cells(self.cell_config):
+            session = get_cell_session(self.cell, None)
+            pool = _cell_adapter(session, "http://na.testserver").poolmanager.connection_from_url(
+                "http://na.testserver"
+            )
+            assert pool.pool is not None
+            assert pool.pool.maxsize == CELL_SESSION_POOL_MAXSIZE
+
+    @responses.activate
+    def test_request_leaves_the_shared_session_open(self) -> None:
+        with override_cells(self.cell_config):
+            responses.add(responses.GET, "http://na.testserver/api/0/imaginary/", json={})
+            session = get_cell_session(self.cell, None)
+            with patch.object(session, "close", wraps=session.close) as mock_close:
+                CellSiloClient(self.cell).request("GET", "/api/0/imaginary/")
+                CellSiloClient(self.cell).request("GET", "/api/0/imaginary/")
+            assert mock_close.call_count == 0
+            assert len(responses.calls) == 2
+
+    def test_close_cell_sessions_forgets_and_closes(self) -> None:
+        with override_cells(self.cell_config):
+            session = get_cell_session(self.cell, None)
+            with patch.object(session, "close", wraps=session.close) as mock_close:
+                close_cell_sessions()
+            assert mock_close.call_count == 1
+            assert get_cell_session(self.cell, None) is not session


### PR DESCRIPTION
Every cross-silo request opened a fresh TCP connection. `BaseApiClient._request` builds a session per call and closes it on exit, so the session's connection pool never held anything: `safe_create_connection` spans under the webhook drain transaction match `http.client` spans one to one. The cost per new connection is the TCP/TLS handshake (dominant on the cross-region hop) plus the cell IP allowlist rebuild inside `safe_create_connection`, which re-resolves every cell address.

`CellSiloClient` now sends on one process-wide `SafeSession` per cell and retry policy, created on first use and never closed:

- `BaseApiClient.borrow_session()` is the per-request session scope. The default still builds and closes a session per call; `CellSiloClient` overrides it to hand out the shared session without closing it. `build_session()` keeps building a fresh, correctly configured session for anyone who wants one.
- The registry is a locked module-level dict, not thread-local: webhook drains run deliveries on short-lived pool threads, and a thread-local session would die with them. Cells get separate sessions so a `PoolManager` LRU-evicting a cell's host pool cannot quietly bring per-request connections back.
- `SafeSession` and `BlacklistAdapter` accept `pool_maxsize`. The `HTTPAdapter` default of 10 is below a drain's concurrent deliveries, and with non-blocking pools every surplus connection is created and then discarded, so reuse would silently fail for the threads past the cap. Cell sessions use 32; idle slots cost nothing.
- The cell IP check is bound to the session's pools and runs on every new connection, so it is unchanged by reuse. Test teardown closes the shared sessions so a test that patches the check or the cell set gets a fresh one.

Also covers the integration proxy and the cross-cell forwarding tasks, which go through the same client.

Verification after rollout: the ratio of `sentry.net.socket.safe_create_connection` to `http.client` spans under the drain transaction is the connection churn rate. Watch `hybridcloud.deliver_webhooks.failure{reason:timeout_reset}` for a step from keep-alive connections the cell closed while idle; urllib3 drops detected-closed connections before reuse, but a close that races the send surfaces as a reset.

Refs [CW-1885](https://linear.app/getsentry/issue/CW-1885/reuse-cell-http-connections-across-webhook-deliveries-with-a-process)
