### PR TITLE
ref(auth): Split login banner formats

### DIFF
--- a/src/sentry/api/endpoints/auth_config.py
+++ b/src/sentry/api/endpoints/auth_config.py
@@ -41,7 +41,7 @@ class AuthConfigResponse(TypedDict):
     googleLoginLink: NotRequired[str]
     vstsLoginLink: NotRequired[str]
     warning: NotRequired[str]
-    loginBanner: NotRequired[str]
+    loginBannerMarkdown: NotRequired[str]
 
 
 @control_silo_endpoint
@@ -126,8 +126,10 @@ class AuthConfigEndpoint(Endpoint, OrganizationMixin):
         if "session_expired" in request.COOKIES:
             context["warning"] = str(WARN_SESSION_EXPIRED)
 
+        raw_additional_login_context = additional_context.run_callbacks(request)
+        raw_additional_login_context.pop("login_banner_legacy_html", None)
         additional_login_context = convert_dict_key_case(
-            additional_context.run_callbacks(request), snake_to_camel_case
+            raw_additional_login_context, snake_to_camel_case
         )
         context.update(additional_login_context)
 

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3101,9 +3101,6 @@ SENTRY_SLICING_LOGICAL_PARTITION_COUNT = 256
 # to a slice ID
 SENTRY_SLICING_CONFIG: Mapping[str, Mapping[tuple[int, int], int]] = {}
 
-# Show banners on the login page that are defined in layout.html
-SHOW_LOGIN_BANNER = False
-
 # Mapping of (logical topic names, slice id) to physical topic names
 # and kafka broker names. The kafka broker names are used to construct
 # the broker config from KAFKA_CLUSTERS. This is used for slicing only.

--- a/src/sentry/templates/sentry/partial/alerts.html
+++ b/src/sentry/templates/sentry/partial/alerts.html
@@ -2,7 +2,7 @@
 {% load sentry_assets %}
 
 {% block css %}
-{% if show_login_banner or show_partner_login_banner %}
+{% if login_banner_legacy_html or show_partner_login_banner %}
 <style type="text/css">
   .alert-banner {
     padding-top: 0.75rem;
@@ -87,8 +87,8 @@
   <div class="alert-banner partner">
     <div class="alert-message">Complete your registration by checking your inbox for our email and following the sign-in link.</div>
   </div>
-  {% elif show_login_banner %}
+  {% elif login_banner_legacy_html %}
   <div class="alert-banner default">
-    <div class="alert-message">Did you know you can use Sentry to monitor your agents? Well you can, <a target="_blank" href="https://docs.sentry.io/product/agents/?utm_source=website">learn more about agent tracing now</a>.</div>
+    <div class="alert-message">{{ login_banner_legacy_html|safe }}</div>
   </div>
 {% endif %}

--- a/src/sentry/web/frontend/auth_login.py
+++ b/src/sentry/web/frontend/auth_login.py
@@ -592,7 +592,6 @@ class AuthLoginView(BaseView, ReactMixin):
             "join_request_link": self.get_join_request_link(
                 organization=organization, request=request
             ),  # NOTE: not utilized in basic login page (only org login)
-            "show_login_banner": settings.SHOW_LOGIN_BANNER,
             "show_partner_login_banner": request.GET.get("partner") is not None,
             "referrer": request.GET.get("referrer"),
         }

--- a/static/app/types/auth.tsx
+++ b/static/app/types/auth.tsx
@@ -148,7 +148,7 @@ export type AuthConfig = {
   serverHostname: string;
   githubLoginLink?: string;
   googleLoginLink?: string;
-  loginBanner?: string;
+  loginBannerMarkdown?: string;
   vstsLoginLink?: string;
   warning?: string;
 };

