### PR TITLE
perf(issues): Skip integration fetch when no group has a linked issue

### DIFF
--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -12,7 +12,7 @@ from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import Min, prefetch_related_objects
 
-from sentry import tagstore
+from sentry import features, tagstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.constants import LOG_LEVELS
@@ -60,6 +60,7 @@ from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.users.services.user.serial import serialize_generic_user
 from sentry.users.services.user.service import user_service
+from sentry.utils import metrics
 from sentry.utils.cache import cache
 from sentry.utils.safe import safe_execute
 from sentry.utils.snuba import aliased_query, get_snuba_column_name, raw_query
@@ -756,6 +757,23 @@ class GroupSerializerBase(Serializer, ABC):
         org_id: int, groups: Sequence[Group]
     ) -> Sequence[Mapping[int, Sequence[Any]]]:
         from sentry.integrations.base import IntegrationFeatures
+
+        # The cross-silo issue tracking lookups below will never have results
+        # without GroupLink rows, skip the lookup in that case.
+        if groups and features.has(
+            "organizations:issue-annotations-skip-integration-fetch",
+            groups[0].project.organization,
+        ):
+            has_linked_issues = GroupLink.objects.filter(
+                group_id__in=[group.id for group in groups],
+                linked_type=GroupLink.LinkedType.issue,
+            ).exists()
+            metrics.incr(
+                "group.annotations.integration_fetch",
+                tags={"outcome": "fetched" if has_linked_issues else "skipped"},
+            )
+            if not has_linked_issues:
+                return []
 
         integration_annotations = []
         # find all the integration installs that have issue tracking

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -349,6 +349,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:issue-standardized-markdown-for-llm", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Batch latest-event attachment lookups in the issue stream
     manager.add("organizations:issue-stream-batched-latest-event-attachments", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=False)
+    # Skip the control-silo integration fetch when annotating groups with no linked issues
+    manager.add("organizations:issue-annotations-skip-integration-fetch", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Remove trace and breadcrumbs from issue summary input
     manager.add("organizations:issue-summary-experimental", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Show the "recommended" sort as an option in the issue stream sort dropdown

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -10,6 +10,8 @@ from sentry import audit_log, buffer, tsdb
 from sentry.analytics.events.issue_viewed import IssueViewedEvent
 from sentry.buffer.redis import RedisBuffer
 from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_key_jobs
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.services.integration import integration_service
 from sentry.issues.action_log import action_context_scope
 from sentry.issues.action_log.types import ActionSource, GroupActionActor, ReconcileStatusAction
 from sentry.issues.constants import cache_key_for_issue_view
@@ -48,6 +50,7 @@ pytestmark = [requires_snuba]
 
 SECRET = "test-seer-api-shared-secret-thirty-two-bytes!"
 FLAG = "organizations:seer-agent-token-flow"
+SKIP_INTEGRATION_FETCH_FLAG = "organizations:issue-annotations-skip-integration-fetch"
 
 
 class GroupDetailsTest(APITestCase, SnubaTestCase):
@@ -236,6 +239,97 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
 
         assert response.data["annotations"] == [
             {"url": "https://example.com/browse/api-123", "displayName": "api-123"}
+        ]
+
+    def _create_issue_tracking_integration(self, group: Group) -> Integration:
+        return self.create_integration(
+            organization=group.organization,
+            provider="jira",
+            external_id="some_id",
+            name="Hello world",
+            metadata={"base_url": "https://example.com"},
+        )
+
+    def test_annotations_skip_integration_fetch_without_linked_issues(self) -> None:
+        group = self.create_group()
+        self._create_issue_tracking_integration(group)
+        self.login_as(user=self.user)
+
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
+        with (
+            mock.patch(
+                "sentry.api.serializers.models.group.integration_service",
+                wraps=integration_service,
+            ) as mock_integration_service,
+            self.feature(SKIP_INTEGRATION_FETCH_FLAG),
+        ):
+            response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["annotations"] == []
+        mock_integration_service.get_integrations.assert_not_called()
+
+    def test_annotations_fetch_integrations_without_skip_flag(self) -> None:
+        group = self.create_group()
+        self._create_issue_tracking_integration(group)
+        self.login_as(user=self.user)
+
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
+        with (
+            mock.patch(
+                "sentry.api.serializers.models.group.integration_service",
+                wraps=integration_service,
+            ) as mock_integration_service,
+        ):
+            response = self.client.get(url, format="json")
+
+        assert response.status_code == 200
+        assert response.data["annotations"] == []
+        mock_integration_service.get_integrations.assert_called_once_with(
+            organization_id=group.organization.id
+        )
+
+    def test_integration_external_issue_annotation_with_skip_flag(self) -> None:
+        group = self.create_group()
+        integration = self._create_issue_tracking_integration(group)
+        self.create_integration_external_issue(group=group, integration=integration, key="api-123")
+        self.login_as(user=self.user)
+
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
+        with (
+            mock.patch(
+                "sentry.api.serializers.models.group.integration_service",
+                wraps=integration_service,
+            ) as mock_integration_service,
+            self.feature(SKIP_INTEGRATION_FETCH_FLAG),
+        ):
+            response = self.client.get(url, format="json")
+
+        assert response.data["annotations"] == [
+            {"url": "https://example.com/browse/api-123", "displayName": "api-123"}
+        ]
+        mock_integration_service.get_integrations.assert_called_once_with(
+            organization_id=group.organization.id
+        )
+
+    def test_platform_external_issue_annotation_with_skip_flag(self) -> None:
+        # PlatformExternalIssue rows join on group_id and have no GroupLink, so they must survive
+        # a skip that is driven entirely by the absence of GroupLink rows.
+        self.login_as(user=self.user)
+
+        group = self.create_group()
+        self.create_platform_external_issue(
+            group=group,
+            service_type="sentry-app",
+            web_url="https://example.com/issues/2",
+            display_name="Issue#2",
+        )
+        url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
+        with self.feature(SKIP_INTEGRATION_FETCH_FLAG):
+            response = self.client.get(url, format="json")
+
+        assert response.data["annotations"] == [
+            {"url": "https://example.com/issues/2", "displayName": "Issue#2"}
         ]
 
     def test_permalink_superuser(self) -> None:


### PR DESCRIPTION
`GroupSerializerBase._resolve_integration_annotations` fetched every organization integration over an RPC to the control silo on every issue detail and issue stream request. Issue-tracking annotations derive solely from region-local GroupLink rows, so when a group has none, that fetch and the per-integration GroupLink/ExternalIssue queries behind it produce nothing.

`organizations:issue-annotations-skip-integration-fetch` and the `group.annotations.integration_fetch` metric will only be used during rollout and will be removed in a future PR.