### PR TITLE
fix(admin): positioning of base sample rate in dynamic sampling table

### DIFF
--- a/static/gsAdmin/views/dynamicSamplingPanel.tsx
+++ b/static/gsAdmin/views/dynamicSamplingPanel.tsx
@@ -449,11 +449,9 @@ const PanelHeaderRight = styled('div')`
 `;
 
 const BaseSampleRateWrapper = styled(Alert)`
-  padding: ${p => p.theme.space.md};
   margin-right: ${p => p.theme.space.md};
   font-size: ${p => p.theme.font.size.md};
   font-weight: 600;
-  width: max-content;
   flex-basis: 50%;
 `;
 


### PR DESCRIPTION
Before: 
<img width="432" height="173" alt="Screenshot 2026-09-02 at 13 59 44" src="https://github.com/user-attachments/assets/824e20d9-3cf3-4296-894a-b7953dc7a690" />

After:
<img width="445" height="191" alt="Screenshot 2026-09-02 at 13 59 33" src="https://github.com/user-attachments/assets/15b34f2a-0ee4-48d2-b3c7-96690c41fffe" />
