### PR TITLE
fix(replays): keep replay details loading until the project slug resolves

### DIFF
--- a/static/app/components/events/highlights/highlightsDataSection.spec.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.spec.tsx
@@ -39,6 +39,10 @@ describe('HighlightsDataSection', () => {
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [project],
+    });
     ProjectsStore.loadInitialData([project]);
     jest.clearAllMocks();
   });

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -102,6 +102,43 @@ describe('useReplayData', () => {
     );
   });
 
+  it('should stay pending until the projects store resolves the project slug', async () => {
+    const {mockReplayResponse, expectedReplay} = getMockReplayRecord({
+      count_errors: 0,
+      count_segments: 0,
+      error_ids: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
+      body: {data: mockReplayResponse},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {data: []},
+    });
+    ProjectsStore.reset();
+
+    const {result} = renderHookWithProviders(useReplayData, {
+      initialProps: {
+        replayId: mockReplayResponse.id,
+        orgSlug: organization.slug,
+      },
+    });
+
+    await waitFor(() => expect(result.current.replayRecord).toEqual(expectedReplay));
+    expect(result.current.projectSlug).toBeNull();
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.status).toBe('pending');
+
+    act(() => {
+      ProjectsStore.loadInitialData([project]);
+    });
+
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.projectSlug).toBe(project.slug);
+    expect(result.current.status).toBe('success');
+  });
+
   it('should concat N segment responses and pass them into ReplayReader', async () => {
     const startedAt = new Date('12:00:00 01-01-2023');
     const finishedAt = new Date('12:00:10 01-01-2023');

--- a/static/app/utils/replays/hooks/useReplayData.spec.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.spec.tsx
@@ -42,6 +42,10 @@ describe('useReplayData', () => {
     jest.useFakeTimers();
     ProjectsStore.loadInitialData([project]);
     MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [project],
+    });
   });
 
   afterEach(() => {
@@ -102,7 +106,7 @@ describe('useReplayData', () => {
     );
   });
 
-  it('should stay pending until the projects store resolves the project slug', async () => {
+  it('should stay pending until the projects request resolves the project slug', async () => {
     const {mockReplayResponse, expectedReplay} = getMockReplayRecord({
       count_errors: 0,
       count_segments: 0,
@@ -115,6 +119,14 @@ describe('useReplayData', () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/events/`,
       body: {data: []},
+    });
+    let resolveProjects = () => {};
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [project],
+      asyncDelay: new Promise<void>(resolve => {
+        resolveProjects = resolve;
+      }),
     });
     ProjectsStore.reset();
 
@@ -132,10 +144,45 @@ describe('useReplayData', () => {
 
     act(() => {
       ProjectsStore.loadInitialData([project]);
+      resolveProjects();
     });
 
     await waitFor(() => expect(result.current.isPending).toBe(false));
     expect(result.current.projectSlug).toBe(project.slug);
+    expect(result.current.status).toBe('success');
+  });
+
+  it('should stop pending when the projects request fails', async () => {
+    const {mockReplayResponse, expectedReplay} = getMockReplayRecord({
+      count_errors: 0,
+      count_segments: 0,
+      error_ids: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/replays/${mockReplayResponse.id}/`,
+      body: {data: mockReplayResponse},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {data: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      statusCode: 500,
+      body: {detail: 'boom'},
+    });
+    ProjectsStore.reset();
+
+    const {result} = renderHookWithProviders(useReplayData, {
+      initialProps: {
+        replayId: mockReplayResponse.id,
+        orgSlug: organization.slug,
+      },
+    });
+
+    await waitFor(() => expect(result.current.replayRecord).toEqual(expectedReplay));
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+    expect(result.current.projectSlug).toBeNull();
     expect(result.current.status).toBe('success');
   });
 

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -8,6 +8,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
+import {getBootstrapProjectsQueryOptions} from 'sentry/bootstrap/bootstrapRequests';
 import {ALL_ACCESS_PROJECTS} from 'sentry/components/pageFilters/constants';
 import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
@@ -21,7 +22,6 @@ import {useFeedbackEvents} from 'sentry/utils/replays/hooks/useFeedbackEvents';
 import {useReplayProjectSlug} from 'sentry/utils/replays/hooks/useReplayProjectSlug';
 import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
 import type {RawReplayError} from 'sentry/utils/replays/types';
-import {useProjects} from 'sentry/utils/useProjects';
 import type {ReplayRecord} from 'sentry/views/explore/replays/types';
 
 export function replayRecordApiOptions({
@@ -166,7 +166,9 @@ export function useReplayData({
   );
 
   const projectSlug = useReplayProjectSlug({replayRecord});
-  const {fetching: isFetchingProjects} = useProjects();
+  const {isPending: isFetchingProjects} = useQuery(
+    getBootstrapProjectsQueryOptions(orgSlug)
+  );
   const isResolvingProjectSlug = !!replayRecord && !projectSlug && isFetchingProjects;
 
   const getAttachmentsQueryOptions = useCallback(

--- a/static/app/utils/replays/hooks/useReplayData.tsx
+++ b/static/app/utils/replays/hooks/useReplayData.tsx
@@ -21,6 +21,7 @@ import {useFeedbackEvents} from 'sentry/utils/replays/hooks/useFeedbackEvents';
 import {useReplayProjectSlug} from 'sentry/utils/replays/hooks/useReplayProjectSlug';
 import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
 import type {RawReplayError} from 'sentry/utils/replays/types';
+import {useProjects} from 'sentry/utils/useProjects';
 import type {ReplayRecord} from 'sentry/views/explore/replays/types';
 
 export function replayRecordApiOptions({
@@ -165,6 +166,8 @@ export function useReplayData({
   );
 
   const projectSlug = useReplayProjectSlug({replayRecord});
+  const {fetching: isFetchingProjects} = useProjects();
+  const isResolvingProjectSlug = !!replayRecord && !projectSlug && isFetchingProjects;
 
   const getAttachmentsQueryOptions = useCallback(
     ({cursor, per_page}: {cursor: string; per_page: number}) =>
@@ -397,6 +400,7 @@ export function useReplayData({
 
   const allStatuses = [
     replayId ? fetchReplayStatus : undefined,
+    isResolvingProjectSlug ? 'pending' : undefined,
     enableAttachments ? fetchAttachmentsStatus : undefined,
     enableErrors ? fetchErrorsStatus : undefined,
     enableExtraErrors ? fetchExtraErrorsStatus : undefined,

--- a/static/app/views/explore/replays/detail/header/replayDetailsUserBadge.spec.tsx
+++ b/static/app/views/explore/replays/detail/header/replayDetailsUserBadge.spec.tsx
@@ -32,6 +32,10 @@ jest.useFakeTimers();
 describe('replayDetailsUserBadge', () => {
   beforeEach(() => {
     MockApiClient.clearMockResponses();
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [project],
+    });
   });
 
   it('should show LIVE badge when last received segment is within 5 minutes', async () => {


### PR DESCRIPTION
On a cold load of the replay details page, the replay record can arrive before the organization's projects list finishes loading. Until the projects store has the replay's project, the project slug is `null`, so the recording-segment and error queries are never enabled and never count as pending. 

`useReplayData` now reports pending while the record is loaded, the project slug is unresolved, and the projects store is still fetching. 

Closes REPLAY-999.