### PR TITLE
feat(admin): Query all regions in parallel on the customers page

### DIFF
--- a/static/gsAdmin/components/customerGrid.tsx
+++ b/static/gsAdmin/components/customerGrid.tsx
@@ -19,7 +19,7 @@ type Props = Omit<Partial<ResultGridProps>, 'endpoint'> &
   Pick<ResultGridProps, 'endpoint'>;
 
 const growth = (current: number | undefined, prev: number | undefined) =>
-  current && prev ? current / prev - 1 : 0;
+  current === undefined || !prev ? 0 : current / prev - 1;
 
 /**
  * Mirrors the server's sort keys so the all-regions view can keep merged

--- a/static/gsAdmin/components/customerGrid.tsx
+++ b/static/gsAdmin/components/customerGrid.tsx
@@ -18,6 +18,56 @@ type ResultGridProps = React.ComponentProps<typeof ResultGrid>;
 type Props = Omit<Partial<ResultGridProps>, 'endpoint'> &
   Pick<ResultGridProps, 'endpoint'>;
 
+const growth = (current: number | undefined, prev: number | undefined) =>
+  current && prev ? current / prev - 1 : 0;
+
+/**
+ * Mirrors the server's sort keys so the all-regions view can keep merged
+ * results ordered client-side. Returns the value the key sorts on, descending.
+ */
+const sortValueForRow = (row: Subscription, sortBy: string): number => {
+  switch (sortBy) {
+    case 'date':
+      return new Date(row.dateJoined).getTime();
+    case 'members':
+      return row.totalMembers ?? 0;
+    case 'events.30d':
+      return row.stats?.events30d ?? 0;
+    case 'events.30d.growth':
+      return growth(row.stats?.events30d, row.stats?.eventsPrev30d);
+    case 'events.24h':
+      return row.stats?.events24h ?? 0;
+    case 'events.24h.growth':
+      return growth(row.stats?.events24h, row.stats?.eventsPrev24h);
+    case 'projects':
+      return row.totalProjects ?? 0;
+    default:
+      return 0;
+  }
+};
+
+const columns = [
+  <th key="customer">Customer</th>,
+  <th key="events" style={{width: 130, textAlign: 'center'}}>
+    Events (30d)
+  </th>,
+  <th key="members" style={{width: 85, textAlign: 'center'}}>
+    Members
+  </th>,
+  <th key="status" style={{width: 150, textAlign: 'center'}}>
+    Status
+  </th>,
+  <th key="ondemand" style={{width: 100, textAlign: 'center'}}>
+    OnDemand
+  </th>,
+  <th key="acv" style={{width: 100, textAlign: 'center'}}>
+    ACV
+  </th>,
+  <th key="joined" style={{width: 150, textAlign: 'right'}}>
+    Joined
+  </th>,
+];
+
 const getRow = (row: Subscription) => [
   <td key="customer">
     <CustomerName>
@@ -87,27 +137,11 @@ export function CustomerGrid(props: Props) {
       exactMatchQuery={(row: Subscription, query: string) => row.slug === query}
       path="/_admin/customers/"
       method="GET"
-      columns={[
-        <th key="customer">Customer</th>,
-        <th key="events" style={{width: 130, textAlign: 'center'}}>
-          Events (30d)
-        </th>,
-        <th key="members" style={{width: 85, textAlign: 'center'}}>
-          Members
-        </th>,
-        <th key="status" style={{width: 150, textAlign: 'center'}}>
-          Status
-        </th>,
-        <th key="ondemand" style={{width: 100, textAlign: 'center'}}>
-          OnDemand
-        </th>,
-        <th key="acv" style={{width: 100, textAlign: 'center'}}>
-          ACV
-        </th>,
-        <th key="joined" style={{width: 150, textAlign: 'right'}}>
-          Joined
-        </th>,
-      ]}
+      sortValueForRow={sortValueForRow}
+      columns={columns}
+      // Keep the contextual Region column with the other metadata, between
+      // ACV and Joined.
+      regionColumnIndex={columns.length - 1}
       columnsForRow={getRow}
       hasSearch
       filters={{

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -524,6 +524,26 @@ describe('ResultGrid allowAllRegions', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows no cross-region hint while all regions are already queried', async () => {
+    // The user-details membership grid combines allowAllRegions with
+    // probeAllRegions; the probe hint only applies after narrowing to one region.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme', members: 5}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Beta', members: 10}],
+    });
+
+    renderGrid(undefined, {}, {...allRegionsProps, probeAllRegions: true});
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'View in us'})).not.toBeInTheDocument();
+  });
+
   it('marks a region as failed when the fetch itself rejects (e.g. blocked request)', async () => {
     // The real API client swallows fetch rejections without calling success
     // or error, so the grid must resolve the region through requestPromise.

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -570,6 +570,90 @@ describe('ResultGrid allowAllRegions', () => {
     ).toBeInTheDocument();
   });
 
+  it('loads the next page of every region that has one', async () => {
+    const usFirstPage = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      match: [MockApiClient.matchData({cursor: ''})],
+      body: [{id: '1', name: 'Acme', members: 5}],
+      headers: {
+        Link:
+          '<https://us.example.com/api/0/_admin/cells/us/customers/?cursor=0:1:0>; ' +
+          'rel="next"; results="true"; cursor="0:1:0"',
+      },
+    });
+    const usSecondPage = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      match: [MockApiClient.matchData({cursor: '0:1:0'})],
+      body: [{id: '2', name: 'Beta', members: 4}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '3', name: 'Ceta', members: 3}],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    // Only the us region has a second page, so only it is named.
+    const loadMore = await screen.findByRole('button', {name: 'Load more (us)'});
+    expect(usFirstPage).toHaveBeenCalledTimes(1);
+    expect(usSecondPage).not.toHaveBeenCalled();
+
+    await userEvent.click(loadMore);
+
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+    // The rows already on screen stay, merged with the new page.
+    expect(screen.getByText('Acme')).toBeInTheDocument();
+    expect(screen.getByText('Ceta')).toBeInTheDocument();
+  });
+
+  it('drops the load more control once every region is exhausted', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      match: [MockApiClient.matchData({cursor: ''})],
+      body: [{id: '1', name: 'Acme', members: 5}],
+      headers: {
+        Link:
+          '<https://us.example.com/api/0/_admin/cells/us/customers/?cursor=0:1:0>; ' +
+          'rel="next"; results="true"; cursor="0:1:0"',
+      },
+    });
+    // The last page reports no further results.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      match: [MockApiClient.matchData({cursor: '0:1:0'})],
+      body: [{id: '2', name: 'Beta', members: 4}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Load more (us)'}));
+
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByRole('button', {name: /Load more/})).not.toBeInTheDocument()
+    );
+  });
+
+  it('shows no load more control when a single page holds every result', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme', members: 5}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Beta', members: 10}],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /Load more/})).not.toBeInTheDocument();
+  });
+
   it('errors only when every region fails', async () => {
     MockApiClient.addMockResponse({
       url: '/_admin/cells/us/customers/',

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -638,6 +638,41 @@ describe('ResultGrid allowAllRegions', () => {
     );
   });
 
+  it('keeps the warning of a failed region while another region loads more', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      match: [MockApiClient.matchData({cursor: ''})],
+      body: [{id: '1', name: 'Acme', members: 5}],
+      headers: {
+        Link:
+          '<https://us.example.com/api/0/_admin/cells/us/customers/?cursor=0:1:0>; ' +
+          'rel="next"; results="true"; cursor="0:1:0"',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      match: [MockApiClient.matchData({cursor: '0:1:0'})],
+      body: [{id: '2', name: 'Beta', members: 4}],
+    });
+    // The de region never answers, so it holds no cursor and nothing retries
+    // it. Its results stay missing from the merged table.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      statusCode: 500,
+      body: {},
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('1 region failed')).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Load more (us)'}));
+
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+    expect(screen.getByText('1 region failed')).toBeInTheDocument();
+    expect(screen.getByLabelText('Some regions failed to load')).toBeInTheDocument();
+  });
+
   it('shows no load more control when a single page holds every result', async () => {
     MockApiClient.addMockResponse({
       url: '/_admin/cells/us/customers/',

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -6,6 +6,7 @@ import {ResultGrid} from 'admin/components/resultGrid';
 
 const US_URL = 'https://us.example.com/api/0/';
 const DE_URL = 'https://de.example.com/api/0/';
+const EU_URL = 'https://eu.example.com/api/0/';
 
 function setupCells() {
   ConfigStore.set('cells', [
@@ -702,6 +703,52 @@ describe('ResultGrid allowAllRegions', () => {
     });
 
     renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('Something bad happened :/')).toBeInTheDocument();
+  });
+
+  it('errors when every region of a load more fails with nothing to show', async () => {
+    ConfigStore.set('cells', [
+      {name: 'us', locality_url: US_URL},
+      {name: 'de', locality_url: DE_URL},
+      {name: 'eu', locality_url: EU_URL},
+    ]);
+
+    // The us region answers empty but promises a further page, so it is the
+    // only region a load more asks again.
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      match: [MockApiClient.matchData({cursor: ''})],
+      body: [],
+      headers: {
+        Link:
+          '<https://us.example.com/api/0/_admin/cells/us/customers/?cursor=0:1:0>; ' +
+          'rel="next"; results="true"; cursor="0:1:0"',
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      match: [MockApiClient.matchData({cursor: '0:1:0'})],
+      statusCode: 500,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      statusCode: 500,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/eu/customers/',
+      statusCode: 500,
+      body: {},
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('2 regions failed')).toBeInTheDocument();
+    expect(screen.queryByText('Something bad happened :/')).not.toBeInTheDocument();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Load more (us)'}));
 
     expect(await screen.findByText('Something bad happened :/')).toBeInTheDocument();
   });

--- a/static/gsAdmin/components/resultGrid.spec.tsx
+++ b/static/gsAdmin/components/resultGrid.spec.tsx
@@ -329,3 +329,241 @@ describe('ResultGrid probeAllRegions', () => {
     expect(screen.queryByRole('button', {name: 'View in de'})).not.toBeInTheDocument();
   });
 });
+
+describe('ResultGrid allowAllRegions', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    setupCells();
+  });
+
+  const allRegionsProps = {
+    allowAllRegions: true,
+    sortValueForRow: (row: any) => row.members ?? 0,
+    defaultSort: 'members',
+  };
+
+  it('queries every region in parallel and shows a Region column', async () => {
+    const usRequest = MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme', members: 5}],
+    });
+    const deRequest = MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Beta', members: 10}],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+    expect(screen.getByRole('columnheader', {name: 'Region'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'us'})).toBeInTheDocument();
+    expect(screen.getByRole('cell', {name: 'de'})).toBeInTheDocument();
+    expect(usRequest).toHaveBeenCalledWith(
+      '/_admin/cells/us/customers/',
+      expect.objectContaining({host: US_URL})
+    );
+    expect(deRequest).toHaveBeenCalledWith(
+      '/_admin/cells/de/customers/',
+      expect.objectContaining({host: DE_URL})
+    );
+  });
+
+  it('keeps the merged rows sorted by the sort value', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [
+        {id: '1', name: 'Acme', members: 5},
+        {id: '3', name: 'Corge', members: 20},
+      ],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Beta', members: 10}],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+
+    const rows = screen.getAllByRole('row').slice(1); // drop the header row
+    const names = rows.map(row => row.textContent);
+    expect(names[0]).toContain('Corge');
+    expect(names[1]).toContain('Beta');
+    expect(names[2]).toContain('Acme');
+  });
+
+  it('places the Region column at regionColumnIndex', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme', members: 5}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [],
+    });
+
+    renderGrid(
+      undefined,
+      {},
+      {
+        ...allRegionsProps,
+        columns: [<th key="name">Customer</th>, <th key="joined">Joined</th>],
+        columnsForRow: (row: any) => [
+          <td key="name">{row.name}</td>,
+          <td key="joined">2024</td>,
+        ],
+        regionColumnIndex: 1,
+      }
+    );
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers.map(h => h.textContent)).toEqual(['Customer', 'Region', 'Joined']);
+    const cells = screen.getAllByRole('cell');
+    expect(cells.map(c => c.textContent)).toEqual(['Acme', 'us', '2024']);
+  });
+
+  it('shows the still-loading regions and a progress bar instead of "No results"', async () => {
+    let finishDe!: () => void;
+    const deGate = new Promise<void>(resolve => {
+      finishDe = resolve;
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme', members: 5}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Beta', members: 10}],
+      asyncDelay: deGate,
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    // The status note lists the outstanding region and the table shows an
+    // indeterminate progress bar while any region is still loading.
+    expect(await screen.findByText('Still loading')).toBeInTheDocument();
+    const status = screen.getByRole('status');
+    expect(status).toHaveTextContent('de');
+    expect(screen.getByTestId('table-progress')).toBeInTheDocument();
+    expect(screen.queryByText('No results')).not.toBeInTheDocument();
+
+    // Rows that already arrived render below.
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+
+    finishDe();
+
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText('Still loading')).not.toBeInTheDocument()
+    );
+    expect(screen.queryByTestId('table-progress')).not.toBeInTheDocument();
+  });
+
+  it('shows "No results" only once every region has answered empty', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('No results')).toBeInTheDocument();
+    expect(screen.queryByText('Still loading')).not.toBeInTheDocument();
+  });
+
+  it('switches to a single region from the selector', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme', members: 5}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      body: [{id: '2', name: 'Beta', members: 10}],
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('Beta')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: /Region/}));
+    await userEvent.click(await screen.findByRole('option', {name: 'us'}));
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    await waitFor(() => expect(screen.queryByText('Beta')).not.toBeInTheDocument());
+    expect(screen.queryByRole('columnheader', {name: 'Region'})).not.toBeInTheDocument();
+  });
+
+  it('flags a failed region with a warning icon and tooltip', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      body: [{id: '1', name: 'Acme', members: 5}],
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      statusCode: 500,
+      body: {},
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    expect(await screen.findByText('1 region failed')).toBeInTheDocument();
+
+    const icon = screen.getByLabelText('Some regions failed to load');
+    await userEvent.hover(icon);
+    expect(
+      await screen.findByText('Could not load results from: de')
+    ).toBeInTheDocument();
+  });
+
+  it('marks a region as failed when the fetch itself rejects (e.g. blocked request)', async () => {
+    // The real API client swallows fetch rejections without calling success
+    // or error, so the grid must resolve the region through requestPromise.
+    const stubApi = {
+      clear: jest.fn(),
+      request: jest.fn((url: string, options: any) => {
+        if (url.startsWith('/_admin/cells/us/')) {
+          options.success([{id: '1', name: 'Acme', members: 5}], 'success', {
+            getResponseHeader: () => null,
+          });
+          return {requestPromise: Promise.resolve()};
+        }
+        return {requestPromise: Promise.reject(new Error('Failed to fetch'))};
+      }),
+    };
+
+    renderGrid(undefined, {}, {...allRegionsProps, api: stubApi});
+
+    expect(await screen.findByText('Acme')).toBeInTheDocument();
+    expect(await screen.findByText('1 region failed')).toBeInTheDocument();
+    await userEvent.hover(screen.getByLabelText('Some regions failed to load'));
+    expect(
+      await screen.findByText('Could not load results from: de')
+    ).toBeInTheDocument();
+  });
+
+  it('errors only when every region fails', async () => {
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/us/customers/',
+      statusCode: 500,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: '/_admin/cells/de/customers/',
+      statusCode: 500,
+      body: {},
+    });
+
+    renderGrid(undefined, {}, allRegionsProps);
+
+    expect(await screen.findByText('Something bad happened :/')).toBeInTheDocument();
+  });
+});

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -1,4 +1,5 @@
-import {cloneElement, Component, isValidElement} from 'react';
+import {cloneElement, Component, Fragment, isValidElement} from 'react';
+import {keyframes} from '@emotion/react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
@@ -10,13 +11,14 @@ import {Input} from '@sentry/scraps/input';
 import {Flex, Container} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Pagination} from '@sentry/scraps/pagination';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import type {Client} from 'sentry/api';
 import {EmptyMessage} from 'sentry/components/emptyMessage';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {Panel} from 'sentry/components/panels/panel';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
