### PR TITLE
fix(autofix): Disable code-changes reset when PR iteration is paused

### DIFF
--- a/static/app/components/events/autofix/v3/artifactCard.tsx
+++ b/static/app/components/events/autofix/v3/artifactCard.tsx
@@ -4,6 +4,7 @@ import {Button} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {IconRefresh} from 'sentry/icons';
 import {IconCopy} from 'sentry/icons/iconCopy';
@@ -35,20 +36,16 @@ export function ArtifactCard({
           trailingItems={
             <Fragment>
               {allowReset && (
-                <Button
-                  size="xs"
-                  variant="transparent"
-                  icon={<IconRefresh size="xs" />}
-                  aria-label={t('Re-run step')}
-                  tooltipProps={{
-                    title: resetTooltip ?? t('Re-run step'),
-                    // Disabled buttons swallow pointer events; drop skipWrapper
-                    // so the tooltip can hang off a wrapper instead.
-                    skipWrapper: resetTooltip ? false : undefined,
-                  }}
-                  onClick={onReset}
-                  disabled={!onReset}
-                />
+                <Tooltip title={resetTooltip ?? t('Re-run step')}>
+                  <Button
+                    size="xs"
+                    variant="transparent"
+                    icon={<IconRefresh size="xs" />}
+                    aria-label={t('Re-run step')}
+                    onClick={onReset}
+                    disabled={!onReset}
+                  />
+                </Tooltip>
               )}
               <Button
                 size="xs"

--- a/static/app/components/events/autofix/v3/artifactCard.tsx
+++ b/static/app/components/events/autofix/v3/artifactCard.tsx
@@ -16,6 +16,7 @@ interface ArtifactCardProps {
   allowReset?: boolean;
   onCopy?: () => void;
   onReset?: () => void;
+  resetTooltip?: string;
 }
 
 export function ArtifactCard({
@@ -25,6 +26,7 @@ export function ArtifactCard({
   onCopy,
   allowReset,
   onReset,
+  resetTooltip,
 }: ArtifactCardProps) {
   return (
     <Container border="primary" radius="md" padding="lg" background="primary">
@@ -38,7 +40,12 @@ export function ArtifactCard({
                   variant="transparent"
                   icon={<IconRefresh size="xs" />}
                   aria-label={t('Re-run step')}
-                  tooltipProps={{title: t('Re-run step')}}
+                  tooltipProps={{
+                    title: resetTooltip ?? t('Re-run step'),
+                    // Disabled buttons swallow pointer events; drop skipWrapper
+                    // so the tooltip can hang off a wrapper instead.
+                    skipWrapper: resetTooltip ? false : undefined,
+                  }}
                   onClick={onReset}
                   disabled={!onReset}
                 />

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1555,6 +1555,39 @@ describe('ArtifactCard', () => {
       expect(screen.getByRole('button', {name: 'Re-run step'})).toBeDisabled();
     });
 
+    it('disables reset when PR iteration is paused', async () => {
+      const autofix: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          repo_pr_states: {'org/repo': makePR()},
+          pr_iteration_paused: true,
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofix}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: manualPrIterationOrganization}
+      );
+
+      const resetButton = screen.getByRole('button', {name: 'Re-run step'});
+      expect(resetButton).toBeDisabled();
+
+      await userEvent.hover(resetButton);
+      expect(
+        await screen.findByText('PR iteration has been stopped for this Autofix run')
+      ).toBeInTheDocument();
+    });
+
     it('keeps reset enabled with the feature flag even when PRs exist', () => {
       const autofix: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -13,6 +13,7 @@ import {
   getAutofixArtifactFromSection,
   isCodeChangesArtifact,
   isPrIterationBlock,
+  isPrIterationPaused,
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
@@ -24,7 +25,10 @@ import {
   FeedbackList,
   usePrIterationFeedback,
 } from 'sentry/components/events/autofix/v3/feedbackList';
-import {PrIterationFeedbackForm} from 'sentry/components/events/autofix/v3/prIterationFeedbackForm';
+import {
+  PR_ITERATION_PAUSED_TOOLTIP,
+  PrIterationFeedbackForm,
+} from 'sentry/components/events/autofix/v3/prIterationFeedbackForm';
 import {useResetAutofixStep} from 'sentry/components/events/autofix/v3/useResetAutofixStep';
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
 import {IconCode} from 'sentry/icons/iconCode';
@@ -112,8 +116,11 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
   const noCodingAgents =
     Object.values(autofix.runState?.coding_agents ?? {}).length === 0;
 
+  const isPaused = isPrIterationPaused(autofix.runState);
+
   // Reset-after-PR is only reachable where reset opens the manual form.
   const isResetEligible =
+    !isPaused &&
     !hasFailedOnlyPRs &&
     (hasManualPrIterationFeature
       ? noCodingAgents && (hasPRs || autofix.runState?.status !== 'processing')
@@ -324,6 +331,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
       }
       allowReset
       onReset={canReset ? () => setShouldShowReset(true) : undefined}
+      resetTooltip={isPaused ? PR_ITERATION_PAUSED_TOOLTIP : undefined}
     >
       <FeedbackList items={feedback} />
       {content}

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -20,6 +20,10 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
 
+export const PR_ITERATION_PAUSED_TOOLTIP = t(
+  'PR iteration has been stopped for this Autofix run'
+);
+
 interface PrIterationFeedbackFormProps {
   autofix: ReturnType<typeof useExplorerAutofix>;
   groupId: string;
@@ -45,7 +49,7 @@ export function PrIterationFeedbackForm({
   const prompt = t('Anything else you want to see on your PR?');
   // A disabled control fires no pointer events, so the tooltip hangs off the
   // wrapper element rather than the control itself.
-  const pausedTooltip = t('PR iteration has been stopped for this Autofix run');
+  const pausedTooltip = PR_ITERATION_PAUSED_TOOLTIP;
 
   const handleSubmit = async () => {
     // Also guards the Enter hotkey, which clicks the button directly.


### PR DESCRIPTION
fix(autofix): Disable code-changes reset when PR iteration is paused

When a run has stopped iterating, the reset control on the code
changes card stayed clickable even though the feedback box did not.
Disable it and reuse the same tooltip so both explain why.

<img width="1638" height="478" alt="image" src="https://github.com/user-attachments/assets/3caee82b-8dec-4a34-8b74-eaeba52c0a92" />
