### PR TITLE
fix(dashboards): tighten and align the widget table star column

### DIFF
--- a/static/app/components/tables/gridEditable/index.tsx
+++ b/static/app/components/tables/gridEditable/index.tsx
@@ -116,9 +116,9 @@ export function GridEditable<
       props.columnOrder.map(column => ({
         key: String(column.key),
         resizable,
-        width: column.width,
+        width: grid.staticColumnWidths?.[String(column.key)] ?? column.width,
       })),
-    [props.columnOrder, resizable]
+    [grid.staticColumnWidths, props.columnOrder, resizable]
   );
 
   const onColumnResize = (columnIndex: number, width: number) => {

--- a/static/app/components/tables/gridEditable/types.ts
+++ b/static/app/components/tables/gridEditable/types.ts
@@ -68,4 +68,10 @@ export type GridData<
     dataRow?: DataRow,
     rowIndex?: number
   ) => React.ReactNode[];
+  /**
+   * CSS grid tracks keyed by column, for columns that should size to their
+   * content rather than to the table's minimum column width. Takes precedence
+   * over the column's own width.
+   */
+  staticColumnWidths?: Record<string, number | string>;
 };

--- a/static/app/components/tables/gridEditable/types.ts
+++ b/static/app/components/tables/gridEditable/types.ts
@@ -68,10 +68,5 @@ export type GridData<
     dataRow?: DataRow,
     rowIndex?: number
   ) => React.ReactNode[];
-  /**
-   * CSS grid tracks keyed by column, for columns that should size to their
-   * content rather than to the table's minimum column width. Takes precedence
-   * over the column's own width.
-   */
   staticColumnWidths?: Record<string, number | string>;
 };

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.spec.tsx
@@ -80,6 +80,22 @@ describe('TableWidgetVisualization', () => {
       expect($headers[0]!.querySelector('svg')).toBeInTheDocument();
     });
 
