### PR TITLE
feat(investigations): Add the Seer orchestration client

### DIFF
--- a/src/sentry/investigations/seer_client.py
+++ b/src/sentry/investigations/seer_client.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+from typing import Any, Literal, TypedDict, cast
+from uuid import UUID, uuid5
+
+import orjson
+from django.conf import settings
+from pydantic import BaseModel, Field, StrictBool, StrictInt, ValidationError
+from urllib3 import BaseHTTPResponse, HTTPConnectionPool
+
+from sentry.investigations.models import (
+    InvestigationOrchestrationCommand,
+    InvestigationOrchestrationRun,
+)
+from sentry.net.http import connection_from_url
+from sentry.seer.agent.monitoring_providers import get_monitoring_provider_connections
+from sentry.seer.models import SeerApiError
+from sentry.seer.signed_seer_api import SeerViewerContext, make_signed_seer_api_request
+
+_CREATE_REQUEST_NAMESPACE = UUID("3bed27f2-9ab9-49ce-8d64-7d78d5c3fd76")
+investigation_connection_pool = connection_from_url(
+    settings.SEER_AUTOFIX_URL,
+    timeout=settings.SEER_DEFAULT_TIMEOUT,
+)
+
+
+class InvestigationRunResponse(TypedDict):
+    runId: int
+    created: bool
+    projection: dict[str, Any]
+
+
+class InvestigationCommandResponse(TypedDict):
+    runId: int
+    requestId: str
+    accepted: bool
+    duplicate: bool
+    workflowVersion: int
+    projection: dict[str, Any]
+
+
+class _InvestigationRunResponseModel(BaseModel):
+    run_id: StrictInt = Field(alias="runId")
+    created: StrictBool
+    projection: dict[str, Any]
+
+
+class _InvestigationCommandResponseModel(BaseModel):
+    run_id: StrictInt = Field(alias="runId")
+    request_id: UUID = Field(alias="requestId")
+    accepted: Literal[True]
+    duplicate: StrictBool
+    workflow_version: StrictInt = Field(alias="workflowVersion")
+    projection: dict[str, Any]
+
+
+__all__ = [
+    "InvestigationCommandResponse",
+    "InvestigationRunResponse",
+    "create_investigation_orchestration_run",
+    "dispatch_investigation_orchestration_command",
+    "get_investigation_orchestration_run",
+]
+
+
+def _decode_response(response: BaseHTTPResponse) -> dict[str, Any]:
+    if response.status < 200 or response.status >= 300:
+        raise SeerApiError("Investigation orchestration request failed", response.status)
+    try:
+        value = orjson.loads(response.data)
+    except orjson.JSONDecodeError as error:
+        raise SeerApiError("Seer returned an invalid response", 502) from error
+    if not isinstance(value, dict):
+        raise SeerApiError("Seer returned an invalid response", 502)
+    return value
+
+
+def _validate_run_response(value: dict[str, Any]) -> InvestigationRunResponse:
+    try:
+        model = _InvestigationRunResponseModel.parse_obj(value)
+    except ValidationError as error:
+        raise SeerApiError("Seer returned an invalid response", 502) from error
+    if model.run_id < 1:
+        raise SeerApiError("Seer returned an invalid response", 502)
+    normalized = {
+        "runId": model.run_id,
+        "created": model.created,
+        "projection": model.projection,
+    }
+    return cast(InvestigationRunResponse, normalized)
+
+
+def _validate_command_response(value: dict[str, Any]) -> InvestigationCommandResponse:
+    try:
+        model = _InvestigationCommandResponseModel.parse_obj(value)
+    except ValidationError as error:
+        raise SeerApiError("Seer returned an invalid response", 502) from error
+    if model.run_id < 1 or model.workflow_version < 1:
+        raise SeerApiError("Seer returned an invalid response", 502)
+    normalized = {
+        "runId": model.run_id,
+        "requestId": str(model.request_id),
+        "accepted": model.accepted,
+        "duplicate": model.duplicate,
+        "workflowVersion": model.workflow_version,
+        "projection": model.projection,
+    }
+    return cast(InvestigationCommandResponse, normalized)
+
+
+def _post(
+    path: str,
+    body: dict[str, Any],
+    *,
+    viewer_context: SeerViewerContext,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> dict[str, Any]:
+    response = make_signed_seer_api_request(
+        connection_pool or investigation_connection_pool,
+        path,
+        body=orjson.dumps(body),
+        viewer_context=viewer_context,
+    )
+    return _decode_response(response)
+
+
+def _get(
+    path: str,
+    *,
+    viewer_context: SeerViewerContext,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> dict[str, Any]:
+    response = make_signed_seer_api_request(
+        connection_pool or investigation_connection_pool,
+        path,
+        body=b"",
+        method="GET",
+        viewer_context=viewer_context,
+    )
+    return _decode_response(response)
+
+
+def _validate_viewer_organization(
+    viewer_context: SeerViewerContext,
+    organization_id: int,
+) -> None:
+    if viewer_context.get("organization_id") != organization_id:
+        raise SeerApiError("Viewer context organization does not match investigation", 400)
+
+
+def create_investigation_orchestration_run(
+    run: InvestigationOrchestrationRun,
+    *,
+    viewer_context: SeerViewerContext,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> InvestigationRunResponse:
+    _validate_viewer_organization(viewer_context, run.investigation.organization_id)
+    body: dict[str, Any] = {
+        "requestId": str(
+            uuid5(
+                _CREATE_REQUEST_NAMESPACE,
+                f"{run.investigation.organization_id}:{run.investigation_id}:{run.id}",
+            )
+        ),
+        "investigationId": run.investigation_id,
+        "source": run.source,
+        "activeTimeBudgetSeconds": 1800,
+    }
+    monitoring_providers = get_monitoring_provider_connections(
+        run.investigation.organization,
+        run.investigation.created_by_id,
+    )
+    if monitoring_providers:
+        body["monitoringProviders"] = [provider.dict() for provider in monitoring_providers]
+    response = _post(
+        "/v1/automation/investigations",
+        body,
+        viewer_context=viewer_context,
+        connection_pool=connection_pool,
+    )
+    return _validate_run_response(response)
+
+
+def dispatch_investigation_orchestration_command(
+    command: InvestigationOrchestrationCommand,
+    *,
+    viewer_context: SeerViewerContext,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> InvestigationCommandResponse:
+    investigation = command.orchestration_run.investigation
+    _validate_viewer_organization(viewer_context, investigation.organization_id)
+    seer_run = command.orchestration_run.seer_run
+    seer_run_id = seer_run.seer_run_state_id if seer_run is not None else None
+    if seer_run_id is None:
+        raise SeerApiError("Investigation has no Seer run", 409)
+    body: dict[str, Any] = {
+        "requestId": str(command.request_id),
+        "expectedWorkflowVersion": command.expected_workflow_version,
+        "command": {"type": command.type, **command.payload},
+    }
+    monitoring_providers = get_monitoring_provider_connections(
+        investigation.organization,
+        command.actor_id or investigation.created_by_id,
+    )
+    if monitoring_providers:
+        body["monitoringProviders"] = [provider.dict() for provider in monitoring_providers]
+    response = _post(
+        f"/v1/automation/investigations/{seer_run_id}/commands",
+        body,
+        viewer_context=viewer_context,
+        connection_pool=connection_pool,
+    )
+    return _validate_command_response(response)
+
+
+def get_investigation_orchestration_run(
+    run: InvestigationOrchestrationRun,
+    *,
+    viewer_context: SeerViewerContext,
+    connection_pool: HTTPConnectionPool | None = None,
+) -> InvestigationRunResponse:
+    _validate_viewer_organization(viewer_context, run.investigation.organization_id)
+    seer_run = run.seer_run
+    seer_run_id = seer_run.seer_run_state_id if seer_run is not None else None
+    if seer_run_id is None:
+        raise SeerApiError("Investigation has no Seer run", 409)
+    response = _get(
+        f"/v1/automation/investigations/{seer_run_id}",
+        viewer_context=viewer_context,
+        connection_pool=connection_pool,
+    )
+    return _validate_run_response(response)

--- a/src/sentry/investigations/seer_client.py
+++ b/src/sentry/investigations/seer_client.py
@@ -6,7 +6,7 @@ from uuid import UUID, uuid5
 import orjson
 from django.conf import settings
 from pydantic import BaseModel, Field, StrictBool, StrictInt, ValidationError
-from urllib3 import BaseHTTPResponse, HTTPConnectionPool
+from urllib3 import BaseHTTPResponse
 
 from sentry.investigations.models import (
     InvestigationOrchestrationCommand,
@@ -113,10 +113,9 @@ def _post(
     body: dict[str, Any],
     *,
     viewer_context: SeerViewerContext,
-    connection_pool: HTTPConnectionPool | None = None,
 ) -> dict[str, Any]:
     response = make_signed_seer_api_request(
-        connection_pool or investigation_connection_pool,
+        investigation_connection_pool,
         path,
         body=orjson.dumps(body),
         viewer_context=viewer_context,
@@ -128,10 +127,9 @@ def _get(
     path: str,
     *,
     viewer_context: SeerViewerContext,
-    connection_pool: HTTPConnectionPool | None = None,
 ) -> dict[str, Any]:
     response = make_signed_seer_api_request(
-        connection_pool or investigation_connection_pool,
+        investigation_connection_pool,
         path,
         body=b"",
         method="GET",
@@ -152,7 +150,6 @@ def create_investigation_orchestration_run(
     run: InvestigationOrchestrationRun,
     *,
     viewer_context: SeerViewerContext,
-    connection_pool: HTTPConnectionPool | None = None,
 ) -> InvestigationRunResponse:
     _validate_viewer_organization(viewer_context, run.investigation.organization_id)
     body: dict[str, Any] = {
@@ -176,7 +173,6 @@ def create_investigation_orchestration_run(
         "/v1/automation/investigations",
         body,
         viewer_context=viewer_context,
-        connection_pool=connection_pool,
     )
     return _validate_run_response(response)
 
@@ -185,7 +181,6 @@ def dispatch_investigation_orchestration_command(
     command: InvestigationOrchestrationCommand,
     *,
     viewer_context: SeerViewerContext,
-    connection_pool: HTTPConnectionPool | None = None,
 ) -> InvestigationCommandResponse:
     investigation = command.orchestration_run.investigation
     _validate_viewer_organization(viewer_context, investigation.organization_id)
@@ -208,7 +203,6 @@ def dispatch_investigation_orchestration_command(
         f"/v1/automation/investigations/{seer_run_id}/commands",
         body,
         viewer_context=viewer_context,
-        connection_pool=connection_pool,
     )
     return _validate_command_response(response)
 
@@ -217,7 +211,6 @@ def get_investigation_orchestration_run(
     run: InvestigationOrchestrationRun,
     *,
     viewer_context: SeerViewerContext,
-    connection_pool: HTTPConnectionPool | None = None,
 ) -> InvestigationRunResponse:
     _validate_viewer_organization(viewer_context, run.investigation.organization_id)
     seer_run = run.seer_run
@@ -227,6 +220,5 @@ def get_investigation_orchestration_run(
     response = _get(
         f"/v1/automation/investigations/{seer_run_id}",
         viewer_context=viewer_context,
-        connection_pool=connection_pool,
     )
     return _validate_run_response(response)

--- a/src/sentry/seer/models/run.py
+++ b/src/sentry/seer/models/run.py
@@ -18,6 +18,7 @@ class SeerRunType(models.TextChoices):
     PR_REVIEW = "pr_review"
     ASSISTED_QUERY = "assisted_query"
     FEATURE_RUN = "feature_run"
+    INVESTIGATION = "investigation"
 
 
 class SeerRunMirrorStatus(models.TextChoices):

--- a/tests/sentry/investigations/test_seer_client.py
+++ b/tests/sentry/investigations/test_seer_client.py
@@ -21,10 +21,12 @@ from sentry.testutils.cases import TestCase
 
 class InvestigationOrchestrationSeerClientTest(TestCase):
     @override_settings(SEER_API_SHARED_SECRET="investigation-protocol-test-secret")
+    @mock.patch("sentry.investigations.seer_client.investigation_connection_pool")
     @mock.patch("sentry.investigations.seer_client.get_monitoring_provider_connections")
     def test_create_and_command_use_the_protocol_contract(
         self,
         get_connections: mock.Mock,
+        pool: mock.Mock,
     ) -> None:
         investigation, run = create_agentic_manual_investigation(
             organization=self.organization,
@@ -61,7 +63,6 @@ class InvestigationOrchestrationSeerClientTest(TestCase):
             organization_id=self.organization.id,
             user_id=self.user.id,
         )
-        pool = mock.Mock()
         pool.host = "seer"
         pool.port = 9091
         pool.scheme = "http"
@@ -92,17 +93,14 @@ class InvestigationOrchestrationSeerClientTest(TestCase):
         created = create_investigation_orchestration_run(
             run,
             viewer_context=viewer_context,
-            connection_pool=pool,
         )
         replayed = create_investigation_orchestration_run(
             run,
             viewer_context=viewer_context,
-            connection_pool=pool,
         )
         accepted = dispatch_investigation_orchestration_command(
             command,
             viewer_context=viewer_context,
-            connection_pool=pool,
         )
 
         assert created == {"runId": 8128, "created": True, "projection": {}}
@@ -155,7 +153,6 @@ class InvestigationOrchestrationSeerClientTest(TestCase):
             dispatch_investigation_orchestration_command(
                 command,
                 viewer_context=viewer_context,
-                connection_pool=pool,
             )
 
     def test_create_rejects_a_mismatched_viewer_organization(self) -> None:

--- a/tests/sentry/investigations/test_seer_client.py
+++ b/tests/sentry/investigations/test_seer_client.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+from unittest import mock
+from uuid import UUID, uuid4
+
+import orjson
+import pytest
+from django.test import override_settings
+
+from sentry.investigations.seer_client import (
+    create_investigation_orchestration_run,
+    dispatch_investigation_orchestration_command,
+    get_investigation_orchestration_run,
+)
+from sentry.investigations.services.orchestration import create_agentic_manual_investigation
+from sentry.seer.models import SeerApiError
+from sentry.seer.models.run import SeerRunType
+from sentry.seer.signed_seer_api import SeerViewerContext
+from sentry.testutils.cases import TestCase
+
+
+class InvestigationOrchestrationSeerClientTest(TestCase):
+    @override_settings(SEER_API_SHARED_SECRET="investigation-protocol-test-secret")
+    @mock.patch("sentry.investigations.seer_client.get_monitoring_provider_connections")
+    def test_create_and_command_use_the_protocol_contract(
+        self,
+        get_connections: mock.Mock,
+    ) -> None:
+        investigation, run = create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title=None,
+            source={"type": "manual", "prompt": "Investigate latency"},
+            project_ids=[self.project.id],
+            filters={},
+        )
+        provider = mock.Mock()
+        provider.dict.return_value = {
+            "type": "header_auth",
+            "provider_key": "example",
+            "url": "https://example.invalid",
+        }
+        get_connections.return_value = [provider]
+        run.update(
+            seer_run=self.create_seer_run(
+                organization=self.organization,
+                type=SeerRunType.INVESTIGATION,
+                seer_run_state_id=8128,
+            )
+        )
+        run.refresh_from_db()
+        command = self.create_investigation_orchestration_command(
+            orchestration_run=run,
+            request_id=uuid4(),
+            actor_id=self.user.id,
+            expected_workflow_version=1,
+            type="retry",
+            payload={"target": "run"},
+        )
+        viewer_context = SeerViewerContext(
+            organization_id=self.organization.id,
+            user_id=self.user.id,
+        )
+        pool = mock.Mock()
+        pool.host = "seer"
+        pool.port = 9091
+        pool.scheme = "http"
+        pool.urlopen.side_effect = [
+            mock.Mock(
+                status=200,
+                data=b'{"runId":8128,"created":true,"projection":{}}',
+            ),
+            mock.Mock(
+                status=200,
+                data=b'{"runId":8128,"created":false,"projection":{}}',
+            ),
+            mock.Mock(
+                status=200,
+                data=orjson.dumps(
+                    {
+                        "runId": 8128,
+                        "requestId": str(command.request_id),
+                        "accepted": True,
+                        "duplicate": False,
+                        "workflowVersion": 2,
+                        "projection": {},
+                    }
+                ),
+            ),
+        ]
+
+        created = create_investigation_orchestration_run(
+            run,
+            viewer_context=viewer_context,
+            connection_pool=pool,
+        )
+        replayed = create_investigation_orchestration_run(
+            run,
+            viewer_context=viewer_context,
+            connection_pool=pool,
+        )
+        accepted = dispatch_investigation_orchestration_command(
+            command,
+            viewer_context=viewer_context,
+            connection_pool=pool,
+        )
+
+        assert created == {"runId": 8128, "created": True, "projection": {}}
+        assert replayed == {"runId": 8128, "created": False, "projection": {}}
+        create_request = pool.urlopen.call_args_list[0]
+        replay_request = pool.urlopen.call_args_list[1]
+        assert create_request.args[:2] == ("POST", "/v1/automation/investigations")
+        assert replay_request.args[:2] == ("POST", "/v1/automation/investigations")
+        create_body = orjson.loads(create_request.kwargs["body"])
+        replay_body = orjson.loads(replay_request.kwargs["body"])
+        assert create_body["requestId"] == replay_body["requestId"]
+        assert str(UUID(create_body["requestId"])) == create_body["requestId"]
+        assert create_body["investigationId"] == investigation.id
+        assert create_body["source"] == run.source
+        assert create_body["activeTimeBudgetSeconds"] == 1800
+        assert create_body["monitoringProviders"] == [provider.dict.return_value]
+        assert "Authorization" in create_request.kwargs["headers"]
+        assert "X-Viewer-Context" in create_request.kwargs["headers"]
+
+        assert accepted["runId"] == 8128
+        command_request = pool.urlopen.call_args_list[2]
+        assert command_request.args[:2] == (
+            "POST",
+            "/v1/automation/investigations/8128/commands",
+        )
+        command_body = orjson.loads(command_request.kwargs["body"])
+        assert command_body == {
+            "requestId": str(command.request_id),
+            "expectedWorkflowVersion": 1,
+            "command": {"type": "retry", "target": "run"},
+            "monitoringProviders": [provider.dict.return_value],
+        }
+        assert "Authorization" in command_request.kwargs["headers"]
+        assert "X-Viewer-Context" in command_request.kwargs["headers"]
+
+        pool.urlopen.side_effect = None
+        pool.urlopen.return_value = mock.Mock(
+            status=200,
+            data=orjson.dumps(
+                {
+                    "runId": 8128,
+                    "requestId": str(command.request_id),
+                    "duplicate": False,
+                    "workflowVersion": 2,
+                    "projection": {},
+                }
+            ),
+        )
+        with pytest.raises(SeerApiError):
+            dispatch_investigation_orchestration_command(
+                command,
+                viewer_context=viewer_context,
+                connection_pool=pool,
+            )
+
+    def test_create_rejects_a_mismatched_viewer_organization(self) -> None:
+        _, run = create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title=None,
+            source={"type": "manual", "prompt": "Investigate latency"},
+            project_ids=[],
+            filters={},
+        )
+
+        with pytest.raises(SeerApiError):
+            create_investigation_orchestration_run(
+                run,
+                viewer_context=SeerViewerContext(
+                    organization_id=self.create_organization().id,
+                    user_id=self.user.id,
+                ),
+            )
+
+    @mock.patch("sentry.investigations.seer_client.make_signed_seer_api_request")
+    def test_get_uses_signed_viewer_context_and_validates_the_response(
+        self,
+        make_request: mock.Mock,
+    ) -> None:
+        make_request.return_value = mock.Mock(
+            status=200,
+            data=b'{"runId":8128,"created":false,"projection":{}}',
+        )
+        viewer_context = SeerViewerContext(
+            organization_id=self.organization.id,
+            user_id=self.user.id,
+        )
+        _, run = create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title=None,
+            source={"type": "manual", "prompt": "Investigate latency"},
+            project_ids=[],
+            filters={},
+        )
+        run.update(
+            seer_run=self.create_seer_run(
+                organization=self.organization,
+                type=SeerRunType.INVESTIGATION,
+                seer_run_state_id=8128,
+            )
+        )
+
+        result = get_investigation_orchestration_run(run, viewer_context=viewer_context)
+
+        assert result == {"runId": 8128, "created": False, "projection": {}}
+        assert make_request.call_args.args[1] == "/v1/automation/investigations/8128"
+        assert make_request.call_args.kwargs == {
+            "body": b"",
+            "method": "GET",
+            "viewer_context": viewer_context,
+        }
+
+        make_request.return_value = mock.Mock(status=200, data=b"[]")
+        with pytest.raises(SeerApiError):
+            get_investigation_orchestration_run(run, viewer_context=viewer_context)
+
+        make_request.return_value = mock.Mock(status=503, data=b"{}")
+        with pytest.raises(SeerApiError):
+            get_investigation_orchestration_run(run, viewer_context=viewer_context)
+
+    @mock.patch("sentry.investigations.seer_client.make_signed_seer_api_request")
+    def test_get_rejects_a_mismatched_viewer_organization(self, make_request: mock.Mock) -> None:
+        _, run = create_agentic_manual_investigation(
+            organization=self.organization,
+            user_id=self.user.id,
+            title=None,
+            source={"type": "manual", "prompt": "Investigate latency"},
+            project_ids=[],
+            filters={},
+        )
+
+        with pytest.raises(SeerApiError):
+            get_investigation_orchestration_run(
+                run,
+                viewer_context=SeerViewerContext(
+                    organization_id=self.create_organization().id,
+                    user_id=self.user.id,
+                ),
+            )
+
+        assert make_request.call_count == 0


### PR DESCRIPTION
Sentry's outbound half of the investigation orchestration protocol. Three signed calls to Seer: create a run, dispatch a command, and read a run's projection.

Each validates the response envelope with a strict pydantic model and rejects anything malformed as a 502 rather than letting it reach the caller. Each also binds the supplied viewer context to the investigation's organization before any request is made, so a context for one organization cannot be used to act on another.

Creation is idempotent from Sentry's side: the request id is a uuid5 of the organization, investigation, and orchestration run, so a retried dispatch reuses it.

Split out from #123242