### PR TITLE
feat(apidocs): Convert internal request fields to omit_from_public_schema

### DIFF
--- a/src/sentry/api/serializers/rest_framework/dashboard.py
+++ b/src/sentry/api/serializers/rest_framework/dashboard.py
@@ -7,12 +7,12 @@ from typing import Any, TypedDict
 
 import sentry_sdk
 from django.db.models import Max
-from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
 from sentry import features, options
 from sentry.api.serializers.rest_framework import CamelSnakeSerializer
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.constants import ALL_ACCESS_PROJECTS
 from sentry.discover.arithmetic import ArithmeticError, categorize_columns
 from sentry.exceptions import InvalidSearchQuery
@@ -413,7 +413,11 @@ class ThresholdMaxKeys(Enum):
     MAX_2 = "max2"
 
 
-@extend_schema_serializer(exclude_fields=["dataset_source"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "dataset_source": "Records whether the widget's dataset was chosen by the user or inferred; internal provenance.",
+    }
+)
 class DashboardWidgetSerializer(CamelSnakeSerializer[Dashboard]):
     # Is a string because output serializers also make it a string.
     id = serializers.CharField(required=False)

--- a/src/sentry/api/serializers/rest_framework/groupsearchview.py
+++ b/src/sentry/api/serializers/rest_framework/groupsearchview.py
@@ -1,10 +1,11 @@
 from typing import NotRequired, TypedDict
 
-from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from sentry.api.serializers.models.groupsearchview import GroupSearchViewTimeFilters
 from sentry.api.serializers.rest_framework import ValidationError
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.models.project import Project
 from sentry.models.savedsearch import SORT_LITERALS, SortOptions
 
@@ -110,7 +111,11 @@ class ViewValidator(serializers.Serializer):
         return data
 
 
-@extend_schema_serializer(exclude_fields=["id"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "id": "Inherited from ViewValidator for updates; the server assigns the id on create.",
+    }
+)
 class GroupSearchViewPostValidator(ViewValidator):
     starred = serializers.BooleanField(
         required=False, help_text="Whether to star the issue view for the current user."

--- a/src/sentry/api/serializers/rest_framework/project_key.py
+++ b/src/sentry/api/serializers/rest_framework/project_key.py
@@ -1,7 +1,7 @@
-from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 
 from sentry.api.fields.empty_integer import EmptyIntegerField
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.loader.browsersdkversion import get_all_browser_sdk_version_choices
 from sentry.loader.dynamic_sdk_options import DynamicSdkLoaderOption
 from sentry.models.projectkey import UseCase
@@ -64,11 +64,11 @@ class DynamicSdkLoaderOptionSerializer(serializers.Serializer):
         return super().to_internal_value(new_data)
 
 
-@extend_schema_serializer(
-    exclude_fields=[
-        "public",
-        "secret",
-    ],
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "public": "Lets a caller supply existing DSN key material; used by relocation and import, not by general clients.",
+        "secret": "Lets a caller supply existing DSN key material; used by relocation and import, not by general clients.",
+    }
 )
 class ProjectKeyPostSerializer(serializers.Serializer):
     name = serializers.CharField(

--- a/src/sentry/apidocs/omissions.py
+++ b/src/sentry/apidocs/omissions.py
@@ -7,7 +7,7 @@ add help_text instead; sentry.apidocs.hooks spells out when omission is correct.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import TypeVar
 
 from drf_spectacular.drainage import get_override, set_override
@@ -19,10 +19,13 @@ OMISSION_REASONS_OVERRIDE = "sentry_omission_reasons"
 T = TypeVar("T", bound=type)
 
 
-def sentry_schema_serializer(*, omit_from_public_schema: dict[str, str]) -> Callable[[T], T]:
+def sentry_schema_serializer(
+    *, omit_from_public_schema: dict[str, str], deprecate_fields: Sequence[str] | None = None
+) -> Callable[[T], T]:
     """Withhold fields from the generated schema, recording why for each one.
 
     Each value is the reason that field is not part of the public API surface.
+    ``deprecate_fields`` is passed through to drf-spectacular unchanged.
     """
     if not omit_from_public_schema:
         raise ValueError(
@@ -48,6 +51,14 @@ def sentry_schema_serializer(*, omit_from_public_schema: dict[str, str]) -> Call
         reasons = {**(get_override(klass, OMISSION_REASONS_OVERRIDE, {}) or {})}
         reasons.update(omit_from_public_schema)
         set_override(klass, OMISSION_REASONS_OVERRIDE, reasons)
+
+        if deprecate_fields:
+            existing_deprecated = get_override(klass, "deprecate_fields", []) or []
+            set_override(
+                klass,
+                "deprecate_fields",
+                list(dict.fromkeys([*existing_deprecated, *deprecate_fields])),
+            )
         return klass
 
     return decorator

--- a/src/sentry/core/endpoints/organization_teams.py
+++ b/src/sentry/core/endpoints/organization_teams.py
@@ -1,6 +1,6 @@
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_serializer
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, status
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -48,11 +48,11 @@ class OrganizationTeamsPermission(OrganizationPermission):
     }
 
 
-@extend_schema_serializer(deprecate_fields=["name"])
 @sentry_schema_serializer(
     omit_from_public_schema={
         "idp_provisioned": "Set by SCIM and identity-provider provisioning, not by API clients.",
-    }
+    },
+    deprecate_fields=["name"],
 )
 class TeamPostSerializer(serializers.Serializer):
     slug = SentrySerializerSlugField(

--- a/src/sentry/core/endpoints/organization_teams.py
+++ b/src/sentry/core/endpoints/organization_teams.py
@@ -1,6 +1,6 @@
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
-from drf_spectacular.utils import OpenApiResponse, extend_schema
+from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_serializer
 from rest_framework import serializers, status
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -48,6 +48,7 @@ class OrganizationTeamsPermission(OrganizationPermission):
     }
 
 
