### PR TITLE
feat(event formatter): keep breadcrumbs out of the MCP payload

### DIFF
--- a/src/sentry/issues/formatting/autofix.py
+++ b/src/sentry/issues/formatting/autofix.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.issues.formatting.formatter import Format, Formatter, get_formatter
+from sentry.issues.formatting.formatter import Consumer, Format, Formatter, get_formatter
 
 
 def _artifacts(autofix: Mapping[str, Any]) -> dict[str, Any]:
@@ -60,8 +60,14 @@ def _pull_requests(autofix: Mapping[str, Any], fmt: Formatter) -> str:
     return fmt.block("Pull Requests", "\n".join(lines)) if lines else ""
 
 
-def format_autofix(data: Mapping[str, Any], format: Format = "markdown") -> str:
-    """Render a serialized autofix state response (``{"autofix": {...}}``) into text."""
+def format_autofix(
+    data: Mapping[str, Any], format: Format = "markdown", consumer: Consumer = "ui"
+) -> str:
+    """Render a serialized autofix state response (``{"autofix": {...}}``) into text.
+
+    Takes ``consumer`` to satisfy the adapter signature; the autofix body is the same for the UI
+    and for API clients, so nothing varies on it yet.
+    """
     autofix = data.get("autofix")
     if not autofix:  # no autofix run on this issue yet
         return ""

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -88,6 +88,10 @@ class XmlFormatter(Formatter):
 
 Format = Literal["markdown", "xml"]
 
+# Who the output is being rendered for. The UI and API clients ramp on separate features and
+# want different sections from the same endpoint, so adapters take this alongside the format.
+Consumer = Literal["ui", "api"]
+
 
 class FormattedResponse(TypedDict):
     """The ``formatted`` field the mixin adds to a response when ``?llmFormat`` is requested."""

--- a/src/sentry/issues/formatting/mixin.py
+++ b/src/sentry/issues/formatting/mixin.py
@@ -1,9 +1,12 @@
 """REST delivery for the formatter.
 
 A mixin that adds a ``formatted`` field to an endpoint's JSON response when ``?llmFormat`` is
-requested. Endpoints opt in by setting ``formatter_adapter`` (serialized response -> text).
-Gated by the ``organizations:issue-standardized-markdown-for-llm`` feature: when it's off the
-mixin is inert and the response is untouched.
+requested. Endpoints opt in by setting ``formatter_adapter`` (serialized response + format +
+consumer -> text). Gated by the ``organizations:issue-standardized-markdown-for-llm`` feature
+(``-api`` for API clients): when it's off the mixin is inert and the response is untouched.
+
+The adapter is told which consumer it is rendering for, because the two want different content
+from the same endpoint -- see ``format_event_response``.
 """
 
 from __future__ import annotations
@@ -16,9 +19,13 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry import features
-from sentry.issues.formatting.formatter import Format
+from sentry.issues.formatting.formatter import Consumer, Format
 from sentry.issues.formatting.limits import LIMITS_LOW
-from sentry.issues.formatting.sections import EVENT_SECTIONS_WITH_USER, format_issue
+from sentry.issues.formatting.sections import (
+    EVENT_SECTIONS_WITH_USER,
+    breadcrumbs_section,
+    format_issue,
+)
 
 if TYPE_CHECKING:
     # for typing, treat the super() chain as an Endpoint; runtime uses the real base via MRO
@@ -38,17 +45,27 @@ QUERY_PARAM = "llmFormat"
 VALID_FORMATS: tuple[Format, ...] = get_args(Format)
 
 
-def formatter_feature_for(request: Request) -> str:
+_CONSUMER_FEATURES: dict[Consumer, str] = {
+    "ui": FORMATTER_FEATURE,
+    "api": FORMATTER_FEATURE_API,
+}
+
+
+def consumer_for(request: Request) -> Consumer:
     """Session and viewer-context callers are the UI; a token or key is an API client.
 
-    An unrecognised caller lands on the API feature deliberately: it is the narrower rollout.
+    An unrecognised caller lands on ``"api"`` deliberately: it is the narrower rollout.
     """
-    return FORMATTER_FEATURE if request.auth is None else FORMATTER_FEATURE_API
+    return "ui" if request.auth is None else "api"
+
+
+def formatter_feature_for(request: Request) -> str:
+    return _CONSUMER_FEATURES[consumer_for(request)]
 
 
 class FormattableResponseMixin(_Base):
