### PR TITLE
fix(billing): Show account credits when no billing details are on file

### DIFF
--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -71,12 +71,8 @@ export function BillingDetailsPanel({
   }
 
   const taxFieldInfo = getTaxFieldInfo(billingDetails?.countryCode);
-  const balance =
-    subscription.accountBalance < 0
-      ? tct('[credits] credit', {
-          credits: formatCurrency(0 - subscription.accountBalance),
-        })
-      : formatCurrency(subscription.accountBalance);
+  const {accountBalance} = subscription;
+  const isCredit = accountBalance < 0;
 
   return (
     <Flex
@@ -95,11 +91,13 @@ export function BillingDetailsPanel({
           {t('Business address')}
         </Heading>
         {formError && <Alert variant="danger">{formError}</Alert>}
-        {!isEditing && !!subscription.accountBalance && (
+        {!isEditing && !!accountBalance && (
           <Text>
-            {tct('Account balance: [balance]', {
-              balance,
-            })}
+            {isCredit
+              ? tct('Account credits: [amount]', {
+                  amount: formatCurrency(0 - accountBalance),
+                })
+              : tct('Balance due: [amount]', {amount: formatCurrency(accountBalance)})}
           </Text>
         )}
         {isEditing ? (

--- a/static/gsApp/views/subscriptionPage/billingInformation.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/billingInformation.spec.tsx
@@ -194,7 +194,7 @@ describe('Subscription > BillingInformation', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders without credit if account balance > 0', async () => {
+  it('renders balance due if account balance > 0', async () => {
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-details/`,
       method: 'GET',
@@ -205,10 +205,10 @@ describe('Subscription > BillingInformation', () => {
 
     render(<BillingInformation subscription={sub} />, {organization});
 
-    expect(await screen.findByText('Account balance: $100')).toBeInTheDocument();
+    expect(await screen.findByText('Balance due: $100')).toBeInTheDocument();
   });
 
-  it('renders with credit if account balance < 0', async () => {
+  it('renders account credits if account balance < 0', async () => {
     MockApiClient.addMockResponse({
       url: `/customers/${organization.slug}/billing-details/`,
       method: 'GET',
@@ -219,7 +219,7 @@ describe('Subscription > BillingInformation', () => {
 
     render(<BillingInformation subscription={sub} />, {organization});
 
-    expect(await screen.findByText('Account balance: $100 credit')).toBeInTheDocument();
+    expect(await screen.findByText('Account credits: $100')).toBeInTheDocument();
   });
 
   it('hides account balance when it is 0', async () => {
@@ -229,7 +229,8 @@ describe('Subscription > BillingInformation', () => {
     render(<BillingInformation subscription={sub} />, {organization});
 
     await screen.findByText('Payment method');
-    expect(screen.queryByText(/account balance/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/account credits/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/balance due/i)).not.toBeInTheDocument();
   });
 
   it('can update credit card with setupintent', async () => {

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.spec.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.spec.tsx
@@ -30,7 +30,8 @@ describe('BillingInfoCard', () => {
     await screen.findByText('Test company, Display Address');
     expect(screen.getByText('Billing email: test@gmail.com')).toBeInTheDocument();
     expect(screen.getByText('Visa ending in 4242')).toBeInTheDocument();
-    expect(screen.getByText('Account balance: $10')).toBeInTheDocument();
+    // a positive balance is owed, not credit
+    expect(screen.getByText('Balance due: $10')).toBeInTheDocument();
   });
 
   it('renders with some pre-existing info', async () => {
@@ -50,15 +51,60 @@ describe('BillingInfoCard', () => {
       screen.getByText('No billing email or tax number on file')
     ).toBeInTheDocument();
     expect(screen.getByText('Visa ending in 4242')).toBeInTheDocument();
-    expect(screen.getByText('Account balance: $10 credit')).toBeInTheDocument();
+    expect(screen.getByText('Account credits: $10')).toBeInTheDocument();
   });
 
   it('renders without pre-existing info', async () => {
-    const subscription = SubscriptionFixture({organization, paymentSource: null});
+    const subscription = SubscriptionFixture({
+      organization,
+      paymentSource: null,
+      accountBalance: 0,
+    });
     render(<BillingInfoCard organization={organization} subscription={subscription} />);
 
     expect(screen.getByText('Billing information')).toBeInTheDocument();
     await screen.findByText('No billing details on file');
     expect(screen.getByText('No payment method on file')).toBeInTheDocument();
+    expect(screen.queryByText(/Account credits/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Balance due/)).not.toBeInTheDocument();
+  });
+
+  it('renders the account credit without billing details or a payment method', async () => {
+    const subscription = SubscriptionFixture({
+      organization,
+      paymentSource: null,
+      accountBalance: -10_00,
+    });
+    render(<BillingInfoCard organization={organization} subscription={subscription} />);
+
+    expect(await screen.findByText('No billing details on file')).toBeInTheDocument();
+    expect(screen.getByText('No payment method on file')).toBeInTheDocument();
+    // the credit comes off the subscription, so it renders regardless of what
+    // billing details or payment method are on file
+    expect(screen.getByText('Account credits: $10')).toBeInTheDocument();
+  });
+
+  it('renders the account credit when only non-address details are on file', async () => {
+    MockApiClient.addMockResponse({
+      url: `/customers/${organization.slug}/billing-details/`,
+      method: 'GET',
+      body: BillingDetailsFixture({
+        addressLine1: null,
+        addressLine2: null,
+        city: null,
+        region: null,
+        postalCode: null,
+        countryCode: null,
+        displayAddress: null,
+        addressType: null,
+      }),
+    });
+    const subscription = SubscriptionFixture({organization, accountBalance: -10_00});
+    render(<BillingInfoCard organization={organization} subscription={subscription} />);
+
+    // hasSomeBillingDetails() ignores the email/company/tax fields, so this org
+    // still falls into the empty state
+    expect(await screen.findByText('No billing details on file')).toBeInTheDocument();
+    expect(screen.getByText('Account credits: $10')).toBeInTheDocument();
   });
 });

--- a/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/billingInfoCard.tsx
@@ -29,7 +29,8 @@ export function BillingInfoCard({
       title={t('Billing information')}
       sections={[
         <Stack key="billing-info" gap="md" align="start" maxWidth="100%">
-          <BillingDetailsInfo subscription={subscription} />
+          <AccountBalanceInfo subscription={subscription} />
+          <BillingDetailsInfo />
           <PaymentSourceInfo subscription={subscription} />
         </Stack>,
         <LinkButton
@@ -48,7 +49,25 @@ export function BillingInfoCard({
   );
 }
 
-function BillingDetailsInfo({subscription}: {subscription: Subscription}) {
+function AccountBalanceInfo({subscription}: {subscription: Subscription}) {
+  const {accountBalance} = subscription;
+
+  if (!accountBalance) {
+    return null;
+  }
+
+  const isCredit = accountBalance < 0;
+
+  return (
+    <Text bold ellipsis size="sm">
+      {isCredit
+        ? tct('Account credits: [amount]', {amount: formatCurrency(0 - accountBalance)})
+        : tct('Balance due: [amount]', {amount: formatCurrency(accountBalance)})}
+    </Text>
+  );
+}
+
+function BillingDetailsInfo() {
   const {layout} = usePrimaryNavigation();
   const isMobile = layout === 'mobile';
   const {data: billingDetails, isLoading} = useBillingDetails();
@@ -91,22 +110,8 @@ function BillingDetailsInfo({subscription}: {subscription: Subscription}) {
     secondaryDetails.push(`${taxFieldInfo.label}: ${billingDetails.taxNumber}`);
   }
 
-  const balance =
-    subscription.accountBalance < 0
-      ? tct('[credits] credit', {
-          credits: formatCurrency(0 - subscription.accountBalance),
-        })
-      : formatCurrency(subscription.accountBalance);
-
   return (
     <Stack overflow="hidden" gap="sm" maxWidth={isMobile ? MAX_WIDTH : '100%'}>
-      {!!subscription.accountBalance && (
-        <Text ellipsis size="sm" variant="muted">
-          {tct('Account balance: [balance]', {
-            balance,
-          })}
-        </Text>
-      )}
       <Text ellipsis size="sm" variant="muted">
         {primaryDetails.length > 0
           ? primaryDetails.join(', ')


### PR DESCRIPTION
The account credit was rendered inside `BillingDetailsInfo`, below an early return that
fires when `hasSomeBillingDetails()` is false — so any org without an address on file saw
"No billing details on file" and no credit, even though the balance comes off the
subscription. Free and trial orgs were hit hardest: they rarely have an address on file
and don't get the next bill card either, so the credit had nowhere to appear.

This moves the balance into its own `AccountBalanceInfo` sibling, matching how the
settings billing details panel already renders it.

It also reworks the copy, which leaned on a trailing word to tell the two states apart
and made an owed balance read as though the customer had the money:

- negative balance → "Account credits: $10"
- positive balance → "Balance due: $10"

| Before | After |
| --- | --- |
| <img width="2524" height="694" alt="CleanShot 2026-09-02 @ 10 08@2x" src="https://github.com/user-attachments/assets/63dea304-1941-43c6-9f6e-d5c669af9bb7" /> | <img width="2524" height="694" alt="CleanShot 2026-09-02 @ 10 06@2x" src="https://github.com/user-attachments/assets/1cd51de1-a61d-4097-b178-e7d99a911cde" /> |