### PR TITLE
feat(integrations): Search GitHub issue form options

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -77,6 +77,30 @@ logger = logging.getLogger("sentry.integrations.github")
 # many requests left for other features that need to reach Github
 MINIMUM_REQUESTS = 200
 
+SEARCH_ASSIGNABLE_USERS_QUERY = """
+query SearchAssignableUsers($owner: String!, $name: String!, $search: String!) {
+  repository(owner: $owner, name: $name) {
+    results: assignableUsers(first: 100, query: $search) {
+      nodes {
+        login
+      }
+    }
+  }
+}
+"""
+
+SEARCH_LABELS_QUERY = """
+query SearchLabels($owner: String!, $name: String!, $search: String!) {
+  repository(owner: $owner, name: $name) {
+    results: labels(first: 100, query: $search) {
+      nodes {
+        name
+      }
+    }
+  }
+}
+"""
+
 # When Github advertises the total page count up front, the pages after the
 # first are fetched concurrently. Bounded to keep the fan-out comfortably under
 # Github's secondary (concurrent request) rate limits.
@@ -179,6 +203,8 @@ class GitHubApiRequestType(StrEnum):
     REFRESH_ACCESS_TOKEN = "refresh_access_token"
     REPO_HOOKS = "repo_hooks"
     SEARCH_ISSUES = "search_issues"
+    SEARCH_ISSUE_ASSIGNEES = "search_issue_assignees"
+    SEARCH_ISSUE_LABELS = "search_issue_labels"
     SEARCH_REPOSITORIES = "search_repositories"
     UPDATE_COMMENT = "update_comment"
     UPDATE_ISSUE_ASSIGNEES = "update_issue_assignees"
@@ -799,6 +825,42 @@ class GitHubBaseClient(
             page_number_limit=page_number_limit,
             api_request_type=GitHubApiRequestType.GET_ASSIGNEES,
         )
