### PR TITLE
feat(inbound-filters): Add a catch-all data type to custom inbound filters

### DIFF
--- a/src/sentry/api/endpoints/project_custom_inbound_filters.py
+++ b/src/sentry/api/endpoints/project_custom_inbound_filters.py
@@ -17,8 +17,8 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.parameters import GlobalParams
+from sentry.ingest.inbound_filters import get_supported_condition_types
 from sentry.models.custominboundfilter import (
-    DATA_TYPE_BY_CONDITION_TYPE,
     CustomInboundFilter,
     CustomInboundFilterConditionType,
     CustomInboundFilterDataType,
@@ -31,7 +31,6 @@ MAX_FILTERS_PER_PROJECT = 50
 
 
 # Ingestion feature an organization needs before a filter can target a data type.
-# Errors need none.
 _REQUIRED_FEATURE_BY_DATA_TYPE: Mapping[CustomInboundFilterDataType, str] = {
     CustomInboundFilterDataType.LOG: "organizations:ourlogs-ingestion",
     CustomInboundFilterDataType.METRIC: "organizations:tracemetrics-ingestion",
@@ -59,6 +58,15 @@ class CustomInboundFilterSerializer(serializers.ModelSerializer[CustomInboundFil
         max_length=256, allow_blank=True, allow_null=True, required=False, trim_whitespace=True
     )
     active = serializers.BooleanField(required=False)
+    dataType = serializers.ChoiceField(
+        source="data_type",
+        choices=[data_type.value for data_type in CustomInboundFilterDataType],
+        help_text=(
+            "The data the filter matches against. `all` is the catch-all: it filters every "
+            "data type Sentry ingests, including ones added later, and accepts only the "
+            "conditions that every data type carries a field for."
+        ),
+    )
     conditions = CustomInboundFilterConditionSerializer(
         many=True,
         allow_empty=False,
@@ -75,37 +83,54 @@ class CustomInboundFilterSerializer(serializers.ModelSerializer[CustomInboundFil
 
     class Meta:
         model = CustomInboundFilter
-        fields = ["id", "name", "active", "conditions", "dateCreated", "dateUpdated"]
+        fields = ["id", "name", "active", "dataType", "conditions", "dateCreated", "dateUpdated"]
 
     def create(self, validated_data: dict[str, Any]) -> CustomInboundFilter:
         return CustomInboundFilter.objects.create(**validated_data)
 
-    def validate_conditions(self, conditions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def validate_dataType(self, data_type: str) -> str:
         organization = self.context["project"].organization
         request = self.context["request"]
-        condition_types = {condition["type"] for condition in conditions}
 
-        data_types = {
-            DATA_TYPE_BY_CONDITION_TYPE[condition_type]
-            for condition_type in condition_types
-            if condition_type in DATA_TYPE_BY_CONDITION_TYPE
-        }
-        if len(data_types) > 1:
+        required_feature = _REQUIRED_FEATURE_BY_DATA_TYPE.get(
+            CustomInboundFilterDataType(data_type)
+        )
+        if required_feature and not features.has(
+            required_feature, organization, actor=request.user
+        ):
             raise serializers.ValidationError(
-                "A filter matches one data type, so error, log, and metric conditions "
-                "cannot be combined."
+                f"{data_type.capitalize()} filters are not enabled for this organization."
             )
 
-        for data_type in data_types:
-            required_feature = _REQUIRED_FEATURE_BY_DATA_TYPE.get(data_type)
-            if required_feature and not features.has(
-                required_feature, organization, actor=request.user
-            ):
-                raise serializers.ValidationError(
-                    f"{data_type.capitalize()} filters are not enabled for this organization."
-                )
+        return data_type
 
-        return conditions
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        # A partial update may change the data type or the conditions alone, so the
+        # other side comes from the stored filter.
+        stored = self.instance
+        conditions = attrs.get("conditions")
+        if conditions is None:
+            conditions = stored.conditions if stored else None
+
+        raw_data_type = attrs.get("data_type") or (stored.data_type if stored else None)
+        if conditions is None or raw_data_type is None:
+            return attrs
+
+        data_type = CustomInboundFilterDataType(raw_data_type)
+        supported = get_supported_condition_types(data_type)
+        unsupported = sorted({condition["type"] for condition in conditions} - set(supported))
+        if unsupported:
+            raise serializers.ValidationError(
+                {
+                    "conditions": (
+                        f"A filter on {data_type.value} data cannot use the "
+                        f"{', '.join(unsupported)} condition. It accepts "
+                        f"{', '.join(supported)}."
+                    )
+                }
+            )
+
+        return attrs
 
 
 class ProjectCustomInboundFilterEndpoint(ProjectEndpoint):
@@ -132,6 +157,7 @@ class ProjectCustomInboundFilterEndpoint(ProjectEndpoint):
             "filter_id": str(custom_filter.id),
             "filter_name": custom_filter.name,
             "active": custom_filter.active,
+            "data_type": custom_filter.data_type,
             "conditions": custom_filter.conditions,
             "operation": operation,
         }
@@ -304,7 +330,7 @@ class CustomInboundFilterDetailsEndpoint(ProjectCustomInboundFilterEndpoint):
             return Response(serializer.errors, status=400)
 
         changes: dict[str, Any] = {}
-        for field in ("name", "active", "conditions"):
+        for field in ("name", "active", "data_type", "conditions"):
             if field not in serializer.validated_data:
                 continue
 
@@ -323,7 +349,7 @@ class CustomInboundFilterDetailsEndpoint(ProjectCustomInboundFilterEndpoint):
                 event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
                 data=self.get_audit_log_data(project, custom_filter, "edit", changes),
             )
-            if changes.keys() & {"active", "conditions"}:
+            if changes.keys() & {"active", "data_type", "conditions"}:
                 schedule_invalidate_project_config(
                     project_id=project.id, trigger="custom_inbound_filters"
                 )

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from rest_framework import serializers
 
 from sentry.models.custominboundfilter import (
-    DATA_TYPE_BY_CONDITION_TYPE,
     CustomInboundFilter,
     CustomInboundFilterConditionType,
     CustomInboundFilterDataType,
@@ -557,9 +556,9 @@ def _field_matcher(name: str) -> _ConditionMatcher:
     return match
 
 
-# A filter's data type selects the item its conditions match against, since only that
-# item carries such data. Release lives on a different field on each of them.
-_MATCHERS_BY_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMatchers] = {
+# Replays, sessions and profiles are not selectable data types: Relay reads their
+# release under `event.release`, so they cannot be told apart from errors.
+_MATCHERS_BY_SINGLE_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMatchers] = {
     CustomInboundFilterDataType.ERROR: {
         CustomInboundFilterConditionType.ERROR_TYPE: _custom_error_type_condition,
         CustomInboundFilterConditionType.ERROR_MESSAGE: _custom_error_message_condition,
@@ -577,23 +576,69 @@ _MATCHERS_BY_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMatchers]
             "trace_metric.attributes.sentry.release.value"
         ),
     },
+    CustomInboundFilterDataType.SPAN: {
+        CustomInboundFilterConditionType.RELEASE: _field_matcher(
+            "span.attributes.sentry.release.value"
+        ),
+    },
 }
 
 
-def _custom_filter_condition(conditions: list[dict[str, Any]]) -> RuleCondition | None:
+def _any_data_type_matcher(matchers: Sequence[_ConditionMatcher]) -> _ConditionMatcher:
+    # Relay reads a field the item does not carry as no match, so the OR reduces to the
+    # item's own field.
+    def match(values: list[str]) -> RuleCondition:
+        return {"op": "or", "inner": [matcher(values) for matcher in matchers]}
+
+    return match
+
+
+def _build_all_data_types_matchers() -> _ConditionMatchers:
+    per_data_type = list(_MATCHERS_BY_SINGLE_DATA_TYPE.values())
+    shared_condition_types = set.intersection(*(set(matchers) for matchers in per_data_type))
+
+    return {
+        condition_type: _any_data_type_matcher(
+            [matchers[condition_type] for matchers in per_data_type]
+        )
+        for condition_type in CustomInboundFilterConditionType
+        if condition_type in shared_condition_types
+    }
+
+
+_MATCHERS_BY_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMatchers] = {
+    CustomInboundFilterDataType.ALL: _build_all_data_types_matchers(),
+    **_MATCHERS_BY_SINGLE_DATA_TYPE,
+}
+
+
+def get_supported_condition_types(
+    data_type: CustomInboundFilterDataType,
+) -> list[CustomInboundFilterConditionType]:
+    return list(_MATCHERS_BY_DATA_TYPE[data_type])
+
+
+def _custom_filter_condition(
+    conditions: list[dict[str, Any]], data_type: str
+) -> RuleCondition | None:
     """
     Translates a custom inbound filter's conditions into a Relay rule condition.
 
-    Conditions are combined with AND. Returns None if any condition cannot be
-    translated (a type or value shape unknown to this revision, or a type whose
-    data the matched item does not carry): since every condition narrows the
-    match, dropping only the broken condition would filter more data than
-    configured.
+    Conditions are combined with AND. Returns None if the filter cannot be translated
+    (a data type, condition type, or value shape unknown to this revision, or a
+    condition type whose field the filter's data type does not carry): since every
+    condition narrows the match, dropping only the broken condition would filter more
+    data than configured.
     """
     if not conditions:
         return None
 
-    parsed: list[tuple[CustomInboundFilterConditionType, list[str]]] = []
+    try:
+        matchers = _MATCHERS_BY_DATA_TYPE[CustomInboundFilterDataType(data_type)]
+    except ValueError:
+        return None
+
+    rule_conditions: list[RuleCondition] = []
     for condition in conditions:
         try:
             condition_type = CustomInboundFilterConditionType(condition.get("type", ""))
@@ -604,22 +649,6 @@ def _custom_filter_condition(conditions: list[dict[str, Any]]) -> RuleCondition 
         if not (isinstance(values, list) and values and all(isinstance(v, str) for v in values)):
             return None
 
-        parsed.append((condition_type, values))
-
-    # A filter carrying only release conditions falls through to events, mirroring the
-    # legacy `releases` inbound filter.
-    data_type = next(
-        (
-            DATA_TYPE_BY_CONDITION_TYPE[condition_type]
-            for condition_type, _ in parsed
-            if condition_type in DATA_TYPE_BY_CONDITION_TYPE
-        ),
-        CustomInboundFilterDataType.ERROR,
-    )
-    matchers = _MATCHERS_BY_DATA_TYPE[data_type]
-
-    rule_conditions: list[RuleCondition] = []
-    for condition_type, values in parsed:
         matcher = matchers.get(condition_type)
         if matcher is None:
             return None
@@ -637,7 +666,7 @@ def get_custom_inbound_filter_generic_filters(project: Project) -> list[GenericF
         project_id=project.id, active=True
     ).order_by("id")
     for custom_filter in custom_filters:
-        condition = _custom_filter_condition(custom_filter.conditions)
+        condition = _custom_filter_condition(custom_filter.conditions, custom_filter.data_type)
         if condition is not None:
             generic_filters.append(
                 _generic_filter(f"{CUSTOM_INBOUND_FILTER_ID_PREFIX}{custom_filter.id}", condition)

--- a/src/sentry/models/custominboundfilter.py
+++ b/src/sentry/models/custominboundfilter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from enum import StrEnum
 
 from django.db import models
@@ -18,22 +17,11 @@ class CustomInboundFilterConditionType(StrEnum):
 
 
 class CustomInboundFilterDataType(StrEnum):
+    ALL = "all"
     ERROR = "error"
     LOG = "log"
     METRIC = "metric"
-
-
-# The data type each condition reads a field of. A filter targets a single data type,
-# so its conditions must all map to the same one. `release` is absent because every
-# data type carries a release, so it does not tie a filter to one data type.
-DATA_TYPE_BY_CONDITION_TYPE: Mapping[
-    CustomInboundFilterConditionType, CustomInboundFilterDataType
-] = {
-    CustomInboundFilterConditionType.ERROR_TYPE: CustomInboundFilterDataType.ERROR,
-    CustomInboundFilterConditionType.ERROR_MESSAGE: CustomInboundFilterDataType.ERROR,
-    CustomInboundFilterConditionType.LOG_MESSAGE: CustomInboundFilterDataType.LOG,
-    CustomInboundFilterConditionType.METRIC_NAME: CustomInboundFilterDataType.METRIC,
-}
+    SPAN = "span"
 
 
 @cell_silo_model

--- a/src/sentry/testutils/helpers/backups.py
+++ b/src/sentry/testutils/helpers/backups.py
@@ -68,7 +68,10 @@ from sentry.models.authidentity import AuthIdentity
 from sentry.models.authprovider import AuthProvider
 from sentry.models.code_review_event import CodeReviewEvent, CodeReviewEventStatus
 from sentry.models.counter import Counter
-from sentry.models.custominboundfilter import CustomInboundFilter
+from sentry.models.custominboundfilter import (
+    CustomInboundFilter,
+    CustomInboundFilterDataType,
+)
 from sentry.models.dashboard import (
     Dashboard,
     DashboardFavoriteUser,
@@ -508,7 +511,8 @@ class ExhaustiveFixtures(Fixtures):
         CustomInboundFilter.objects.create(
             project=project,
             name=f"custom-inbound-filter-{slug}",
-            conditions=[{"op": "eq", "name": "event.release", "value": ["1.0.0"]}],
+            data_type=CustomInboundFilterDataType.ALL,
+            conditions=[{"type": "release", "value": ["1.0.0"]}],
         )
 
         # Auth*

--- a/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
+++ b/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
@@ -28,6 +28,7 @@ class CustomInboundFiltersTest(APITestCase):
         first_filter = self.create_project_custom_inbound_filter(
             project=self.project,
             name="Release filter",
+            data_type="all",
             conditions=[{"type": "release", "value": ["1.*"]}],
         )
         second_filter = self.create_project_custom_inbound_filter(
@@ -50,12 +51,14 @@ class CustomInboundFiltersTest(APITestCase):
             "id": str(first_filter.id),
             "name": "Release filter",
             "active": True,
+            "dataType": "all",
             "conditions": [{"type": "release", "value": ["1.*"]}],
         }
         assert second_data == {
             "id": str(second_filter.id),
             "name": "Error filter",
             "active": False,
+            "dataType": "error",
             "conditions": [{"type": "error_message", "value": ["TypeError*"]}],
         }
 
@@ -72,6 +75,7 @@ class CustomInboundFiltersTest(APITestCase):
                 method="post",
                 name="Important errors",
                 active=False,
+                dataType="error",
                 conditions=conditions,
                 status_code=201,
             )
@@ -80,6 +84,7 @@ class CustomInboundFiltersTest(APITestCase):
         assert custom_filter.project_id == self.project.id
         assert custom_filter.name == "Important errors"
         assert custom_filter.active is False
+        assert custom_filter.data_type == "error"
         assert custom_filter.conditions == conditions
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -90,6 +95,7 @@ class CustomInboundFiltersTest(APITestCase):
         assert audit_entry.target_object == custom_filter.id
         assert audit_entry.data["operation"] == "add"
         assert audit_entry.data["filter_name"] == "Important errors"
+        assert audit_entry.data["data_type"] == "error"
         assert audit_entry.data["conditions"] == conditions
 
     def test_post_without_name(self) -> None:
@@ -100,6 +106,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.organization.slug,
                 self.project.slug,
                 method="post",
+                dataType="error",
                 conditions=conditions,
                 status_code=201,
             )
@@ -120,47 +127,127 @@ class CustomInboundFiltersTest(APITestCase):
 
         assert response.data["detail"] == "You do not have that feature enabled"
 
-    def test_rejects_conditions_from_two_data_types(self) -> None:
-        conditions = [
-            {"type": "error_message", "value": ["TypeError*"]},
-            {"type": "log_message", "value": ["Rate limit*"]},
+    def test_rejects_condition_the_data_type_does_not_carry(self) -> None:
+        cases = [
+            (
+                "error",
+                [
+                    {"type": "error_message", "value": ["TypeError*"]},
+                    {"type": "log_message", "value": ["Rate limit*"]},
+                ],
+                "A filter on error data cannot use the log_message condition. "
+                "It accepts error_type, error_message, release.",
+            ),
+            (
+                "log",
+                [
+                    {"type": "error_type", "value": ["TypeError"]},
+                    {"type": "log_message", "value": ["Rate limit*"]},
+                ],
+                "A filter on log data cannot use the error_type condition. "
+                "It accepts log_message, release.",
+            ),
+            (
+                "span",
+                [
+                    {"type": "release", "value": ["1.*"]},
+                    {"type": "metric_name", "value": ["counter.*"]},
+                ],
+                "A filter on span data cannot use the metric_name condition. It accepts release.",
+            ),
+            (
+                "all",
+                [
+                    {"type": "release", "value": ["1.*"]},
+                    {"type": "error_message", "value": ["TypeError*"]},
+                ],
+                "A filter on all data cannot use the error_message condition. It accepts release.",
+            ),
         ]
 
-        with self.feature([*self.features, "organizations:ourlogs-ingestion"]):
+        for data_type, conditions, expected in cases:
+            with self.feature([*self.features, "organizations:ourlogs-ingestion"]):
+                response = self.get_error_response(
+                    self.organization.slug,
+                    self.project.slug,
+                    method="post",
+                    name="Mixed data types",
+                    dataType=data_type,
+                    conditions=conditions,
+                )
+
+            assert str(response.data["conditions"][0]) == expected
+
+    def test_post_catch_all(self) -> None:
+        conditions = [{"type": "release", "value": ["1.*"]}]
+
+        with self.feature(self.features), outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                method="post",
+                name="Bad release, every data type",
+                dataType="all",
+                conditions=conditions,
+                status_code=201,
+            )
+
+        custom_filter = CustomInboundFilter.objects.get(id=response.data["id"])
+        assert response.data["dataType"] == "all"
+        assert custom_filter.data_type == "all"
+
+    def test_post_span(self) -> None:
+        """Relay ingests spans for every organization, so a span filter needs no feature."""
+        with self.feature(self.features), outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                method="post",
+                name="Spans from a bad release",
+                dataType="span",
+                conditions=[{"type": "release", "value": ["1.*"]}],
+                status_code=201,
+            )
+
+        custom_filter = CustomInboundFilter.objects.get(id=response.data["id"])
+        assert response.data["dataType"] == "span"
+        assert custom_filter.data_type == "span"
+
+    def test_catch_all_needs_no_ingestion_feature(self) -> None:
+        """The catch-all filters whichever data types the organization ingests."""
+        with self.feature(self.features):
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                method="post",
+                name="Bad release",
+                dataType="all",
+                conditions=[{"type": "release", "value": ["1.*"]}],
+                status_code=201,
+            )
+
+    def test_rejects_unknown_data_type(self) -> None:
+        with self.feature(self.features):
             response = self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
                 method="post",
