### PR TITLE
feat(hybridcloud): Add per-category and silo/type tags to outbox SLO …

### DIFF
--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -453,8 +453,10 @@ class OutboxBase(Model):
         :return: A list of dictionaries with "category" and "depth" keys,
         ordered by depth descending.
         """
-        assert "shard_scope" in shard_key and "shard_identifier" in shard_key, (
-            "shard_key must include shard_scope and shard_identifier to avoid an unbounded query"
+        missing_columns = set(cls.sharding_columns) - shard_key.keys()
+        assert not missing_columns, (
+            f"shard_key must include all sharding columns to avoid an unbounded query, "
+            f"missing: {missing_columns}"
         )
         rows = (
             cls.objects.filter(**shard_key)

--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -406,21 +406,18 @@ class OutboxBase(Model):
     def get_shard_depths_descending(cls, limit: int | None = 10) -> list[dict[str, int | str]]:
         """
         Queries all outbox shards for their total depth, aggregated by their
-        sharding columns as specified by the outbox class implementation, and
-        by category.
+        sharding columns as specified by the outbox class implementation.
 
         :param limit: Limits the query to the top N rows with the greatest shard
         depth. If limit is None, the entire set of rows will be returned.
-        :return: A list of dictionaries, containing shard depths, category, and
-        shard relevant column values.
+        :return: A list of dictionaries, containing shard depths and shard
+        relevant column values.
         """
         if limit is not None:
             assert limit > 0, "Limit must be a positive integer if specified"
 
         base_depth_query = (
-            cls.objects.values(*cls.sharding_columns, "category")
-            .annotate(depth=Count("*"))
-            .order_by("-depth")
+            cls.objects.values(*cls.sharding_columns).annotate(depth=Count("*")).order_by("-depth")
         )
 
         if limit is not None:
@@ -434,12 +431,33 @@ class OutboxBase(Model):
             shard_information = {
                 shard_column: shard_row[shard_column] for shard_column in cls.sharding_columns
             }
-            shard_information["category"] = shard_row["category"]
             shard_information["depth"] = shard_row["depth"]
             aggregated_shard_information.append(shard_information)
 
         return aggregated_shard_information
 >>>>>>> 1e1810e4 (feat(hybridcloud): Add per-category and silo/type tags to outbox SLO metrics)
+
+    @classmethod
+    def get_shard_category_breakdown(cls, shard_key: Mapping[str, int]) -> list[dict[str, int]]:
+        """
+        For a single shard (identified by its sharding column values), returns
+        depth broken down by category, ordered by depth descending. Intended
+        for enriching logging about a shard already known to be deep -- a
+        shard's sharding columns combined with category is too high
+        cardinality for a metric tag.
+
+        :param shard_key: A mapping of sharding column name to value, as
+        returned by get_shard_depths_descending.
+        :return: A list of dictionaries with "category" and "depth" keys,
+        ordered by depth descending.
+        """
+        rows = (
+            cls.objects.filter(**shard_key)
+            .values("category")
+            .annotate(depth=Count("*"))
+            .order_by("-depth")
+        )
+        return [{"category": row["category"], "depth": row["depth"]} for row in rows]
 
     @classmethod
     def get_category_depths(cls) -> dict[int, int]:

--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -453,6 +453,9 @@ class OutboxBase(Model):
         :return: A list of dictionaries with "category" and "depth" keys,
         ordered by depth descending.
         """