+    it('Sizes the is_starred_transaction column to its content', () => {
+      const starredTableData: TabularData = {
+        data: [{is_starred_transaction: true, transaction: '/api/foo'}],
+        meta: {
+          fields: {is_starred_transaction: 'boolean', transaction: 'string'},
+          units: {is_starred_transaction: null, transaction: null},
+        },
+      };
+
+      render(<TableWidgetVisualization tableData={starredTableData} />);
+
+      expect(screen.getByRole('table')).toHaveStyle({
+        gridTemplateColumns: 'max-content minmax(90px, auto)',
+      });
+    });
+
     it('Renders alias text instead of star icon when alias is provided', () => {
       const starredTableData: TabularData = {
         data: [{is_starred_transaction: true, transaction: '/api/foo'}],

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -1,6 +1,7 @@
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {getNextSort} from 'sentry/components/tables/getNextSort';
@@ -144,6 +145,29 @@ export const FRAMELESS_STYLES = {
   height: '100%',
 };
 
+/**
+ * The starred column only ever holds an icon, so it hugs its content rather
+ * than stretching to the table's minimum column width.
+ */
+const STARRED_COLUMN_WIDTH = 'max-content';
+
+function isStarredColumn(key: string, aliases?: Record<string, string>): boolean {
+  return key === SpanFields.IS_STARRED_TRANSACTION && !aliases?.[key];
+}
+
+function getStaticColumnWidths(
+  columns: TabularColumn[],
+  aliases?: Record<string, string>
+): Record<string, string> | undefined {
+  const starredColumn = columns.find(
+    column =>
+      isStarredColumn(column.key, aliases) &&
+      (column.width === undefined || column.width === COL_WIDTH_UNDEFINED)
+  );
+
+  return starredColumn ? {[starredColumn.key]: STARRED_COLUMN_WIDTH} : undefined;
+}
+
 function prettifyColumnKey(key: string): string {
   if (isEquation(key) || parseFunction(key)) {
     return key;
@@ -236,6 +260,7 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
       // GridEditable needs name, but this functionality is replaced by aliases
       columnOrder={columnOrder.map(column => ({...column, name: column.key}))}
       grid={{
+        staticColumnWidths: getStaticColumnWidths(columnOrder, aliases),
         getColumnSort: (_tableColumn, columnIndex) => {
           const column = columnOrder[columnIndex]!;
           const sortColumn = getSortField(column.key) ?? column.key;
@@ -271,18 +296,17 @@ export function TableWidgetVisualization(props: TableWidgetVisualizationProps) {
         },
         renderHeadCell: (_tableColumn, columnIndex) => {
           const column = columnOrder[columnIndex]!;
-          const isStarredColumn = column.key === SpanFields.IS_STARRED_TRANSACTION;
-          const hasAlias = !!aliases?.[column.key];
+          if (isStarredColumn(column.key, aliases)) {
+            return <StarColumnHeader columnKey={column.key} />;
+          }
+
           let name: React.ReactNode =
             aliases?.[column.key] || prettifyColumnKey(column.key);
-          if (isStarredColumn && !hasAlias) {
-            name = <IconStar isSolid size="md" variant="warning" />;
-          } else if (isEquation(column.key)) {
+          if (isEquation(column.key)) {
             name = stripEquationPrefix(name as string);
           }
-          const tooltipTitle = isStarredColumn && !hasAlias ? column.key : name;
 
-          return <StyledTooltip title={tooltipTitle}>{name}</StyledTooltip>;
+          return <StyledTooltip title={name}>{name}</StyledTooltip>;
         },
         renderBodyCell: (tableColumn, dataRow, rowIndex, columnIndex) => {
           const field = tableColumn.key;
@@ -383,22 +407,19 @@ TableWidgetVisualization.LoadingPlaceholder = function ({
       data={[]}
       resizable={false}
       grid={{
+        staticColumnWidths: getStaticColumnWidths(columns ?? [], aliases),
         renderHeadCell: (_tableColumn, columnIndex) => {
           if (!columns) {
             return null;
           }
           const column = columns[columnIndex]!;
-          const isStarredColumn = column.key === SpanFields.IS_STARRED_TRANSACTION;
-          const hasAlias = !!aliases?.[column.key];
-          const displayAsIcon = isStarredColumn && !hasAlias;
-          const name: React.ReactNode = displayAsIcon ? (
-            <IconStar isSolid size="md" variant="warning" />
-          ) : (
-            aliases?.[column.key] || prettifyColumnKey(column.key)
-          );
-          const tooltipTitle = displayAsIcon ? column.key : name;
+          if (isStarredColumn(column.key, aliases)) {
+            return <StarColumnHeader columnKey={column.key} />;
+          }
 
-          return <StyledTooltip title={tooltipTitle}>{name}</StyledTooltip>;
+          const name = aliases?.[column.key] || prettifyColumnKey(column.key);
+
+          return <StyledTooltip title={name}>{name}</StyledTooltip>;
         },
       }}
     />
@@ -408,4 +429,22 @@ TableWidgetVisualization.LoadingPlaceholder = function ({
 const StyledTooltip = styled(Tooltip)`
   display: initial;
   vertical-align: middle;
+`;
+
+function StarColumnHeader({columnKey}: {columnKey: string}) {
+  return (
+    <StarColumnTooltip title={columnKey}>
+      <Flex align="center" justify="center">
+        <IconStar isSolid variant="warning" />
+      </Flex>
+    </StarColumnTooltip>
+  );
+}
+
+/**
+ * Fills the header cell so the star centers over the star buttons below it,
+ * which are wider than the star they contain.
+ */
+const StarColumnTooltip = styled(StyledTooltip)`
+  flex: 1;
 `;

--- a/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/tableWidget/tableWidgetVisualization.tsx
@@ -441,10 +441,6 @@ function StarColumnHeader({columnKey}: {columnKey: string}) {
   );
 }
 
-/**
- * Fills the header cell so the star centers over the star buttons below it,
- * which are wider than the star they contain.
- */
 const StarColumnTooltip = styled(StyledTooltip)`
   flex: 1;
 `;

--- a/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
+++ b/static/app/views/insights/common/components/tableCells/starredSegmentCell.tsx
@@ -106,6 +106,7 @@ export function StarredSegmentCell({
           <IconStar
             variant={isStarred ? 'warning' : 'muted'}
             isSolid={isStarred}
+            size="sm"
             data-test-id="starred-transaction-column"
           />
         }


### PR DESCRIPTION
The starred transaction column in a dashboard table widget took `GridEditable`'s 90px minimum track to hold a single icon.

I added a `grid.staticColumnWidths` to `GridEditable`, which actually moves it close to what `DataTable` already exposes -> will make it easier to migrate soon!  Now the column sizes to its content and the header star centers over the buttons. 

<table>
<thead>
<tr>
<th>Before</th>
<th>After</th>
</tr>
</thead>
<tbody>
<tr>
<td>
<img width="1500" height="958" alt="de-1589-before" src="https://github.com/user-attachments/assets/151d2dad-a036-43c4-8175-69062883fe52" />
</td>
<td>
<img width="1500" height="958" alt="de-1589-after" src="https://github.com/user-attachments/assets/3c8b36e9-9c18-4533-81fa-777158328c0d" />
</td>
</tr>
</tbody>
</table>

Closes DE-1589.