-                name="Mixed data types",
-                conditions=conditions,
+                dataType="replay",
+                conditions=[{"type": "release", "value": ["1.*"]}],
             )
 
-        assert (
-            str(response.data["conditions"][0])
-            == "A filter matches one data type, so error, log, and metric conditions "
-            "cannot be combined."
-        )
+        assert '"replay" is not a valid choice.' in str(response.data["dataType"][0])
 
-    def test_rejects_error_type_with_another_data_type(self) -> None:
-        conditions = [
-            {"type": "error_type", "value": ["TypeError"]},
-            {"type": "log_message", "value": ["Rate limit*"]},
-        ]
-
-        with self.feature([*self.features, "organizations:ourlogs-ingestion"]):
+    def test_rejects_missing_data_type(self) -> None:
+        with self.feature(self.features):
             response = self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
                 method="post",
-                name="Error type and log",
-                conditions=conditions,
+                conditions=[{"type": "release", "value": ["1.*"]}],
             )
 
-        assert (
-            str(response.data["conditions"][0])
-            == "A filter matches one data type, so error, log, and metric conditions "
-            "cannot be combined."
-        )
+        assert str(response.data["dataType"][0]) == "This field is required."
 
     def test_allows_error_type_with_error_message(self) -> None:
         conditions = [
@@ -174,6 +261,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.project.slug,
                 method="post",
                 name="Type and message",
+                dataType="error",
                 conditions=conditions,
                 status_code=201,
             )
