### PR TITLE
fix(issues): Prefer the crash location for synthetic exception titles

### DIFF
--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -219,6 +219,11 @@ export type EventMetadata = {
   message?: string;
   origin?: string;
   stripped_crash?: boolean;
+  /**
+   * Set when the SDK fabricated the exception to carry a stacktrace. Its `type` is then a
+   * platform label (`SIGSEGV`, `AppHang`) rather than the identity of what went wrong.
+   */
+  synthetic?: boolean;
   title?: string;
   type?: string;
   uri?: string;

--- a/static/app/utils/events.spec.tsx
+++ b/static/app/utils/events.spec.tsx
@@ -1,0 +1,45 @@
+import {GroupFixture} from 'sentry-fixture/group';
+
+import type {EventMetadata} from 'sentry/types/event';
+import {EventOrGroupType} from 'sentry/types/event';
+import {getTitle} from 'sentry/utils/events';
+
+describe('getTitle', () => {
+  const errorGroup = (metadata: EventMetadata) =>
+    GroupFixture({type: EventOrGroupType.ERROR, culprit: 'CrashCapture', metadata});
+
+  it('prefers the exception type', () => {
+    expect(getTitle(errorGroup({type: 'ValueError', function: 'doThing'})).title).toBe(
+      'ValueError'
+    );
+  });
+
+  it('falls back to the crash location when there is no type', () => {
+    expect(getTitle(errorGroup({function: 'doThing'})).title).toBe('doThing');
+  });
+
+  // A synthetic exception is one the SDK fabricated to carry a stacktrace, so its type is a
+  // platform label (`SIGSEGV`) rather than the identity of what went wrong. The order flips.
+  it('prefers the crash location for a synthetic exception', () => {
+    expect(
+      getTitle(errorGroup({type: 'SIGSEGV', function: 'ForceCrash', synthetic: true}))
+        .title
+    ).toBe('ForceCrash');
+  });
+
+  it('falls back to the type for a synthetic exception that did not symbolicate', () => {
+    expect(getTitle(errorGroup({type: 'SIGSEGV', synthetic: true})).title).toBe(
+      'SIGSEGV'
+    );
+  });
+
+  it('has something to show when a synthetic exception has neither', () => {
+    expect(getTitle(errorGroup({synthetic: true})).title).toBe('<unknown>');
+  });
+
+  // Groups stored before the server recorded `synthetic` have no such key, so they must keep
+  // taking the original branch.
+  it('leaves metadata without the flag alone', () => {
+    expect(getTitle(errorGroup({function: 'ForceCrash'})).title).toBe('ForceCrash');
+  });
+});

--- a/static/app/utils/events.tsx
+++ b/static/app/utils/events.tsx
@@ -87,7 +87,11 @@ export function getTitle(event: Event | BaseGroup | GroupTombstoneHelper | Simpl
 
       return {
         subtitle: culprit,
-        title: metadata.type || metadata.function || '<unknown>',
+        // A synthetic exception's type is a platform label, so the crash location identifies
+        // the issue better. Mirrors `ErrorEvent.compute_title` on the server.
+        title: metadata.synthetic
+          ? metadata.function || metadata.type || '<unknown>'
+          : metadata.type || metadata.function || '<unknown>',
       };
     }
     case EventOrGroupType.CSP:


### PR DESCRIPTION
Relates to https://github.com/getsentry/sentry/pull/123322

`getTitle` builds an error issue's title from `metadata` rather than using the one the server computed. Applying the rule the server used to apply to the frontend: exception type -> crash location. 

No type for synthetic exception was set before, so in practice the crash location won.

[#123322](https://github.com/getsentry/sentry/pull/123322) changes that. It records the type for synthetic exceptions. That means that events with no usable crash location have something better to show than `<unknown>`. It also marks the metadata `synthetic`. Left as-is, this function would then pick the type. For the same symbolicated crash we would get:

| | title |
| --- | --- |
| today | `ForceCrash` |
| #123322 without this change | `SIGSEGV` ← regression |
| #123322 with this change | `ForceCrash` |

This PR aims to prevent the middle row. This would also affect `sentry-native`, Android and MetricKit, which set `mechanism.synthetic` already. Their issues show a function name today and would regress.

The fix mirrors the server's preference: for a synthetic exception the crash location wins and the type is the fallback, so the two agree on the title. Crashes that did not symbolicate have no crash location and still fall back to the type, which is the improvement of #123322.

**Land this before #123322.** It is a no-op on its own. `metadata.synthetic` does not exist yet, so the existing branch is the one taken, and there is no window in which the UI and the server disagree.

Worth knowing while reviewing: the API response already carries a correct `title` field for these issues. The duplication between it and `getTitle` is what makes this fix necessary and is left alone here. Not sure what's going on there.