### PR TITLE
fix(issue detection): Fix missing evidence data in segment-based occurrences

### DIFF
--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -83,6 +83,8 @@ EVIDENCE_SPAN_DATA_KEYS = frozenset(
         "http.request.request_start",
         "http.request.response_start",
         "http.response_content_length",
+        "sentry.category",
+        "sentry.group",
         "url",
     )
 )

--- a/src/sentry/spans/consumers/process_segments/message.py
+++ b/src/sentry/spans/consumers/process_segments/message.py
@@ -584,6 +584,13 @@ def _get_evidence_span_for_occurrence(span: dict[str, Any]) -> dict[str, Any]:
         if key in EVIDENCE_SPAN_DATA_KEYS
     }
 
+    # The span's `hash` value is used in the FE for the Span Evidence and Grouping Info sections of
+    # the issue details page, but gets dropped during normalization. Transaction-based spans
+    # calculate it and add it in post-normalization, so that doesn't matter, but for segment-based
+    # spans normalization happens after hash calculation, meaning the value will be lost unless we
+    # store it somewhere which survives normalization.
+    filtered_data["hash"] = span.get("hash")
+
     return {
         "span_id": span["span_id"],
         "trace_id": span.get("trace_id"),

--- a/tests/sentry/spans/consumers/process_segments/test_message.py
+++ b/tests/sentry/spans/consumers/process_segments/test_message.py
@@ -605,6 +605,8 @@ def test_evidence_span_truncates_descriptions_and_data_separately() -> None:
                 "code.filepath": "F" * (MAX_SPAN_DATA_VALUE_LENGTH * 2),
                 "code.lineno": 42,  # non-strings pass through untouched
                 "db.system": "postgresql",  # not in the allowlist
+                "sentry.group": "0123456789abcdef",
+                "sentry.category": "db",
                 # The span schema allows any attribute to be an array or an object, so an
                 # allowlisted key is not guaranteed to hold a scalar.
                 "url": ["U" * (MAX_SPAN_DATA_VALUE_LENGTH * 2)] * (MAX_EVIDENCE_LIST_ITEMS * 2),
@@ -619,6 +621,9 @@ def test_evidence_span_truncates_descriptions_and_data_separately() -> None:
     assert "db.system" not in span["data"]
     assert len(span["data"]["url"]) == MAX_EVIDENCE_LIST_ITEMS
     assert {len(v) for v in span["data"]["url"]} == {MAX_SPAN_DATA_VALUE_LENGTH}
+    assert span["data"]["sentry.group"] == "0123456789abcdef"
+    assert span["data"]["sentry.category"] == "db"
+    assert span["data"]["hash"] == "abcdef0123456789"
     assert span["trace_id"] == "t" * 32
     # Raw `attributes` forms the bulk of a span's size and must not reach the occurrence
     assert "attributes" not in span


### PR DESCRIPTION
There are a few values (`span.hash`, `span.sentry_tags.group` and `span.sentry_tags.category`) which our issue details' Span Evidence and Grouping Info sections depend on that are present in transaction-derived evidence spans but don't come through in segment-derived ones. 

This is the first half of a fix for that problem, adding the values into the data we store in segment-based occurrences. Because of both schema and process differences between the transaction and segment processing pipelines, the data has to live in slightly different spots (`span.data.hash`, `span.data.sentry_group`, and `span.data.sentry_category`, respectively), so we'll need a follow-up to this PR (the second half of the fix) to update the front end to look in both locations for the data it needs.