@@ -193,6 +281,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.project.slug,
                 method="post",
                 name="Release range",
+                dataType="error",
                 conditions=conditions,
                 status_code=201,
             )
@@ -207,6 +296,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.project.slug,
                 method="post",
                 name="",
+                dataType="error",
                 conditions=[],
             )
 
@@ -220,6 +310,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.project.slug,
                 method="post",
                 name="Empty value",
+                dataType="error",
                 conditions=[{"type": "release", "value": []}],
             )
 
@@ -235,6 +326,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.organization.slug,
                 self.project.slug,
                 method="post",
+                dataType="error",
                 conditions=conditions,
             )
 
@@ -253,26 +345,28 @@ class CustomInboundFiltersTest(APITestCase):
                 self.organization.slug,
                 self.project.slug,
                 method="post",
+                dataType="error",
                 conditions=[{"type": "release", "value": ["1.*"]}],
             )
 
         assert "at most 2" in response.data["detail"]
         assert CustomInboundFilter.objects.filter(project_id=self.project.id).count() == 2
 
-    def test_rejects_conditions_without_required_ingestion_feature(self) -> None:
+    def test_rejects_data_type_without_required_ingestion_feature(self) -> None:
         cases = [
-            ("log_message", ["Rate limit*"], "Log filters are not enabled"),
-            ("metric_name", ["counter.*"], "Metric filters are not enabled"),
+            ("log", "log_message", ["Rate limit*"], "Log filters are not enabled"),
+            ("metric", "metric_name", ["counter.*"], "Metric filters are not enabled"),
         ]
