### PR TITLE
feat(apidocs): Document issue ignore and snooze fields

### DIFF
--- a/src/sentry/api/helpers/group_index/validators/group.py
+++ b/src/sentry/api/helpers/group_index/validators/group.py
@@ -1,7 +1,6 @@
 from collections.abc import Mapping
 from typing import Any
 
-from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
 from sentry.api.fields.actor import ActorField
@@ -12,17 +11,6 @@ from sentry.types.actor import Actor
 from sentry.types.group import SUBSTATUS_UPDATE_CHOICES, PriorityLevel
 
 
-@extend_schema_serializer(
-    exclude_fields=[
-        "ignoreDuration",
-        "ignoreCount",
-        "ignoreWindow",
-        "ignoreUserCount",
-        "ignoreUserWindow",
-        "inboxDetails",
-        "snoozeDuration",
-    ]
-)
 class GroupValidator(serializers.Serializer[Group]):
     inbox = serializers.BooleanField(
         help_text="If true, marks the issue as reviewed by the requestor."
@@ -70,17 +58,40 @@ class GroupValidator(serializers.Serializer[Group]):
     # These fields are not documented in the API docs. #
     ####################################################
     # These are already covered by the `statusDetails` serializer field.
-    ignoreDuration = serializers.IntegerField(min_value=0)
-    ignoreCount = serializers.IntegerField(min_value=0)
-    ignoreWindow = serializers.IntegerField(min_value=0, max_value=7 * 24 * 60)
-    ignoreUserCount = serializers.IntegerField(min_value=0)
-    ignoreUserWindow = serializers.IntegerField(min_value=0, max_value=7 * 24 * 60)
+    ignoreDuration = serializers.IntegerField(
+        min_value=0,
+        help_text="Ignore the issue for this many minutes.",
+    )
+    ignoreCount = serializers.IntegerField(
+        min_value=0,
+        help_text="Ignore the issue until it is seen this many more times.",
+    )
+    ignoreWindow = serializers.IntegerField(
+        min_value=0,
+        max_value=7 * 24 * 60,
+        help_text="Window in minutes over which `ignoreCount` is measured. Maximum is 7 days.",
+    )
+    ignoreUserCount = serializers.IntegerField(
+        min_value=0,
+        help_text="Ignore the issue until it affects this many more users.",
+    )
+    ignoreUserWindow = serializers.IntegerField(
+        min_value=0,
+        max_value=7 * 24 * 60,
+        help_text="Window in minutes over which `ignoreUserCount` is measured. Maximum is 7 days.",
+    )
     # The `inboxDetails`` field is empty.
-    inboxDetails = InboxDetailsValidator()
+    inboxDetails = InboxDetailsValidator(
+        help_text="Details recorded when the issue is moved out of the inbox.",
+    )
     # The `snooze` field is deprecated.
     # TODO(dcramer): remove in 9.0
     # for the moment, the CLI sends this for any issue update, so allow nulls
-    snoozeDuration = serializers.IntegerField(allow_null=True, min_value=0)
+    snoozeDuration = serializers.IntegerField(
+        allow_null=True,
+        min_value=0,
+        help_text="Snooze the issue for this many minutes.",
+    )
 
     def validate_assignedTo(self, value: Actor | None) -> Actor | None:
         if not value:


### PR DESCRIPTION
The ignore/snooze parameters on the issue update endpoints are accepted on the wire but were excluded from the schema, so SDK clients could not express them.

Adds `help_text` to all seven and removes the exclusion. The window fields are capped at 7 days by their validators, which the descriptions now state.