### PR TITLE
fix(seer): Keep long PR feedback comments inside the code changes card

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1110,39 +1110,6 @@ describe('ArtifactCard', () => {
       expect(screen.queryByText(/eyJ2ZXJzaW9u/)).not.toBeInTheDocument();
     });
 
-    it('keeps angle-bracketed prose that is not real markup', () => {
-      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
-        ...mockAutofix,
-        runState: {
-          run_id: 123,
-          blocks: [],
-          status: 'completed',
-          updated_at: '2026-01-01T00:00:00Z',
-          queued_feedback: [
-            {
-              text: 'Wrap it in <Flex minWidth="0"> and return Optional<int>',
-              source: {type: 'user-ui'},
-            },
-          ],
-        },
-      };
-
-      render(
-        <CodeChangesCard
-          groupId="1"
-          autofix={autofixWithQueued}
-          section={makeSection('code_changes', 'completed', [
-            [makePatch('org/repo', 'src/app.py')],
-          ])}
-        />,
-        {organization: prIterationOrganization}
-      );
-
-      expect(
-        screen.getByText('Wrap it in <Flex minWidth="0"> and return Optional<int>')
-      ).toBeInTheDocument();
-    });
-
     it('collapses a long comment into a disclosure', async () => {
       const longText = `Timeouts abort the upload batch. ${'x'.repeat(400)} End of comment.`;
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1068,7 +1068,7 @@ describe('ArtifactCard', () => {
       expect(feedbackLink).toHaveAttribute('href', commentUrl);
     });
 
-    it('renders a bot comment as markdown, dropping the hidden control marker', () => {
+    it('strips markup and markdown syntax from bot comments', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
@@ -1079,7 +1079,7 @@ describe('ArtifactCard', () => {
           queued_feedback: [
             {
               // Shaped like a real Bugbot comment.
-              text: '<!-- BUGBOT_REVIEW -->\n### Bugbot found <a href="https://cursor.com/open?link=eyJ2ZXJzaW9u">1 issue</a>. Medium severity.',
+              text: '<!-- BUGBOT_REVIEW -->\n### Bugbot found <a href="https://cursor.com/open?link=eyJ2ZXJzaW9u">1 issue</a>. **Medium Severity**',
               source: {
                 type: 'github-pr-comment',
                 comment: {
@@ -1103,12 +1103,11 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      const heading = screen.getByRole('heading', {level: 3});
-      expect(heading).toHaveTextContent('Bugbot found 1 issue. Medium severity.');
+      expect(
+        screen.getByText('Bugbot found 1 issue. Medium Severity')
+      ).toBeInTheDocument();
       expect(screen.queryByText(/BUGBOT_REVIEW/)).not.toBeInTheDocument();
-
-      const link = screen.getByRole('link', {name: '1 issue'});
-      expect(link).toHaveAttribute('href', 'https://cursor.com/open?link=eyJ2ZXJzaW9u');
+      expect(screen.queryByText(/eyJ2ZXJzaW9u/)).not.toBeInTheDocument();
     });
 
     it('collapses a long comment into a disclosure', async () => {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1110,6 +1110,39 @@ describe('ArtifactCard', () => {
       expect(screen.queryByText(/eyJ2ZXJzaW9u/)).not.toBeInTheDocument();
     });
 
+    it('keeps angle-bracketed prose that is not real markup', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [
+            {
+              text: 'Wrap it in <Flex minWidth="0"> and return Optional<int>',
+              source: {type: 'user-ui'},
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(
+        screen.getByText('Wrap it in <Flex minWidth="0"> and return Optional<int>')
+      ).toBeInTheDocument();
+    });
+
     it('collapses a long comment into a disclosure', async () => {
       const longText = `Timeouts abort the upload batch. ${'x'.repeat(400)} End of comment.`;
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1068,6 +1068,116 @@ describe('ArtifactCard', () => {
       expect(feedbackLink).toHaveAttribute('href', commentUrl);
     });
 
+    it('strips markup and markdown syntax from bot comments', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [
+            {
+              // Shaped like a real Bugbot comment.
+              text: '<!-- BUGBOT_REVIEW -->\n### Bugbot found <a href="https://cursor.com/open?link=eyJ2ZXJzaW9u">1 issue</a>. **Medium Severity**',
+              source: {
+                type: 'github-pr-comment',
+                comment: {
+                  html_url: 'https://github.com/org/repo/pull/42#issuecomment-1',
+                  user: {login: 'cursor'},
+                },
+              },
+            },
+          ],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(
+        screen.getByText('Bugbot found 1 issue. Medium Severity')
+      ).toBeInTheDocument();
+      expect(screen.queryByText(/BUGBOT_REVIEW/)).not.toBeInTheDocument();
+      expect(screen.queryByText(/eyJ2ZXJzaW9u/)).not.toBeInTheDocument();
+    });
+
+    it('collapses a long comment into a disclosure', async () => {
+      const longText = `Timeouts abort the upload batch. ${'x'.repeat(400)} End of comment.`;
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: longText, source: {type: 'user-ui'}}],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      // Twice over: the summary's clipped preview, plus the still-mounted body.
+      const collapsed = screen.getAllByText(/End of comment\./);
+      expect(collapsed).toHaveLength(2);
+      const preview = collapsed.find(el => el.closest('summary'))!;
+      const body = collapsed.find(el => !el.closest('summary'))!;
+      const details = body.closest('details');
+      expect(details).not.toHaveAttribute('open');
+      expect(body).not.toBeVisible();
+
+      await userEvent.click(preview);
+
+      expect(details).toHaveAttribute('open');
+      expect(body).toBeVisible();
+      expect(screen.getAllByText(/End of comment\./)).toHaveLength(1);
+    });
+
+    it('does not collapse a short comment', () => {
+      const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
+        ...mockAutofix,
+        runState: {
+          run_id: 123,
+          blocks: [],
+          status: 'completed',
+          updated_at: '2026-01-01T00:00:00Z',
+          queued_feedback: [{text: 'Make the button blue', source: {type: 'user-ui'}}],
+        },
+      };
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={autofixWithQueued}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py')],
+          ])}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      const comment = screen.getByText('Make the button blue');
+      expect(comment).toBeVisible();
+      expect(comment.closest('details')).toBeNull();
+    });
+
     it('groups a review body with its inline comments under a state header', () => {
       const reviewUrl = 'https://github.com/org/repo/pull/42#pullrequestreview-999';
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1068,7 +1068,7 @@ describe('ArtifactCard', () => {
       expect(feedbackLink).toHaveAttribute('href', commentUrl);
     });
 
-    it('strips markup and markdown syntax from bot comments', () => {
+    it('renders a bot comment as markdown, dropping the hidden control marker', () => {
       const autofixWithQueued: ReturnType<typeof useExplorerAutofix> = {
         ...mockAutofix,
         runState: {
@@ -1079,7 +1079,7 @@ describe('ArtifactCard', () => {
           queued_feedback: [
             {
               // Shaped like a real Bugbot comment.
-              text: '<!-- BUGBOT_REVIEW -->\n### Bugbot found <a href="https://cursor.com/open?link=eyJ2ZXJzaW9u">1 issue</a>. **Medium Severity**',
+              text: '<!-- BUGBOT_REVIEW -->\n### Bugbot found <a href="https://cursor.com/open?link=eyJ2ZXJzaW9u">1 issue</a>. Medium severity.',
               source: {
                 type: 'github-pr-comment',
                 comment: {
@@ -1103,11 +1103,12 @@ describe('ArtifactCard', () => {
         {organization: prIterationOrganization}
       );
 
-      expect(
-        screen.getByText('Bugbot found 1 issue. Medium Severity')
-      ).toBeInTheDocument();
+      const heading = screen.getByRole('heading', {level: 3});
+      expect(heading).toHaveTextContent('Bugbot found 1 issue. Medium severity.');
       expect(screen.queryByText(/BUGBOT_REVIEW/)).not.toBeInTheDocument();
-      expect(screen.queryByText(/eyJ2ZXJzaW9u/)).not.toBeInTheDocument();
+
+      const link = screen.getByRole('link', {name: '1 issue'});
+      expect(link).toHaveAttribute('href', 'https://cursor.com/open?link=eyJ2ZXJzaW9u');
     });
 
     it('collapses a long comment into a disclosure', async () => {

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -1,12 +1,11 @@
 import {useMemo} from 'react';
-import {useTheme} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LetterAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Tag, type TagProps} from '@sentry/scraps/badge';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
-import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -104,9 +103,7 @@ type IterationFeedback = ParsedFeedback & {
   status: FeedbackStatus;
 };
 
-// The collapsed-state summary line and the collapse-length decision both need
-// plain prose, not markdown source — this is where bot control markers like
-// `<!-- BUGBOT_REVIEW -->` get dropped for that purpose.
+// Bot comments arrive as HTML-flavored markdown; keep only the visible prose.
 function toPlainText(text: string): string {
   return markdownToPlainText(text).replace(/\s+/g, ' ').trim();
 }
@@ -115,7 +112,7 @@ function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
   // `ui_text` is the short display label the backend derives per source; fall
   // back to the raw prompt `text` for feedback serialized before it existed.
   const base = {
-    text: parsed.ui_text ?? parsed.text,
+    text: toPlainText(parsed.ui_text ?? parsed.text),
     timestamp: parsed.timestamp,
   };
   const source = parsed.source;
@@ -668,28 +665,24 @@ function CommentBody({
   externalUrl?: string;
   muted?: boolean;
 }) {
-  // The disclosure preview and the collapse decision both read the flattened
-  // prose length, not the markdown source's — a short comment wrapped in a lot
-  // of bot HTML shouldn't collapse, and a long one written in terse markdown
-  // should.
-  const plainText = useMemo(() => toPlainText(text), [text]);
-
+  // `anywhere` (not `break-word`) shrinks min-content so a URL can't widen the column.
   const body = (
-    <Stack gap="xs">
-      <MarkdownColor muted={muted}>
-        <Markdown raw={text} />
-      </MarkdownColor>
+    <Text
+      variant={muted ? 'muted' : undefined}
+      css={css`
+        overflow-wrap: anywhere;
+      `}
+    >
+      {text}
       {externalUrl && (
-        <Flex justify="end">
-          <ExternalLink href={externalUrl} aria-label={t('Open in GitHub')}>
-            <InlineOpenIcon size="xs" />
-          </ExternalLink>
-        </Flex>
+        <ExternalLink href={externalUrl} aria-label={t('Open in GitHub')}>
+          <InlineOpenIcon size="xs" />
+        </ExternalLink>
       )}
-    </Stack>
+    </Text>
   );
 
-  if (plainText.length <= MAX_UNCOLLAPSED_COMMENT_LENGTH) {
+  if (text.length <= MAX_UNCOLLAPSED_COMMENT_LENGTH) {
     return body;
   }
 
@@ -699,7 +692,7 @@ function CommentBody({
         isOpen ? null : (
           <Flex flex="1" minWidth="0">
             <Text variant={muted ? 'muted' : undefined} ellipsis>
-              {plainText}
+              {text}
             </Text>
           </Flex>
         )
@@ -709,18 +702,6 @@ function CommentBody({
     </CollapsibleContent>
   );
 }
-
-// `Markdown` sets `overflow-wrap: break-word` on its own root, which (unlike
-// `anywhere`) doesn't shrink min-content — override it so a long URL can't
-// widen the column. `overflow-wrap` is inherited, so this reaches every
-// paragraph/heading `Markdown` renders underneath.
-const MarkdownColor = styled('div')<{muted?: boolean}>`
-  color: ${p => p.theme.tokens.content[p.muted ? 'secondary' : 'primary']};
-
-  & > div {
-    overflow-wrap: anywhere !important;
-  }
-`;
 
 // One-avatar-square frame that positions a corner badge against its avatar.
 function AvatarFrame({children}: {children: React.ReactNode}) {

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -103,22 +103,9 @@ type IterationFeedback = ParsedFeedback & {
   status: FeedbackStatus;
 };
 
-const HTML_TAG = /<\/?([a-zA-Z][a-zA-Z0-9-]*)(?:\s[^<>]*)?\/?>/g;
-
-// `Optional<int>` and `<Flex>` are prose, not markup, but the plain-text pass
-// below would strip them as unknown tags. Escape everything the browser doesn't
-// know as a real element so it survives as text.
-function escapeNonHtmlTags(text: string): string {
-  return text.replace(HTML_TAG, (tag, name: string) =>
-    document.createElement(name) instanceof HTMLUnknownElement
-      ? tag.replace('<', '&lt;')
-      : tag
-  );
-}
-
 // Bot comments arrive as HTML-flavored markdown; keep only the visible prose.
 function toPlainText(text: string): string {
-  return markdownToPlainText(escapeNonHtmlTags(text)).replace(/\s+/g, ' ').trim();
+  return markdownToPlainText(text).replace(/\s+/g, ' ').trim();
 }
 
 function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -1,11 +1,12 @@
 import {useMemo} from 'react';
-import {css, useTheme} from '@emotion/react';
+import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LetterAvatar, UserAvatar} from '@sentry/scraps/avatar';
 import {Tag, type TagProps} from '@sentry/scraps/badge';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
+import {Markdown} from '@sentry/scraps/markdown';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -103,7 +104,9 @@ type IterationFeedback = ParsedFeedback & {
   status: FeedbackStatus;
 };
 
-// Bot comments arrive as HTML-flavored markdown; keep only the visible prose.
+// The collapsed-state summary line and the collapse-length decision both need
+// plain prose, not markdown source — this is where bot control markers like
+// `<!-- BUGBOT_REVIEW -->` get dropped for that purpose.
 function toPlainText(text: string): string {
   return markdownToPlainText(text).replace(/\s+/g, ' ').trim();
 }
@@ -112,7 +115,7 @@ function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
   // `ui_text` is the short display label the backend derives per source; fall
   // back to the raw prompt `text` for feedback serialized before it existed.
   const base = {
-    text: toPlainText(parsed.ui_text ?? parsed.text),
+    text: parsed.ui_text ?? parsed.text,
     timestamp: parsed.timestamp,
   };
   const source = parsed.source;
@@ -665,24 +668,28 @@ function CommentBody({
   externalUrl?: string;
   muted?: boolean;
 }) {
-  // `anywhere` (not `break-word`) shrinks min-content so a URL can't widen the column.
+  // The disclosure preview and the collapse decision both read the flattened
+  // prose length, not the markdown source's — a short comment wrapped in a lot
+  // of bot HTML shouldn't collapse, and a long one written in terse markdown
+  // should.
+  const plainText = useMemo(() => toPlainText(text), [text]);
+
   const body = (
-    <Text
-      variant={muted ? 'muted' : undefined}
-      css={css`
-        overflow-wrap: anywhere;
-      `}
-    >
-      {text}
+    <Stack gap="xs">
+      <MarkdownColor muted={muted}>
+        <Markdown raw={text} />
+      </MarkdownColor>
       {externalUrl && (
-        <ExternalLink href={externalUrl} aria-label={t('Open in GitHub')}>
-          <InlineOpenIcon size="xs" />
-        </ExternalLink>
+        <Flex justify="end">
+          <ExternalLink href={externalUrl} aria-label={t('Open in GitHub')}>
+            <InlineOpenIcon size="xs" />
+          </ExternalLink>
+        </Flex>
       )}
-    </Text>
+    </Stack>
   );
 
-  if (text.length <= MAX_UNCOLLAPSED_COMMENT_LENGTH) {
+  if (plainText.length <= MAX_UNCOLLAPSED_COMMENT_LENGTH) {
     return body;
   }
 
@@ -692,7 +699,7 @@ function CommentBody({
         isOpen ? null : (
           <Flex flex="1" minWidth="0">
             <Text variant={muted ? 'muted' : undefined} ellipsis>
-              {text}
+              {plainText}
             </Text>
           </Flex>
         )
@@ -702,6 +709,18 @@ function CommentBody({
     </CollapsibleContent>
   );
 }
+
+// `Markdown` sets `overflow-wrap: break-word` on its own root, which (unlike
+// `anywhere`) doesn't shrink min-content — override it so a long URL can't
+// widen the column. `overflow-wrap` is inherited, so this reaches every
+// paragraph/heading `Markdown` renders underneath.
+const MarkdownColor = styled('div')<{muted?: boolean}>`
+  color: ${p => p.theme.tokens.content[p.muted ? 'secondary' : 'primary']};
+
+  & > div {
+    overflow-wrap: anywhere !important;
+  }
+`;
 
 // One-avatar-square frame that positions a corner badge against its avatar.
 function AvatarFrame({children}: {children: React.ReactNode}) {

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -1,5 +1,5 @@
 import {useMemo} from 'react';
-import {useTheme} from '@emotion/react';
+import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {LetterAvatar, UserAvatar} from '@sentry/scraps/avatar';
@@ -9,6 +9,7 @@ import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {CollapsibleContent} from 'sentry/components/ai/chat/collapsibleContent';
 import {
   isPrIterationBlock,
   type AutofixSection,
@@ -27,6 +28,7 @@ import {t} from 'sentry/locale';
 import type {AvatarUser, User} from 'sentry/types/user';
 import {defined} from 'sentry/utils/defined';
 import {userDisplayName} from 'sentry/utils/formatters';
+import {markdownToPlainText} from 'sentry/utils/marked/marked';
 
 const AVATAR_SIZE = 24;
 const SOURCE_BADGE_SIZE = 14;
@@ -101,11 +103,16 @@ type IterationFeedback = ParsedFeedback & {
   status: FeedbackStatus;
 };
 
+// Bot comments arrive as HTML-flavored markdown; keep only the visible prose.
+function toPlainText(text: string): string {
+  return markdownToPlainText(text).replace(/\s+/g, ' ').trim();
+}
+
 function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {
   // `ui_text` is the short display label the backend derives per source; fall
   // back to the raw prompt `text` for feedback serialized before it existed.
   const base = {
-    text: parsed.ui_text ?? parsed.text,
+    text: toPlainText(parsed.ui_text ?? parsed.text),
     timestamp: parsed.timestamp,
   };
   const source = parsed.source;
@@ -645,6 +652,9 @@ function OtherComment({item}: {item: IterationFeedback}) {
   return <CommentBody text={item.text} />;
 }
 
+// Past this length a comment collapses into a disclosure.
+const COLLAPSED_LENGTH = 280;
+
 function CommentBody({
   text,
   externalUrl,
@@ -654,8 +664,14 @@ function CommentBody({
   externalUrl?: string;
   muted?: boolean;
 }) {
-  return (
-    <Text variant={muted ? 'muted' : undefined}>
+  // `anywhere` (not `break-word`) shrinks min-content so a URL can't widen the column.
+  const body = (
+    <Text
+      variant={muted ? 'muted' : undefined}
+      css={css`
+        overflow-wrap: anywhere;
+      `}
+    >
       {text}
       {externalUrl && (
         <ExternalLink href={externalUrl} aria-label={t('Open in GitHub')}>
@@ -663,6 +679,27 @@ function CommentBody({
         </ExternalLink>
       )}
     </Text>
+  );
+
+  if (text.length <= COLLAPSED_LENGTH) {
+    return body;
+  }
+
+  return (
+    // The preview clears on open, so the body below is never a duplicate of it.
+    <CollapsibleContent
+      title={isOpen =>
+        isOpen ? null : (
+          <Flex flex="1" minWidth="0">
+            <Text variant={muted ? 'muted' : undefined} ellipsis>
+              {text}
+            </Text>
+          </Flex>
+        )
+      }
+    >
+      {body}
+    </CollapsibleContent>
   );
 }
 

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -652,8 +652,7 @@ function OtherComment({item}: {item: IterationFeedback}) {
   return <CommentBody text={item.text} />;
 }
 
-// Past this length a comment collapses into a disclosure.
-const COLLAPSED_LENGTH = 280;
+const MAX_UNCOLLAPSED_COMMENT_LENGTH = 280;
 
 function CommentBody({
   text,
@@ -681,12 +680,11 @@ function CommentBody({
     </Text>
   );
 
-  if (text.length <= COLLAPSED_LENGTH) {
+  if (text.length <= MAX_UNCOLLAPSED_COMMENT_LENGTH) {
     return body;
   }
 
   return (
-    // The preview clears on open, so the body below is never a duplicate of it.
     <CollapsibleContent
       title={isOpen =>
         isOpen ? null : (

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -103,9 +103,22 @@ type IterationFeedback = ParsedFeedback & {
   status: FeedbackStatus;
 };
 
+const HTML_TAG = /<\/?([a-zA-Z][a-zA-Z0-9-]*)(?:\s[^<>]*)?\/?>/g;
+
+// `Optional<int>` and `<Flex>` are prose, not markup, but the plain-text pass
+// below would strip them as unknown tags. Escape everything the browser doesn't
+// know as a real element so it survives as text.
+function escapeNonHtmlTags(text: string): string {
+  return text.replace(HTML_TAG, (tag, name: string) =>
+    document.createElement(name) instanceof HTMLUnknownElement
+      ? tag.replace('<', '&lt;')
+      : tag
+  );
+}
+
 // Bot comments arrive as HTML-flavored markdown; keep only the visible prose.
 function toPlainText(text: string): string {
-  return markdownToPlainText(text).replace(/\s+/g, ' ').trim();
+  return markdownToPlainText(escapeNonHtmlTags(text)).replace(/\s+/g, ' ').trim();
 }
 
 function parseFeedbackItem(parsed: RawFeedback): ParsedFeedback | null {

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -624,7 +624,9 @@ function GithubReviewBodyComment({item}: {item: IterationFeedback}) {
   }
   const tag = reviewStateTag(item.reviewState);
   return (
-    <Flex align="center" gap="sm" wrap="wrap">
+    // `minWidth="0"` so the nowrap preview inside can't set this row's automatic
+    // minimum size and push past the card.
+    <Flex align="center" gap="sm" wrap="wrap" minWidth="0">
       {tag && <Tag variant={tag.variant}>{tag.label}</Tag>}
       {/* A bare state change has no body — show just the link. */}
       {item.text ? (


### PR DESCRIPTION
previously a really long feedback would flow over and cover other parts of UI

we fix it by making the feedback collapsible if the feedback is too long to display

also we get rid of markdown comments so it's slightly easier to read

| before | after |
| - | - |
| <img width="2274" height="682" alt="image" src="https://github.com/user-attachments/assets/82f9d025-c342-4f39-8d4e-bad7dd240f62" /> | <img width="2212" height="900" alt="image" src="https://github.com/user-attachments/assets/a6609b97-2195-4d20-bf1a-9fddb061393e" /> | 

after expanded:
<img width="1148" height="494" alt="image" src="https://github.com/user-attachments/assets/ed4de1c9-f9c8-4956-a55f-3ef59d5b6d9d" />

and it also works for code reviews with multiple comments: 

<img width="1076" height="641" alt="image" src="https://github.com/user-attachments/assets/4b263dfd-94cc-4cd4-a401-1e70bc4462ef" />

<img width="1063" height="378" alt="image" src="https://github.com/user-attachments/assets/7e50160e-0fa7-4a46-a8cd-11fe91f53f9b" />