-        for condition_type, value, expected in cases:
+        for data_type, condition_type, value, expected in cases:
             with self.feature(self.features):
                 response = self.get_error_response(
                     self.organization.slug,
                     self.project.slug,
                     method="post",
+                    dataType=data_type,
                     conditions=[{"type": condition_type, "value": value}],
                 )
-            assert expected in str(response.data["conditions"][0])
+            assert expected in str(response.data["dataType"][0])
 
 
 class CustomInboundFilterDetailsTest(APITestCase):
@@ -304,6 +398,7 @@ class CustomInboundFilterDetailsTest(APITestCase):
         assert response.data["id"] == str(self.custom_filter.id)
         assert response.data["name"] == "Original filter"
         assert response.data["active"] is True
+        assert response.data["dataType"] == "error"
         assert response.data["conditions"] == [{"type": "release", "value": ["1.*"]}]
 
     def test_put(self) -> None:
@@ -399,25 +494,80 @@ class CustomInboundFilterDetailsTest(APITestCase):
                 event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
             ).exists()
 
-    def test_put_rejects_conditions_from_two_data_types(self) -> None:
-        conditions = [
-            {"type": "error_message", "value": ["TypeError*"]},
-            {"type": "log_message", "value": ["Rate limit*"]},
-        ]
-
+    def test_put_validates_new_conditions_against_stored_data_type(self) -> None:
+        """A partial update sending conditions alone keeps the stored data type."""
         with self.feature([*self.features, "organizations:ourlogs-ingestion"]):
             response = self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
                 self.custom_filter.id,
