### PR TITLE
fix(admin): Parse project ID in admin home project search

### DIFF
--- a/static/gsAdmin/views/home.spec.tsx
+++ b/static/gsAdmin/views/home.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {ConfigStore} from 'sentry/stores/configStore';
 

--- a/static/gsAdmin/views/home.spec.tsx
+++ b/static/gsAdmin/views/home.spec.tsx
@@ -1,0 +1,88 @@
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {ConfigStore} from 'sentry/stores/configStore';
+
+import {HomePage} from 'admin/views/home';
+
+const US_URL = 'https://us.example.com/api/0/';
+
+const projectResult = {
+  id: '123',
+  slug: 'my-proj',
+  organization: {slug: 'my-org'},
+};
+
+function renderHomePage() {
+  return render(<HomePage />, {
+    initialRouterConfig: {
+      location: {pathname: '/_admin/'},
+      route: '/_admin/',
+    },
+  });
+}
+
+describe('HomePage project search', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    ConfigStore.set('cells', [{name: 'us', locality_url: US_URL}]);
+  });
+
+  it('searches by bare project ID and navigates on select', async () => {
+    const projectsMock = MockApiClient.addMockResponse({
+      url: '/projects/',
+      body: [projectResult],
+    });
+
+    const {router} = renderHomePage();
+    const user = userEvent.setup();
+
+    await user.type(screen.getByRole('textbox', {name: 'Projects (by ID)'}), '123');
+
+    expect(await screen.findByText('my-org')).toBeInTheDocument();
+    expect(projectsMock).toHaveBeenCalledWith(
+      '/projects/',
+      expect.objectContaining({
+        host: US_URL,
+        query: {query: 'id:123', per_page: 10, show: 'all'},
+      })
+    );
+
+    await user.click(screen.getByText('my-org'));
+    expect(router.location.pathname).toBe('/_admin/customers/my-org/projects/my-proj/');
+  });
+
+  it('does not duplicate an existing id: prefix', async () => {
+    const projectsMock = MockApiClient.addMockResponse({
+      url: '/projects/',
+      body: [projectResult],
+    });
+
+    renderHomePage();
+    const user = userEvent.setup();
+
+    await user.type(screen.getByRole('textbox', {name: 'Projects (by ID)'}), 'id:123');
+
+    expect(await screen.findByText('my-org')).toBeInTheDocument();
+    expect(projectsMock).toHaveBeenCalledWith(
+      '/projects/',
+      expect.objectContaining({
+        query: expect.objectContaining({query: 'id:123'}),
+      })
+    );
+  });
+
+  it('does not query for input without a valid ID', async () => {
+    const projectsMock = MockApiClient.addMockResponse({
+      url: '/projects/',
+      body: [projectResult],
+    });
+
+    renderHomePage();
+    const user = userEvent.setup();
+
+    await user.type(screen.getByRole('textbox', {name: 'Projects (by ID)'}), 'my-proj');
+
+    expect(await screen.findByText('No results found')).toBeInTheDocument();
+    await waitFor(() => expect(projectsMock).not.toHaveBeenCalled());
+  });
+});

--- a/static/gsAdmin/views/home.spec.tsx
+++ b/static/gsAdmin/views/home.spec.tsx
@@ -83,6 +83,6 @@ describe('HomePage project search', () => {
     await user.type(screen.getByRole('textbox', {name: 'Projects (by ID)'}), 'my-proj');
 
     expect(await screen.findByText('No results found')).toBeInTheDocument();
-   expect(projectsMock).not.toHaveBeenCalled();
+    expect(projectsMock).not.toHaveBeenCalled();
   });
 });

--- a/static/gsAdmin/views/home.spec.tsx
+++ b/static/gsAdmin/views/home.spec.tsx
@@ -51,7 +51,7 @@ describe('HomePage project search', () => {
     expect(router.location.pathname).toBe('/_admin/customers/my-org/projects/my-proj/');
   });
 
-  it('does not duplicate an existing id: prefix', async () => {
+  it('accepts an existing id: prefix', async () => {
     const projectsMock = MockApiClient.addMockResponse({
       url: '/projects/',
       body: [projectResult],
@@ -83,6 +83,6 @@ describe('HomePage project search', () => {
     await user.type(screen.getByRole('textbox', {name: 'Projects (by ID)'}), 'my-proj');
 
     expect(await screen.findByText('No results found')).toBeInTheDocument();
-    await waitFor(() => expect(projectsMock).not.toHaveBeenCalled());
+   expect(projectsMock).not.toHaveBeenCalled();
   });
 });

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -27,7 +27,7 @@ type ProjectSearchResult = Pick<Project, 'id' | 'slug'> & {
   organization: Pick<OrganizationSummary, 'slug'>;
 };
 
-function parseProjectId(query: string): string | null {
+function normalizeProjectIdQuery(query: string): string | null {
   const match = query.match(/^(?:id:)?\s*(\d+)$/);
   return match?.[1] ?? null;
 }

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -227,7 +227,7 @@ export function HomePage() {
             ]}
             onSelectResult={projSelect}
             queryOptions={query => {
-              const projectId = parseProjectId(query);
+              const projectId = normalizeProjectIdQuery(query);
               return {
                 ...apiOptions.as<ProjectSearchResult[]>()('/projects/', {
                   query: {query: `id:${projectId}`, per_page: 10, show: 'all'},

--- a/static/gsAdmin/views/home.tsx
+++ b/static/gsAdmin/views/home.tsx
@@ -26,6 +26,11 @@ type ProjectSearchResult = Pick<Project, 'id' | 'slug'> & {
   organization: Pick<OrganizationSummary, 'slug'>;
 };
 
+function parseProjectId(query: string): string | null {
+  const match = query.match(/^(?:id:)?\s*(\d+)$/);
+  return match?.[1] ?? null;
+}
+
 function renderOrganizationResult(organization: OrganizationSearchResult) {
   return (
     <Text as="span">
@@ -225,13 +230,17 @@ export function HomePage() {
               project.organization.slug,
             ]}
             onSelectResult={projSelect}
-            queryOptions={query =>
-              apiOptions.as<ProjectSearchResult[]>()('/projects/', {
-                query: {query: `id:${query}`, per_page: 10, show: 'all'},
-                host: localityUrl,
-                staleTime: 30_000,
-              })
-            }
+            queryOptions={query => {
+              const projectId = parseProjectId(query);
+              return {
+                ...apiOptions.as<ProjectSearchResult[]>()('/projects/', {
+                  query: {query: `id:${projectId}`, per_page: 10, show: 'all'},
+                  host: localityUrl,
+                  staleTime: 30_000,
+                }),
+                enabled: projectId !== null,
+              };
+            }}
             renderResult={renderProjectResult}
           />
         </Container>


### PR DESCRIPTION
- The project search on the `_admin` index prefixed every input with `id:`. Input that already contained an `id:` prefix, or any non-numeric input, produced `query=id:id:<value>`. The backend rejected it with a 400, and the client retried, so the field appeared to re-poll and fail.
- Parse the project ID from the input. The field now accepts a bare number or an `id:<number>` value.
- Skip the request when the input holds no valid ID. The dropdown then shows "No results found" instead of an error.