### PR TITLE
ref: Make "category" optional in locality config

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -3338,8 +3338,6 @@ if SILO_DEVSERVER:
     SENTRY_LOCALITIES = [
         {
             "name": "us",
-            # TODO(cells): Deprecate category
-            "category": "MULTI_TENANT",
             "cells": ["us"],
             "new_org_cell": "us",
         }

--- a/src/sentry/conf/types/cell_config.py
+++ b/src/sentry/conf/types/cell_config.py
@@ -14,8 +14,9 @@ class CellConfig(TypedDict):
 # Locality is a collection of cells
 class LocalityConfig(TypedDict):
     name: str
-    category: str
     cells: list[str]
+    """Deprecated and ignored. Visibility is defined via `visible`/`signup_visible`."""
+    category: NotRequired[str]
     new_org_cell: str
     visible: NotRequired[bool]
     signup_visible: NotRequired[bool]

--- a/src/sentry/conf/types/cell_config.py
+++ b/src/sentry/conf/types/cell_config.py
@@ -14,9 +14,9 @@ class CellConfig(TypedDict):
 # Locality is a collection of cells
 class LocalityConfig(TypedDict):
     name: str
-    cells: list[str]
-    """Deprecated and ignored. Visibility is defined via `visible`/`signup_visible`."""
     category: NotRequired[str]
+    """Deprecated and ignored. Visibility is defined via `visible`/`signup_visible`."""
+    cells: list[str]
     new_org_cell: str
     visible: NotRequired[bool]
     signup_visible: NotRequired[bool]

--- a/src/sentry/types/cell.py
+++ b/src/sentry/types/cell.py
@@ -260,7 +260,6 @@ def generate_monolith_cell_directory() -> CellDirectory:
     )
     locality = Locality(
         name=cell.name,
-        category=RegionCategory.MULTI_TENANT,
         cells=frozenset([cell.name]),
         new_org_cell=cell.name,
         visible=cell.visible,
@@ -274,7 +273,6 @@ def _parse_locality_config(
     for config_value in locality_config:
         yield Locality(
             name=config_value["name"],
-            category=RegionCategory(config_value["category"]),
             cells=frozenset(config_value["cells"]),
             new_org_cell=config_value["new_org_cell"],
             visible=bool(config_value.get("visible", True)),


### PR DESCRIPTION
The "category" field is now optional in config. If passed, it is
ignored in favor of the preferred "visible"/"signup_visible" flags.