### PR TITLE
feat(models): Add a get_or_none helper so first() isn't the ergonomic choice

### DIFF
--- a/src/sentry/db/models/manager/base.py
+++ b/src/sentry/db/models/manager/base.py
@@ -490,6 +490,18 @@ class BaseManager(_base_manager_base[M]):
         Triggered when a model bound to this manager is deleted.
         """
 
+    # Redeclared so mypy binds M; from_queryset leaves the queryset row typevar unbound.
+    def get_or_none(self, *args: Any, **kwargs: Any) -> M | None:
+        """Like ``get()``, but returns ``None`` instead of raising ``DoesNotExist``.
+
+        Still raises ``MultipleObjectsReturned`` if more than one row matches.
+        Prefer this over ``first()`` when the lookup is unique and order does not matter.
+        """
+        try:
+            return self.get(*args, **kwargs)
+        except self.model.DoesNotExist:
+            return None
+
     def get_queryset(self) -> BaseQuerySet[M]:
         """
         Returns a new QuerySet object.  Subclasses can override this method to

--- a/src/sentry/db/models/manager/base_query_set.py
+++ b/src/sentry/db/models/manager/base_query_set.py
@@ -98,6 +98,26 @@ class BaseQuerySet(QuerySet[M, R]):
         """
         return self.using(router.db_for_read(self.model, replica=True))
 
+    def get_or_none(self, *args: Any, **kwargs: Any) -> R | None:
+        """Like ``get()``, but returns ``None`` instead of raising ``DoesNotExist``.
+
+        Still raises ``MultipleObjectsReturned`` if more than one row matches.
+        Prefer this over ``first()`` when the lookup is unique and order does not matter.
+        """
+        try:
+            return self.get(*args, **kwargs)
+        except self.model.DoesNotExist:
+            return None
+
+    # django-stubs types these as plain QuerySet[M, ...], which drops BaseQuerySet methods.
+    def values(self, *fields: Any, **expressions: Any) -> BaseQuerySet[M, dict[str, Any]]:
+        return super().values(*fields, **expressions)  # type: ignore[return-value]
+
+    def values_list(
+        self, *fields: Any, flat: bool = False, named: bool = False
+    ) -> BaseQuerySet[M, Any]:
+        return super().values_list(*fields, flat=flat, named=named)  # type: ignore[return-value]
+
     def defer(self, *args: Any, **kwargs: Any) -> Self:
         raise NotImplementedError("Use ``values_list`` instead [performance].")
 

--- a/src/sentry/issues/derived/check.py
+++ b/src/sentry/issues/derived/check.py
@@ -213,7 +213,7 @@ def check_derived_data(
             _check_cache.set(check_id, replayed_derived)
             raise CheckTimeout(check_id)
 
-    current = GroupDerivedData.objects.filter(group_id=check_id.group_id).first()
+    current = GroupDerivedData.objects.get_or_none(group_id=check_id.group_id)
     if current is None or not check_id.matches(current):
         _check_cache.delete(check_id)
         return CheckInvalidated()

--- a/src/sentry/issues/derived/promote.py
+++ b/src/sentry/issues/derived/promote.py
@@ -93,7 +93,7 @@ def promote_to_live(candidate: GroupDerivedData) -> PromotionResult:
     row = (
         GroupDerivedData.objects.filter(group_id=candidate.group_id)
         .values_list("id", "generated_at")
-        .first()
+        .get_or_none()
     )
 
     if row is None:

--- a/tests/sentry/db/models/manager/test_base_query_set.py
+++ b/tests/sentry/db/models/manager/test_base_query_set.py
@@ -1,6 +1,8 @@
 from contextlib import contextmanager
 from unittest import mock
 
+import pytest
+
 from sentry.models.group import Group
 from sentry.signals import post_update
 from sentry.testutils.cases import TestCase
@@ -13,6 +15,26 @@ def catch_signal(signal):
     signal.connect(handler)
     yield handler
     signal.disconnect(handler)
+
+
+class TestGetOrNone(TestCase):
+    def test_found(self) -> None:
+        assert Group.objects.get_or_none(id=self.group.id) == self.group
+
+    def test_missing(self) -> None:
+        assert Group.objects.get_or_none(id=0) is None
+
+    def test_multiple_raises(self) -> None:
+        other = self.create_group()
+        with pytest.raises(Group.MultipleObjectsReturned):
+            Group.objects.filter(id__in=[self.group.id, other.id]).get_or_none()
+
+    def test_values_list(self) -> None:
+        assert (
+            Group.objects.filter(id=self.group.id).values_list("id", flat=True).get_or_none()
+            == self.group.id
+        )
+        assert Group.objects.filter(id=0).values_list("id", flat=True).get_or_none() is None
 
 
 class TestUpdateWithReturning(TestCase):


### PR DESCRIPTION
first() is often more convenient than get() due to the None default, but it doesn't verify that there is only one result and it forces an ordering even where there isn't necessarily one, leading to potentially odd query plan choices.

This adds `get_or_none` which is intended to be a `get()` variant that returns None, reducing the inclination to use `first()`.
