### PR TITLE
fix(auth): Keep login button available for password managers

### DIFF
--- a/static/app/views/authV2/authLogin/components/emailAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/emailAuth.spec.tsx
@@ -1,6 +1,7 @@
 import {UserFixture} from 'sentry-fixture/user';
 
 import {
+  fireEvent,
   render,
   screen,
   userEvent,
@@ -21,18 +22,20 @@ describe('EmailAuth', () => {
     });
     render(<EmailAuth onAuthResult={onAuthResult} />);
 
-    expect(
-      screen.queryByRole('button', {name: 'Log in to Sentry'})
-    ).not.toBeInTheDocument();
+    const loginButton = screen.getByRole('button', {name: 'Log in to Sentry'});
+    expect(loginButton).toBeEnabled();
+    expect(loginButton).toHaveAttribute('tabindex', '-1');
+    expect(loginButton).not.toHaveAttribute('aria-hidden');
+    expect(loginButton).toHaveStyle({pointerEvents: 'none'});
     await userEvent.type(
       screen.getByRole('textbox', {name: 'Email'}),
       'user@example.com'
     );
-    expect(
-      screen.queryByRole('button', {name: 'Log in to Sentry'})
-    ).not.toBeInTheDocument();
+    expect(loginButton).toHaveAttribute('tabindex', '-1');
     await userEvent.type(screen.getByLabelText('Password'), 'secret');
-    await userEvent.click(await screen.findByRole('button', {name: 'Log in to Sentry'}));
+    expect(loginButton).not.toHaveAttribute('tabindex');
+    expect(loginButton).toHaveStyle({pointerEvents: 'auto'});
+    await userEvent.click(loginButton);
 
     await waitFor(() =>
       expect(request).toHaveBeenCalledWith(
@@ -49,6 +52,33 @@ describe('EmailAuth', () => {
         nextUri: '/organizations/',
         user,
       })
+    );
+  });
+
+  it('allows password managers to submit immediately after autofill', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/auth/login/',
+      method: 'POST',
+      body: {nextUri: '/organizations/', user: UserFixture()},
+    });
+    render(<EmailAuth onAuthResult={jest.fn()} />);
+
+    const emailInput = screen.getByRole('textbox', {name: 'Email'});
+    const passwordInput = screen.getByLabelText('Password');
+    const loginButton = screen.getByRole('button', {name: 'Log in to Sentry'});
+
+    emailInput.setAttribute('value', 'user@example.com');
+    passwordInput.setAttribute('value', 'secret');
+    fireEvent.click(loginButton);
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        '/auth/login/',
+        expect.objectContaining({
+          method: 'POST',
+          data: {username: 'user@example.com', password: 'secret', orgSlug: null},
+        })
+      )
     );
   });
 

--- a/static/app/views/authV2/authLogin/components/emailAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/emailAuth.tsx
@@ -44,6 +44,7 @@ export function EmailAuth({onAuthResult, organizationSlug}: EmailAuthProps) {
   const authError = emailAuth.errorMessage;
   const isEmailAuthTransitioning = emailAuth.isPending || Boolean(emailAuth.result);
   const isPending = isEmailAuthTransitioning || passwordReset.isPending;
+  const hasLoginCredentials = Boolean(email && password);
 
   function handleEmailChange(event: React.ChangeEvent<HTMLInputElement>) {
     setEmail(event.currentTarget.value);
@@ -211,23 +212,27 @@ export function EmailAuth({onAuthResult, organizationSlug}: EmailAuthProps) {
           </Flex>
           <Flex flex="1" justify="end" paddingTop="sm">
             <AnimatePresence initial={false} mode="wait">
-              {!passwordReset.result &&
-                !isPasswordRecovery &&
-                Boolean(email && password) && (
-                  <MotionButton
-                    key="login"
-                    type="submit"
-                    variant="primary"
-                    size="sm"
-                    busy={isEmailAuthTransitioning}
-                    initial={{opacity: 0, y: 5}}
-                    animate={{opacity: 1, y: 0}}
-                    exit={{opacity: 0, scale: 0.96}}
-                    transition={theme.motion.framer.smooth.moderate}
-                  >
-                    {t('Log in to Sentry')}
-                  </MotionButton>
-                )}
+              {!passwordReset.result && !isPasswordRecovery && (
+                <MotionButton
+                  key="login"
+                  type="submit"
+                  variant="primary"
+                  size="sm"
+                  busy={isEmailAuthTransitioning}
+                  tabIndex={hasLoginCredentials ? undefined : -1}
+                  initial={false}
+                  animate={
+                    hasLoginCredentials
+                      ? {opacity: 1, scale: 1, y: 0}
+                      : {opacity: 0, scale: 0.96, y: 5}
+                  }
+                  exit={{opacity: 0, scale: 0.96}}
+                  style={{pointerEvents: hasLoginCredentials ? 'auto' : 'none'}}
+                  transition={theme.motion.framer.smooth.moderate}
+                >
+                  {t('Log in to Sentry')}
+                </MotionButton>
+              )}
               {!passwordReset.result && isPasswordRecovery && Boolean(email) && (
                 <MotionButton
                   key="password-reset"


### PR DESCRIPTION
Password managers can fill input values and click submit without emitting React change events. The Auth V2 login button was mounted only after React state contained both credentials, so one-step sign-in could not find it.

Keep the enabled submit button mounted while making it visually and interactively unavailable until credentials are entered normally. Read submitted values from `FormData` so password-manager autofill can authenticate immediately.