### PR TITLE
feat(apidocs): Document alert rule and monitor fields

### DIFF
--- a/src/sentry/incidents/endpoints/organization_alert_rule_details.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_details.py
@@ -3,7 +3,7 @@ import logging
 from collections.abc import Callable
 
 from django.contrib.auth.models import AnonymousUser
-from drf_spectacular.utils import extend_schema, extend_schema_serializer
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -139,7 +139,6 @@ def remove_alert_rule(
         return Response("This rule has already been deleted", status=status.HTTP_400_BAD_REQUEST)
 
 
-@extend_schema_serializer(exclude_fields=["thresholdPeriod"])
 class OrganizationAlertRuleDetailsPutSerializer(serializers.Serializer):
     name = serializers.CharField(max_length=256, help_text="The name for the rule.")
     aggregate = serializers.CharField(
@@ -240,7 +239,13 @@ Metric alert rule trigger actions follow the following structure:
     owner = OwnerActorField(
         required=False, allow_null=True, help_text="The ID of the team or user that owns the rule."
     )
-    thresholdPeriod = serializers.IntegerField(required=False, default=1, min_value=1, max_value=20)
+    thresholdPeriod = serializers.IntegerField(
+        required=False,
+        default=1,
+        min_value=1,
+        max_value=20,
+        help_text="Number of consecutive times the threshold must be met before the alert fires.",
+    )
 
 
 def _check_project_access[T](

--- a/src/sentry/incidents/endpoints/organization_alert_rule_index.py
+++ b/src/sentry/incidents/endpoints/organization_alert_rule_index.py
@@ -19,7 +19,7 @@ from django.db.models import (
 from django.db.models.fields import BigIntegerField
 from django.db.models.functions import Cast, Coalesce
 from django.http.response import HttpResponseBase
-from drf_spectacular.utils import extend_schema, extend_schema_serializer
+from drf_spectacular.utils import extend_schema
 from rest_framework import serializers, status
 from rest_framework.exceptions import ParseError, ValidationError
 from rest_framework.request import Request
@@ -595,7 +595,6 @@ class OrganizationCombinedRuleIndexEndpoint(OrganizationEndpoint):
         )
 
 
-@extend_schema_serializer(exclude_fields=["thresholdPeriod"])
 class OrganizationAlertRuleIndexPostSerializer(serializers.Serializer):
     name = serializers.CharField(
         max_length=256,
@@ -726,7 +725,13 @@ Metric alert rule trigger actions follow the following structure:
         choices=ExtrapolationMode.as_text_choices(),
         help_text="How sampled spans are scaled to estimate the true aggregate. Only applies to alerts on the `events_analytics_platform` dataset. New alerts accept `client_and_server_weighted` and `unknown`; `server_weighted` and `none` are rejected.",
     )
-    thresholdPeriod = serializers.IntegerField(required=False, default=1, min_value=1, max_value=20)
+    thresholdPeriod = serializers.IntegerField(
+        required=False,
+        default=1,
+        min_value=1,
+        max_value=20,
+        help_text="Number of consecutive times the threshold must be met before the alert fires.",
+    )
 
 
 @extend_schema(tags=["Alerts"])

--- a/src/sentry/monitors/validators.py
+++ b/src/sentry/monitors/validators.py
@@ -9,7 +9,7 @@ from django.db.models import F
 from django.db.models.functions import TruncMinute
 from django.utils import timezone
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 from rest_framework.fields import empty
 
@@ -309,7 +309,6 @@ class ConfigValidator(serializers.Serializer):
         return attrs
 
 
-@extend_schema_serializer(exclude_fields=["alert_rule"])
 class MonitorValidator(CamelSnakeSerializer):
     project = ProjectField(
         scope="project:read",
@@ -341,7 +340,10 @@ class MonitorValidator(CamelSnakeSerializer):
         help_text="Disable creation of monitor incidents",
     )
     config = ConfigValidator(help_text="The configuration for the monitor.")
-    alert_rule = MonitorAlertRuleValidator(required=False)
+    alert_rule = MonitorAlertRuleValidator(
+        required=False,
+        help_text="Alert rule configuration created alongside the monitor.",
+    )
 
     def validate(self, attrs):
         # When creating a new monitor, check if we would exceed the organization limit
@@ -584,7 +586,6 @@ class ContextsValidator(serializers.Serializer):
     trace = TraceContextValidator(required=False)
 
 
-@extend_schema_serializer(exclude_fields=["contexts"])
 class MonitorCheckInValidator(serializers.Serializer):
     status = serializers.ChoiceField(
         choices=(
@@ -606,7 +607,11 @@ class MonitorCheckInValidator(serializers.Serializer):
         allow_null=True,
         help_text="Name of the environment.",
     )
-    contexts = ContextsValidator(required=False, allow_null=True)
+    contexts = ContextsValidator(
+        required=False,
+        allow_null=True,
+        help_text="Additional context sent with the check-in, such as the trace it belongs to.",
+    )
 
 
 class MonitorBulkEditValidator(MonitorValidator):


### PR DESCRIPTION
`thresholdPeriod` on both alert-rule endpoints, and `alert_rule` / `contexts` on the monitor validators, were accepted on the wire but excluded from the schema.

Documenting `alert_rule` and `contexts` also brings their nested validators into the schema as components, which is why the diff adds more properties than fields touched here.

Stacked on https://github.com/getsentry/sentry/pull/123463.