### PR TITLE
feat(seer-infra-telemetry): Add hints, links, and visibility toggle to Datadog installation flow

### DIFF
--- a/static/app/components/pipeline/integrationDatadog/index.spec.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.spec.tsx
@@ -19,6 +19,24 @@ describe('DatadogCredentialsStep', () => {
     expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
   });
 
+  it('points key help links at the selected site settings pages', async () => {
+    render(<DatadogCredentialsStep {...makeStepProps({stepData: {}})} />);
+
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Datadog Site'}),
+      'us3.datadoghq.com (US3)'
+    );
+
+    expect(screen.getByRole('link', {name: /API Keys/})).toHaveAttribute(
+      'href',
+      'https://app.us3.datadoghq.com/organization-settings/api-keys'
+    );
+    expect(screen.getByRole('link', {name: /Application Keys/})).toHaveAttribute(
+      'href',
+      'https://app.us3.datadoghq.com/organization-settings/application-keys'
+    );
+  });
+
   it('calls advance with credentials on submit', async () => {
     const advance = jest.fn();
     render(<DatadogCredentialsStep {...makeStepProps({stepData: {}, advance})} />);

--- a/static/app/components/pipeline/integrationDatadog/index.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.tsx
@@ -3,6 +3,7 @@ import {z} from 'zod';
 
 import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
 import {Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
 import type {
@@ -10,10 +11,14 @@ import type {
   PipelineStepProps,
 } from 'sentry/components/pipeline/types';
 import {pipelineComplete} from 'sentry/components/pipeline/types';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 import {requestErrorToFieldErrors} from 'sentry/utils/requestError/requestErrorToFieldErrors';
-import {DATADOG_SITES, DATADOG_SITE_VALUES} from 'sentry/utils/seer/datadogSites';
+import {
+  DATADOG_SITES,
+  DATADOG_SITE_VALUES,
+  datadogOrgSettingsUrl,
+} from 'sentry/utils/seer/datadogSites';
 
 const credentialsSchema = z.object({
   apiKey: z.string().min(1, t('API key is required')),
@@ -65,30 +70,54 @@ function DatadogCredentialsStep({
             </field.Layout.Stack>
           )}
         </form.AppField>
-        <form.AppField name="apiKey">
-          {field => (
-            <field.Layout.Stack label={t('API Key')} required>
-              <field.Input
-                type="password"
-                value={field.state.value}
-                onChange={field.handleChange}
-                placeholder="********************************"
-              />
-            </field.Layout.Stack>
-          )}
-        </form.AppField>
-        <form.AppField name="appKey">
-          {field => (
-            <field.Layout.Stack label={t('Application Key')} required>
-              <field.Input
-                type="password"
-                value={field.state.value}
-                onChange={field.handleChange}
-                placeholder="****************************************"
-              />
-            </field.Layout.Stack>
-          )}
-        </form.AppField>
+        <form.Subscribe selector={state => state.values.site}>
+          {site => {
+            const keysHref = (page: 'api-keys' | 'application-keys') =>
+              site
+                ? datadogOrgSettingsUrl(site, page)
+                : 'https://docs.datadoghq.com/account_management/api-app-keys/';
+            return (
+              <Stack gap="lg">
+                <form.AppField name="apiKey">
+                  {field => (
+                    <field.Layout.Stack
+                      label={t('API Key')}
+                      hintText={tct(
+                        'Identifies your Datadog organization. Create one under [link:Organization Settings › API Keys].',
+                        {link: <ExternalLink href={keysHref('api-keys')} />}
+                      )}
+                      required
+                    >
+                      <field.Password
+                        value={field.state.value}
+                        onChange={value => field.handleChange(value.trim())}
+                        placeholder="********************************"
+                      />
+                    </field.Layout.Stack>
+                  )}
+                </form.AppField>
+                <form.AppField name="appKey">
+                  {field => (
+                    <field.Layout.Stack
+                      label={t('Application Key')}
+                      hintText={tct(
+                        'Authorizes requests on top of the API key. Create one under [link:Organization Settings › Application Keys].',
+                        {link: <ExternalLink href={keysHref('application-keys')} />}
+                      )}
+                      required
+                    >
+                      <field.Password
+                        value={field.state.value}
+                        onChange={value => field.handleChange(value.trim())}
+                        placeholder="****************************************"
+                      />
+                    </field.Layout.Stack>
+                  )}
+                </form.AppField>
+              </Stack>
+            );
+          }}
+        </form.Subscribe>
         <Flex>
           <form.SubmitButton busy={isAdvancing} disabled={isInitializing}>
             {t('Continue')}

--- a/static/app/components/pipeline/integrationDatadog/index.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.tsx
@@ -60,7 +60,13 @@ function DatadogCredentialsStep({
         </Text>
         <form.AppField name="site">
           {field => (
-            <field.Layout.Stack label={t('Datadog Site')} required>
+            <field.Layout.Stack
+              label={t('Datadog Site')}
+              hintText={t(
+                'The region your Datadog organization is hosted in, shown in your Datadog URL.'
+              )}
+              required
+            >
               <field.Select
                 value={field.state.value}
                 onChange={value => field.handleChange(value)}

--- a/static/app/components/pipeline/integrationDatadog/index.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.tsx
@@ -14,11 +14,14 @@ import {pipelineComplete} from 'sentry/components/pipeline/types';
 import {t, tct} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 import {requestErrorToFieldErrors} from 'sentry/utils/requestError/requestErrorToFieldErrors';
-import {
-  DATADOG_SITES,
-  DATADOG_SITE_VALUES,
-  datadogOrgSettingsUrl,
-} from 'sentry/utils/seer/datadogSites';
+import {DATADOG_SITES, DATADOG_SITE_VALUES} from 'sentry/utils/seer/datadogSites';
+
+function datadogOrgSettingsUrl(
+  site: string,
+  page: 'api-keys' | 'application-keys'
+): string {
+  return `https://app.${site}/organization-settings/${page}`;
+}
 
 const credentialsSchema = z.object({
   apiKey: z.string().min(1, t('API key is required')),

--- a/static/app/utils/seer/datadogSites.ts
+++ b/static/app/utils/seer/datadogSites.ts
@@ -14,10 +14,3 @@ export const DATADOG_SITE_VALUES = DATADOG_SITES.map(site => site.value) as [
   string,
   ...string[],
 ];
-
-export function datadogOrgSettingsUrl(
-  site: string,
-  page: 'api-keys' | 'application-keys'
-): string {
-  return `https://app.${site}/organization-settings/${page}`;
-}

--- a/static/app/utils/seer/datadogSites.ts
+++ b/static/app/utils/seer/datadogSites.ts
@@ -14,3 +14,10 @@ export const DATADOG_SITE_VALUES = DATADOG_SITES.map(site => site.value) as [
   string,
   ...string[],
 ];
+
+export function datadogOrgSettingsUrl(
+  site: string,
+  page: 'api-keys' | 'application-keys'
+): string {
+  return `https://app.${site}/organization-settings/${page}`;
+}


### PR DESCRIPTION
fixes CW-1990

Before:
<img width="682" height="505" alt="Screenshot 2026-09-02 at 10 03 50 AM" src="https://github.com/user-attachments/assets/9e705a24-f9fe-4f6a-a2cc-86a142dd632f" />

After:
- Hints for each field, with direct links to the org's API/app key settings (uses the entered Datadog site). Fallback links to the docs if the user hasn't entered their site yet.
- Visibility toggle on the key fields.
- Trim whitespace from the keys.

https://github.com/user-attachments/assets/0d5c5f90-4b01-4d28-87e2-96d91bd30c79