--- a/static/app/views/authV2/authLogin/index.spec.tsx
+++ b/static/app/views/authV2/authLogin/index.spec.tsx
@@ -310,8 +310,8 @@ describe('AuthLogin', () => {
       githubLoginLink: '',
       googleLoginLink: '',
       hasNewsletter: false,
-      loginBanner:
-        'Try agent monitoring. <a href="https://example.com/agents">Learn more</a>.',
+      loginBannerMarkdown:
+        'Try agent monitoring. [Learn more](https://example.com/agents).',
       pendingMfa: null,
       serverHostname: 'sentry.example.com',
       vstsLoginLink: '',

--- a/static/app/views/authV2/authLogin/index.tsx
+++ b/static/app/views/authV2/authLogin/index.tsx
@@ -14,6 +14,7 @@ import {IconGithub, IconGoogle, IconLab, IconSentry, IconVsts} from 'sentry/icon
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {AuthConfig} from 'sentry/types/auth';
+import {MarkedText} from 'sentry/utils/marked/markedText';
 import {isNotFoundError} from 'sentry/utils/requestError/requestError';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {AuthV2CookieState, useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
@@ -298,12 +299,9 @@ export default function AuthLogin() {
           </AnimatePresence>
         </LoginContainer>
 
-        {loginConfig?.loginBanner && (
+        {loginConfig?.loginBannerMarkdown && (
           <Alert variant="muted">
-            {/* Login banners are trusted server and plugin configuration, matching the legacy template contract. */}
-            <Text as="div" dangerouslySetInnerHTML={{__html: loginConfig.loginBanner}}>
-              {null}
-            </Text>
+            <MarkedText text={loginConfig.loginBannerMarkdown} inline />
           </Alert>
         )}
       </Stack>

--- a/tests/sentry/api/endpoints/test_auth_config.py
+++ b/tests/sentry/api/endpoints/test_auth_config.py
@@ -106,16 +106,22 @@ class AuthConfigEndpointTest(APITestCase):
         }
 
     def test_login_banner(self) -> None:
-        banner = 'Banner message <a href="https://example.com">Learn more</a>.'
+        banner = "Banner message [Learn more](https://example.com)."
         with patch.object(
             additional_context,
             "_callbacks",
-            {lambda request: {"login_banner": banner}},
+            {
+                lambda request: {
+                    "login_banner_markdown": banner,
+                    "login_banner_legacy_html": "<strong>Legacy banner</strong>",
+                }
+            },
         ):
             response = self.client.get(self.path)
 
-        assert response.data["loginBanner"] == banner
-        assert "login_banner" not in response.data
+        assert response.data["loginBannerMarkdown"] == banner
+        assert "loginBannerLegacyHtml" not in response.data
+        assert "login_banner_markdown" not in response.data
 
     def test_additional_context_keys_are_camelized(self) -> None:
         with patch.object(

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -31,7 +31,7 @@ from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
 from sentry.users.models.user import User
 from sentry.utils import json
-from sentry.web.frontend.auth_login import AuthLoginView
+from sentry.web.frontend.auth_login import AuthLoginView, additional_context
 
 
 # TODO(dcramer): need tests for SSO behavior and single org behavior
@@ -49,6 +49,17 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
 
         assert resp.status_code == 200
         self.assertTemplateUsed("sentry/login.html")
+
+    def test_renders_legacy_login_banner(self) -> None:
+        banner = 'Banner message <a href="https://example.com">Learn more</a>.'
+        with mock.patch.object(
+            additional_context,
+            "_callbacks",
+            {lambda request: {"login_banner_legacy_html": banner}},
+        ):
+            response = self.client.get(self.path)
+
+        assert banner.encode() in response.content
 
     def test_renders_react_template_with_cookie(self) -> None:
         self.client.cookies["sentry_react_auth"] = "1"


### PR DESCRIPTION
Auth V2 currently accepts login banner HTML through the auth-config API, extending the trusted legacy Django template contract into the frontend.

This gives each renderer an explicit format: Auth V2 receives Markdown and renders it through the sanitized inline Markdown renderer, while legacy HTML remains in server-side template context and is removed before API serialization. Deployment-specific banner copy and the old `SHOW_LOGIN_BANNER` setting are removed from Sentry.

Depends on https://github.com/getsentry/getsentry/pull/21811 being deployed first so the production banner remains uninterrupted.