-import {IconList, IconSearch} from 'sentry/icons';
+import {IconList, IconSearch, IconWarning} from 'sentry/icons';
 import type {Cell} from 'sentry/types/system';
 import {getCells} from 'sentry/utils/cells';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
@@ -28,6 +30,12 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {ResultTable} from 'admin/components/resultTable';
 
 type Option = [key: string, label: string];
+
+/**
+ * Sentinel region-selector value that means "query every region at once".
+ * Locality URLs are always full URLs, so this cannot collide with one.
+ */
+const ALL_REGIONS = 'all';
 
 function extractColumnLabel(col: React.ReactNode): string {
   if (!isValidElement(col)) {
@@ -77,7 +85,7 @@ function Filter({name, queryKey, options, path, location, value}: FilterProps) {
   return (
     <CompactSelect
       trigger={triggerProps => (
-        <OverlayTrigger.Button {...triggerProps} prefix={name} size="xs" />
+        <OverlayTrigger.Button {...triggerProps} prefix={name} size="sm" />
       )}
       value={value}
       onChange={opt => onFilter(opt.value)}
@@ -105,6 +113,7 @@ function SortBy({options, path, location, value}: SortByProps) {
           {...triggerProps}
           icon={<IconList size="xs" />}
           prefix="Sort By"
+          size="sm"
         />
       )}
       value={value}
@@ -140,6 +149,21 @@ interface ResultGridProps {
    * The relative path to map result URLs to
    */
   path: string;
+  /**
+   * Adds an "All regions" option to the region selector — selected by default —
+   * that queries every region in parallel and merges the results into a single
+   * table with a Region column (placed by `regionColumnIndex`). Rows appear as
+   * each region responds.
+   *
+   * Cursors do not compose across regions, so this mode always merges each
+   * region's first page and hides pagination. Provide `sortValueForRow` so the
+   * merged rows keep a coherent order as regions trickle in.
+   *
+   * Only meaningful together with `isRegional`/`isCellScoped`.
+   *
+   * @default false
+   */
+  allowAllRegions?: boolean;
   /**
    * Button on the right side of the header
    */
@@ -268,6 +292,12 @@ interface ResultGridProps {
    */
   probeAllRegionsHint?: string;
   /**
+   * Index in `columns` where the all-regions Region column is inserted.
+   *
+   * @default 0
+   */
+  regionColumnIndex?: number;
+  /**
    * Translates the data object from the request into rows
    */
   rowsFromData?: (data: any, cell: Cell | undefined) => any[];
@@ -276,12 +306,26 @@ interface ResultGridProps {
    */
   sortOptions?: Option[];
   /**
+   * Returns the numeric sort value of a row for the given `sortBy` key, used
+   * to keep the merged all-regions table sorted client-side (descending, to
+   * match the server's ordering). Each region's page is already server-sorted;
+   * this lets the merged view interleave them correctly as responses arrive.
+   *
+   * Only used in the `allowAllRegions` mode.
+   */
+  sortValueForRow?: (row: any, sortBy: string) => number;
+  /**
    * TODO
    */
   useQueryString?: boolean;
 }
 
 export type State = {
+  /**
+   * Whether the grid is in the all-regions mode: every region is queried in
+   * parallel and the results are merged. `cell` is undefined while active.
+   */
+  allRegions: boolean;
   cell: Cell | undefined;
   cursor: string;
   error: boolean;
@@ -295,10 +339,18 @@ export type State = {
   missingExactMatch: boolean;
   pageLinks: string | null;
   /**
+   * Names of regions whose all-regions request is still in flight.
+   */
+  pendingRegions: string[];
+  /**
    * Whether we are currently probing other regions after a missing exact match.
    */
   probingRegions: boolean;
   query: string;
+  /**
+   * Names of regions whose all-regions request failed.
+   */
+  regionErrors: string[];
   /**
    * Other regions that have at least one match for the active search.
    */
@@ -333,6 +385,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     hasPagination: true,
     isCellScoped: false,
     isRegional: false,
+    allowAllRegions: false,
     probeAcrossRegions: false,
     probeAllRegions: false,
     useQueryString: true,
@@ -347,6 +400,13 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     const needsRegion = this.props.isRegional || this.props.isCellScoped;
     const cells = getCells();
 
+    const requestedCell = regionUrl
+      ? cells.find(c => c.locality_url === extractQuery(regionUrl))
+      : undefined;
+    const allRegions = Boolean(
+      needsRegion && this.props.allowAllRegions && !requestedCell
+    );
+
     this.state = {
       rows: [],
       loading: true,
@@ -354,16 +414,15 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       pageLinks: null,
       cursor: extractQuery(cursor),
       query: extractQuery(query),
-      cell: needsRegion
-        ? regionUrl
-          ? cells.find(c => c.locality_url === extractQuery(regionUrl))
-          : cells[0]
-        : undefined,
+      allRegions,
+      cell: needsRegion && !allRegions ? (requestedCell ?? cells[0]) : undefined,
       sortBy: extractQuery(sortBy, this.props.defaultSort),
       filters: Object.assign({}, queryParams),
       regionMatches: [],
       probingRegions: false,
       missingExactMatch: false,
+      pendingRegions: [],
+      regionErrors: [],
     };
   }
 
@@ -406,6 +465,8 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         regionMatches: [],
         probingRegions: false,
         missingExactMatch: false,
+        pendingRegions: [],
+        regionErrors: [],
       },
       this.fetchData
     );
@@ -416,6 +477,13 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
    * when the user switches regions or searches again before probes resolve).
    */
   probeToken = 0;
+
+  /**
+   * Monotonic token used to discard responses from a superseded all-regions
+   * fetch (e.g. the user changed the sort or region while regions were still
+   * responding).
+   */
+  fetchToken = 0;
 
   refresh() {
     this.setState({loading: true}, this.fetchData);
@@ -440,15 +508,20 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     // the token) and clear its UI state here, the single entry point for fetches,
     // so it's reset regardless of which caller (refresh/onCursor/onSearch) we hit.
     this.probeToken += 1;
+    this.fetchToken += 1;
     if (
       this.state.probingRegions ||
       this.state.regionMatches.length > 0 ||
-      this.state.missingExactMatch
+      this.state.missingExactMatch ||
+      this.state.pendingRegions.length > 0 ||
+      this.state.regionErrors.length > 0
     ) {
       this.setState({
         probingRegions: false,
         regionMatches: [],
         missingExactMatch: false,
+        pendingRegions: [],
+        regionErrors: [],
       });
     }
 
@@ -459,6 +532,11 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       sortBy: this.state.sortBy,
       cursor: this.state.cursor,
     };
+
+    if (this.state.allRegions) {
+      this.fetchAllRegions(queryParams);
+      return;
+    }
 
     const endpoint = this.cellEndpoint(this.state.cell);
 
@@ -535,6 +613,107 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
   };
 
   /**
+   * Re-sort merged all-regions rows with `sortValueForRow`, descending to
+   * match the server's ordering. Without the prop, rows keep arrival order.
+   */
+  sortRows(rows: any[]) {
+    const {sortValueForRow} = this.props;
+    if (!sortValueForRow) {
+      return rows;
+    }
+    const {sortBy} = this.state;
+    return rows.toSorted(
+      (a, b) => sortValueForRow(b, sortBy) - sortValueForRow(a, sortBy)
+    );
+  }
+
+  /**
+   * Query every region in parallel and merge the results into one table. Each
+   * region's rows are tagged with their cell (rendered as the Region column)
+   * and the merged set is re-sorted as every response arrives, so the table
+   * stays coherently ordered while regions trickle in.
+   */
+  fetchAllRegions = (queryParams: Record<string, any>) => {
+    const cells = getCells();
+    const token = this.fetchToken;
+
+    if (cells.length === 0) {
+      this.setState({loading: false, error: false, rows: [], pageLinks: null});
+      return;
+    }
+
+    this.setState({
+      loading: false,
+      error: false,
+      rows: [],
+      pageLinks: null,
+      pendingRegions: cells.map(c => c.name),
+      regionErrors: [],
+    });
+
+    // Cursors do not compose across regions; always merge first pages.
+    const params = {...queryParams, cursor: ''};
+
+    cells.forEach(cell => {
+      const markFailed = () => {
+        if (token !== this.fetchToken) {
+          return;
+        }
+        this.setState(prev => {
+          if (!prev.pendingRegions.includes(cell.name)) {
+            return null;
+          }
+          const regionErrors = [...prev.regionErrors, cell.name];
+          return {
+            error: regionErrors.length === cells.length,
+            pendingRegions: prev.pendingRegions.filter(name => name !== cell.name),
+            regionErrors,
+          };
+        });
+      };
+
+      const request = this.props.api.request(this.cellEndpoint(cell), {
+        method: this.props.method,
+        host: cell.locality_url,
+        data: params,
+        success: data => {
+          if (token !== this.fetchToken) {
+            return;
+          }
+          const rows = this.props.rowsFromData?.(data, cell) ?? data;
+          const tagged = (Array.isArray(rows) ? rows : []).map(row => ({
+            ...row,
+            __region: cell,
+          }));
+          this.setState(prev => {
+            if (!prev.pendingRegions.includes(cell.name)) {
+              return null;
+            }
+            return {
+              rows: this.sortRows([...prev.rows, ...tagged]),
+              pendingRegions: prev.pendingRegions.filter(name => name !== cell.name),
+            };
+          });
+          this.props.onLoad?.();
+        },
+        error: res => {
+          markFailed();
+          if (this.props.onError) {
+            this.props.onError(res);
+          }
+        },
+      });
+
+      // The API client swallows a rejection of the fetch itself (a blocked
+      // request, a network failure) without running either callback, which
+      // would leave the region pending forever. Catch it here so the region
+      // resolves to failed. An abort from api.clear() also lands here, but
+      // the fetch token was already bumped by then, so markFailed ignores it.
+      request?.requestPromise?.catch(markFailed);
+    });
+  };
+
+  /**
    * Fire a cheap (`per_page: 1`) search against every other region to find out
    * which ones have matches for the current query. Runs only after the active
    * region returns no results, so there is no cost on the common path.
@@ -586,14 +765,35 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
   };
 
   onChangeCell = (localityUrl: string | undefined) => {
+    // Invalidate any in-flight probe before switching regions.
+    this.probeToken += 1;
+
+    if (localityUrl === ALL_REGIONS) {
+      this.setState(
+        {
+          allRegions: true,
+          cell: undefined,
+          loading: true,
+          regionMatches: [],
+          probingRegions: false,
+        },
+        this.fetchData
+      );
+      return;
+    }
+
     const cell = getCells().find(c => c.locality_url === localityUrl);
     if (cell === undefined) {
       return;
     }
-    // Invalidate any in-flight probe before switching regions.
-    this.probeToken += 1;
     this.setState(
-      {cell, loading: true, regionMatches: [], probingRegions: false},
+      {
+        allRegions: false,
+        cell,
+        loading: true,
+        regionMatches: [],
+        probingRegions: false,
+      },
       this.fetchData
     );
   };
@@ -628,10 +828,35 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     this.setState({cursor: cursor ?? '', loading: true}, this.fetchData);
   };
 
+  /**
+   * Where the Region column sits in the all-regions mode, clamped to the
+   * column list.
+   */
+  clampedRegionIndex() {
+    const {columns, regionColumnIndex} = this.props;
+    return Math.min(Math.max(regionColumnIndex ?? 0, 0), columns.length);
+  }
+
+  /**
+   * The table columns, with the Region column inserted in the all-regions mode.
+   */
+  effectiveColumns() {
+    if (!this.state.allRegions) {
+      return this.props.columns;
+    }
+    return this.props.columns.toSpliced(
+      this.clampedRegionIndex(),
+      0,
+      <th key="__region" style={{width: 70}}>
+        Region
+      </th>
+    );
+  }
+
   renderLoading() {
     return (
       <tr>
-        <td colSpan={this.props.columns.length}>
+        <td colSpan={this.effectiveColumns().length}>
           <LoadingIndicator>Hold on to your butts!</LoadingIndicator>
         </td>
       </tr>
@@ -641,7 +866,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
   renderError() {
     return (
       <tr>
-        <td colSpan={this.props.columns.length}>
+        <td colSpan={this.effectiveColumns().length}>
           <ErrorAlert variant="danger" showIcon>
             Something bad happened :/
           </ErrorAlert>
@@ -653,15 +878,38 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
   renderNoResults() {
     return (
       <tr>
-        <td colSpan={this.props.columns.length}>
+        <td colSpan={this.effectiveColumns().length}>
           <EmptyMessage>No results</EmptyMessage>
         </td>
       </tr>
     );
   }
 
+  /**
+   * The all-regions table body. Rows render as regions respond. The "still
+   * updating" signal lives outside the body: an indeterminate bar on top of
+   * the table plus the pending-regions note in the selector row, so rows
+   * never shift while regions trickle in. "No results" only shows once every
+   * region has answered.
+   */
+  renderAllRegionsBody() {
+    const {loading, pendingRegions, rows} = this.state;
+    if (rows.length > 0) {
+      return this.renderResults();
+    }
+    if (loading || pendingRegions.length > 0) {
+      return this.renderLoading();
+    }
+    return this.renderNoResults();
+  }
+
   renderRegionHint() {
     const {probeAcrossRegions, probeAllRegions} = this.props;
+
+    // The all-regions mode already shows every region's results.
+    if (this.state.allRegions) {
+      return null;
+    }
 
     if (
       (!probeAcrossRegions && !probeAllRegions) ||
@@ -731,8 +979,14 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
   }
 
   renderResults() {
-    const columnLabels = this.props.columns.map(extractColumnLabel);
-    const firstPrimaryIndex = columnLabels.findIndex(label => (label ?? '') !== '');
+    const {allRegions} = this.state;
+    const regionIndex = allRegions ? this.clampedRegionIndex() : -1;
+    const columnLabels = this.effectiveColumns().map(extractColumnLabel);
+    // The Region column is contextual — keep the record's own first labeled
+    // column as the mobile-primary cell.
+    const firstPrimaryIndex = columnLabels.findIndex(
+      (label, index) => index !== regionIndex && (label ?? '') !== ''
+    );
 
     // CSS custom properties on <tr> carry column labels to ::before pseudo-elements
     // via inheritance, which works even when cells are rendered inside wrapper components
@@ -745,7 +999,11 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     );
 
     return this.state.rows.map((row, i) => {
-      const cells = this.props.columnsForRow?.(row, this.state.rows, this.state) ?? [];
+      const rowRegion: Cell | undefined = allRegions ? row.__region : undefined;
+      const rowCells = this.props.columnsForRow?.(row, this.state.rows, this.state) ?? [];
+      const cells = allRegions
+        ? rowCells.toSpliced(regionIndex, 0, <td key="__region">{rowRegion?.name}</td>)
+        : rowCells;
       const labeledCells = cells.map((cell, j) => {
         if (!isValidElement(cell)) {
           return cell;
@@ -759,8 +1017,10 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
           extraProps
         );
       });
+      const rowKey = this.props.keyForRow?.(row) ?? i;
       return (
-        <tr key={this.props.keyForRow?.(row) ?? i} style={labelVars}>
+        // Row ids can collide across regions, so scope the key by region.
+        <tr key={rowRegion ? `${rowRegion.name}:${rowKey}` : rowKey} style={labelVars}>
           {labeledCells}
         </tr>
       );
@@ -774,7 +1034,6 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       sortOptions,
       path,
       location,
-      columns,
       hasPagination,
       hasSearch,
       inPanel,
@@ -785,18 +1044,25 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
 
     const resultTable = (
       <TableScrollWrapper>
+        {this.state.pendingRegions.length > 0 && (
+          <TableProgressBar data-test-id="table-progress" aria-hidden>
+            <TableProgressValue />
+          </TableProgressBar>
+        )}
         <ResultTable>
           <thead>
-            <tr>{columns}</tr>
+            <tr>{this.effectiveColumns()}</tr>
           </thead>
           <tbody>
-            {this.state.loading
-              ? this.renderLoading()
-              : this.state.error
-                ? this.renderError()
-                : this.state.rows.length === 0
-                  ? this.renderNoResults()
-                  : this.renderResults()}
+            {this.state.error
+              ? this.renderError()
+              : this.state.allRegions
+                ? this.renderAllRegionsBody()
+                : this.state.loading
+                  ? this.renderLoading()
+                  : this.state.rows.length === 0
+                    ? this.renderNoResults()
+                    : this.renderResults()}
           </tbody>
         </ResultTable>
       </TableScrollWrapper>
@@ -824,45 +1090,105 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
 
     const cells = getCells();
     const needsRegion = this.props.isRegional || this.props.isCellScoped;
+    const hasSelectors =
+      needsRegion ||
+      Boolean(sortOptions && sortOptions.length > 0) ||
+      Object.keys(ensuredFilters).length > 0;
 
-    // The note shares the row of the selectors and stays at the right end. It
-    // never renders above the results, so nothing moves while the probe runs.
-    const probeNote = this.state.probingRegions ? (
-      <RegionHintNote>Checking other regions…</RegionHintNote>
-    ) : null;
+    const regionOptions = [
+      ...(this.props.allowAllRegions ? [{label: 'All regions', value: ALL_REGIONS}] : []),
+      ...cells.map(c => {
+        const hasMatch = this.state.regionMatches.some(
+          m => m.locality_url === c.locality_url
+        );
+        return {
+          label: c.name,
+          value: c.locality_url,
+          trailingItems: hasMatch ? <Tag variant="success">found</Tag> : undefined,
+        };
+      }),
+    ];
+
+    // The status note shares the row of the selectors and stays at the right
+    // end, so nothing moves while requests run. While regions load it lists
+    // the outstanding ones; when a region failed, a warning icon with a
+    // tooltip names the failed regions.
+    const {pendingRegions, regionErrors} = this.state;
+    const probeNote =
+      pendingRegions.length > 0 || regionErrors.length > 0 ? (
+        <RegionStatusNote role="status" align="center" gap="sm" wrap="wrap">
+          {regionErrors.length > 0 && (
+            <Tooltip title={`Could not load results from: ${regionErrors.join(', ')}`}>
+              <IconWarning
+                variant="warning"
+                size="sm"
+                aria-label="Some regions failed to load"
+              />
+            </Tooltip>
+          )}
+          {pendingRegions.length > 0 ? (
+            <Fragment>
+              <span>Still loading</span>
+              {pendingRegions.map(name => (
+                <Tag key={name} variant="muted">
+                  {name}
+                </Tag>
+              ))}
+            </Fragment>
+          ) : (
+            <span>
+              {regionErrors.length} {regionErrors.length === 1 ? 'region' : 'regions'}{' '}
+              failed
+            </span>
+          )}
+        </RegionStatusNote>
+      ) : this.state.probingRegions ? (
+        <RegionHintNote>Checking other regions…</RegionHintNote>
+      ) : null;
 
     return (
       <Container data-test-id="result-grid">
         <SortSearchForm onSubmit={this.onSearch}>
           {needsRegion && (
-            <CompactSelect
-              trigger={triggerProps => (
-                <OverlayTrigger.Button {...triggerProps} prefix="Region" />
-              )}
-              value={this.state.cell ? this.state.cell.locality_url : undefined}
-              options={cells.map(c => {
-                const hasMatch = this.state.regionMatches.some(
-                  m => m.locality_url === c.locality_url
-                );
-                return {
-                  label: c.name,
-                  value: c.locality_url,
-                  trailingItems: hasMatch ? (
-                    <Tag variant="success">found</Tag>
-                  ) : undefined,
-                };
-              })}
-              onChange={opt => this.onChangeCell(opt.value)}
-            />
+            <SelectorItem>
+              <CompactSelect
+                trigger={triggerProps => (
+                  <OverlayTrigger.Button {...triggerProps} prefix="Region" size="sm" />
+                )}
+                value={
+                  this.state.allRegions
+                    ? ALL_REGIONS
+                    : this.state.cell
+                      ? this.state.cell.locality_url
+                      : undefined
+                }
+                options={regionOptions}
+                onChange={opt => this.onChangeCell(opt.value)}
+              />
+            </SelectorItem>
           )}
           {sortOptions && sortOptions.length > 0 && (
-            <SortBy
-              options={sortOptions ?? []}
-              value={this.state.sortBy}
-              path={path}
-              location={location}
-            />
+            <SelectorItem>
+              <SortBy
+                options={sortOptions ?? []}
+                value={this.state.sortBy}
+                path={path}
+                location={location}
+              />
+            </SelectorItem>
           )}
+          {Object.keys(ensuredFilters).map(filterKey => (
+            <SelectorItem key={filterKey}>
+              <Filter
+                queryKey={filterKey}
+                value={extractQuery(this.state.filters[filterKey])}
+                path={path}
+                location={location}
+                {...ensuredFilters[filterKey]!}
+              />
+            </SelectorItem>
+          ))}
+          {hasSelectors && <RowFiller aria-hidden />}
           {probeNote}
           {hasSearch && (
             <Flex align="center" gap="xs" width="100%">
@@ -884,20 +1210,6 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
             </Flex>
           )}
         </SortSearchForm>
-        {Object.keys(ensuredFilters).length > 0 && (
-          <FilterList>
-            {Object.keys(ensuredFilters).map(filterKey => (
-              <Filter
-                key={filterKey}
-                queryKey={filterKey}
-                value={extractQuery(this.state.filters[filterKey])}
-                path={path}
-                location={location}
-                {...ensuredFilters[filterKey]!}
-              />
-            ))}
-          </FilterList>
-        )}
         {this.renderRegionHint()}
         {table}
         {hasPagination && this.state.pageLinks && (
@@ -912,11 +1224,38 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
 }
 
 const TableScrollWrapper = styled(Container)`
+  position: relative;
   overflow-x: auto;
 
   @media (max-width: 768px) {
     overflow-x: visible;
   }
+`;
+
+const indeterminateSlide = keyframes`
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(300%);
+  }
+`;
+
+const TableProgressBar = styled('div')`
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  overflow: hidden;
+  background: ${p => p.theme.tokens.background.transparent.accent.muted};
+`;
+
+const TableProgressValue = styled('div')`
+  width: 40%;
+  height: 100%;
+  background: ${p => p.theme.tokens.graphics.accent.vibrant};
+  animation: ${indeterminateSlide} 1.2s ease-in-out infinite;
 `;
 
 const SortSearchForm = styled('form')`
@@ -929,21 +1268,7 @@ const SortSearchForm = styled('form')`
   }
 
   /* Gross hack to fix z-index of dropdowns on top of each other */
-  > div > button + div {
-    z-index: ${p => p.theme.zIndex.dropdown + 2};
-  }
-`;
-
-const FilterList = styled('div')`
-  width: 100%;
-  margin-bottom: ${p => p.theme.space.md};
-  display: flex;
-  gap: ${p => p.theme.space.xs};
-  flex-wrap: wrap;
-  align-items: center;
-
-  /* Gross hack to fix z-index of dropdowns on top of each other */
-  > div > button + div {
+  button + div {
     z-index: ${p => p.theme.zIndex.dropdown + 2};
   }
 `;
@@ -969,6 +1294,43 @@ const ErrorAlert = styled(Alert)`
 
 const RegionHintAlert = styled(Alert)`
   margin-bottom: ${p => p.theme.space.md};
+`;
+
+/**
+ * Stretches each selector so a packed row of dropdowns fills the full width
+ * and its right edge lines up with the search button in the row below.
+ * `RowFiller` keeps the last, partly filled row at natural width.
+ */
+const SelectorItem = styled('div')`
+  display: flex;
+  flex: 1 1 auto;
+  min-width: max-content;
+
+  > div {
+    display: flex;
+    width: 100%;
+  }
+
+  > div > button {
+    width: 100%;
+  }
+`;
+
+/**
+ * Zero-size flex item with an outsized grow factor. It wraps into the last
+ * row of selectors and absorbs that row's free space, so only rows that are
+ * packed edge to edge get justified — like justified text, where the final
+ * line stays left-aligned.
+ */
+const RowFiller = styled('div')`
+  flex: 999 1 auto;
+`;
+
+const RegionStatusNote = styled(Flex)`
+  align-self: center;
+  margin-left: auto;
+  color: ${p => p.theme.tokens.content.secondary};
+  font-size: ${p => p.theme.font.size.sm};
 `;
 
 const RegionHintNote = styled('div')`

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -723,6 +723,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     queryParams: Record<string, any>
   ) => {
     const token = this.fetchToken;
+    const names = pages.map(({cell}) => cell.name);
 
     pages.forEach(({cell, cursor}) => {
       const markFailed = () => {
@@ -735,10 +736,11 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
           }
           const regionErrors = [...prev.regionErrors, cell.name];
           return {
-            // Every region failing with nothing to show is a failed load. A
-            // region failing under rows we already have is a partial result,
-            // so keep the table.
-            error: prev.rows.length === 0 && regionErrors.length === pages.length,
+            // Every region of this load failing with nothing to show is a
+            // failed load. A region failing under rows we already have is a
+            // partial result, so keep the table.
+            error:
+              prev.rows.length === 0 && names.every(name => regionErrors.includes(name)),
             pendingRegions: prev.pendingRegions.filter(name => name !== cell.name),
             regionErrors,
           };

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -155,9 +155,11 @@ interface ResultGridProps {
    * table with a Region column (placed by `regionColumnIndex`). Rows appear as
    * each region responds.
    *
-   * Cursors do not compose across regions, so this mode always merges each
-   * region's first page and hides pagination. Provide `sortValueForRow` so the
-   * merged rows keep a coherent order as regions trickle in.
+   * Cursors do not compose across regions, so this mode holds one cursor per
+   * region and grows the table by a page from each of them, through a "Load
+   * more" control in place of the single-cursor pagination. Provide
+   * `sortValueForRow` so the merged rows keep a coherent order as pages
+   * arrive.
    *
    * Only meaningful together with `isRegional`/`isCellScoped`.
    *
@@ -348,6 +350,12 @@ export type State = {
   probingRegions: boolean;
   query: string;
   /**
+   * The cursor of the next page of every region that still has one, keyed by
+   * cell name. A region leaves the map when it runs out of pages, so an empty
+   * map means the merged table holds every result.
+   */
+  regionCursors: Record<string, string>;
+  /**
    * Names of regions whose all-regions request failed.
    */
   regionErrors: string[];
@@ -428,6 +436,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       missingExactMatch: false,
       pendingRegions: [],
       regionErrors: [],
+      regionCursors: {},
     };
   }
 
@@ -472,6 +481,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         missingExactMatch: false,
         pendingRegions: [],
         regionErrors: [],
+        regionCursors: {},
       },
       this.fetchData
     );
@@ -503,6 +513,26 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       : this.props.endpoint;
   }
 
+  /**
+   * The request parameters for the current search, sort and filters.
+   *
+   * The cursor here is the grid's own; the all-regions view overrides it with
+   * the cursor of the region it is asking.
+   */
+  // TODO(dcramer): this should whitelist filters/sortBy/cursor/perPage
+  buildQueryParams(): Record<string, any> {
+    return {
+      ...this.props.defaultParams,
+      ...(this.props.useQueryString
+        ? (this.props.location?.query ?? {})
+        : this.state.query
+          ? {query: this.state.query}
+          : {}),
+      sortBy: this.state.sortBy,
+      cursor: this.state.cursor,
+    };
+  }
+
   fetchData = () => {
     // Avoid slow-fetch race conditions
     this.props.api.clear();
@@ -519,7 +549,8 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       this.state.regionMatches.length > 0 ||
       this.state.missingExactMatch ||
       this.state.pendingRegions.length > 0 ||
-      this.state.regionErrors.length > 0
+      this.state.regionErrors.length > 0 ||
+      Object.keys(this.state.regionCursors).length > 0
     ) {
       this.setState({
         probingRegions: false,
@@ -527,20 +558,11 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         missingExactMatch: false,
         pendingRegions: [],
         regionErrors: [],
+        regionCursors: {},
       });
     }
 
-    // TODO(dcramer): this should whitelist filters/sortBy/cursor/perPage
-    const queryParams: Record<string, any> = {
-      ...this.props.defaultParams,
-      ...(this.props.useQueryString
-        ? (this.props.location?.query ?? {})
-        : this.state.query
-          ? {query: this.state.query}
-          : {}),
-      sortBy: this.state.sortBy,
-      cursor: this.state.cursor,
-    };
+    const queryParams = this.buildQueryParams();
 
     if (this.state.allRegions) {
       this.fetchAllRegions(queryParams);
@@ -644,7 +666,6 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
    */
   fetchAllRegions = (queryParams: Record<string, any>) => {
     const cells = getCells();
-    const token = this.fetchToken;
 
     if (cells.length === 0) {
       this.setState({loading: false, error: false, rows: [], pageLinks: null});
@@ -658,12 +679,45 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       pageLinks: null,
       pendingRegions: cells.map(c => c.name),
       regionErrors: [],
+      regionCursors: {},
     });
 
-    // Cursors do not compose across regions; always merge first pages.
-    const params = {...queryParams, cursor: ''};
+    this.fetchRegionPages(
+      cells.map(cell => ({cell, cursor: ''})),
+      queryParams
+    );
+  };
 
-    cells.forEach(cell => {
+  /**
+   * Load the next page of every region that still has one and append it to the
+   * merged table. A merged view has no cursor of its own — cursors do not
+   * compose across regions — so it grows a page per region at a time.
+   */
+  loadMoreRegions = () => {
+    const {regionCursors} = this.state;
+    const pages = getCells()
+      .filter(cell => regionCursors[cell.name])
+      .map(cell => ({cell, cursor: regionCursors[cell.name]!}));
+
+    if (pages.length === 0) {
+      return;
+    }
+
+    this.setState({pendingRegions: pages.map(page => page.cell.name), regionErrors: []});
+    this.fetchRegionPages(pages, this.buildQueryParams());
+  };
+
+  /**
+   * Request one page from each given region, merge the rows into the table and
+   * record the cursor of any region that reports a further page.
+   */
+  fetchRegionPages = (
+    pages: Array<{cell: Cell; cursor: string}>,
+    queryParams: Record<string, any>
+  ) => {
+    const token = this.fetchToken;
+
+    pages.forEach(({cell, cursor}) => {
       const markFailed = () => {
         if (token !== this.fetchToken) {
           return;
@@ -674,7 +728,10 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
           }
           const regionErrors = [...prev.regionErrors, cell.name];
           return {
-            error: regionErrors.length === cells.length,
+            // Every region failing with nothing to show is a failed load. A
+            // region failing under rows we already have is a partial result,
+            // so keep the table.
+            error: prev.rows.length === 0 && regionErrors.length === pages.length,
             pendingRegions: prev.pendingRegions.filter(name => name !== cell.name),
             regionErrors,
           };
@@ -684,8 +741,8 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       const request = this.props.api.request(this.cellEndpoint(cell), {
         method: this.props.method,
         host: cell.locality_url,
-        data: params,
-        success: data => {
+        data: {...queryParams, cursor},
+        success: (data, _, resp) => {
           if (token !== this.fetchToken) {
             return;
           }
@@ -694,13 +751,23 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
             ...row,
             __region: cell,
           }));
+          const next = parseLinkHeader(resp?.getResponseHeader('Link') ?? '').next;
+          const nextCursor = next?.results === true ? (next.cursor ?? '') : '';
+
           this.setState(prev => {
             if (!prev.pendingRegions.includes(cell.name)) {
               return null;
             }
+            const regionCursors = {...prev.regionCursors};
+            if (nextCursor) {
+              regionCursors[cell.name] = nextCursor;
+            } else {
+              delete regionCursors[cell.name];
+            }
             return {
               rows: this.sortRows([...prev.rows, ...tagged]),
               pendingRegions: prev.pendingRegions.filter(name => name !== cell.name),
+              regionCursors,
             };
           });
           this.props.onLoad?.();
@@ -783,6 +850,7 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
           allRegions: true,
           cell: undefined,
           loading: true,
+          rows: [],
           regionMatches: [],
           probingRegions: false,
         },
@@ -1123,6 +1191,9 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
     // the outstanding ones; when a region failed, a warning icon with a
     // tooltip names the failed regions.
     const {pendingRegions, regionErrors} = this.state;
+    const moreRegions = cells
+      .map(c => c.name)
+      .filter(name => this.state.regionCursors[name]);
     const probeNote =
       pendingRegions.length > 0 || regionErrors.length > 0 ? (
         <RegionStatusNote role="status" align="center" gap="sm" wrap="wrap">
@@ -1227,6 +1298,17 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
             onCursor={useQueryString ? undefined : this.onCursor}
           />
         )}
+        {hasPagination && this.state.allRegions && moreRegions.length > 0 && (
+          <LoadMoreRow justify="center">
+            <Button
+              size="sm"
+              onClick={this.loadMoreRegions}
+              busy={pendingRegions.length > 0}
+            >
+              {`Load more (${moreRegions.join(', ')})`}
+            </Button>
+          </LoadMoreRow>
+        )}
       </Container>
     );
   }
@@ -1290,6 +1372,10 @@ export const SearchInput = styled(Input)`
   &:focus-visible {
     box-shadow: inset 0 0 0 1px ${p => p.theme.tokens.focus.default};
   }
+`;
+
+const LoadMoreRow = styled(Flex)`
+  margin-bottom: ${p => p.theme.space['2xl']};
 `;
 
 const StyledPagination = styled(Pagination)`

--- a/static/gsAdmin/components/resultGrid.tsx
+++ b/static/gsAdmin/components/resultGrid.tsx
@@ -703,7 +703,14 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
       return;
     }
 
-    this.setState({pendingRegions: pages.map(page => page.cell.name), regionErrors: []});
+    const names = pages.map(page => page.cell.name);
+    // A region that failed keeps its warning unless this load asks it again —
+    // it holds no cursor, so nothing here retries it, and its results are
+    // still missing from the table.
+    this.setState(prev => ({
+      pendingRegions: names,
+      regionErrors: prev.regionErrors.filter(name => !names.includes(name)),
+    }));
     this.fetchRegionPages(pages, this.buildQueryParams());
   };
 
@@ -868,6 +875,8 @@ class ResultGridImpl extends Component<ResultGridProps, State> {
         allRegions: false,
         cell,
         loading: true,
+        pendingRegions: [],
+        regionErrors: [],
         regionMatches: [],
         probingRegions: false,
       },

--- a/static/gsAdmin/components/users/userCustomers.tsx
+++ b/static/gsAdmin/components/users/userCustomers.tsx
@@ -25,9 +25,11 @@ export function UserCustomers({userId}: Props) {
       path={`/_admin/users/${userId}/`}
       endpoint={`/users/${userId}/customers/`}
       isCellScoped
-      // Org memberships are cell-scoped, so this grid only shows the orgs in the
-      // currently selected region. Probe the other regions too and flag when the
-      // user also belongs to orgs elsewhere so admins know to look there.
+      // Org memberships are cell-scoped. Query every region in parallel by
+      // default so the grid shows all of the user's orgs with their region.
+      allowAllRegions
+      // When an admin narrows to a single region, still probe the others and
+      // flag when the user also belongs to orgs elsewhere.
       probeAllRegions
       probeAllRegionsHint="This user also belongs to organizations in other regions — look there too:"
       hasSearch={false}

--- a/static/gsAdmin/views/customers.tsx
+++ b/static/gsAdmin/views/customers.tsx
@@ -5,7 +5,7 @@ export function Customers() {
   return (
     <div>
       <PageHeader title="Customers" />
-      <CustomerGrid endpoint="/customers/" />
+      <CustomerGrid endpoint="/customers/" allowAllRegions />
     </div>
   );
 }


### PR DESCRIPTION
- Query all regions at the same time by default when searching for a customer
- You can still select a specific region to filter on if you want
- Add a loading indicator on the table, and a dynamic text that shows which regions are loading & whether some have failed
- Unify the dropdown filter selectors
- Use the new customer grid in other pages as well, e.g. the user customer table

<img width="1241" height="258" alt="image" src="https://github.com/user-attachments/assets/2f346b99-f87f-42e4-859a-c90472b6d8b9" />


- This change also affects the ResultGrid used in other views: 
Before: 
<img width="1353" height="277" alt="image" src="https://github.com/user-attachments/assets/2de4b2e2-96a3-4f4a-befe-2f76b3361eb6" />


After:
<img width="1270" height="193" alt="image" src="https://github.com/user-attachments/assets/d17bf5fc-a26b-4e2a-982d-3fb3c631a3f7" />