-    # maps this endpoint's serialized response dict + format into rendered text
-    formatter_adapter: Callable[[Mapping[str, Any], Format], str] | None = None
+    # maps this endpoint's serialized response dict + format + consumer into rendered text
+    formatter_adapter: Callable[[Mapping[str, Any], Format, Consumer], str] | None = None
 
     def finalize_response(
         self, request: Request, response: Response, *args: Any, **kwargs: Any
@@ -58,18 +75,19 @@ class FormattableResponseMixin(_Base):
         adapter = self.formatter_adapter
         fmt = request.GET.get(QUERY_PARAM)
         organization = getattr(request, "organization", None)
+        consumer = consumer_for(request)
         if (
             adapter is None
             or fmt not in VALID_FORMATS
             or organization is None
-            or not features.has(formatter_feature_for(request), organization, actor=request.user)
+            or not features.has(_CONSUMER_FEATURES[consumer], organization, actor=request.user)
         ):
             return response
         if response.status_code != 200 or not isinstance(response.data, dict):
             return response
 
         try:
-            content = adapter(response.data, fmt)
+            content = adapter(response.data, fmt, consumer)
         except Exception:
             # never let formatting turn a good response into a 5xx, but keep the traceback:
             # this path degrades silently, so without it a formatter bug is undiagnosable
@@ -80,7 +98,21 @@ class FormattableResponseMixin(_Base):
         return response
 
 
-def format_event_response(data: Mapping[str, Any], fmt: Format) -> str:
+# Sections an API client does not want inlined, even though the UI does.
+#
+# Breadcrumbs: the MCP keeps them out of issue details on purpose and exposes them through its
+# own ``get_issue_breadcrumbs`` tool. Inlining them here would duplicate that tool and add up to
+# ``max_breadcrumbs_chars`` (5k) to every issue-details call whether the caller wants them or
+# not, which is the cost that split exists to avoid.
+_SECTIONS_EXCLUDED_FOR_API = frozenset({breadcrumbs_section})
+
+_SECTIONS_BY_CONSUMER: dict[Consumer, list[Any]] = {
+    "ui": EVENT_SECTIONS_WITH_USER,
+    "api": [s for s in EVENT_SECTIONS_WITH_USER if s not in _SECTIONS_EXCLUDED_FOR_API],
+}
+
+
+def format_event_response(data: Mapping[str, Any], fmt: Format, consumer: Consumer = "ui") -> str:
     """Adapter for event endpoints: the serialized event is what ``format_issue`` consumes.
 
     Renders with the low limits because every ``?llmFormat`` consumer pastes into a model's
@@ -91,4 +123,6 @@ def format_event_response(data: Mapping[str, Any], fmt: Format) -> str:
     Opts into the user identifiers the default section list holds back: this response already
     carries ``user`` in full, so rendering it adds nothing the caller can't already read.
     """
-    return format_issue(data, format=fmt, sections=EVENT_SECTIONS_WITH_USER, limits=LIMITS_LOW)
+    return format_issue(
+        data, format=fmt, sections=_SECTIONS_BY_CONSUMER[consumer], limits=LIMITS_LOW
+    )

--- a/tests/sentry/issues/formatting/test_mixin.py
+++ b/tests/sentry/issues/formatting/test_mixin.py
@@ -3,11 +3,14 @@ from typing import Any, cast
 from rest_framework.request import Request
 
 from sentry.issues.formatting.mixin import (
+    _SECTIONS_BY_CONSUMER,
     FORMATTER_FEATURE,
     FORMATTER_FEATURE_API,
+    consumer_for,
     format_event_response,
     formatter_feature_for,
 )
+from sentry.issues.formatting.sections import breadcrumbs_section
 
 
 def _event_with_request_body(body_chars: int) -> dict[str, Any]:
@@ -47,3 +50,58 @@ class _FakeRequest:
 def test_ui_and_api_callers_check_different_features() -> None:
     assert formatter_feature_for(cast(Request, _FakeRequest(None))) == FORMATTER_FEATURE
     assert formatter_feature_for(cast(Request, _FakeRequest(object()))) == FORMATTER_FEATURE_API
+
+
+def _event_with_breadcrumbs() -> dict[str, Any]:
+    return {
+        "title": "t",
+        "entries": [
+            {
+                "type": "breadcrumbs",
+                "data": {
+                    "values": [
+                        {"category": "http", "level": "info", "message": "GET /devices"},
+                        {"category": "auth", "level": "warning", "message": "token refresh"},
+                    ]
+                },
+            }
+        ],
+    }
+
+
+def test_ui_gets_breadcrumbs_inlined() -> None:
+    out = format_event_response(_event_with_breadcrumbs(), "markdown", "ui")
+    assert "Breadcrumbs" in out
+    assert "GET /devices" in out
+
+
+def test_api_clients_do_not_get_breadcrumbs_inlined() -> None:
+    # the MCP keeps breadcrumbs out of issue details on purpose and serves them from its own
+    # get_issue_breadcrumbs tool; inlining them here would duplicate that tool and spend up to
+    # 5k chars on every call. Everything else still renders.
+    out = format_event_response(_event_with_breadcrumbs(), "markdown", "api")
+    assert "Breadcrumbs" not in out
+    assert "GET /devices" not in out
+    assert "## Title" in out
+
+
+def test_ui_is_the_default_consumer() -> None:
+    # the adapter is called with a consumer by the mixin; the default keeps direct callers and
+    # existing tests on the UI behaviour rather than silently dropping a section
+    assert format_event_response(_event_with_breadcrumbs(), "markdown") == format_event_response(
+        _event_with_breadcrumbs(), "markdown", "ui"
+    )
+
+
+def test_only_breadcrumbs_differ_between_consumers() -> None:
+    # if the two lists ever diverge further, that should be a deliberate edit to
+    # _SECTIONS_EXCLUDED_FOR_API rather than a surprise
+    assert set(_SECTIONS_BY_CONSUMER["ui"]) - set(_SECTIONS_BY_CONSUMER["api"]) == {
+        breadcrumbs_section
+    }
+
+
+def test_consumer_for_keys_off_auth() -> None:
+    # an unrecognised caller must land on "api", the narrower rollout
+    assert consumer_for(cast(Request, _FakeRequest(None))) == "ui"
+    assert consumer_for(cast(Request, _FakeRequest(object()))) == "api"


### PR DESCRIPTION
The MCP deliberately excludes breadcrumbs from get_issue_details and serves them from its own get_issue_breadcrumbs tool. format_event_response hardcoded EVENT_SECTIONS_WITH_USER, so switching the MCP onto the shared formatter would have inlined up to 10 breadcrumbs it has never returned, duplicating that tool and spending up to 5k chars on every call whether the caller wants them or not.