### PR TITLE
fix(auth): Render login warnings

### DIFF
--- a/static/app/views/authV2/authLogin/index.spec.tsx
+++ b/static/app/views/authV2/authLogin/index.spec.tsx
@@ -304,7 +304,7 @@ describe('AuthLogin', () => {
     }
   });
 
-  it('renders the configured login banner', async () => {
+  it('renders warnings above the configured login banner', async () => {
     const authConfig: AuthConfig = {
       canRegister: true,
       githubLoginLink: '',
@@ -315,6 +315,7 @@ describe('AuthLogin', () => {
       pendingMfa: null,
       serverHostname: 'sentry.example.com',
       vstsLoginLink: '',
+      warning: 'Your session has expired.',
     };
     MockApiClient.addMockResponse({
       url: '/auth/config/',
@@ -323,9 +324,12 @@ describe('AuthLogin', () => {
 
     render(<AuthLogin />);
 
-    expect(await screen.findByRole('link', {name: 'Learn more'})).toHaveAttribute(
-      'href',
-      'https://example.com/agents'
+    const warning = await screen.findByText('Your session has expired.');
+    const bannerLink = screen.getByRole('link', {name: 'Learn more'});
+
+    expect(bannerLink).toHaveAttribute('href', 'https://example.com/agents');
+    expect(warning.compareDocumentPosition(bannerLink)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING
     );
   });
 

--- a/static/app/views/authV2/authLogin/index.tsx
+++ b/static/app/views/authV2/authLogin/index.tsx
@@ -299,10 +299,17 @@ export default function AuthLogin() {
           </AnimatePresence>
         </LoginContainer>
 
-        {loginConfig?.loginBannerMarkdown && (
-          <Alert variant="muted">
-            <MarkedText text={loginConfig.loginBannerMarkdown} inline />
-          </Alert>
+        {(loginConfig?.warning || loginConfig?.loginBannerMarkdown) && (
+          <Stack width="100%" gap="md">
+            {loginConfig.warning && (
+              <Alert variant="warning">{loginConfig.warning}</Alert>
+            )}
+            {loginConfig.loginBannerMarkdown && (
+              <Alert variant="muted">
+                <MarkedText text={loginConfig.loginBannerMarkdown} inline />
+              </Alert>
+            )}
+          </Stack>
         )}
       </Stack>
     </Fragment>


### PR DESCRIPTION
Auth config can include warning messages such as session expiration, but the React login page currently ignores them.

Render warnings in a warning alert above the configured login banner, and group both footer messages in a full-width stack. The test verifies that both messages render in the intended order.