### PR TITLE
feat: Autofix routes are on the org only path

### DIFF
--- a/src/sentry/api/urls.py
+++ b/src/sentry/api/urls.py
@@ -1049,6 +1049,15 @@ def create_group_urls(
             name=f"{name_prefix}-group-current-release",
         ),
         re_path(
+            r"^(?P<issue_id>[^/]+)/related-issues/$",
+            RelatedIssuesEndpoint.as_view(),
+            name=f"{name_prefix}-related-issues",
+        ),
+    ]
+
+    # Served only under `/organizations/{org}/issues/`.
+    org_scoped_only: list[URLPattern | URLResolver] = [
+        re_path(
             r"^(?P<issue_id>[^/]+)/autofix/$",
             GroupAutofixEndpoint.as_view(),
             name=f"{name_prefix}-group-autofix",
@@ -1063,15 +1072,6 @@ def create_group_urls(
             GroupAutofixReposEndpoint.as_view(),
             name=f"{name_prefix}-group-autofix-repos",
         ),
-        re_path(
-            r"^(?P<issue_id>[^/]+)/related-issues/$",
-            RelatedIssuesEndpoint.as_view(),
-            name=f"{name_prefix}-related-issues",
-        ),
-    ]
-
-    # Served only under `/organizations/{org}/issues/`.
-    org_scoped_only: list[URLPattern | URLResolver] = [
         re_path(
             r"^(?P<issue_id>[^/]+)/summarize/$",
             GroupAiSummaryEndpoint.as_view(),

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -15,7 +15,6 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.conditional_get import ConditionalGetResponseMixin
-from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -31,7 +30,6 @@ from sentry.apidocs.response_types import (
     as_validation_errors,
 )
 from sentry.apidocs.utils import inline_sentry_response_serializer
-from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.action_log import (
     action_context_scope,
     resolve_action_actor,
@@ -229,11 +227,6 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
             404: RESPONSE_NOT_FOUND,
         },
         examples=AutofixExamples.AUTOFIX_POST_RESPONSE,
-    )
-    @deprecated(
-        CELL_API_DEPRECATION_DATE,
-        suggested_api="sentry-api-0-organization-group-group-autofix",
-        url_names=["sentry-api-0-group-autofix"],
     )
     def post(
         self, request: Request, group: Group
@@ -528,11 +521,6 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
             404: RESPONSE_NOT_FOUND,
         },
         examples=AutofixExamples.AUTOFIX_GET_RESPONSE,
-    )
-    @deprecated(
-        CELL_API_DEPRECATION_DATE,
-        suggested_api="sentry-api-0-organization-group-group-autofix",
-        url_names=["sentry-api-0-group-autofix"],
     )
     def get(self, request: Request, group: Group) -> Response[AutofixStateResponse]:
         """

--- a/src/sentry/seer/endpoints/group_ai_summary.py
+++ b/src/sentry/seer/endpoints/group_ai_summary.py
@@ -9,8 +9,6 @@ from rest_framework.response import Response
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.helpers.deprecation import deprecated
-from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
 from sentry.ratelimits.config import RateLimitConfig
@@ -38,11 +36,6 @@ class GroupAiSummaryEndpoint(GroupAiEndpoint):
         }
     )
 
-    @deprecated(
-        CELL_API_DEPRECATION_DATE,
-        suggested_api="sentry-api-0-organization-group-group-ai-summary",
-        url_names=["sentry-api-0-group-ai-summary"],
-    )
     def post(self, request: Request, group: Group) -> Response:
         data = orjson.loads(request.body) if request.body else {}
         force_event_id = data.get("event_id", None)

--- a/src/sentry/seer/endpoints/group_autofix_setup_check.py
+++ b/src/sentry/seer/endpoints/group_autofix_setup_check.py
@@ -9,8 +9,7 @@ from sentry import options, quotas
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
-from sentry.api.helpers.deprecation import deprecated
-from sentry.constants import CELL_API_DEPRECATION_DATE, DataCategory, ObjectStatus
+from sentry.constants import DataCategory, ObjectStatus
 from sentry.integrations.services.integration import integration_service
 from sentry.issues.endpoints.bases.group import GroupAiEndpoint
 from sentry.models.group import Group
@@ -76,11 +75,6 @@ class GroupAutofixSetupCheck(GroupAiEndpoint):
         }
     )
 
-    @deprecated(
-        CELL_API_DEPRECATION_DATE,
-        suggested_api="sentry-api-0-organization-group-group-autofix-setup",
-        url_names=["sentry-api-0-group-autofix-setup"],
-    )
     def get(self, request: Request, group: Group) -> Response:
         """
         Checks if we are able to run Autofix on the given group.


### PR DESCRIPTION
The three autofix routes (/autofix/, /autofix/setup/, /autofix/repos/) are moved out of the shared list and into org_scoped_only, so they're served only under /organizations/{org}/issues/ and no longer registered on the legacy /issues/ path.

/issues/ has been deprecated for years and will be fully removed soon, there is no reason to support it there
