### PR TITLE
feat(buttonTracking): Track anonymous custom events

### DIFF
--- a/static/gsApp/overrides/useButtonTracking.spec.tsx
+++ b/static/gsApp/overrides/useButtonTracking.spec.tsx
@@ -54,6 +54,24 @@ describe('buttonTracking', () => {
     </OrganizationContext>
   );
 
+  const anonymousWrapper = ({children}: ButtonProps) => (
+    <OrganizationContext value={null}>
+      <RouterProvider
+        router={createMemoryRouter(
+          [
+            {
+              path: '/auth/login/',
+              handle: {path: '/auth/login/'},
+              element: children,
+            },
+          ],
+          {initialEntries: ['/auth/login/']}
+        )}
+        future={{v7_startTransition: true}}
+      />
+    </OrganizationContext>
+  );
+
   afterEach(() => {
     jest.mocked(rawTrackAnalyticsEvent).mockClear();
   });
@@ -158,5 +176,38 @@ describe('buttonTracking', () => {
       text: 'Create Alert',
     });
     expect(rawTrackAnalyticsEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('tracks explicit events without an organization', () => {
+    const {result} = renderHook(useButtonTracking, {
+      wrapper: anonymousWrapper,
+    });
+
+    result.current({
+      clickType: 'button',
+      'aria-label': 'Return to the old login experience',
+      analyticsEventKey: 'auth_v2.login.legacy_fallback_clicked',
+      analyticsEventName: 'Auth V2: Legacy Login Fallback Clicked',
+      analyticsParams: {state: 'login'},
+    });
+
+    expect(rawTrackAnalyticsEvent).toHaveBeenCalledWith({
+      eventName: 'Auth V2: Legacy Login Fallback Clicked',
+      eventKey: 'auth_v2.login.legacy_fallback_clicked',
+      organization: null,
+      parameterized_path: 'auth.login',
+      text: 'Return to the old login experience',
+      state: 'login',
+    });
+  });
+
+  it('does not track automatic button events without an organization', () => {
+    const {result} = renderHook(useButtonTracking, {
+      wrapper: anonymousWrapper,
+    });
+
+    result.current({clickType: 'button', 'aria-label': 'Uninstrumented'});
+
+    expect(rawTrackAnalyticsEvent).not.toHaveBeenCalled();
   });
 });

--- a/static/gsApp/overrides/useButtonTracking.tsx
+++ b/static/gsApp/overrides/useButtonTracking.tsx
@@ -18,7 +18,10 @@ export function useButtonTracking() {
     analyticsParams,
     'aria-label': ariaLabel,
   }: TrackingProps) => {
-    const considerSendingAnalytics = organization && Boolean(matches);
+    const hasCustomAnalytics =
+      analyticsEventKey !== undefined || analyticsEventName !== undefined;
+    const considerSendingAnalytics =
+      Boolean(matches) && (Boolean(organization) || hasCustomAnalytics);
 
     if (considerSendingAnalytics) {
       const routeString = getEventPath(matches);
@@ -36,7 +39,7 @@ export function useButtonTracking() {
       rawTrackAnalyticsEvent({
         eventKey,
         eventName,
-        organization,
+        organization: organization ?? null,
         // pass in the parameterized path as well
         parameterized_path: reloadPath,
         text: ariaLabel,


### PR DESCRIPTION
Logged-out flows need to instrument deliberate button interactions, but the shared button tracking hook currently drops every event when organization context is unavailable.

Allow buttons with an explicit analytics event key or name to emit with a null organization. Automatic button tracking remains organization-scoped to avoid increasing generic event volume on anonymous routes.

Tests cover both the explicit anonymous event and the unchanged suppression of automatic anonymous events.