-                conditions=conditions,
+                conditions=[{"type": "log_message", "value": ["Rate limit*"]}],
             )
 
         assert (
             str(response.data["conditions"][0])
-            == "A filter matches one data type, so error, log, and metric conditions "
-            "cannot be combined."
+            == "A filter on error data cannot use the log_message condition. "
+            "It accepts error_type, error_message, release."
         )
+
+    def test_put_to_catch_all(self) -> None:
+        with self.feature(self.features), outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                dataType="all",
+            )
+
+        self.custom_filter.refresh_from_db()
+        assert response.data["dataType"] == "all"
+        assert self.custom_filter.data_type == "all"
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            audit_entry = AuditLogEntry.objects.get(
+                organization_id=self.organization.id,
+                event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
+            )
+        assert audit_entry.data["changes"] == {"data_type": {"old": "error", "new": "all"}}
+
+    def test_put_widening_data_type_and_conditions_together(self) -> None:
+        """A data type and the conditions it allows are validated as one update."""
+        with self.feature(self.features), outbox_runner():
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                dataType="all",
+                conditions=[{"type": "release", "value": ["2.*"]}],
+            )
+
+        self.custom_filter.refresh_from_db()
+        assert self.custom_filter.data_type == "all"
+        assert self.custom_filter.conditions == [{"type": "release", "value": ["2.*"]}]
+
+    def test_put_rejects_data_type_the_stored_conditions_do_not_fit(self) -> None:
+        """Widening alone would strand conditions the new data type cannot read."""
+        error_filter = self.create_project_custom_inbound_filter(
+            project=self.project,
+            name="Error filter",
+            conditions=[{"type": "error_message", "value": ["TypeError*"]}],
+        )
+
+        with self.feature(self.features):
+            response = self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                error_filter.id,
+                dataType="all",
+            )
+
+        assert (
+            str(response.data["conditions"][0])
+            == "A filter on all data cannot use the error_message condition. "
+            "It accepts release."
+        )
+        error_filter.refresh_from_db()
+        assert error_filter.data_type == "error"
 
     def test_delete(self) -> None:
         with self.feature(self.features), outbox_runner():
