### PR TITLE
feat(apidocs): Document organization member and SCIM fields

### DIFF
--- a/src/sentry/core/endpoints/organization_details.py
+++ b/src/sentry/core/endpoints/organization_details.py
@@ -10,7 +10,7 @@ from django.db import models, router, transaction
 from django.db.models.query_utils import DeferredAttribute
 from django.urls import reverse
 from django.utils import timezone as django_timezone
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_serializer
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, status
 from rest_framework.exceptions import PermissionDenied
 from sentry_sdk import capture_exception
@@ -892,11 +892,6 @@ def create_console_platform_audit_log(
         )
 
 
-@extend_schema_serializer(
-    exclude_fields=[
-        "apdexThreshold",
-    ]
-)
 class OrganizationDetailsPutSerializer(serializers.Serializer):
     # general
     slug = serializers.CharField(
@@ -1085,7 +1080,10 @@ Below is an example of a payload for a set of advanced data scrubbing rules for 
 
     # private attributes
     # legacy features
-    apdexThreshold = serializers.IntegerField(required=False)
+    apdexThreshold = serializers.IntegerField(
+        required=False,
+        help_text="Deprecated. Response-time threshold in milliseconds previously used to compute Apdex.",
+    )
 
 
 # NOTE: We override the permission class of this endpoint in getsentry with the OrganizationDetailsPermission class

--- a/src/sentry/core/endpoints/organization_member_index.py
+++ b/src/sentry/core/endpoints/organization_member_index.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.conf import settings
 from django.db import router, transaction
 from django.db.models import Exists, F, OuterRef, Q
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import extend_schema, extend_schema_serializer
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -50,6 +50,7 @@ from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 
 
+@extend_schema_serializer(deprecate_fields=["role", "teams"])
 class OrganizationMemberRequestSerializer(serializers.Serializer[dict[str, Any]]):
     email = AllowedEmailField(
         max_length=75, required=True, help_text="The email address to send the invitation to."

--- a/src/sentry/core/endpoints/organization_member_index.py
+++ b/src/sentry/core/endpoints/organization_member_index.py
@@ -3,7 +3,7 @@ from typing import Any
 from django.conf import settings
 from django.db import router, transaction
 from django.db.models import Exists, F, OuterRef, Q
-from drf_spectacular.utils import extend_schema, extend_schema_serializer
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -50,15 +50,14 @@ from sentry.users.services.user.service import user_service
 from sentry.utils import metrics
 
 
-@extend_schema_serializer(
-    deprecate_fields=["role", "teams"], exclude_fields=["regenerate", "role", "teams"]
-)
 class OrganizationMemberRequestSerializer(serializers.Serializer[dict[str, Any]]):
     email = AllowedEmailField(
         max_length=75, required=True, help_text="The email address to send the invitation to."
     )
     role = serializers.ChoiceField(
-        choices=roles.get_choices(), default=organization_roles.get_default().id
+        choices=roles.get_choices(),
+        default=organization_roles.get_default().id,
+        help_text="Deprecated, use `orgRole`. The organization-level role to assign.",
     )  # deprecated, use orgRole
     orgRole = serializers.ChoiceField(
         choices=ROLE_CHOICES,
@@ -67,7 +66,10 @@ class OrganizationMemberRequestSerializer(serializers.Serializer[dict[str, Any]]
         help_text="The organization-level role of the new member. Roles include:",  # choices will follow in the docs
     )
     teams = serializers.ListField(
-        required=False, allow_null=False, default=list
+        required=False,
+        allow_null=False,
+        default=list,
+        help_text="Deprecated, use `teamRoles`. Slugs of teams to add the member to.",
     )  # deprecated, use teamRoles
     teamRoles = serializers.ListField(
         required=False,
@@ -88,7 +90,10 @@ class OrganizationMemberRequestSerializer(serializers.Serializer[dict[str, Any]]
         required=False,
         help_text="Whether or not to re-invite a user who has already been invited to the organization. Defaults to True.",
     )
-    regenerate = serializers.BooleanField(required=False)
+    regenerate = serializers.BooleanField(
+        required=False,
+        help_text="Reissue the invite token, invalidating any previously sent invite link.",
+    )
 
     def validate_email(self, email: str) -> str:
         users = user_service.get_many_by_email(

--- a/src/sentry/core/endpoints/organization_member_team_details.py
+++ b/src/sentry/core/endpoints/organization_member_team_details.py
@@ -28,6 +28,7 @@ from sentry.apidocs.constants import (
     RESPONSE_UNAUTHORIZED,
 )
 from sentry.apidocs.examples.team_examples import TeamExamples
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.apidocs.parameters import GlobalParams
 from sentry.apidocs.response_types import DetailResponse
 from sentry.auth.access import Access
@@ -55,10 +56,14 @@ class OrganizationMemberTeamSerializerResponse(TypedDict):
     teamRole: Literal["contributor", "admin"]
 
 
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "isActive": "Reported in responses, but the update handler only applies teamRole; "
+        "a value sent here is validated and discarded.",
+    }
+)
 class OrganizationMemberTeamSerializer(serializers.Serializer[dict[str, Any]]):
-    isActive = serializers.BooleanField(
-        help_text="Whether the member's team membership is active rather than pending approval.",
-    )
+    isActive = serializers.BooleanField()
     teamRole = serializers.ChoiceField(
         choices=team_roles.get_descriptions(),
         default=team_roles.get_default().id,

--- a/src/sentry/core/endpoints/organization_member_team_details.py
+++ b/src/sentry/core/endpoints/organization_member_team_details.py
@@ -1,7 +1,7 @@
 from collections.abc import Mapping
 from typing import Any, Literal, TypedDict
 
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_serializer
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, status
 from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
@@ -55,9 +55,10 @@ class OrganizationMemberTeamSerializerResponse(TypedDict):
     teamRole: Literal["contributor", "admin"]
 
 
-@extend_schema_serializer(exclude_fields=["isActive"])
 class OrganizationMemberTeamSerializer(serializers.Serializer[dict[str, Any]]):
-    isActive = serializers.BooleanField()
+    isActive = serializers.BooleanField(
+        help_text="Whether the member's team membership is active rather than pending approval.",
+    )
     teamRole = serializers.ChoiceField(
         choices=team_roles.get_descriptions(),
         default=team_roles.get_default().id,

--- a/src/sentry/core/endpoints/scim/members.py
+++ b/src/sentry/core/endpoints/scim/members.py
@@ -10,7 +10,6 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import (
     extend_schema,
     extend_schema_field,
-    extend_schema_serializer,
     inline_serializer,
 )
 from rest_framework import serializers
@@ -112,10 +111,13 @@ class SCIMPatchOperationSerializer(serializers.Serializer):
         raise serializers.ValidationError(f'"{value}" is not a valid choice')
 
 
-@extend_schema_serializer(exclude_fields=("schemas",))
 class SCIMPatchRequestSerializer(serializers.Serializer):
     # we don't actually use "schemas" for anything atm but its part of the spec
-    schemas = serializers.ListField(child=serializers.CharField(), required=False)
+    schemas = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="SCIM schema URIs identifying the request format. Must be the PatchOp schema.",
+    )
     Operations = serializers.ListField(
         child=SCIMPatchOperationSerializer(),
         required=True,

--- a/src/sentry/core/endpoints/scim/teams.py
+++ b/src/sentry/core/endpoints/scim/teams.py
@@ -100,10 +100,13 @@ class SCIMTeamPatchOperationSerializer(serializers.Serializer):
         raise serializers.ValidationError(f'"{value}" is not a valid choice')
 
 
-@extend_schema_serializer(exclude_fields="schemas")
 class SCIMTeamPatchRequestSerializer(serializers.Serializer):
     # we don't actually use "schemas" for anything atm but its part of the spec
-    schemas = serializers.ListField(child=serializers.CharField(), required=True)
+    schemas = serializers.ListField(
+        child=serializers.CharField(),
+        required=True,
+        help_text="SCIM schema URIs identifying the request format. Must be the PatchOp schema.",
+    )
     Operations = serializers.ListField(
         child=SCIMTeamPatchOperationSerializer(),
         required=True,


### PR DESCRIPTION
Seven fields across the organization-member, team-membership and SCIM patch serializers were accepted on the wire but excluded from the schema.

`role` and `teams` are marked deprecated in favour of `orgRole` and `teamRoles`, matching the comments already on those fields. `apdexThreshold` is documented as deprecated rather than removed, since it is still accepted.

One latent bug fixed along the way: `SCIMTeamPatchRequestSerializer` had `exclude_fields="schemas"` — a bare string, not a list. drf-spectacular tests membership with `in`, so it matched by substring and would have hidden any field whose name is a substring of "schemas". That field is now documented instead.

Stacked on https://github.com/getsentry/sentry/pull/123463.