### PR TITLE
feat(apidocs): Add omit_from_public_schema with a required reason

### DIFF
--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -198,16 +198,18 @@ def _validate_request_body(
     for body_param, param_data in schema["properties"].items():
         # Ensure body parameters have a description. Our API docs don't
         # display body params without a description, so it's easy to miss them.
-        # We should be explicitly excluding them as better practice however.
 
         # There is an edge case where a body param might be reference that we should ignore for now
         if "description" not in param_data and "$ref" not in param_data:
             raise SentryApiBuildError(
-                f"""Body parameter '{body_param}' is missing a description for endpoint {endpoint_name}. You can either:
-            1. Add a 'help_text' kwarg to the serializer field
-            2. Remove the field if you're using an inline_serializer
-            3. For a DRF serializer, you must explicitly exclude this field by decorating the request serializer with
-            @extend_schema_serializer(exclude_fields=[{body_param}])."""
+                f"""Body parameter '{body_param}' is missing a description for endpoint {endpoint_name}.
+
+            Add a 'help_text' kwarg to the serializer field, or remove the field if you're
+            using an inline_serializer.
+
+            Withholding it instead -- @sentry_schema_serializer(omit_from_public_schema=
+            {{"{body_param}": "<why>"}}) -- drops it from the schema and every generated SDK.
+            Only do that if the field should not be public at all, never to fix this error."""
             )
 
     # Required params are stored in a list and not in the param itself

--- a/src/sentry/apidocs/omissions.py
+++ b/src/sentry/apidocs/omissions.py
@@ -1,0 +1,53 @@
+"""Withholding a serializer field from the public API schema.
+
+Omitted fields vanish from the generated schema and every generated SDK, but are
+still accepted at runtime. A missing description is not a reason to use this --
+add help_text instead; sentry.apidocs.hooks spells out when omission is correct.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TypeVar
+
+from drf_spectacular.drainage import get_override, set_override
+
+# Override key holding ``{field: reason}``. Read by the linter and by anything
+# reporting on the public surface; drf-spectacular itself ignores it.
+OMISSION_REASONS_OVERRIDE = "sentry_omission_reasons"
+
+T = TypeVar("T", bound=type)
+
+
+def sentry_schema_serializer(*, omit_from_public_schema: dict[str, str]) -> Callable[[T], T]:
+    """Withhold fields from the generated schema, recording why for each one.
+
+    Each value is the reason that field is not part of the public API surface.
+    """
+    if not omit_from_public_schema:
+        raise ValueError(
+            "sentry_schema_serializer() requires at least one field in "
+            "omit_from_public_schema; remove the decorator instead."
+        )
+
+    for field, reason in omit_from_public_schema.items():
+        if not reason or not reason.strip():
+            raise ValueError(
+                f"omit_from_public_schema['{field}'] needs a reason explaining why the "
+                f"field is not part of the public API surface. If the field is simply "
+                f"undocumented, add a help_text to it instead of omitting it."
+            )
+
+    def decorator(klass: T) -> T:
+        # Merge rather than replace: a class may carry exclude_fields from a
+        # stacked @extend_schema_serializer, and subclasses inherit the override.
+        existing = get_override(klass, "exclude_fields", []) or []
+        merged = list(dict.fromkeys([*existing, *omit_from_public_schema]))
+        set_override(klass, "exclude_fields", merged)
+
+        reasons = {**(get_override(klass, OMISSION_REASONS_OVERRIDE, {}) or {})}
+        reasons.update(omit_from_public_schema)
+        set_override(klass, OMISSION_REASONS_OVERRIDE, reasons)
+        return klass
+
+    return decorator

--- a/tests/sentry/apidocs/test_omissions.py
+++ b/tests/sentry/apidocs/test_omissions.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+import pytest
+from drf_spectacular.drainage import get_override
+from drf_spectacular.utils import extend_schema_serializer
+from rest_framework import serializers
+
+from sentry.apidocs.omissions import OMISSION_REASONS_OVERRIDE, sentry_schema_serializer
+
+
+@sentry_schema_serializer(
+    omit_from_public_schema={"internalOnly": "Untyped escape hatch; not public surface."}
+)
+class OmittingSerializer(serializers.Serializer):
+    documented = serializers.CharField(help_text="A documented field.", required=False)
+    internalOnly = serializers.DictField(required=False)
+
+
+def test_omitted_field_lands_in_the_override_drf_spectacular_reads() -> None:
+    # openapi.py filters serializer properties on this exact override.
+    assert get_override(OmittingSerializer, "exclude_fields") == ["internalOnly"]
+
+
+def test_documented_field_is_not_omitted() -> None:
+    assert "documented" not in get_override(OmittingSerializer, "exclude_fields", [])
+
+
+def test_reasons_are_recorded() -> None:
+    reasons = get_override(OmittingSerializer, OMISSION_REASONS_OVERRIDE)
+    assert reasons == {"internalOnly": "Untyped escape hatch; not public surface."}
+
+
+def test_legacy_exclude_fields_still_honored() -> None:
+    @extend_schema_serializer(exclude_fields=["legacy"])
+    class LegacySerializer(serializers.Serializer):
+        legacy = serializers.CharField(required=False)
+
+    assert get_override(LegacySerializer, "exclude_fields") == ["legacy"]
+    assert get_override(LegacySerializer, OMISSION_REASONS_OVERRIDE) is None
+
+
+def test_stacked_decorators_merge_rather_than_clobber() -> None:
+    @sentry_schema_serializer(omit_from_public_schema={"new": "A stated reason."})
+    @extend_schema_serializer(exclude_fields=["legacy"])
+    class StackedSerializer(serializers.Serializer):
+        legacy = serializers.CharField(required=False)
+        new = serializers.CharField(required=False)
+
+    assert sorted(get_override(StackedSerializer, "exclude_fields")) == ["legacy", "new"]
+
+
+def test_subclass_inherits_without_mutating_parent() -> None:
+    @sentry_schema_serializer(omit_from_public_schema={"childOnly": "A stated reason."})
+    class Child(OmittingSerializer):
+        childOnly = serializers.CharField(required=False)
+
+    assert sorted(get_override(Child, "exclude_fields")) == ["childOnly", "internalOnly"]
+    assert get_override(OmittingSerializer, "exclude_fields") == ["internalOnly"]
+
+
+@pytest.mark.parametrize("reason", ["", "   ", "\n"])
+def test_blank_reason_is_rejected(reason: str) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        sentry_schema_serializer(omit_from_public_schema={"field": reason})
+    assert "field" in str(excinfo.value)
+    assert "help_text" in str(excinfo.value)
+
+
+def test_empty_mapping_is_rejected() -> None:
+    with pytest.raises(ValueError):
+        sentry_schema_serializer(omit_from_public_schema={})


### PR DESCRIPTION
`exclude_fields` hides a field from the generated OpenAPI schema, and that schema feeds SDK scaffolding — so an excluded field is missing from every generated client and downstream tools cannot set it.

Almost none of the ~135 current exclusions were deliberate. The docs build fails when a public body parameter has no description, and its error offered exclusion as one of three peer remedies, so the cheapest one won. This adds `sentry_schema_serializer(omit_from_public_schema={field: reason})`, which keeps the justification at the call site instead of in a list that drifts, and rewrites that error so `help_text` is the answer.

Withheld fields are still accepted at runtime — this hides a field from documentation, it does not restrict it, which is why the name refers to the schema rather than to privacy. It lowers onto the same drf-spectacular override, so both spellings work side by side and no migration window is needed.

The exclusion backfill follows in separate PRs.