### PR TITLE
fix(auth): Adapt organization clear action for mobile

### DIFF
--- a/static/app/views/authV2/authLogin/components/organizationAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationAuth.tsx
@@ -1,3 +1,4 @@
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Avatar} from '@sentry/scraps/avatar';
@@ -10,14 +11,22 @@ import {IconClose, IconMegaphone} from 'sentry/icons';
 import {IdentityIcon} from 'sentry/icons/identityIcon';
 import {t, tct} from 'sentry/locale';
 import {getCsrfToken} from 'sentry/utils/getCsrfToken';
+import {useMedia} from 'sentry/utils/useMedia';
 import type {AuthOrganization} from 'sentry/views/authV2/authLogin/hooks/useAuthOrganization';
 
 interface OrganizationAuthProps {
   authOrganization: AuthOrganization;
+  hideClearButton?: boolean;
   onClear?: () => void;
 }
 
-export function OrganizationAuth({authOrganization, onClear}: OrganizationAuthProps) {
+export function OrganizationAuth({
+  authOrganization,
+  hideClearButton = false,
+  onClear,
+}: OrganizationAuthProps) {
+  const theme = useTheme();
+  const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.sm})`);
   const {organization, provider, joinRequestUrl, ssoRequired} = authOrganization;
   const avatarProps = organization.avatarUrl
     ? ({
@@ -79,43 +88,58 @@ export function OrganizationAuth({authOrganization, onClear}: OrganizationAuthPr
     </form>
   );
 
-  return (
-    <OrganizationCardStack gap="0" border="secondary" radius="md" position="relative">
-      <Flex align="center" gap="lg" padding="lg">
-        {orgBadge}
-        {ssoAction}
-      </Flex>
+  const showClearButton = Boolean(onClear) && !hideClearButton;
 
-      {joinRequestUrl && (
-        <Flex
-          align="center"
-          justify="between"
-          gap="lg"
-          borderTop="secondary"
-          padding="sm lg"
-        >
-          <Text size="sm">{t('Not a member?')}</Text>
-          <LinkButton
-            href={joinRequestUrl}
-            icon={<IconMegaphone />}
-            size="xs"
-            variant="transparent"
-          >
-            {t('Request to join')}
-          </LinkButton>
+  return (
+    <Stack align="start" gap="md">
+      <OrganizationCardStack
+        width="100%"
+        gap="0"
+        border="secondary"
+        radius="md"
+        position="relative"
+      >
+        <Flex align="center" gap="lg" padding="lg">
+          {orgBadge}
+          {ssoAction}
         </Flex>
+
+        {joinRequestUrl && (
+          <Flex
+            align="center"
+            justify="between"
+            gap="lg"
+            borderTop="secondary"
+            padding="sm lg"
+          >
+            <Text size="sm">{t('Not a member?')}</Text>
+            <LinkButton
+              href={joinRequestUrl}
+              icon={<IconMegaphone />}
+              size="xs"
+              variant="transparent"
+            >
+              {t('Request to join')}
+            </LinkButton>
+          </Flex>
+        )}
+        {showClearButton && !isSmallScreen && (
+          <ClearButton
+            aria-label={t('Clear organization login context')}
+            icon={<IconClose />}
+            size="zero"
+            tooltipProps={{title: t('Clear organization login context')}}
+            variant="transparent"
+            onClick={onClear}
+          />
+        )}
+      </OrganizationCardStack>
+      {showClearButton && isSmallScreen && (
+        <Button icon={<IconClose />} size="zero" variant="transparent" onClick={onClear}>
+          {t('Wrong Organization')}
+        </Button>
       )}
-      {onClear && (
-        <ClearButton
-          aria-label={t('Clear organization login context')}
-          icon={<IconClose />}
-          size="zero"
-          tooltipProps={{title: t('Clear organization login context')}}
-          variant="transparent"
-          onClick={onClear}
-        />
-      )}
-    </OrganizationCardStack>
+    </Stack>
   );
 }
 

--- a/static/app/views/authV2/authLogin/components/requiredOrganizationSso.tsx
+++ b/static/app/views/authV2/authLogin/components/requiredOrganizationSso.tsx
@@ -20,7 +20,11 @@ export function RequiredOrganizationSso({
   return (
     <Stack align="center" gap="md">
       <Container width="100%">
-        <OrganizationAuth authOrganization={authOrganization} onClear={onClear} />
+        <OrganizationAuth
+          authOrganization={authOrganization}
+          hideClearButton
+          onClear={onClear}
+        />
       </Container>
       <Flex width="100%" align="center" justify="between">
         <Button


### PR DESCRIPTION
On narrow screens, the floating clear action sits outside the visible login card area and is difficult to discover or tap.

The organization authentication card now moves the action beneath the card below 800px and labels it “Wrong Organization,” while retaining the compact floating control on larger screens. The required-SSO flow opts out because it already provides its own under-card action.
