### PR TITLE
feat(dynamic-sampling): Add option to clamp the recalibration factor

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/cache.py
+++ b/src/sentry/dynamic_sampling/per_org/cache.py
@@ -13,9 +13,8 @@ from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
 from sentry.dynamic_sampling.tasks.common import are_equal_with_epsilon, sample_rate_to_float
 from sentry.dynamic_sampling.tasks.constants import (
     DEFAULT_REDIS_CACHE_KEY_TTL,
-    MAX_REBALANCE_FACTOR,
-    MIN_REBALANCE_FACTOR,
     adjusted_factor_ttl_ms,
+    bounded_rebalance_factor,
 )
 from sentry.dynamic_sampling.tasks.helpers import (
     recalibrate_orgs as legacy_recalibration_cache,
@@ -73,8 +72,9 @@ def write_recalibration_factor(org_id: int, factor: float | None) -> bool:
         metrics.incr("dynamic_sampling.per_org.recalibration.factor_write_skipped")
         return False
 
-    if MIN_REBALANCE_FACTOR <= factor <= MAX_REBALANCE_FACTOR:
-        set_adjusted_factor(org_id, factor)
+    bounded_factor = bounded_rebalance_factor(factor)
+    if bounded_factor is not None:
+        set_adjusted_factor(org_id, bounded_factor)
     else:
         delete_adjusted_factor(org_id)
     return True

--- a/src/sentry/dynamic_sampling/tasks/constants.py
+++ b/src/sentry/dynamic_sampling/tasks/constants.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from sentry import options
+from sentry.utils import metrics
 
 # TTL in milliseconds for values persisted by the dynamic sampling tasks.
 DEFAULT_REDIS_CACHE_KEY_TTL = 24 * 60 * 60 * 1000  # 24 hours
@@ -20,6 +21,24 @@ MAX_TRANSACTIONS_PER_PROJECT = 20
 # MIN and MAX rebalance factor in order to make sure we don't go crazy when rebalancing orgs.
 MIN_REBALANCE_FACTOR = 0.1
 MAX_REBALANCE_FACTOR = 10
+
+CLAMP_REBALANCE_FACTOR_OPTION = "dynamic-sampling.recalibration.clamp-factor"
+
+
+def bounded_rebalance_factor(factor: float) -> float | None:
+    """The factor bounded to [MIN_REBALANCE_FACTOR, MAX_REBALANCE_FACTOR].
+
+    An out-of-range factor is clamped to the nearest bound when the clamp option
+    is on, and discarded (None) otherwise. A discarded factor tells the caller
+    to delete the stored factor.
+    """
+    if MIN_REBALANCE_FACTOR <= factor <= MAX_REBALANCE_FACTOR:
+        return factor
+    if options.get(CLAMP_REBALANCE_FACTOR_OPTION):
+        metrics.incr("dynamic_sampling.recalibration.factor_clamped")
+        return min(max(factor, MIN_REBALANCE_FACTOR), MAX_REBALANCE_FACTOR)
+    return None
+
 
 # Parameters to bound the execution time of queries in Snuba.
 MAX_SECONDS = 60

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -16,7 +16,7 @@ from sentry.dynamic_sampling.tasks.boost_low_volume_projects import (
     fetch_projects_with_total_root_transaction_count_and_rates,
 )
 from sentry.dynamic_sampling.tasks.common import GetActiveOrgsVolumes, OrganizationDataVolume
-from sentry.dynamic_sampling.tasks.constants import MAX_REBALANCE_FACTOR, MIN_REBALANCE_FACTOR
+from sentry.dynamic_sampling.tasks.constants import bounded_rebalance_factor
 from sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs import (
     compute_adjusted_factor,
     delete_adjusted_factor,
@@ -141,14 +141,15 @@ def recalibrate_org(org_id: OrganizationId, total: int, indexed: int) -> None:
         )
         return
 
-    if adjusted_factor < MIN_REBALANCE_FACTOR or adjusted_factor > MAX_REBALANCE_FACTOR:
+    bounded_factor = bounded_rebalance_factor(adjusted_factor)
+    if bounded_factor is None:
         # In case the new factor would result into too much recalibration, we want to remove it from cache,
         # effectively removing the generated rule.
         delete_adjusted_factor(org_id)
         return
 
     # At the end we set the adjusted factor.
-    set_guarded_adjusted_factor(org_id, adjusted_factor)
+    set_guarded_adjusted_factor(org_id, bounded_factor)
 
 
 @instrumented_task(
@@ -199,11 +200,12 @@ def recalibrate_project(
         )
         return
 
-    if adjusted_factor < MIN_REBALANCE_FACTOR or adjusted_factor > MAX_REBALANCE_FACTOR:
+    bounded_factor = bounded_rebalance_factor(adjusted_factor)
+    if bounded_factor is None:
         # In case the new factor would result into too much recalibration, we want to remove it from cache,
         # effectively removing the generated rule.
         delete_adjusted_project_factor(project_id)
         return
 
     # At the end we set the adjusted factor.
-    set_guarded_adjusted_project_factor(project_id, adjusted_factor)
+    set_guarded_adjusted_project_factor(project_id, bounded_factor)

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2395,6 +2395,15 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# When True, a recalibration factor outside the rebalance bounds is clamped to the
+# nearest bound instead of deleted. Deletion drops the factor back to 1.0 for a full
+# cycle, which makes the effective sample rate oscillate; clamping keeps it steady.
+register(
+    "dynamic-sampling.recalibration.clamp-factor",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Stops dynamic sampling rules from being emitted in relay config.
 # This is required for ST instances that have flakey flags as we want to be able kill DS ruining customer data if necessary.
 # It is only a killswitch for behaviour, it may actually increase infra load if flipped for a user currently being sampled.

--- a/tests/sentry/dynamic_sampling/per_org/test_cache.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_cache.py
@@ -195,6 +195,17 @@ class WriteCachesTest(TestCase):
             mocks[DELETE_FACTOR].assert_called_once_with(self.organization.id)
             mocks[SET_FACTOR].assert_not_called()
 
+    def test_a_factor_out_of_bounds_is_clamped_when_the_clamp_option_is_on(self) -> None:
+        with override_options({"dynamic-sampling.recalibration.clamp-factor": True}):
+            for factor, bound in (
+                (MIN_REBALANCE_FACTOR / 2, MIN_REBALANCE_FACTOR),
+                (MAX_REBALANCE_FACTOR * 2, MAX_REBALANCE_FACTOR),
+            ):
+                mocks = self._write(DynamicSamplingResults(recalibration_factor=factor))
+
+                mocks[SET_FACTOR].assert_called_once_with(self.organization.id, bound)
+                mocks[DELETE_FACTOR].assert_not_called()
+
     def test_a_pass_without_a_factor_leaves_the_stored_one_alone(self) -> None:
         mocks = self._write(DynamicSamplingResults())
 

--- a/tests/sentry/dynamic_sampling/tasks/test_constants.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_constants.py
@@ -1,0 +1,42 @@
+import pytest
+
+from sentry.dynamic_sampling.tasks.constants import (
+    MAX_REBALANCE_FACTOR,
+    MIN_REBALANCE_FACTOR,
+    bounded_rebalance_factor,
+)
+from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
+
+
+@django_db_all
+@pytest.mark.parametrize(
+    "factor,expected",
+    [
+        (1.5, 1.5),
+        (MIN_REBALANCE_FACTOR, MIN_REBALANCE_FACTOR),
+        (MAX_REBALANCE_FACTOR, MAX_REBALANCE_FACTOR),
+        (MIN_REBALANCE_FACTOR / 2, None),
+        (MAX_REBALANCE_FACTOR * 2, None),
+    ],
+)
+def test_an_out_of_bounds_factor_is_discarded_by_default(
+    factor: float, expected: float | None
+) -> None:
+    assert bounded_rebalance_factor(factor) == expected
+
+
+@django_db_all
+@override_options({"dynamic-sampling.recalibration.clamp-factor": True})
+@pytest.mark.parametrize(
+    "factor,expected",
+    [
+        (1.5, 1.5),
+        (MIN_REBALANCE_FACTOR / 2, MIN_REBALANCE_FACTOR),
+        (MAX_REBALANCE_FACTOR * 2, MAX_REBALANCE_FACTOR),
+    ],
+)
+def test_an_out_of_bounds_factor_is_clamped_when_the_option_is_on(
+    factor: float, expected: float
+) -> None:
+    assert bounded_rebalance_factor(factor) == expected


### PR DESCRIPTION
- Until now, out of bounds (<0.1 and >10) recalibration factors are being reset. This means that when an org cannot reach its sample rate goals for whatever reason (most prominently growing traffic), dynamic sampling will reset the recalibration factor to 1.0 by deleting the cache entry. This leads to sawtooth-style behavior
- Add logic & option to switch this over to clamping the recalibration factor. If we can't reach the desired factor, so be it, but the sawtooth is worse than not reaching the desired sample rate.
- Applies to the legacy and per-org pipelines

Closes TET-2926