### PR TITLE
ref(autofix): skip_quota used when also skipping quota checks

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -524,8 +524,8 @@ def trigger_autofix_agent(
         stopping_point: Where to stop the automated pipeline (only used for new runs)
         allow_free_cohort: Internal-only flag set by night shift to bypass
             quota for free cohort orgs. Not exposed via the API.
-        skip_quota: Do not record SEER_AUTOFIX usage after a new run starts.
-            The availability check still applies.
+        skip_quota: Bypass SEER_AUTOFIX quota checks and usage recording for a
+            new run.
     """
     # check billing quota for triggering a new autofix run
     # Free cohort orgs bypass quota only when called from night shift

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -532,7 +532,9 @@ def trigger_autofix_agent(
     # (allow_free_cohort=True). The API endpoint never sets this flag,
     # so manual triggers still require quota.
     if run_id is None:
-        skip_quota_check = allow_free_cohort and is_free_cohort_org(group.organization)
+        skip_quota_check = skip_quota or (
+            allow_free_cohort and is_free_cohort_org(group.organization)
+        )
         if not skip_quota_check:
             has_budget: bool = quotas.backend.check_seer_quota(
                 org_id=group.organization.id,

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -916,17 +916,15 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client_class.return_value = mock_client
         mock_client.start_run.return_value = MagicMock(seer_run_state_id=12345)
 
-        trigger_autofix_agent(
-            group=self.group,
-            step=AutofixStep.ROOT_CAUSE,
-            referrer=AutofixReferrer.UNKNOWN,
-            skip_quota=True,
-        )
+        with patch("sentry.seer.autofix.autofix_agent.features.has", return_value=False):
+            trigger_autofix_agent(
+                group=self.group,
+                step=AutofixStep.ROOT_CAUSE,
+                referrer=AutofixReferrer.UNKNOWN,
+                skip_quota=True,
+            )
 
-        mock_check_quota.assert_called_once_with(
-            org_id=self.group.organization.id,
-            data_category=DataCategory.SEER_AUTOFIX,
-        )
+        mock_check_quota.assert_not_called()
         mock_record_run.assert_not_called()
 
     @patch("sentry.quotas.backend.record_seer_run")


### PR DESCRIPTION
Adds skip_quota into skip_quota_check flag to ensure top-level arg is taken into account when doing any quota operations.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>