### PR TITLE
feat(apidocs): Document notification, external team and release fields

### DIFF
--- a/src/sentry/integrations/api/bases/external_actor.py
+++ b/src/sentry/integrations/api/bases/external_actor.py
@@ -3,7 +3,6 @@ from typing import Any, TypedDict
 
 from django.db import IntegrityError
 from django.http import Http404
-from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
@@ -178,11 +177,13 @@ class ExternalUserSerializer(ExternalActorSerializerBase):
         fields = ["user_id", "external_id", "external_name", "provider", "integration_id", "id"]
 
 
-@extend_schema_serializer(exclude_fields=["team_id"])
 class ExternalTeamSerializer(ExternalActorSerializerBase):
     _actor_key = "team_id"
 
-    team_id = serializers.IntegerField(required=True)
+    team_id = serializers.IntegerField(
+        required=True,
+        help_text="ID of the Sentry team to link to the external team.",
+    )
 
     def validate_team_id(self, team_id: int) -> Team:
         """Ensure that this team exists and that they belong to the organization."""

--- a/src/sentry/notifications/api/serializers/notification_action_request.py
+++ b/src/sentry/notifications/api/serializers/notification_action_request.py
@@ -2,7 +2,6 @@ from collections.abc import Sequence
 from typing import TypedDict
 
 from django.db import router, transaction
-from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
 from sentry.api.serializers.rest_framework.base import CamelSnakeModelSerializer
@@ -46,7 +45,6 @@ class NotificationActionInputData(TypedDict, total=False):
     target_type: int
 
 
-@extend_schema_serializer(exclude_fields=["sentry_app_id", "target_type"])
 class NotificationActionSerializer(CamelSnakeModelSerializer):
     """
     Django Rest Framework serializer for incoming NotificationAction API payloads
@@ -95,11 +93,13 @@ Required if **service_type** is `slack` or `opsgenie`.
     # TODO: Include in documentation when any notification action works with sentry_app_id
     sentry_app_id = serializers.IntegerField(
         required=False,
+        help_text="ID of the custom integration to notify, when the target is a Sentry app.",
     )
     # TODO: Include in documentation when any notification action works with anything other than "specific"
     target_type = serializers.CharField(
         required=False,
         default="specific",
+        help_text="How the notification target is addressed.",
     )
 
     def validate_integration_id(self, integration_id: int) -> int:

--- a/src/sentry/releases/endpoints/organization_release_details.py
+++ b/src/sentry/releases/endpoints/organization_release_details.py
@@ -1,6 +1,6 @@
 import sentry_sdk
 from django.db.models import Q
-from drf_spectacular.utils import OpenApiParameter, extend_schema, extend_schema_serializer
+from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -61,12 +61,12 @@ class InvalidSortException(Exception):
     pass
 
 
-@extend_schema_serializer(exclude_fields=["headCommits", "status"])
 class OrganizationReleaseSerializer(ReleaseSerializer):
     headCommits = ListField(
         child=ReleaseHeadCommitSerializerDeprecated(),
         required=False,
         allow_null=False,
+        help_text="Deprecated, use `commits`. Head commits to associate with the release.",
     )
     refs = ListField(
         child=ReleaseHeadCommitSerializer(),


### PR DESCRIPTION
Five fields across the notification-action, external-team and release serializers were accepted on the wire but excluded from the schema.

Adds `help_text` and removes the exclusions. `headCommits` is marked deprecated in favour of `commits`, matching how the handler treats it; `status` on the release serializer already had a description and only needed the exclusion lifted.