### PR TITLE
fix(auth): Keep organization lookup busy during transition

### DIFF
--- a/static/app/views/authV2/authLogin/components/organizationSlugInput.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationSlugInput.spec.tsx
@@ -34,6 +34,10 @@ describe('OrganizationSlugInput', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Locate'}));
 
     await waitFor(() => expect(onSelect).toHaveBeenCalledWith('acme'));
+    expect(screen.getByRole('button', {name: 'Locate'})).toHaveAttribute(
+      'aria-busy',
+      'true'
+    );
   });
 
   it('latches an invalid organization until the slug changes', async () => {

--- a/static/app/views/authV2/authLogin/components/organizationSlugInput.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationSlugInput.tsx
@@ -23,6 +23,8 @@ export function OrganizationSlugInput({onCancel, onSelect}: OrganizationSlugInpu
   const normalizedSlug = slug.trim();
   const organizationQuery = useAuthOrganization(submittedSlug);
   const hasError = Boolean(submittedSlug && organizationQuery.isError);
+  const isLocating =
+    organizationQuery.isFetching || Boolean(submittedSlug && organizationQuery.isSuccess);
   const organizationNotFound = hasError && isNotFoundError(organizationQuery.error);
   const errorMessage = hasError
     ? organizationNotFound
@@ -93,7 +95,7 @@ export function OrganizationSlugInput({onCancel, onSelect}: OrganizationSlugInpu
           autoFocus
           data-1p-ignore
           placeholder={t('Organization Slug')}
-          readOnly={organizationQuery.isFetching}
+          readOnly={isLocating}
           spellCheck={false}
           value={slug}
           aria-invalid={hasError}
@@ -113,12 +115,7 @@ export function OrganizationSlugInput({onCancel, onSelect}: OrganizationSlugInpu
             </Tooltip>
           ) : null}
           {!organizationNotFound && normalizedSlug ? (
-            <Button
-              busy={organizationQuery.isFetching}
-              size="zero"
-              type="submit"
-              variant="transparent"
-            >
+            <Button busy={isLocating} size="zero" type="submit" variant="transparent">
               {t('Locate')}
             </Button>
           ) : null}


### PR DESCRIPTION
Keep the organization lookup button busy after a successful response while the organization card replaces the input. This avoids briefly restoring the idle button during the exit animation.

The lookup input remains read-only through the same transition, and the component test covers the successful response-to-navigation handoff.