+@extend_schema_serializer(deprecate_fields=["name"])
 @sentry_schema_serializer(
     omit_from_public_schema={
         "idp_provisioned": "Set by SCIM and identity-provider provisioning, not by API clients.",

--- a/src/sentry/core/endpoints/organization_teams.py
+++ b/src/sentry/core/endpoints/organization_teams.py
@@ -1,6 +1,6 @@
 from django.db import IntegrityError, router, transaction
 from django.db.models import Q
-from drf_spectacular.utils import OpenApiResponse, extend_schema, extend_schema_serializer
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import serializers, status
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
@@ -16,6 +16,7 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.team import TeamSerializer, TeamSerializerResponse
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.examples.team_examples import TeamExamples
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.apidocs.parameters import (
     CursorQueryParam,
     GlobalParams,
@@ -47,7 +48,11 @@ class OrganizationTeamsPermission(OrganizationPermission):
     }
 
 
-@extend_schema_serializer(exclude_fields=["idp_provisioned"], deprecate_fields=["name"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "idp_provisioned": "Set by SCIM and identity-provider provisioning, not by API clients.",
+    }
+)
 class TeamPostSerializer(serializers.Serializer):
     slug = SentrySerializerSlugField(
         help_text="""Uniquely identifies a team and is used for the interface. If not

--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -2,12 +2,13 @@ import logging
 import re
 
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
+from drf_spectacular.utils import extend_schema_field
 from jsonschema.exceptions import ValidationError as SchemaValidationError
 from rest_framework import serializers
 from rest_framework.serializers import Serializer, ValidationError
 
 from sentry.api.serializers.rest_framework.base import camel_to_snake_case
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.apidocs.parameters import build_typed_list
 from sentry.integrations.models.integration_feature import Feature
 from sentry.models.apiscopes import ApiScopes
@@ -103,7 +104,12 @@ class URLField(serializers.URLField):
         return url
 
 
-@extend_schema_serializer(exclude_fields=["popularity", "features", "status", "isDisabled"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "popularity": "Internal ranking value used to order integrations in the directory.",
+        "isDisabled": "Set by Sentry when an integration is disabled; not client-settable.",
+    }
+)
 class SentryAppParser(Serializer):
     name = serializers.CharField(help_text="The name of the custom integration.")
     author = serializers.CharField(

--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -109,7 +109,7 @@ class URLField(serializers.URLField):
         "popularity": "Internal ranking value used to order integrations in the directory.",
         "isDisabled": "Set by Sentry when an integration is disabled; not client-settable.",
         "features": "Set through the integration's own configuration flow rather than this endpoint.",
-        "status": "Publication state, moved by Sentry's review process rather than by clients.",
+        "status": "Only applied for elevated Sentry staff; ignored for everyone else.",
     }
 )
 class SentryAppParser(Serializer):

--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -108,6 +108,8 @@ class URLField(serializers.URLField):
     omit_from_public_schema={
         "popularity": "Internal ranking value used to order integrations in the directory.",
         "isDisabled": "Set by Sentry when an integration is disabled; not client-settable.",
+        "features": "Set through the integration's own configuration flow rather than this endpoint.",
+        "status": "Publication state, moved by Sentry's review process rather than by clients.",
     }
 )
 class SentryAppParser(Serializer):

--- a/tests/sentry/apidocs/test_omissions.py
+++ b/tests/sentry/apidocs/test_omissions.py
@@ -69,3 +69,32 @@ def test_blank_reason_is_rejected(reason: str) -> None:
 def test_empty_mapping_is_rejected() -> None:
     with pytest.raises(ValueError):
         sentry_schema_serializer(omit_from_public_schema={})
+
+
+def test_deprecate_fields_is_passed_through() -> None:
+    @sentry_schema_serializer(
+        omit_from_public_schema={"hidden": "A stated reason."}, deprecate_fields=["legacy"]
+    )
+    class DeprecatingSerializer(serializers.Serializer):
+        hidden = serializers.CharField(required=False)
+        legacy = serializers.CharField(required=False)
+
+    assert get_override(DeprecatingSerializer, "exclude_fields") == ["hidden"]
+    assert get_override(DeprecatingSerializer, "deprecate_fields") == ["legacy"]
+
+
+def test_deprecate_fields_merges_with_a_stacked_decorator() -> None:
+    @sentry_schema_serializer(
+        omit_from_public_schema={"hidden": "A stated reason."}, deprecate_fields=["new"]
+    )
+    @extend_schema_serializer(deprecate_fields=["old"])
+    class StackedDeprecating(serializers.Serializer):
+        hidden = serializers.CharField(required=False)
+        old = serializers.CharField(required=False)
+        new = serializers.CharField(required=False)
+
+    assert sorted(get_override(StackedDeprecating, "deprecate_fields")) == ["new", "old"]
+
+
+def test_omitting_without_deprecating_sets_no_deprecate_override() -> None:
+    assert get_override(OmittingSerializer, "deprecate_fields") is None


### PR DESCRIPTION
Seven fields across five request serializers are genuinely not public API surface. Moves them from bare `exclude_fields` to `omit_from_public_schema` so each carries a stated reason:

- `idp_provisioned` — set by SCIM and identity-provider provisioning, not by clients
- `public` / `secret` on project keys — let a caller supply existing DSN key material; used by relocation and import
- `popularity` / `isDisabled` on custom integrations — internal ranking and state
- `dataset_source` — records whether a widget's dataset was user-chosen or inferred
- `id` on the issue-view POST validator — inherited from the update validator; the server assigns it on create

No schema change: these were already withheld, they just had no recorded justification.

Stacked on https://github.com/getsentry/sentry/pull/123462.