+
+    def search_issue_assignees(self, repo: str, query: str) -> list[Any]:
+        return self._search_issue_field(
+            repo,
+            query,
+            graphql_query=SEARCH_ASSIGNABLE_USERS_QUERY,
+            api_request_type=GitHubApiRequestType.SEARCH_ISSUE_ASSIGNEES,
+        )
+
+    def search_issue_labels(self, repo: str, query: str) -> list[Any]:
+        return self._search_issue_field(
+            repo,
+            query,
+            graphql_query=SEARCH_LABELS_QUERY,
+            api_request_type=GitHubApiRequestType.SEARCH_ISSUE_LABELS,
+        )
+
+    def _search_issue_field(
+        self,
+        repo: str,
+        query: str,
+        *,
+        graphql_query: str,
+        api_request_type: GitHubApiRequestType,
+    ) -> list[Any]:
+        owner, repo_name = repo.split("/", 1)
+        response = self.post(
+            path="/graphql",
+            data={
+                "query": graphql_query,
+                "variables": {"owner": owner, "name": repo_name, "search": query},
+            },
+            allow_text=False,
+            api_request_type=api_request_type,
+        )
+        return response["data"]["repository"]["results"]["nodes"]
 
     def _get_with_pagination(
         self,

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -68,6 +68,7 @@ from sentry.utils import metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 from sentry.utils.dates import deprecated_utcnow
 from sentry.utils.iterators import chunked
+from sentry.utils.safe import get_path
 from sentry.utils.tracing import start_span
 
 logger = logging.getLogger("sentry.integrations.github")
@@ -861,7 +862,19 @@ class GitHubBaseClient(
             allow_text=False,
             api_request_type=api_request_type,
         )
-        return response["data"]["repository"]["results"]["nodes"]
+        if not is_graphql_response(response):
+            raise ApiError("Response is not JSON")
+
+        errors = response.get("errors", [])
+        if any(error.get("type") == "RATE_LIMITED" for error in errors):
+            raise ApiRateLimitedError("GitHub rate limit exceeded")
+
+        nodes = get_path(response, "data", "repository", "results", "nodes")
+        if nodes is None:
+            message = "\n".join(error.get("message", "") for error in errors).strip()
+            raise ApiError(message or "Invalid GitHub GraphQL response")
+
+        return nodes
 
     def _get_with_pagination(
         self,

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -83,6 +83,7 @@ query SearchAssignableUsers($owner: String!, $name: String!, $search: String!) {
     results: assignableUsers(first: 100, query: $search) {
       nodes {
         login
+        name
       }
     }
   }

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -386,6 +386,15 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
 
         return (("", "Unassigned"),) + users
 
+    def search_allowed_assignees(self, repo: str, query: str) -> Sequence[tuple[str, str]]:
+        client = self.get_client()
+        try:
+            response = client.search_issue_assignees(repo, query)
+        except Exception as e:
+            self.raise_error(e)
+
+        return tuple((user["login"], user["login"]) for user in response)
+
     def get_repo_labels(
         self, owner: str, repo: str, page_number_limit: int | None = None
     ) -> Sequence[tuple[str, str]]:
@@ -407,3 +416,12 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         )
 
         return labels
+
+    def search_repo_labels(self, repo: str, query: str) -> Sequence[tuple[str, str]]:
+        client = self.get_client()
+        try:
+            response = client.search_issue_labels(repo, query)
+        except Exception as e:
+            self.raise_error(e)
+
+        return tuple((label["name"], label["name"]) for label in response)

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -37,6 +37,12 @@ PAGE_LIMIT = 1
 
 
 class GitHubIssuesSpec(SourceCodeIssueIntegration):
+    @staticmethod
+    def _format_assignee(user: Mapping[str, Any]) -> tuple[str, str]:
+        login = user["login"]
+        name = user.get("name")
+        return login, f"{name} (@{login})" if name else login
+
     def raise_error(self, exc: Exception, identity: Identity | None = None) -> NoReturn:
         if isinstance(exc, ApiError):
             if exc.code == 422:
@@ -382,7 +388,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         except Exception as e:
             self.raise_error(e)
 
-        users = tuple((u["login"], u["login"]) for u in response)
+        users = tuple(self._format_assignee(user) for user in response)
 
         return (("", "Unassigned"),) + users
 
@@ -393,19 +399,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         except Exception as e:
             self.raise_error(e)
 
-        users = []
-        for user in response:
-            login = user["login"]
-            name = user.get("name")
-            display_name = name.strip() if isinstance(name, str) else ""
-            label = (
-                f"{display_name} (@{login})"
-                if display_name and display_name.casefold() != login.casefold()
-                else login
-            )
-            users.append((login, label))
-
-        user_choices = tuple(users)
+        user_choices = tuple(self._format_assignee(user) for user in response)
         return user_choices if query else (("", "Unassigned"),) + user_choices
 
     def get_repo_labels(

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -393,7 +393,8 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         except Exception as e:
             self.raise_error(e)
 
-        return tuple((user["login"], user["login"]) for user in response)
+        users = tuple((user["login"], user["login"]) for user in response)
+        return users if query else (("", "Unassigned"),) + users
 
     def get_repo_labels(
         self, owner: str, repo: str, page_number_limit: int | None = None

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -393,8 +393,20 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
         except Exception as e:
             self.raise_error(e)
 
-        users = tuple((user["login"], user["login"]) for user in response)
-        return users if query else (("", "Unassigned"),) + users
+        users = []
+        for user in response:
+            login = user["login"]
+            name = user.get("name")
+            display_name = name.strip() if isinstance(name, str) else ""
+            label = (
+                f"{display_name} (@{login})"
+                if display_name and display_name.casefold() != login.casefold()
+                else login
+            )
+            users.append((login, label))
+
+        user_choices = tuple(users)
+        return user_choices if query else (("", "Unassigned"),) + user_choices
 
     def get_repo_labels(
         self, owner: str, repo: str, page_number_limit: int | None = None

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -111,7 +111,15 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
             return Response({"detail": "Invalid repository"}, status=400)
 
         assert isinstance(installation, self.installation_class)
-        if field == "assignee":
+        if not query:
+            # TODO: Use GraphQL for preloads after validating these queries across supported
+            # GHES versions.
+            if field == "assignee":
+                choices = installation.get_allowed_assignees(repo, PAGE_LIMIT)
+            else:
+                owner, repo_name = repo.split("/", 1)
+                choices = installation.get_repo_labels(owner, repo_name, PAGE_LIMIT)
+        elif field == "assignee":
             choices = installation.search_allowed_assignees(repo, query)
         else:
             choices = installation.search_repo_labels(repo, query)

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -112,16 +112,8 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
 
         assert isinstance(installation, self.installation_class)
         if field == "assignee":
-            choices = (
-                installation.search_allowed_assignees(repo, query)
-                if query
-                else installation.get_allowed_assignees(repo, PAGE_LIMIT)
-            )
+            choices = installation.search_allowed_assignees(repo, query)
         else:
-            if query:
-                choices = installation.search_repo_labels(repo, query)
-            else:
-                owner, repo_name = repo.split("/", 1)
-                choices = installation.get_repo_labels(owner, repo_name, PAGE_LIMIT)
+            choices = installation.search_repo_labels(repo, query)
 
         return Response([{"label": label, "value": value} for value, label in choices])

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -12,7 +12,7 @@ from sentry.integrations.source_code_management.metrics import (
     SourceCodeSearchEndpointHaltReason,
 )
 from sentry.integrations.source_code_management.search import SourceCodeSearchEndpoint
-from sentry.shared_integrations.exceptions import ApiError
+from sentry.shared_integrations.exceptions import ApiError, IntegrationError
 
 T = TypeVar("T", bound=SourceCodeIssueIntegration)
 
@@ -111,17 +111,22 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
             return Response({"detail": "Invalid repository"}, status=400)
 
         assert isinstance(installation, self.installation_class)
-        if not query:
-            # TODO: Use GraphQL for preloads after validating these queries across supported
-            # GHES versions.
-            if field == "assignee":
-                choices = installation.get_allowed_assignees(repo, PAGE_LIMIT)
+        try:
+            if not query:
+                # TODO: Use GraphQL for preloads after validating these queries across supported
+                # GHES versions.
+                if field == "assignee":
+                    choices = installation.get_allowed_assignees(repo, PAGE_LIMIT)
+                else:
+                    owner, repo_name = repo.split("/", 1)
+                    choices = installation.get_repo_labels(owner, repo_name, PAGE_LIMIT)
+            elif field == "assignee":
+                choices = installation.search_allowed_assignees(repo, query)
             else:
-                owner, repo_name = repo.split("/", 1)
-                choices = installation.get_repo_labels(owner, repo_name, PAGE_LIMIT)
-        elif field == "assignee":
-            choices = installation.search_allowed_assignees(repo, query)
-        else:
-            choices = installation.search_repo_labels(repo, query)
+                choices = installation.search_repo_labels(repo, query)
+        except IntegrationError as error:
+            if installation.is_broken_integration_error(error) == "rate_limited":
+                return Response({"detail": "Rate limit exceeded"}, status=429)
+            return Response({"detail": "Unable to fetch options from GitHub"}, status=400)
 
         return Response([{"label": label, "value": value} for value, label in choices])

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -3,6 +3,7 @@ from typing import TypeVar
 from rest_framework.response import Response
 
 from sentry.api.base import control_silo_endpoint
+from sentry.exceptions import InvalidIdentity
 from sentry.integrations.github.integration import GitHubIntegration, build_repository_query
 from sentry.integrations.github_enterprise.integration import GitHubEnterpriseIntegration
 from sentry.integrations.models.integration import Integration
@@ -124,7 +125,7 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
                 choices = installation.search_allowed_assignees(repo, query)
             else:
                 choices = installation.search_repo_labels(repo, query)
-        except IntegrationError as error:
+        except (IntegrationError, InvalidIdentity) as error:
             if installation.is_broken_integration_error(error) == "rate_limited":
                 return Response({"detail": "Rate limit exceeded"}, status=429)
             return Response({"detail": "Unable to fetch options from GitHub"}, status=400)

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -100,7 +100,9 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
                 [{"label": i["name"], "value": i["full_name"]} for i in response.get("items", [])]
             )
 
-    def handle_search_field(self, installation: T, field: str, repo: str | None) -> Response | None:
+    def handle_search_field(
+        self, installation: T, field: str, query: str, repo: str | None
+    ) -> Response | None:
         if field not in {"assignee", "labels"}:
             return None
         if not repo:
@@ -110,9 +112,16 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
 
         assert isinstance(installation, self.installation_class)
         if field == "assignee":
-            choices = installation.get_allowed_assignees(repo, PAGE_LIMIT)
+            choices = (
+                installation.search_allowed_assignees(repo, query)
+                if query
+                else installation.get_allowed_assignees(repo, PAGE_LIMIT)
+            )
         else:
-            owner, repo_name = repo.split("/", 1)
-            choices = installation.get_repo_labels(owner, repo_name, PAGE_LIMIT)
+            if query:
+                choices = installation.search_repo_labels(repo, query)
+            else:
+                owner, repo_name = repo.split("/", 1)
+                choices = installation.get_repo_labels(owner, repo_name, PAGE_LIMIT)
 
         return Response([{"label": label, "value": value} for value, label in choices])

--- a/src/sentry/integrations/source_code_management/search.py
+++ b/src/sentry/integrations/source_code_management/search.py
@@ -87,7 +87,9 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
     ) -> Response:
         raise NotImplementedError
 
-    def handle_search_field(self, installation: T, field: str, repo: str | None) -> Response | None:
+    def handle_search_field(
+        self, installation: T, field: str, query: str, repo: str | None
+    ) -> Response | None:
         return None
 
     def get(
@@ -144,7 +146,7 @@ class SourceCodeSearchEndpoint(IntegrationEndpoint, Generic[T], ABC):
                 return self.handle_search_repositories(integration, installation, query)
 
             repo = request.GET.get(self.repository_field) if self.repository_field else None
-            response = self.handle_search_field(installation, field, repo)
+            response = self.handle_search_field(installation, field, query, repo)
             if response is not None:
                 return response
 

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1137,6 +1137,39 @@ class GitHubApiClientTest(TestCase):
 
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
     @responses.activate
+    def test_search_issue_assignees_missing_repository(self, get_jwt) -> None:
+        self.add_graphql_response({"data": {"repository": None}})
+
+        with pytest.raises(ApiError, match="Invalid GitHub GraphQL response"):
+            self.github_client.search_issue_assignees(self.repo.name, "user")
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_search_issue_labels_query_error(self, get_jwt) -> None:
+        self.add_graphql_response(
+            {
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "message": "Could not resolve to a Repository with the requested name.",
+                    }
+                ]
+            }
+        )
+
+        with pytest.raises(ApiError, match="Could not resolve to a Repository"):
+            self.github_client.search_issue_labels(self.repo.name, "bug")
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
+    def test_search_issue_field_rate_limited(self, get_jwt) -> None:
+        self.add_graphql_response({"errors": [{"type": "RATE_LIMITED"}]})
+
+        with pytest.raises(ApiRateLimitedError):
+            self.github_client.search_issue_assignees(self.repo.name, "user")
+
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    @responses.activate
     def test_get_pull_request_status(self, get_jwt) -> None:
         self.add_graphql_response(
             {

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -178,12 +178,12 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         responses.add(
             responses.GET,
             "https://api.github.com/repos/getsentry/sentry/assignees",
-            json=[{"login": "MeredithAnya"}],
+            json=[{"login": "MeredithAnya", "name": "Meredith Anya"}],
         )
 
         assert self.install.get_allowed_assignees(self.repo) == (
             ("", "Unassigned"),
-            ("MeredithAnya", "MeredithAnya"),
+            ("MeredithAnya", "Meredith Anya (@MeredithAnya)"),
         )
 
         if self.should_call_api_without_proxying():

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -194,20 +194,12 @@ class GithubSearchTest(APITestCase):
     @responses.activate
     def test_prefetches_assignee_results(self) -> None:
         responses.add(
-            responses.POST,
-            self.graphql_url,
-            json={
-                "data": {
-                    "repository": {
-                        "results": {
-                            "nodes": [
-                                {"login": "octocat", "name": "The Octocat"},
-                                {"login": "github-actions[bot]", "name": None},
-                            ]
-                        }
-                    }
-                }
-            },
+            responses.GET,
+            self.base_url + "/repos/test/example/assignees",
+            json=[
+                {"login": "octocat", "name": "The Octocat"},
+                {"login": "github-actions[bot]", "name": None},
+            ],
         )
 
         resp = self.client.get(
@@ -221,9 +213,6 @@ class GithubSearchTest(APITestCase):
             {"value": "octocat", "label": "The Octocat (@octocat)"},
             {"value": "github-actions[bot]", "label": "github-actions[bot]"},
         ]
-        request_body = orjson.loads(responses.calls[0].request.body)
-        assert "\n        name\n" in request_body["query"]
-        assert request_body["variables"]["search"] == ""
 
     @responses.activate
     def test_searches_assignees(self) -> None:
@@ -257,13 +246,9 @@ class GithubSearchTest(APITestCase):
     @responses.activate
     def test_prefetches_label_results(self) -> None:
         responses.add(
-            responses.POST,
-            self.graphql_url,
-            json={
-                "data": {
-                    "repository": {"results": {"nodes": [{"name": "bug"}, {"name": "enhancement"}]}}
-                }
-            },
+            responses.GET,
+            self.base_url + "/repos/test/example/labels",
+            json=[{"name": "bug"}, {"name": "enhancement"}],
         )
 
         resp = self.client.get(
@@ -276,8 +261,6 @@ class GithubSearchTest(APITestCase):
             {"value": "bug", "label": "bug"},
             {"value": "enhancement", "label": "enhancement"},
         ]
-        request_body = orjson.loads(responses.calls[0].request.body)
-        assert request_body["variables"]["search"] == ""
 
     @responses.activate
     def test_searches_labels(self) -> None:

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -2,6 +2,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock, patch
 from urllib.parse import urlencode
 
+import orjson
 import responses
 from django.urls import reverse
 
@@ -26,6 +27,7 @@ class GithubSearchTest(APITestCase):
     # one to ensure that github:enterprise behaves as expected.
     provider = "github"
     base_url = "https://api.github.com"
+    graphql_url = "https://api.github.com/graphql"
 
     def _create_integration(self) -> Integration:
         future = datetime.now() + timedelta(hours=1)
@@ -191,10 +193,17 @@ class GithubSearchTest(APITestCase):
 
     @responses.activate
     def test_prefetches_assignee_results(self) -> None:
+        assignees_url = self.base_url + "/repos/test/example/assignees"
+        paginated_url = f"{assignees_url}?per_page=100"
         responses.add(
             responses.GET,
-            self.base_url + "/repos/test/example/assignees",
+            paginated_url,
             json=[{"login": "octocat"}],
+            headers={
+                "link": (
+                    f'<{paginated_url}&page=2>; rel="next", <{paginated_url}&page=2>; rel="last"'
+                )
+            },
         )
 
         resp = self.client.get(
@@ -207,6 +216,30 @@ class GithubSearchTest(APITestCase):
             {"value": "", "label": "Unassigned"},
             {"value": "octocat", "label": "octocat"},
         ]
+        assert len(responses.calls) == 1
+
+    @responses.activate
+    def test_searches_assignees(self) -> None:
+        responses.add(
+            responses.POST,
+            self.graphql_url,
+            json={"data": {"repository": {"results": {"nodes": [{"login": "target-user"}]}}}},
+        )
+
+        resp = self.client.get(
+            self.url,
+            data={"field": "assignee", "query": "TARGET", "repo": "test/example"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.data == [{"value": "target-user", "label": "target-user"}]
+        request_body = orjson.loads(responses.calls[0].request.body)
+        assert "assignableUsers" in request_body["query"]
+        assert request_body["variables"] == {
+            "owner": "test",
+            "name": "example",
+            "search": "TARGET",
+        }
 
     @responses.activate
     def test_prefetches_label_results(self) -> None:
@@ -226,6 +259,35 @@ class GithubSearchTest(APITestCase):
             {"value": "bug", "label": "bug"},
             {"value": "enhancement", "label": "enhancement"},
         ]
+
+    @responses.activate
+    def test_searches_labels(self) -> None:
+        responses.add(
+            responses.POST,
+            self.graphql_url,
+            json={
+                "data": {
+                    "repository": {"results": {"nodes": [{"name": "Component: Integrations"}]}}
+                }
+            },
+        )
+
+        resp = self.client.get(
+            self.url,
+            data={"field": "labels", "query": "integrations", "repo": "test/example"},
+        )
+
+        assert resp.status_code == 200
+        assert resp.data == [
+            {"value": "Component: Integrations", "label": "Component: Integrations"}
+        ]
+        request_body = orjson.loads(responses.calls[0].request.body)
+        assert "labels" in request_body["query"]
+        assert request_body["variables"] == {
+            "owner": "test",
+            "name": "example",
+            "search": "integrations",
+        }
 
     def test_rejects_invalid_repo_when_prefetching_fields(self) -> None:
         resp = self.client.get(

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -244,6 +244,22 @@ class GithubSearchTest(APITestCase):
         }
 
     @responses.activate
+    def test_searches_assignees_rate_limit(self) -> None:
+        responses.add(
+            responses.POST,
+            self.graphql_url,
+            json={"errors": [{"type": "RATE_LIMITED"}]},
+        )
+
+        resp = self.client.get(
+            self.url,
+            data={"field": "assignee", "query": "target", "repo": "test/example"},
+        )
+
+        assert resp.status_code == 429
+        assert resp.data == {"detail": "Rate limit exceeded"}
+
+    @responses.activate
     def test_prefetches_label_results(self) -> None:
         responses.add(
             responses.GET,
@@ -290,6 +306,29 @@ class GithubSearchTest(APITestCase):
             "name": "example",
             "search": "integrations",
         }
+
+    @responses.activate
+    def test_searches_labels_missing_repository(self) -> None:
+        responses.add(
+            responses.POST,
+            self.graphql_url,
+            json={
+                "errors": [
+                    {
+                        "type": "NOT_FOUND",
+                        "message": "Could not resolve to a Repository with the requested name.",
+                    }
+                ]
+            },
+        )
+
+        resp = self.client.get(
+            self.url,
+            data={"field": "labels", "query": "bug", "repo": "test/missing"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.data == {"detail": "Unable to fetch options from GitHub"}
 
     def test_rejects_invalid_repo_when_prefetching_fields(self) -> None:
         resp = self.client.get(

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -196,7 +196,18 @@ class GithubSearchTest(APITestCase):
         responses.add(
             responses.POST,
             self.graphql_url,
-            json={"data": {"repository": {"results": {"nodes": [{"login": "octocat"}]}}}},
+            json={
+                "data": {
+                    "repository": {
+                        "results": {
+                            "nodes": [
+                                {"login": "octocat", "name": "The Octocat"},
+                                {"login": "github-actions[bot]", "name": None},
+                            ]
+                        }
+                    }
+                }
+            },
         )
 
         resp = self.client.get(
@@ -207,9 +218,11 @@ class GithubSearchTest(APITestCase):
         assert resp.status_code == 200
         assert resp.data == [
             {"value": "", "label": "Unassigned"},
-            {"value": "octocat", "label": "octocat"},
+            {"value": "octocat", "label": "The Octocat (@octocat)"},
+            {"value": "github-actions[bot]", "label": "github-actions[bot]"},
         ]
         request_body = orjson.loads(responses.calls[0].request.body)
+        assert "\n        name\n" in request_body["query"]
         assert request_body["variables"]["search"] == ""
 
     @responses.activate
@@ -217,7 +230,13 @@ class GithubSearchTest(APITestCase):
         responses.add(
             responses.POST,
             self.graphql_url,
-            json={"data": {"repository": {"results": {"nodes": [{"login": "target-user"}]}}}},
+            json={
+                "data": {
+                    "repository": {
+                        "results": {"nodes": [{"login": "target-user", "name": "Target User"}]}
+                    }
+                }
+            },
         )
 
         resp = self.client.get(
@@ -226,7 +245,7 @@ class GithubSearchTest(APITestCase):
         )
 
         assert resp.status_code == 200
-        assert resp.data == [{"value": "target-user", "label": "target-user"}]
+        assert resp.data == [{"value": "target-user", "label": "Target User (@target-user)"}]
         request_body = orjson.loads(responses.calls[0].request.body)
         assert "assignableUsers" in request_body["query"]
         assert request_body["variables"] == {

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -260,6 +260,18 @@ class GithubSearchTest(APITestCase):
         assert resp.data == {"detail": "Rate limit exceeded"}
 
     @responses.activate
+    def test_searches_assignees_invalid_identity(self) -> None:
+        responses.add(responses.POST, self.graphql_url, status=401)
+
+        resp = self.client.get(
+            self.url,
+            data={"field": "assignee", "query": "target", "repo": "test/example"},
+        )
+
+        assert resp.status_code == 400
+        assert resp.data == {"detail": "Unable to fetch options from GitHub"}
+
+    @responses.activate
     def test_prefetches_label_results(self) -> None:
         responses.add(
             responses.GET,

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -193,17 +193,10 @@ class GithubSearchTest(APITestCase):
 
     @responses.activate
     def test_prefetches_assignee_results(self) -> None:
-        assignees_url = self.base_url + "/repos/test/example/assignees"
-        paginated_url = f"{assignees_url}?per_page=100"
         responses.add(
-            responses.GET,
-            paginated_url,
-            json=[{"login": "octocat"}],
-            headers={
-                "link": (
-                    f'<{paginated_url}&page=2>; rel="next", <{paginated_url}&page=2>; rel="last"'
-                )
-            },
+            responses.POST,
+            self.graphql_url,
+            json={"data": {"repository": {"results": {"nodes": [{"login": "octocat"}]}}}},
         )
 
         resp = self.client.get(
@@ -216,7 +209,8 @@ class GithubSearchTest(APITestCase):
             {"value": "", "label": "Unassigned"},
             {"value": "octocat", "label": "octocat"},
         ]
-        assert len(responses.calls) == 1
+        request_body = orjson.loads(responses.calls[0].request.body)
+        assert request_body["variables"]["search"] == ""
 
     @responses.activate
     def test_searches_assignees(self) -> None:
@@ -244,9 +238,13 @@ class GithubSearchTest(APITestCase):
     @responses.activate
     def test_prefetches_label_results(self) -> None:
         responses.add(
-            responses.GET,
-            self.base_url + "/repos/test/example/labels",
-            json=[{"name": "bug"}, {"name": "enhancement"}],
+            responses.POST,
+            self.graphql_url,
+            json={
+                "data": {
+                    "repository": {"results": {"nodes": [{"name": "bug"}, {"name": "enhancement"}]}}
+                }
+            },
         )
 
         resp = self.client.get(
@@ -259,6 +257,8 @@ class GithubSearchTest(APITestCase):
             {"value": "bug", "label": "bug"},
             {"value": "enhancement", "label": "enhancement"},
         ]
+        request_body = orjson.loads(responses.calls[0].request.body)
+        assert request_body["variables"]["search"] == ""
 
     @responses.activate
     def test_searches_labels(self) -> None:

--- a/tests/sentry/integrations/github_enterprise/test_search.py
+++ b/tests/sentry/integrations/github_enterprise/test_search.py
@@ -12,6 +12,7 @@ class GithubEnterpriseSearchTest(test_search.GithubSearchTest):
     # and fill out the slots that customize it to use github:enterprise
     provider = "github_enterprise"
     base_url = "https://github.example.org/api/v3"
+    graphql_url = "https://github.example.org/api/graphql"
 
     def _create_integration(self) -> Integration:
         future = datetime.now() + timedelta(hours=1)


### PR DESCRIPTION
#122886 capped GitHub assignees and labels to the first page to keep form loading fast. #123284 moved those options into a background preload, but the new field endpoint ignored typed search queries.

Keep initial preloads on the existing one-page REST requests, and use GitHub GraphQL filters only for typed searches. This limits the GitHub Enterprise GraphQL rollout to explicit searches while preserving the existing form-load behavior; a TODO marks switching preloads after supported GHES versions are validated.

Both assignee paths use the same label formatting, showing Display Name (@username) when GitHub provides a display name and falling back to the login otherwise. GraphQL option-search failures now return a controlled 429 for rate limits or 400 for other provider errors.

Refs #122886 and #123284