### PR TITLE
ref(assistant): retire project_transaction_threshold_override guide

### DIFF
--- a/src/sentry/assistant/guides.py
+++ b/src/sentry/assistant/guides.py
@@ -15,7 +15,6 @@ GUIDES = {
     "span_op_breakdowns_and_tag_explorer": 17,
     "team_key_transactions": 18,
     "project_transaction_threshold": 19,
-    "project_transaction_threshold_override": 20,
     "semver": 22,
     "release_stages": 23,
     "new_page_filters": 24,

--- a/tests/acceptance/test_performance_summary.py
+++ b/tests/acceptance/test_performance_summary.py
@@ -5,7 +5,6 @@ from urllib.parse import urlencode
 import pytest
 
 from fixtures.page_objects.transaction_summary import TransactionSummaryPage
-from sentry.models.assistant import AssistantActivity
 from sentry.testutils.cases import AcceptanceTestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import no_silo_test
@@ -36,10 +35,6 @@ class PerformanceSummaryTest(AcceptanceTestCase, SnubaTestCase):
         self.path = "/organizations/{}/performance/summary/?{}".format(
             self.org.slug,
             urlencode({"transaction": "/country_by_code/", "project": self.project.id}),
-        )
-
-        AssistantActivity.objects.create(
-            user=self.user, guide_id=20, viewed_ts=before_now(minutes=1)
         )
 
         self.page = TransactionSummaryPage(self.browser)


### PR DESCRIPTION
Backend half of #123128, which removed the frontend content and both anchors for the `project_transaction_threshold_override` tour. That PR has merged, so nothing renders the guide anymore and the id can come out of `GUIDES`.

Guide ids are immutable — they are stored on `AssistantActivity` — so 20 is left as a gap rather than renumbering the entries below it. `project_transaction_threshold` (19) is a different, still-live guide and stays.

No migration for the rows already written against guide 20. `GET /assistant/` builds its response from the registered guides and only intersects seen ids with them, so an orphan row is never surfaced; `PUT` now rejects both the name and the id with a 400, which no client sends now that the anchors are gone. Deleting those rows is optional cleanup, not a prerequisite for this change.

The acceptance test drops an `AssistantActivity` row from `setUp` that existed only to pre-dismiss this tour so it would not cover the threshold modal.

Refs DE-1409
