### PR TITLE
fix(auth): Show WebAuthn authorization progress

### DIFF
--- a/static/app/views/authV2/authLogin/components/secondFactorAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/secondFactorAuth.spec.tsx
@@ -96,10 +96,12 @@ describe('SecondFactorAuth', () => {
         challenge: {webAuthnAuthenticationData: 'challenge'},
       },
     });
+    const authorization = Promise.withResolvers<void>();
     const authRequest = MockApiClient.addMockResponse({
       url: '/auth/2fa/',
       method: 'POST',
       body: {nextUri: '/organizations/', user},
+      asyncDelay: authorization.promise,
     });
 
     render(
@@ -128,6 +130,8 @@ describe('SecondFactorAuth', () => {
         })
       )
     );
+    expect(screen.getByText('Authorizing...')).toBeInTheDocument();
+    act(() => authorization.resolve());
     await waitFor(() =>
       expect(onComplete).toHaveBeenCalledWith({nextUri: '/organizations/', user})
     );

--- a/static/app/views/authV2/authLogin/components/webAuthn2faMethod.tsx
+++ b/static/app/views/authV2/authLogin/components/webAuthn2faMethod.tsx
@@ -151,7 +151,9 @@ export function WebAuthn2FAMethod({
     <Stack gap="lg" align="center">
       <AuthenticatorIconCarousel isActive={isActive} />
       <Text as="p" align="center">
-        {t('Waiting for passkey, biometric, or hardware key')}
+        {isProcessing
+          ? t('Authorizing...')
+          : t('Waiting for passkey, biometric, or hardware key')}
       </Text>
     </Stack>
   );


### PR DESCRIPTION
Keep the existing authenticator guidance while waiting for the browser credential, then show `Authorizing...` while the verification request is in progress.