### PR TITLE
ref(agents): Remove obsolete trace link prop

### DIFF
--- a/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/agentsTracesTableWidget/agentsTracesTableWidgetVisualization.tsx
@@ -21,7 +21,6 @@ export function AgentsTracesTableWidgetVisualization({
       tableWidths={tableWidths}
       dashboardFilters={dashboardFilters}
       frameless={frameless}
-      linkToTraceView
     />
   );
 }

--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -122,7 +122,6 @@ interface TracesTableProps {
   dashboardFilters?: DashboardFilters;
   frameless?: boolean;
   limit?: number;
-  linkToTraceView?: boolean;
   tableWidths?: number[];
 }
 


### PR DESCRIPTION
Trace IDs now always link directly to the trace view, but the agents dashboard still passed a behavior toggle that the table no longer read.