### PR TITLE
feat(apidocs): Convert withheld response keys to omit_from_public_schema

### DIFF
--- a/src/sentry/api/endpoints/organization_trace_item_attributes.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes.py
@@ -217,8 +217,8 @@ EXPAND_QUERY_PARAM = OpenApiParameter(
     type=str,
     enum=["context"],
     # Withheld from the public OpenAPI spec because the context shape it returns
-    # is still evolving. The matching half is the ``exclude_fields=["context"]``
-    # on ``TraceItemAttributeKey``, which keeps that shape out of the spec too.
+    # is still evolving. The matching half is ``omit_from_public_schema`` on
+    # ``TraceItemAttributeKey``, which keeps that shape out of the spec too.
     exclude=True,
     description=(
         "Optional fields to expand. Pass `context` to include attribute metadata "

--- a/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
+++ b/src/sentry/api/endpoints/organization_trace_item_attributes_types.py
@@ -1,7 +1,6 @@
 from typing import Any, Literal, NotRequired, TypedDict
 
-from drf_spectacular.utils import extend_schema_serializer
-
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.search.eap.types import ColumnType
 
 
@@ -42,7 +41,11 @@ class TraceItemAttributeContext(TypedDict):
     replacementAttribute: NotRequired[str]
 
 
-@extend_schema_serializer(exclude_fields=["context"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "context": "The context shape it returns is still evolving.",
+    }
+)
 class TraceItemAttributeKey(TypedDict):
     key: str
     name: str

--- a/src/sentry/api/serializers/models/organization.py
+++ b/src/sentry/api/serializers/models/organization.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Any, ClassVar, TypedDict, cast
 from django.contrib.auth.models import AnonymousUser
 from django.db.models import JSONField
 from django.db.models.functions import Cast
-from drf_spectacular.utils import extend_schema_serializer
 from rest_framework import serializers
 from sentry_relay.auth import PublicKey
 from sentry_relay.exceptions import RelayError
@@ -24,6 +23,7 @@ from sentry.api.serializers.models.role import (
 )
 from sentry.api.serializers.models.team import TeamSerializerResponse
 from sentry.api.utils import generate_locality_url
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.auth.access import Access
 from sentry.auth.services.auth import RpcOrganizationAuthConfig, auth_service
 from sentry.constants import (
@@ -627,7 +627,11 @@ class _OrganizationSerializerResponseOptional(OrganizationSummarySerializerRespo
     dashboardsAsyncQueueParallelLimit: int
 
 
-@extend_schema_serializer(exclude_fields=["availableRoles"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "availableRoles": "Deprecated, superseded by orgRoleList.",
+    }
+)
 class OrganizationSerializerResponse(_OrganizationSerializerResponseOptional):
     experiments: dict[str, str]
     isDefault: bool
@@ -927,19 +931,19 @@ class OrganizationSerializer(OrganizationSummarySerializer):
         return context
 
 
-@extend_schema_serializer(
-    exclude_fields=[
-        "availableRoles",
-        "genAIConsent",
-        "rollbackEnabled",
-        "streamlineOnly",
-        "ingestThroughTrustedRelaysOnly",
-        "enabledConsolePlatforms",
-        "consoleSdkInviteQuota",
-        "dashboardsAsyncQueueParallelLimit",
-        "hasGranularReplayPermissions",
-        "replayAccessMembers",
-    ]
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "availableRoles": "Deprecated, superseded by orgRoleList.",
+        "genAIConsent": "Internal consent flag surfaced only to the Sentry UI.",
+        "rollbackEnabled": "Internal feature toggle surfaced only to the Sentry UI.",
+        "streamlineOnly": "Internal UI preference flag.",
+        "ingestThroughTrustedRelaysOnly": "Internal relay ingestion setting.",
+        "enabledConsolePlatforms": "Internal console-platform allowlist.",
+        "consoleSdkInviteQuota": "Internal console SDK invite quota.",
+        "dashboardsAsyncQueueParallelLimit": "Internal query-queue tuning value.",
+        "hasGranularReplayPermissions": "Internal replay permission flag surfaced only to the Sentry UI.",
+        "replayAccessMembers": "Internal replay access list surfaced only to the Sentry UI.",
+    }
 )
 class OrganizationWithProjectsAndTeamsSerializerResponse(OrganizationSerializerResponse):
     teams: list[TeamSerializerResponse]

--- a/src/sentry/api/serializers/models/organization_member/response.py
+++ b/src/sentry/api/serializers/models/organization_member/response.py
@@ -1,12 +1,11 @@
 from datetime import datetime
 from typing import NotRequired, TypedDict
 
-from drf_spectacular.utils import extend_schema_serializer
-
 from sentry.api.serializers.models.role import (
     OrganizationRoleSerializerResponse,
     TeamRoleSerializerResponse,
 )
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.integrations.api.serializers.models.external_actor import ExternalActorResponse
 from sentry.users.api.serializers.user import UserSerializerResponse
 
@@ -66,7 +65,12 @@ class _TeamRole(TypedDict):
     role: str | None
 
 
-@extend_schema_serializer(exclude_fields=["role", "roleName"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "role": "Deprecated, use orgRole.",
+        "roleName": "Deprecated, derived from orgRole.",
+    }
+)
 class OrganizationMemberResponse(TypedDict):
     externalUsers: NotRequired[list[ExternalActorResponse]]
     role: NotRequired[str]  # Deprecated: use orgRole
@@ -94,7 +98,11 @@ class OrganizationMemberWithProjectsResponse(OrganizationMemberResponse):
     projects: list[str]
 
 
-@extend_schema_serializer(exclude_fields=["roles"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "roles": "Deprecated, use orgRoleList.",
+    }
+)
 class OrganizationMemberWithRolesResponse(OrganizationMemberWithTeamsResponse):
     roles: NotRequired[list[OrganizationRoleSerializerResponse]]  # Deprecated: use orgRoleList
     invite_link: str | None

--- a/src/sentry/incidents/endpoints/serializers/alert_rule.py
+++ b/src/sentry/incidents/endpoints/serializers/alert_rule.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypedDict
 
-from drf_spectacular.utils import extend_schema_serializer
+from sentry.apidocs.omissions import sentry_schema_serializer
 
 if TYPE_CHECKING:
     from sentry.incidents.endpoints.serializers.incident import IncidentSerializerResponse
@@ -30,19 +30,19 @@ class AlertRuleSerializerResponseOptional(TypedDict, total=False):
     extrapolationMode: str | None
 
 
-@extend_schema_serializer(
-    exclude_fields=[
-        "status",
-        "resolution",
-        "thresholdPeriod",
-        "weeklyAvg",
-        "totalThisWeek",
-        "latestIncident",
-        "description",  # TODO: remove this once the feature has been released to add to the public docs, being sure to denote it will only display in Slack notifications
-        "sensitivity",  # For anomaly detection, which is behind a feature flag
-        "seasonality",  # For anomaly detection, which is behind a feature flag
-        "detectionType",  # For anomaly detection, which is behind a feature flag
-    ]
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "status": "Internal numeric alert-rule status; clients read the rule's state through other fields.",
+        "resolution": "Internal resolution window derived from the rule's time window.",
+        "thresholdPeriod": "Internal consecutive-breach counter used by the alert evaluator.",
+        "weeklyAvg": "Computed rollup used by the alert rule UI.",
+        "totalThisWeek": "Computed rollup used by the alert rule UI.",
+        "latestIncident": "Embedded incident snapshot used by the alert rule UI.",
+        "description": "Internal field distinct from the rule name; not part of the documented shape.",
+        "sensitivity": "Anomaly-detection tuning, meaningful only for dynamic detection rules.",
+        "seasonality": "Anomaly-detection tuning, meaningful only for dynamic detection rules.",
+        "detectionType": "Anomaly-detection tuning, meaningful only for dynamic detection rules.",
+    }
 )
 class AlertRuleSerializerResponse(AlertRuleSerializerResponseOptional):
     """

--- a/src/sentry/replays/post_process.py
+++ b/src/sentry/replays/post_process.py
@@ -5,8 +5,7 @@ from collections.abc import Generator, Iterable, Iterator, MutableMapping
 from itertools import zip_longest
 from typing import Any, TypedDict
 
-from drf_spectacular.utils import extend_schema_serializer
-
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.utils.tracing import trace
 
 
@@ -54,7 +53,12 @@ class OTAUpdatesResponseType(TypedDict, total=False):
     update_id: str | None
 
 
-@extend_schema_serializer(exclude_fields=["info_ids", "warning_ids"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "info_ids": "Internal breadcrumb index used by the replay UI.",
+        "warning_ids": "Internal breadcrumb index used by the replay UI.",
+    }
+)
 class ReplayDetailsResponse(TypedDict, total=False):
     id: str
     project_id: str

--- a/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
+++ b/src/sentry/workflow_engine/endpoints/serializers/detector_serializer.py
@@ -4,12 +4,12 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 from django.db.models import OuterRef, Subquery
-from drf_spectacular.utils import extend_schema_serializer
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
 from sentry.api.serializers.models.group import SimpleGroupSerializer
 from sentry.api.serializers.rest_framework.base import convert_dict_key_case, snake_to_camel_case
+from sentry.apidocs.omissions import sentry_schema_serializer
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.models.group import Group
 from sentry.models.options.project_option import ProjectOption
@@ -33,7 +33,12 @@ class DetectorSerializerResponseOptional(TypedDict, total=False):
     description: str | None
 
 
-@extend_schema_serializer(exclude_fields=["alertRuleId", "ruleId"])
+@sentry_schema_serializer(
+    omit_from_public_schema={
+        "alertRuleId": "Legacy identifier retained during the alert-rule to detector migration.",
+        "ruleId": "Legacy identifier retained during the alert-rule to detector migration.",
+    }
+)
 class DetectorSerializerResponse(DetectorSerializerResponseOptional):
     id: str
     projectId: str | None


### PR DESCRIPTION
Twenty-nine response-type keys were hidden from the schema with no recorded reason. Moves them to `omit_from_public_schema` so each says why.

Response omission differs from request omission and is worth flagging: an omitted request field cannot be discovered by clients, but an omitted **response** key is still returned — the client sees it, the generated SDK just has no model for it. Every one of these is preserved as-is rather than newly exposed, so this is a no-op on the schema, but each deserves a product decision about whether it should be documented instead. The reasons record my read; correcting any of them is a one-line change.

Also updates the comment in `organization_trace_item_attributes.py` that referred to the old kwarg by name.

Stacked on https://github.com/getsentry/sentry/pull/123463.