@@ -506,7 +656,12 @@ class CustomInboundFilterProjectConfigInvalidationTest(APITestCase):
             args=[self.organization.slug, self.project.slug, self.custom_filter.id],
         )
         cases = [
-            ("post", list_url, {"conditions": [{"type": "release", "value": ["1.*"]}]}, 201),
+            (
+                "post",
+                list_url,
+                {"dataType": "all", "conditions": [{"type": "release", "value": ["1.*"]}]},
+                201,
+            ),
             ("put", details_url, {"active": False}, 200),
             ("delete", details_url, {}, 204),
         ]

--- a/tests/sentry/ingest/test_inbound_filters.py
+++ b/tests/sentry/ingest/test_inbound_filters.py
@@ -246,11 +246,29 @@ def error_type_rule_condition(values: list[str]) -> dict:
     }
 
 
+def release_rule_condition(values: list[str]) -> dict:
+    """The catch-all shape: the release field of every data type, combined with OR."""
+    return {
+        "op": "or",
+        "inner": [
+            {"op": "glob", "name": "event.release", "value": values},
+            {"op": "glob", "name": "log.attributes.sentry.release.value", "value": values},
+            {
+                "op": "glob",
+                "name": "trace_metric.attributes.sentry.release.value",
+                "value": values,
+            },
+            {"op": "glob", "name": "span.attributes.sentry.release.value", "value": values},
+        ],
+    }
+
+
 @django_db_all
 @pytest.mark.parametrize(
-    ("conditions", "expected_condition"),
+    ("data_type", "conditions", "expected_condition"),
     [
         pytest.param(
+            "error",
             [
                 {"type": "error_message", "value": ["*ConnectionError*"]},
                 {"type": "release", "value": ["1.*", "2.*"]},
@@ -265,11 +283,13 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="error_message_and_release",
         ),
         pytest.param(
+            "error",
             [{"type": "error_type", "value": ["TypeError", "*Timeout"]}],
             error_type_rule_condition(["TypeError", "*Timeout"]),
             id="error_type_only",
         ),
         pytest.param(
+            "error",
             [
                 {"type": "error_type", "value": ["TypeError"]},
                 {"type": "error_message", "value": ["*undefined*"]},
@@ -284,6 +304,7 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="error_type_and_error_message",
         ),
         pytest.param(
+            "error",
             [
                 {"type": "error_type", "value": ["TypeError"]},
                 {"type": "release", "value": ["1.*"]},
@@ -298,6 +319,7 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="error_type_and_release",
         ),
         pytest.param(
+            "log",
             [
                 {"type": "log_message", "value": ["*DEBUG*"]},
                 {"type": "release", "value": ["1.2.3"]},
@@ -316,6 +338,7 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="log_message_and_release",
         ),
         pytest.param(
+            "metric",
             [
                 {"type": "metric_name", "value": ["checkout.*"]},
                 {"type": "release", "value": ["1.2.3"]},
@@ -334,22 +357,51 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="metric_name_and_release",
         ),
         pytest.param(
+            "metric",
             [{"type": "metric_name", "value": ["checkout.*"]}],
             {"op": "glob", "name": "trace_metric.name", "value": ["checkout.*"]},
             id="single_condition_is_not_wrapped",
         ),
         pytest.param(
+            "span",
+            [{"type": "release", "value": ["1.2.3"]}],
+            {"op": "glob", "name": "span.attributes.sentry.release.value", "value": ["1.2.3"]},
+            id="release_on_spans",
+        ),
+        pytest.param(
+            "error",
             [{"type": "release", "value": ["1.*"]}],
             {"op": "glob", "name": "event.release", "value": ["1.*"]},
-            id="release_only_targets_events",
+            id="release_on_errors_reads_the_event_field_only",
+        ),
+        pytest.param(
+            "all",
+            [{"type": "release", "value": ["1.*"]}],
+            release_rule_condition(["1.*"]),
+            id="catch_all_release",
+        ),
+        pytest.param(
+            "all",
+            [
+                {"type": "release", "value": [">2*"]},
+                {"type": "release", "value": ["<4*"]},
+            ],
+            {
+                "op": "and",
+                "inner": [
+                    release_rule_condition([">2*"]),
+                    release_rule_condition(["<4*"]),
+                ],
+            },
+            id="catch_all_release_range",
         ),
     ],
 )
 def test_custom_inbound_filter_condition_translation(
-    default_project, factories, conditions, expected_condition
+    default_project, factories, data_type, conditions, expected_condition
 ) -> None:
     custom_filter = factories.create_project_custom_inbound_filter(
-        default_project, conditions=conditions
+        default_project, data_type=data_type, conditions=conditions
     )
 
     [generic_filter] = get_custom_inbound_filter_generic_filters(default_project)
@@ -462,6 +514,25 @@ def test_custom_inbound_filter_skips_untranslatable_filters(default_project, fac
     factories.create_project_custom_inbound_filter(
         default_project,
         conditions=[{"type": "release", "value": []}],
+    )
+    # A data type this revision does not know, e.g. one a newer deploy wrote.
+    factories.create_project_custom_inbound_filter(
+        default_project,
+        data_type="unknown_data_type",
+        conditions=[{"type": "release", "value": ["1.*"]}],
+    )
+    # A span filter accepts release alone, so any other condition disables the filter
+    # rather than widening it.
+    factories.create_project_custom_inbound_filter(
+        default_project,
+        data_type="span",
+        conditions=[{"type": "error_type", "value": ["TypeError"]}],
+    )
+    # A catch-all can only carry conditions every data type has a field for.
+    factories.create_project_custom_inbound_filter(
+        default_project,
+        data_type="all",
+        conditions=[{"type": "error_message", "value": ["*Error*"]}],
     )
     # A log carries no exception type, so a filter mixing data types matches nothing.
     factories.create_project_custom_inbound_filter(


### PR DESCRIPTION
- Add the `all` and `span` data types (`all`, `error`, `log`, `metric`, `span`)
- `all` is the catch-all. It accepts only the conditions every data type carries a field for (today this is only `release`)
- Each such condition expands into an OR over all of their field paths in the rules serialized to Relay
- A condition added to every data type becomes available to catch-all filters with no further work
- The API now reads and writes `dataType` instead of deriving it from the conditions
- Stacked on #123432, which adds the column. Only merge after #123307, which sends `dataType` from the frontend
- Split out of #122466 on review

Contributes to TET-2841