### PR TITLE
fix(vsts): Stop unresolving when the work item states lookup fails

### DIFF
--- a/src/sentry/integrations/vsts/issues.py
+++ b/src/sentry/integrations/vsts/issues.py
@@ -392,11 +392,15 @@ class VstsIssuesSpec(IssueSyncIntegration, SourceCodeIssueIntegration, ABC):
         try:
             all_states = client.get_work_item_states(project)["value"]
         except ApiError as err:
+            # An empty set is indistinguishable from a project where nothing is done, so
+            # `get_resolve_sync_action` would unresolve on every transition and the inbound
+            # sync would then advance the issue's watermark past the resolve it just lost.
+            # Raising leaves both the status and the watermark alone, as jira already does.
             self.logger.info(
                 "vsts.get-done-states.failed",
                 extra={"integration_id": self.model.id, "exception": err},
             )
-            return set()
+            raise
         return {state["name"] for state in all_states if state["category"] in self.done_categories}
 
     def get_issue_display_name(self, external_issue: ExternalIssue) -> str:

--- a/tests/sentry/integrations/vsts/test_issues.py
+++ b/tests/sentry/integrations/vsts/test_issues.py
@@ -513,7 +513,6 @@ class VstsIssueSyncTest(VstsIssueBase):
 
     @responses.activate
     def test_should_resolve_done_status_failure(self) -> None:
-        """TODO(mgaeta): Should this be NOOP instead of UNRESOLVE when we lose connection?"""
         responses.reset()
         responses.add(
             responses.GET,
@@ -524,7 +523,9 @@ class VstsIssueSyncTest(VstsIssueBase):
             },
         )
 
-        assert (
+        # Answering with an empty set would read as "no state is a done state" and unresolve
+        # every transition, so the lookup has to fail rather than guess.
+        with pytest.raises(ApiError):
             self.integration.get_resolve_sync_action(
                 {
                     "project": self.project_id_with_states,
@@ -532,8 +533,6 @@ class VstsIssueSyncTest(VstsIssueBase):
                     "new_state": "Resolved",
                 }
             )
-            == ResolveSyncAction.UNRESOLVE
-        )
 
     @responses.activate
     def test_should_not_unresolve_resolved_to_closed(self) -> None:


### PR DESCRIPTION
Sentry asks Azure DevOps: *"which work-item states count as done?"* It needs that list to decide whether a status change means "resolve the Sentry issue" or "reopen it."

Old code: if that question failed (network blip, 429), it answered **"none of them are done."** That's a lie shaped like a real answer. Consequences cascade:

1. Every state change now looks like *moved to a not-done state* → `UNRESOLVE` → issue reopens.
2. The task then stamps the issue's watermark with that event's timestamp.
3. The *correct* event queued behind it gets dropped as "stale" — so the issue stays open. Permanently.

New code: don't guess, let the error fly. The caller already bails out before touching the watermark, so both the status and the watermark are left untouched. Jira has always worked this way.

### Context

Found while reviewing #123422, which would let sixteen threads drain a deep VSTS mailbox concurrently — sixteen times as many uncached `states` lookups per second against Azure DevOps, so a 429 burst on a backed-up mailbox reopens issues in bulk. This should land before `vsts` is added to `hybridcloud.webhookpayload.skip_on_failure_providers`.