+        assert "shard_scope" in shard_key and "shard_identifier" in shard_key, (
+            "shard_key must include shard_scope and shard_identifier to avoid an unbounded query"
+        )
         rows = (
             cls.objects.filter(**shard_key)
             .values("category")

--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -438,7 +438,9 @@ class OutboxBase(Model):
 >>>>>>> 1e1810e4 (feat(hybridcloud): Add per-category and silo/type tags to outbox SLO metrics)
 
     @classmethod
-    def get_shard_category_breakdown(cls, shard_key: Mapping[str, int]) -> list[dict[str, int]]:
+    def get_shard_category_breakdown(
+        cls, shard_key: Mapping[str, int | str]
+    ) -> list[dict[str, int]]:
         """
         For a single shard (identified by its sharding column values), returns
         depth broken down by category, ordered by depth descending. Intended

--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -147,6 +147,12 @@ class OutboxBase(Model):
             else:
                 raise
 
+    def _silo_and_type_tags(self) -> dict[str, str]:
+        return {
+            "silo": SiloMode.get_current_mode().value.lower(),
+            "type": type(self).__name__,
+        }
+
     def key_from(self, attrs: Iterable[str]) -> Mapping[str, Any]:
         return {k: _ensure_not_null(k, getattr(self, k)) for k in attrs}
 
@@ -205,7 +211,7 @@ class OutboxBase(Model):
                 self._drain_shard_with_metrics, using=router.db_for_write(type(self))
             )
 
-        tags = {"category": OutboxCategory(self.category).name}
+        tags = {"category": OutboxCategory(self.category).name, **self._silo_and_type_tags()}
         metrics.incr("outbox.saved", 1, tags=tags)
         super().save(*args, **kwargs)
 
@@ -247,7 +253,11 @@ class OutboxBase(Model):
     ) -> Generator[OutboxBase | None]:
         coalesced: OutboxBase | None = self.select_coalesced_messages().last()
         first_coalesced: OutboxBase | None = self.select_coalesced_messages().first() or coalesced
-        tags: dict[str, int | str] = {"category": "None", "synchronous": int(is_synchronous_flush)}
+        tags: dict[str, int | str] = {
+            "category": "None",
+            "synchronous": int(is_synchronous_flush),
+            **self._silo_and_type_tags(),
+        }
 
         if coalesced is not None:
             tags["category"] = OutboxCategory(self.category).name
@@ -319,6 +329,7 @@ class OutboxBase(Model):
                         tags={
                             "category": OutboxCategory(coalesced.category).name,
                             "synchronous": int(is_synchronous_flush),
+                            **coalesced._silo_and_type_tags(),
                         },
                     ),
                     start_span(op="outbox.process", name="outbox.process") as span,
@@ -395,24 +406,54 @@ class OutboxBase(Model):
     def get_shard_depths_descending(cls, limit: int | None = 10) -> list[dict[str, int | str]]:
         """
         Queries all outbox shards for their total depth, aggregated by their
-        sharding columns as specified by the outbox class implementation.
+        sharding columns as specified by the outbox class implementation, and
+        by category.
 
         :param limit: Limits the query to the top N rows with the greatest shard
         depth. If limit is None, the entire set of rows will be returned.
-        :return: A list of dictionaries, containing shard depths and shard
-        relevant column values.
+        :return: A list of dictionaries, containing shard depths, category, and
+        shard relevant column values.
         """
         if limit is not None:
             assert limit > 0, "Limit must be a positive integer if specified"
 
         base_depth_query = (
-            cls.objects.values(*cls.sharding_columns).annotate(depth=Count("*")).order_by("-depth")
+            cls.objects.values(*cls.sharding_columns, "category")
+            .annotate(depth=Count("*"))
+            .order_by("-depth")
         )
 
         if limit is not None:
             base_depth_query = base_depth_query[0:limit]
 
+<<<<<<< HEAD
         return list(base_depth_query)
+=======
+        aggregated_shard_information = list()
+        for shard_row in base_depth_query:
+            shard_information = {
+                shard_column: shard_row[shard_column] for shard_column in cls.sharding_columns
+            }
+            shard_information["category"] = shard_row["category"]
+            shard_information["depth"] = shard_row["depth"]
+            aggregated_shard_information.append(shard_information)
+
+        return aggregated_shard_information
+>>>>>>> 1e1810e4 (feat(hybridcloud): Add per-category and silo/type tags to outbox SLO metrics)
+
+    @classmethod
+    def get_category_depths(cls) -> dict[int, int]:
+        """
+        Queries all outbox shards for their total depth, summed across all
+        shards and grouped only by category. Unlike get_shard_depths_descending,
+        this collapses the shard dimension entirely, so it's suitable for
+        SLO/backlog metrics where a shard-identifier tag would blow up
+        cardinality.
+
+        :return: A mapping of category value to total depth across all shards.
+        """
+        rows = cls.objects.values("category").annotate(depth=Count("*"))
+        return {row["category"]: row["depth"] for row in rows}
 
     @classmethod
     def get_total_outbox_count(cls) -> int:

--- a/src/sentry/hybridcloud/models/outbox.py
+++ b/src/sentry/hybridcloud/models/outbox.py
@@ -423,19 +423,7 @@ class OutboxBase(Model):
         if limit is not None:
             base_depth_query = base_depth_query[0:limit]
 
-<<<<<<< HEAD
         return list(base_depth_query)
-=======
-        aggregated_shard_information = list()
-        for shard_row in base_depth_query:
-            shard_information = {
-                shard_column: shard_row[shard_column] for shard_column in cls.sharding_columns
-            }
-            shard_information["depth"] = shard_row["depth"]
-            aggregated_shard_information.append(shard_information)
-
-        return aggregated_shard_information
->>>>>>> 1e1810e4 (feat(hybridcloud): Add per-category and silo/type tags to outbox SLO metrics)
 
     @classmethod
     def get_shard_category_breakdown(

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.db.models import Max, Min
 from taskbroker_client.task import Task
 
+from sentry import options
 from sentry.hybridcloud.models.outbox import (
     CellOutboxBase,
     ControlOutboxBase,
@@ -68,10 +69,6 @@ def enqueue_outbox_jobs(
 # relationship between the id space of shard_identifiers and the amount of unique,
 # non coalesced work.
 CONCURRENCY = 5
-
-# Above this depth, a shard is backed up enough that we log which shard it is,
-# since the maximum_shard_depth metric alone doesn't identify it.
-DEEP_SHARD_LOG_THRESHOLD = 10_000
 
 
 def schedule_batch(
@@ -153,8 +150,32 @@ def schedule_outbox_model(
         sample_rate=1.0,
     )
 
+    if options.get("hybridcloud.outbox.deep_shard_logging.enabled"):
+        _log_deep_shards(outbox_model, deepest_shards, metrics_tags)
+
+    outbox_count = outbox_model.get_total_outbox_count()
+    metrics.gauge(
+        "deliver_from_outbox.total_outbox_count",
+        value=outbox_count,
+        tags=metrics_tags,
+        sample_rate=1.0,
+    )
+
+    if options.get("hybridcloud.outbox.category_depth_metric.enabled"):
+        _record_category_depths(silo_mode, outbox_model)
+    return scheduled_count
+
+
+def _log_deep_shards(
+    outbox_model: type[OutboxBase],
+    deepest_shards: list[dict[str, int | str]],
+    metrics_tags: Mapping[str, str],
+) -> None:
+    # The maximum_shard_depth metric alone doesn't identify which shard is
+    # backed up, so log the sharding columns of any shard over the threshold.
+    threshold = options.get("hybridcloud.outbox.deep_shard_logging.threshold")
     for shard in deepest_shards:
-        if int(shard["depth"]) < DEEP_SHARD_LOG_THRESHOLD:
+        if int(shard["depth"]) < threshold:
             break
         shard_key = {column: shard[column] for column in outbox_model.sharding_columns}
         category_breakdown = outbox_model.get_shard_category_breakdown(shard_key)
@@ -168,14 +189,8 @@ def schedule_outbox_model(
             },
         )
 
-    outbox_count = outbox_model.get_total_outbox_count()
-    metrics.gauge(
-        "deliver_from_outbox.total_outbox_count",
-        value=outbox_count,
-        tags=metrics_tags,
-        sample_rate=1.0,
-    )
 
+def _record_category_depths(silo_mode: SiloMode, outbox_model: type[OutboxBase]) -> None:
     category_depths = outbox_model.get_category_depths()
     for category, depth in category_depths.items():
         metrics.gauge(
@@ -188,7 +203,6 @@ def schedule_outbox_model(
             },
             sample_rate=1.0,
         )
-    return scheduled_count
 
 
 @instrumented_task(

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -148,12 +148,17 @@ def schedule_outbox_model(
     for shard in deepest_shards:
         if int(shard["depth"]) < DEEP_SHARD_LOG_THRESHOLD:
             break
+        shard_key = {column: shard[column] for column in outbox_model.sharding_columns}
+        category_breakdown = outbox_model.get_shard_category_breakdown(shard_key)
+        top_category = category_breakdown[0]["category"] if category_breakdown else None
         logger.warning(
             "deliver_from_outbox.deep_shard",
             extra={
                 **metrics_tags,
                 **shard,
-                "category": OutboxCategory(int(shard["category"])).name,
+                "category": (
+                    OutboxCategory(top_category).name if top_category is not None else None
+                ),
             },
         )
 

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -181,11 +181,7 @@ def schedule_outbox_model(
         metrics.gauge(
             "deliver_from_outbox.category_shard_depth",
             value=depth,
-            tags={
-                "silo": silo_mode.value.lower(),
-                "type": outbox_model.__name__,
-                "category": _category_name(category),
-            },
+            tags={**metrics_tags, "category": _category_name(category)},
             sample_rate=1.0,
         )
     return scheduled_count

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -181,7 +181,11 @@ def schedule_outbox_model(
         metrics.gauge(
             "deliver_from_outbox.category_shard_depth",
             value=depth,
-            tags={**metrics_tags, "category": _category_name(category)},
+            tags={
+                "silo": silo_mode.value.lower(),
+                "type": outbox_model.__name__,
+                "category": _category_name(category),
+            },
             sample_rate=1.0,
         )
     return scheduled_count

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -100,6 +100,14 @@ def schedule_batch(
         raise
 
 
+def _category_name(category: int) -> str:
+    try:
+        return OutboxCategory(category).name
+    except ValueError:
+        logger.warning("deliver_from_outbox.unknown_category", extra={"category": category})
+        return f"UNKNOWN_{category}"
+
+
 def schedule_outbox_model(
     *,
     silo_mode: SiloMode,
@@ -156,9 +164,7 @@ def schedule_outbox_model(
             extra={
                 **metrics_tags,
                 **shard,
-                "category": (
-                    OutboxCategory(top_category).name if top_category is not None else None
-                ),
+                "category": (_category_name(top_category) if top_category is not None else None),
             },
         )
 
@@ -178,7 +184,7 @@ def schedule_outbox_model(
             tags={
                 "silo": silo_mode.value.lower(),
                 "type": outbox_model.__name__,
-                "category": OutboxCategory(category).name,
+                "category": _category_name(category),
             },
             sample_rate=1.0,
         )

--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import math
 from collections.abc import Mapping
 from typing import Any
@@ -15,12 +16,15 @@ from sentry.hybridcloud.models.outbox import (
     OutboxBase,
     OutboxFlushError,
 )
+from sentry.hybridcloud.outbox.category import OutboxCategory
 from sentry.hybridcloud.tasks.backfill_outboxes import backfill_outboxes_for
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import hybridcloud_control_tasks, hybridcloud_tasks
 from sentry.utils import metrics
 from sentry.utils.env import in_test_environment
+
+logger = logging.getLogger(__name__)
 
 
 @instrumented_task(
@@ -64,6 +68,10 @@ def enqueue_outbox_jobs(
 # relationship between the id space of shard_identifiers and the amount of unique,
 # non coalesced work.
 CONCURRENCY = 5
+
+# Above this depth, a shard is backed up enough that we log which shard it is,
+# since the maximum_shard_depth metric alone doesn't identify it.
+DEEP_SHARD_LOG_THRESHOLD = 10_000
 
 
 def schedule_batch(
@@ -128,7 +136,7 @@ def schedule_outbox_model(
             **task_kwargs,
         )
 
-    deepest_shards = outbox_model.get_shard_depths_descending(limit=1)
+    deepest_shards = outbox_model.get_shard_depths_descending(limit=5)
     max_shard_depth = float(deepest_shards[0]["depth"]) if deepest_shards else 0.0
     metrics.gauge(
         "deliver_from_outbox.maximum_shard_depth",
@@ -137,6 +145,18 @@ def schedule_outbox_model(
         sample_rate=1.0,
     )
 
+    for shard in deepest_shards:
+        if int(shard["depth"]) < DEEP_SHARD_LOG_THRESHOLD:
+            break
+        logger.warning(
+            "deliver_from_outbox.deep_shard",
+            extra={
+                **metrics_tags,
+                **shard,
+                "category": OutboxCategory(int(shard["category"])).name,
+            },
+        )
+
     outbox_count = outbox_model.get_total_outbox_count()
     metrics.gauge(
         "deliver_from_outbox.total_outbox_count",
@@ -144,6 +164,19 @@ def schedule_outbox_model(
         tags=metrics_tags,
         sample_rate=1.0,
     )
+
+    category_depths = outbox_model.get_category_depths()
+    for category, depth in category_depths.items():
+        metrics.gauge(
+            "deliver_from_outbox.category_shard_depth",
+            value=depth,
+            tags={
+                "silo": silo_mode.value.lower(),
+                "type": outbox_model.__name__,
+                "category": OutboxCategory(category).name,
+            },
+            sample_rate=1.0,
+        )
     return scheduled_count
 
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2682,6 +2682,26 @@ register(
     default=[],
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Kill switches for the extra per-tick outbox observability queries run by the
+# outbox scheduler. Both add full or per-shard aggregates over the outbox
+# tables, so they can be turned off if they become expensive during a backlog.
+register(
+    "hybridcloud.outbox.category_depth_metric.enabled",
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "hybridcloud.outbox.deep_shard_logging.enabled",
+    default=True,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+# Shards with at least this many queued rows are logged with their sharding
+# columns and dominant category by the scheduler.
+register(
+    "hybridcloud.outbox.deep_shard_logging.threshold",
+    default=10_000,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 # Break glass controls
 register(
     "hybrid_cloud.rpc.disabled-service-methods",

--- a/tests/sentry/hybridcloud/models/test_outbox.py
+++ b/tests/sentry/hybridcloud/models/test_outbox.py
@@ -729,6 +729,15 @@ class OutboxAggregationTest(TestCase):
         )
         assert breakdown == []
 
+    def test_get_shard_category_breakdown_requires_full_shard_key(self) -> None:
+        with raises(AssertionError):
+            ControlOutbox.get_shard_category_breakdown(
+                {
+                    "shard_identifier": 99,
+                    "shard_scope": OutboxScope.ORGANIZATION_SCOPE.value,
+                }
+            )
+
     def test_total_count(self) -> None:
         assert ControlOutbox.get_total_outbox_count() == 7 + 4 + 1
 

--- a/tests/sentry/hybridcloud/models/test_outbox.py
+++ b/tests/sentry/hybridcloud/models/test_outbox.py
@@ -17,7 +17,7 @@ from sentry.hybridcloud.models.outbox import (
     outbox_context,
 )
 from sentry.hybridcloud.outbox.category import OutboxCategory, OutboxScope
-from sentry.hybridcloud.tasks.deliver_from_outbox import enqueue_outbox_jobs
+from sentry.hybridcloud.tasks.deliver_from_outbox import enqueue_outbox_jobs, schedule_outbox_model
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.projectkey import ProjectKey
@@ -368,16 +368,26 @@ class CellOutboxTest(TestCase):
             assert outbox.select_coalesced_messages().count() == 1
             assert len(list(CellOutbox.find_scheduled_shards())) == 2
 
+            saved_tags = {
+                "category": "ORGANIZATION_MEMBER_UPDATE",
+                "silo": "region",
+                "type": "CellOutbox",
+            }
             expected = [
-                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
-                call("outbox.saved", 1, tags={"category": "ORGANIZATION_MEMBER_UPDATE"}),
+                call("outbox.saved", 1, tags=saved_tags),
+                call("outbox.saved", 1, tags=saved_tags),
+                call("outbox.saved", 1, tags=saved_tags),
+                call("outbox.saved", 1, tags=saved_tags),
+                call("outbox.saved", 1, tags=saved_tags),
                 call(
                     "outbox.processed",
                     2,
-                    tags={"category": "ORGANIZATION_MEMBER_UPDATE", "synchronous": 1},
+                    tags={
+                        "category": "ORGANIZATION_MEMBER_UPDATE",
+                        "synchronous": 1,
+                        "silo": "region",
+                        "type": "CellOutbox",
+                    },
                 ),
             ]
             assert mock_metrics.incr.mock_calls == expected
@@ -642,18 +652,21 @@ class OutboxAggregationTest(TestCase):
                 shard_identifier=2,
                 cell_name="us",
                 shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
+                category=OutboxCategory.AUDIT_LOG_EVENT.value,
                 depth=7,
             ),
             dict(
                 shard_identifier=1,
                 cell_name="eu",
                 shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
+                category=OutboxCategory.AUDIT_LOG_EVENT.value,
                 depth=4,
             ),
             dict(
                 shard_identifier=3,
                 cell_name="us",
                 shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
+                category=OutboxCategory.AUDIT_LOG_EVENT.value,
                 depth=1,
             ),
         ]
@@ -665,6 +678,7 @@ class OutboxAggregationTest(TestCase):
                 shard_identifier=2,
                 cell_name="us",
                 shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
+                category=OutboxCategory.AUDIT_LOG_EVENT.value,
                 depth=7,
             )
         ]
@@ -676,3 +690,60 @@ class OutboxAggregationTest(TestCase):
 
     def test_total_count(self) -> None:
         assert ControlOutbox.get_total_outbox_count() == 7 + 4 + 1
+
+    def test_get_category_depths(self) -> None:
+        ControlOutbox(
+            cell_name="us",
+            shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+            shard_identifier=99,
+            category=OutboxCategory.ORGANIZATION_UPDATE,
+            object_identifier=999999,
+            payload={"foo": "bar"},
+        ).save()
+
+        assert ControlOutbox.get_category_depths() == {
+            OutboxCategory.AUDIT_LOG_EVENT.value: 12,
+            OutboxCategory.ORGANIZATION_UPDATE.value: 1,
+        }
+
+    @patch("sentry.hybridcloud.tasks.deliver_from_outbox.metrics")
+    def test_category_shard_depth_gauge(self, mock_metrics: Mock) -> None:
+        ControlOutbox(
+            cell_name="us",
+            shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+            shard_identifier=99,
+            category=OutboxCategory.ORGANIZATION_UPDATE,
+            object_identifier=999999,
+            payload={"foo": "bar"},
+        ).save()
+
+        schedule_outbox_model(
+            silo_mode=SiloMode.CONTROL,
+            outbox_model=ControlOutbox,
+            drain_task=Mock(),
+        )
+
+        gauge_calls_by_category = {
+            gauge_call.kwargs["tags"]["category"]: gauge_call
+            for gauge_call in mock_metrics.gauge.mock_calls
+            if gauge_call.args and gauge_call.args[0] == "deliver_from_outbox.category_shard_depth"
+        }
+
+        assert gauge_calls_by_category[OutboxCategory.AUDIT_LOG_EVENT.name].kwargs == dict(
+            value=12,
+            tags={
+                "silo": "control",
+                "type": "ControlOutbox",
+                "category": OutboxCategory.AUDIT_LOG_EVENT.name,
+            },
+            sample_rate=1.0,
+        )
+        assert gauge_calls_by_category[OutboxCategory.ORGANIZATION_UPDATE.name].kwargs == dict(
+            value=1,
+            tags={
+                "silo": "control",
+                "type": "ControlOutbox",
+                "category": OutboxCategory.ORGANIZATION_UPDATE.name,
+            },
+            sample_rate=1.0,
+        )

--- a/tests/sentry/hybridcloud/models/test_outbox.py
+++ b/tests/sentry/hybridcloud/models/test_outbox.py
@@ -652,21 +652,18 @@ class OutboxAggregationTest(TestCase):
                 shard_identifier=2,
                 cell_name="us",
                 shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
-                category=OutboxCategory.AUDIT_LOG_EVENT.value,
                 depth=7,
             ),
             dict(
                 shard_identifier=1,
                 cell_name="eu",
                 shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
-                category=OutboxCategory.AUDIT_LOG_EVENT.value,
                 depth=4,
             ),
             dict(
                 shard_identifier=3,
                 cell_name="us",
                 shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
-                category=OutboxCategory.AUDIT_LOG_EVENT.value,
                 depth=1,
             ),
         ]
@@ -678,7 +675,6 @@ class OutboxAggregationTest(TestCase):
                 shard_identifier=2,
                 cell_name="us",
                 shard_scope=OutboxScope.AUDIT_LOG_SCOPE.value,
-                category=OutboxCategory.AUDIT_LOG_EVENT.value,
                 depth=7,
             )
         ]
@@ -687,6 +683,51 @@ class OutboxAggregationTest(TestCase):
         ControlOutbox.objects.all().delete()
         assert ControlOutbox.objects.count() == 0
         assert ControlOutbox.get_shard_depths_descending() == []
+
+    def test_get_shard_category_breakdown(self) -> None:
+        # AUDIT_LOG_SCOPE only permits a single category, so use ORGANIZATION_SCOPE
+        # (a shard identifier not otherwise used in setUp) to exercise a shard with
+        # more than one category.
+        for i in range(3):
+            ControlOutbox(
+                cell_name="us",
+                shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+                shard_identifier=99,
+                category=OutboxCategory.ORGANIZATION_UPDATE,
+                object_identifier=999900 + i,
+                payload={"foo": "bar"},
+            ).save()
+        ControlOutbox(
+            cell_name="us",
+            shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+            shard_identifier=99,
+            category=OutboxCategory.PROJECT_UPDATE,
+            object_identifier=999910,
+            payload={"foo": "bar"},
+        ).save()
+
+        breakdown = ControlOutbox.get_shard_category_breakdown(
+            {
+                "shard_identifier": 99,
+                "cell_name": "us",
+                "shard_scope": OutboxScope.ORGANIZATION_SCOPE.value,
+            }
+        )
+
+        assert breakdown == [
+            dict(category=OutboxCategory.ORGANIZATION_UPDATE.value, depth=3),
+            dict(category=OutboxCategory.PROJECT_UPDATE.value, depth=1),
+        ]
+
+    def test_get_shard_category_breakdown_empty(self) -> None:
+        breakdown = ControlOutbox.get_shard_category_breakdown(
+            {
+                "shard_identifier": 404,
+                "cell_name": "us",
+                "shard_scope": OutboxScope.AUDIT_LOG_SCOPE.value,
+            }
+        )
+        assert breakdown == []
 
     def test_total_count(self) -> None:
         assert ControlOutbox.get_total_outbox_count() == 7 + 4 + 1
@@ -746,4 +787,52 @@ class OutboxAggregationTest(TestCase):
                 "category": OutboxCategory.ORGANIZATION_UPDATE.name,
             },
             sample_rate=1.0,
+        )
+
+    @patch("sentry.hybridcloud.tasks.deliver_from_outbox.DEEP_SHARD_LOG_THRESHOLD", 5)
+    @patch("sentry.hybridcloud.tasks.deliver_from_outbox.logger")
+    def test_deep_shard_log_attributes_dominant_category(self, mock_logger: Mock) -> None:
+        # Add a second deep shard (shard_identifier=99, depth 6) with multiple
+        # categories so we can confirm the log attributes it to the dominant
+        # one, not just any row. AUDIT_LOG_SCOPE only permits a single
+        # category, so this shard uses ORGANIZATION_SCOPE instead.
+        for i in range(4):
+            ControlOutbox(
+                cell_name="us",
+                shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+                shard_identifier=99,
+                category=OutboxCategory.ORGANIZATION_UPDATE,
+                object_identifier=999900 + i,
+                payload={"foo": "bar"},
+            ).save()
+        for i in range(2):
+            ControlOutbox(
+                cell_name="us",
+                shard_scope=OutboxScope.ORGANIZATION_SCOPE,
+                shard_identifier=99,
+                category=OutboxCategory.PROJECT_UPDATE,
+                object_identifier=999910 + i,
+                payload={"foo": "bar"},
+            ).save()
+
+        schedule_outbox_model(
+            silo_mode=SiloMode.CONTROL,
+            outbox_model=ControlOutbox,
+            drain_task=Mock(),
+        )
+
+        deep_shard_calls = {
+            warning_call.kwargs["extra"]["shard_identifier"]: warning_call
+            for warning_call in mock_logger.warning.mock_calls
+            if warning_call.args and warning_call.args[0] == "deliver_from_outbox.deep_shard"
+        }
+        assert set(deep_shard_calls) == {2, 99}
+        assert deep_shard_calls[2].kwargs["extra"]["depth"] == 7
+        assert (
+            deep_shard_calls[2].kwargs["extra"]["category"] == OutboxCategory.AUDIT_LOG_EVENT.name
+        )
+        assert deep_shard_calls[99].kwargs["extra"]["depth"] == 6
+        assert (
+            deep_shard_calls[99].kwargs["extra"]["category"]
+            == OutboxCategory.ORGANIZATION_UPDATE.name
         )

--- a/tests/sentry/hybridcloud/models/test_outbox.py
+++ b/tests/sentry/hybridcloud/models/test_outbox.py
@@ -25,6 +25,7 @@ from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase, TransactionTestCase
 from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.datetime import freeze_time
+from sentry.testutils.helpers.options import override_options
 from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.silo import assume_test_silo_mode, control_silo_test
 from sentry.types.cell import Cell, get_local_cell
@@ -798,7 +799,7 @@ class OutboxAggregationTest(TestCase):
             sample_rate=1.0,
         )
 
-    @patch("sentry.hybridcloud.tasks.deliver_from_outbox.DEEP_SHARD_LOG_THRESHOLD", 5)
+    @override_options({"hybridcloud.outbox.deep_shard_logging.threshold": 5})
     @patch("sentry.hybridcloud.tasks.deliver_from_outbox.logger")
     def test_deep_shard_log_attributes_dominant_category(self, mock_logger: Mock) -> None:
         # Add a second deep shard (shard_identifier=99, depth 6) with multiple
@@ -844,4 +845,46 @@ class OutboxAggregationTest(TestCase):
         assert (
             deep_shard_calls[99].kwargs["extra"]["category"]
             == OutboxCategory.ORGANIZATION_UPDATE.name
+        )
+
+    @override_options({"hybridcloud.outbox.category_depth_metric.enabled": False})
+    @patch("sentry.hybridcloud.tasks.deliver_from_outbox.metrics")
+    def test_category_shard_depth_gauge_disabled(self, mock_metrics: Mock) -> None:
+        with patch.object(ControlOutbox, "get_category_depths") as mock_depths:
+            schedule_outbox_model(
+                silo_mode=SiloMode.CONTROL,
+                outbox_model=ControlOutbox,
+                drain_task=Mock(),
+            )
+
+        mock_depths.assert_not_called()
+        assert not any(
+            gauge_call.args and gauge_call.args[0] == "deliver_from_outbox.category_shard_depth"
+            for gauge_call in mock_metrics.gauge.mock_calls
+        )
+        # The pre-existing gauges are unaffected by the kill switch.
+        assert any(
+            gauge_call.args and gauge_call.args[0] == "deliver_from_outbox.maximum_shard_depth"
+            for gauge_call in mock_metrics.gauge.mock_calls
+        )
+
+    @override_options(
+        {
+            "hybridcloud.outbox.deep_shard_logging.enabled": False,
+            "hybridcloud.outbox.deep_shard_logging.threshold": 5,
+        }
+    )
+    @patch("sentry.hybridcloud.tasks.deliver_from_outbox.logger")
+    def test_deep_shard_log_disabled(self, mock_logger: Mock) -> None:
+        with patch.object(ControlOutbox, "get_shard_category_breakdown") as mock_breakdown:
+            schedule_outbox_model(
+                silo_mode=SiloMode.CONTROL,
+                outbox_model=ControlOutbox,
+                drain_task=Mock(),
+            )
+
+        mock_breakdown.assert_not_called()
+        assert not any(
+            warning_call.args and warning_call.args[0] == "deliver_from_outbox.deep_shard"
+            for warning_call in mock_logger.warning.mock_calls
         )


### PR DESCRIPTION
## What

Adds silo/type tags to outbox save/process metrics, a new `get_category_depths()` that sums shard depth by category, a `deliver_from_outbox.category_shard_depth` gauge per category, and widens the deepest-shard check from top-1 to top-5 with a warning log when any shard exceeds 10k queued items.

## Why

The existing outbox metrics only gave one undifferentiated "worst shard depth" number, which isn't enough to define per-category SLOs. 

Part of CTRL-2 (Update SLOs for Outboxes).

## Test plan

- [x] `.venv/bin/pytest -n3 -svv --reuse-db tests/sentry/hybridcloud/models/test_outbox.py`
- [x] `ruff` and `mypy` clean on both changed files
