### PR TITLE
feat(integrations): Link the configurations crumb to the integration's configurations tab

### DIFF
--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -82,6 +82,23 @@ describe('ConfigureIntegration settings tab', () => {
     expect(screen.queryByText('github.com/sentry-demos')).not.toBeInTheDocument();
   });
 
+  it('links the configurations crumb to the provider configurations tab', async () => {
+    const integration = OrganizationIntegrationsFixture({
+      name: 'sentry-demos',
+      domainName: 'github.com/sentry-demos',
+      provider: {...githubProvider, key: 'github'},
+      configOrganization: [],
+    });
+    mockRequests(integration);
+
+    renderConfigure();
+
+    expect(await screen.findByRole('link', {name: 'Configurations'})).toHaveAttribute(
+      'href',
+      `/settings/${org.slug}/integrations/github/?tab=configurations`
+    );
+  });
+
   it('uses a full domain URL without adding another protocol', async () => {
     const integration = OrganizationIntegrationsFixture({
       name: 'Azure DevOps',

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -43,6 +43,7 @@ import {useNavigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useParams} from 'sentry/utils/useParams';
 import {useProjects} from 'sentry/utils/useProjects';
+import {CrumbLink} from 'sentry/views/settings/components/settingsBreadcrumb';
 import {BreadcrumbTitle} from 'sentry/views/settings/components/settingsBreadcrumb/breadcrumbTitle';
 import {Divider} from 'sentry/views/settings/components/settingsBreadcrumb/divider';
 import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
@@ -550,7 +551,10 @@ function IntegrationNavigationHeader({
   integration: Integration;
   action?: React.ReactNode;
 }) {
+  const organization = useOrganization();
+  const {providerKey} = useParams<{providerKey: string}>();
   const externalUrl = getIntegrationExternalUrl(integration);
+  const configurationsHref = `/settings/${organization.slug}/integrations/${providerKey}/?tab=configurations`;
 
   return (
     <Fragment>
@@ -558,7 +562,7 @@ function IntegrationNavigationHeader({
       <SettingsPageHeader
         title={
           <Flex align="center" gap="sm">
-            <Text as="span">{t('Configurations')}</Text>
+            <CrumbLink to={configurationsHref}>{t('Configurations')}</CrumbLink>
             <Divider />
             <IntegrationIcon size={18} integration={integration} />
             {externalUrl ? (


### PR DESCRIPTION
On an integration's configure page, the `Configurations` crumb in the top navbar (`Settings > Integrations > GitHub > getsentry`) was plain text, so there was no way back to the integration's configurations list from the nav. It is now a link to `?tab=configurations` for the current provider.

**Before (not clickable)**

<img width="515" height="54" alt="image" src="https://github.com/user-attachments/assets/dcfb70bb-d5fb-45cf-9720-36b4a2821e0a" />

**After (clickable)**

<img width="515" height="54" alt="image" src="https://github.com/user-attachments/assets/2ac25dc5-9bb9-485c-a485-3a4ab820e50f" />