### PR TITLE
feat(apidocs): Lint that schema omissions carry a stated reason

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -66,6 +66,12 @@ repos:
         pass_filenames: true
         files: ^src/sentry/.*endpoints/.*\.py$
         require_serial: false
+      - id: check-schema-omissions
+        name: check schema omissions have a stated reason
+        language: system
+        entry: .venv/bin/python src/sentry/apidocs/_check_schema_omissions.py
+        files: ^src/sentry/.*\.py$
+        pass_filenames: false
       - id: sort-mypy-weaklist
         name: sort mypy weaklist
         entry: python3 -m tools.mypy_helpers.sort_weaklist

--- a/src/sentry/apidocs/_check_schema_omissions.py
+++ b/src/sentry/apidocs/_check_schema_omissions.py
@@ -98,7 +98,19 @@ def _class_field_names(cls: ast.ClassDef, classes: dict[str, ast.ClassDef]) -> s
                         and m.targets[0].id == "fields"
                         and isinstance(m.value, (ast.List, ast.Tuple))
                     ):
-                        names.update(e.value for e in m.value.elts if isinstance(e, ast.Constant))
+                        names.update(
+                            e.value
+                            for e in m.value.elts
+                            if isinstance(e, ast.Constant) and isinstance(e.value, str)
+                        )
+                    elif (
+                        isinstance(m, ast.Assign)
+                        and isinstance(m.targets[0], ast.Name)
+                        and m.targets[0].id == "fields"
+                    ):
+                        # Meta.fields = "__all__" (or any non-literal): the field set
+                        # comes from the model, so we cannot enumerate it
+                        names.add("*")
         for base in node.bases:
             bn = _base_name(base)
             if bn in classes:
@@ -119,7 +131,8 @@ def check_file(path: Path) -> tuple[list[Diagnostic], set[str]]:
     except (SyntaxError, UnicodeDecodeError):
         return [], set()
 
-    classes = {n.name: n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)}
+    # module-level only: ast.walk would let a nested class shadow a top-level one
+    classes = {n.name: n for n in tree.body if isinstance(n, ast.ClassDef)}
     out: list[Diagnostic] = []
     used: set[str] = set()
 
@@ -237,12 +250,12 @@ def main(argv: list[str]) -> int:
     diagnostics: list[Diagnostic] = []
     used: set[str] = set()
     for path in iter_files(roots):
-        d, u = check_file(path)
-        diagnostics.extend(d)
-        used |= u
+        found, matched = check_file(path)
+        diagnostics.extend(found)
+        used |= matched
 
-    for d in diagnostics:
-        sys.stdout.write(f"{d}\n")
+    for diagnostic in diagnostics:
+        sys.stdout.write(f"{diagnostic}\n")
 
     stale = SAFELIST - used
     checked_everything = roots == list(DEFAULT_PATHS)

--- a/src/sentry/apidocs/_check_schema_omissions.py
+++ b/src/sentry/apidocs/_check_schema_omissions.py
@@ -1,0 +1,264 @@
+"""Lint: keep fields out of the public schema only on purpose.
+
+drf-spectacular's ``@extend_schema_serializer(exclude_fields=[...])`` drops a
+field from the generated OpenAPI document, and that document scaffolds our SDKs
+-- so an excluded field is missing from every generated client even though the
+API still accepts it. Historically the docs build offered exclusion as one of
+three peer fixes for a missing description, so it became the cheap way to quiet
+the build rather than a deliberate product decision.
+
+This linter makes the deliberate path the only easy one. It reports:
+
+  1. ``exclude_fields`` on any serializer, unless the entry is in SAFELIST.
+     The supported spelling is ``@sentry_schema_serializer(
+     omit_from_public_schema={"field": "why"})``, which records a reason.
+  2. ``omit_from_public_schema`` entries with a blank reason.
+  3. Entries -- either spelling -- naming a field that does not exist on the
+     decorated class or its in-file bases. Those exclude nothing.
+  4. SAFELIST entries that no longer match anything, so the list cannot rot.
+
+Invoke as:
+    python -m sentry.apidocs._check_schema_omissions [paths...]
+
+Exits non-zero on any diagnostic.
+"""
+
+from __future__ import annotations
+
+import ast
+import sys
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_PATHS = ("src/sentry",)
+
+# Bare ``exclude_fields`` entries that predate omit_from_public_schema and have
+# not been converted yet, as "path::Class::field".
+#
+# This list only ever shrinks. Do NOT add to it: a new field either gets a
+# help_text (almost always the right answer) or an omit_from_public_schema entry
+# with a reason. Entries are removed as sites convert, and the linter fails on
+# any entry here that no longer matches, so it cannot silently rot.
+SAFELIST: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True)
+class Diagnostic:
+    path: Path
+    line: int
+    cls: str
+    message: str
+
+    def __str__(self) -> str:
+        return f"{self.path}:{self.line} {self.cls}: {self.message}"
+
+
+def _decorator_name(dec: ast.expr) -> str | None:
+    fn = dec.func if isinstance(dec, ast.Call) else dec
+    return getattr(fn, "id", getattr(fn, "attr", None))
+
+
+# Bases that declare no fields of their own, so a class inheriting only from
+# these has a fully enumerable field set. Anything else (ModelSerializer,
+# CamelSnakeSerializer, project base classes) may contribute fields we cannot
+# see from this file.
+_EMPTY_ROOTS = frozenset({"Serializer", "TypedDict", "object"})
+
+
+def _base_name(node: ast.expr) -> str | None:
+    """Name of a base class, unwrapping generic subscripts like Serializer[T]."""
+    if isinstance(node, ast.Subscript):
+        node = node.value
+    return node.id if isinstance(node, ast.Name) else getattr(node, "attr", None)
+
+
+def _class_field_names(cls: ast.ClassDef, classes: dict[str, ast.ClassDef]) -> set[str]:
+    """Field names on cls, following bases defined in the same file."""
+    names: set[str] = set()
+    seen: set[str] = set()
+    stack = [cls]
+    while stack:
+        node = stack.pop()
+        if node.name in seen:
+            continue
+        seen.add(node.name)
+        for stmt in node.body:
+            if isinstance(stmt, ast.Assign):
+                for t in stmt.targets:
+                    if isinstance(t, ast.Name):
+                        names.add(t.id)
+            elif isinstance(stmt, ast.AnnAssign) and isinstance(stmt.target, ast.Name):
+                names.add(stmt.target.id)
+            elif isinstance(stmt, ast.ClassDef) and stmt.name == "Meta":
+                for m in stmt.body:
+                    if (
+                        isinstance(m, ast.Assign)
+                        and isinstance(m.targets[0], ast.Name)
+                        and m.targets[0].id == "fields"
+                        and isinstance(m.value, (ast.List, ast.Tuple))
+                    ):
+                        names.update(e.value for e in m.value.elts if isinstance(e, ast.Constant))
+        for base in node.bases:
+            bn = _base_name(base)
+            if bn in classes:
+                stack.append(classes[bn])
+            elif bn in _EMPTY_ROOTS or bn is None:
+                continue
+            else:
+                # base defined elsewhere: we cannot enumerate it, so treat the
+                # class as open and skip the "field does not exist" check
+                names.add("*")
+    return names
+
+
+def check_file(path: Path) -> tuple[list[Diagnostic], set[str]]:
+    """Return diagnostics plus the safelist keys this file matched."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except (SyntaxError, UnicodeDecodeError):
+        return [], set()
+
+    classes = {n.name: n for n in ast.walk(tree) if isinstance(n, ast.ClassDef)}
+    out: list[Diagnostic] = []
+    used: set[str] = set()
+
+    for cls in classes.values():
+        for dec in cls.decorator_list:
+            if not isinstance(dec, ast.Call):
+                continue
+            name = _decorator_name(dec)
+            if name not in ("extend_schema_serializer", "sentry_schema_serializer"):
+                continue
+            fields = _class_field_names(cls, classes)
+            open_class = "*" in fields
+
+            for kw in dec.keywords:
+                if kw.arg == "exclude_fields":
+                    entries = _string_entries(kw.value)
+                    for field in entries:
+                        key = f"{path}::{cls.name}::{field}"
+                        if key in SAFELIST:
+                            used.add(key)
+                        else:
+                            out.append(
+                                Diagnostic(
+                                    path,
+                                    dec.lineno,
+                                    cls.name,
+                                    f"exclude_fields={field!r} has no recorded reason. Add a "
+                                    f"help_text to the field, or withhold it deliberately with "
+                                    f"@sentry_schema_serializer(omit_from_public_schema="
+                                    f'{{{field!r}: "<why>"}}).',
+                                )
+                            )
+                        if not open_class and field not in fields:
+                            out.append(
+                                Diagnostic(
+                                    path,
+                                    dec.lineno,
+                                    cls.name,
+                                    f"exclude_fields={field!r} names no field on this class; "
+                                    f"it excludes nothing and should be deleted.",
+                                )
+                            )
+
+                elif kw.arg == "omit_from_public_schema":
+                    if not isinstance(kw.value, ast.Dict):
+                        out.append(
+                            Diagnostic(
+                                path,
+                                dec.lineno,
+                                cls.name,
+                                "omit_from_public_schema must be a {field: reason} mapping.",
+                            )
+                        )
+                        continue
+                    for k, v in zip(kw.value.keys, kw.value.values):
+                        if not isinstance(k, ast.Constant) or not isinstance(k.value, str):
+                            continue
+                        field = k.value
+                        reason = _joined_str(v)
+                        if reason is not None and not reason.strip():
+                            out.append(
+                                Diagnostic(
+                                    path,
+                                    dec.lineno,
+                                    cls.name,
+                                    f"omit_from_public_schema[{field!r}] needs a reason "
+                                    f"explaining why the field is not public surface.",
+                                )
+                            )
+                        if not open_class and field not in fields:
+                            out.append(
+                                Diagnostic(
+                                    path,
+                                    dec.lineno,
+                                    cls.name,
+                                    f"omit_from_public_schema[{field!r}] names no field on this "
+                                    f"class; it omits nothing and should be deleted.",
+                                )
+                            )
+    return out, used
+
+
+def _string_entries(node: ast.expr) -> list[str]:
+    if isinstance(node, (ast.List, ast.Tuple)):
+        return [
+            e.value for e in node.elts if isinstance(e, ast.Constant) and isinstance(e.value, str)
+        ]
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        # a bare string "works" only by substring match; report it as one entry
+        return [node.value]
+    return []
+
+
+def _joined_str(node: ast.expr) -> str | None:
+    """Concatenated string literal, or None when not statically a string."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left, right = _joined_str(node.left), _joined_str(node.right)
+        return None if left is None or right is None else left + right
+    return None
+
+
+def iter_files(roots: Iterable[str]) -> Iterator[Path]:
+    for root in roots:
+        p = Path(root)
+        if p.is_file() and p.suffix == ".py":
+            yield p
+        else:
+            yield from sorted(p.rglob("*.py"))
+
+
+def main(argv: list[str]) -> int:
+    roots = argv[1:] if len(argv) > 1 else list(DEFAULT_PATHS)
+    diagnostics: list[Diagnostic] = []
+    used: set[str] = set()
+    for path in iter_files(roots):
+        d, u = check_file(path)
+        diagnostics.extend(d)
+        used |= u
+
+    for d in diagnostics:
+        sys.stdout.write(f"{d}\n")
+
+    stale = SAFELIST - used
+    checked_everything = roots == list(DEFAULT_PATHS)
+    if stale and checked_everything:
+        for key in sorted(stale):
+            sys.stdout.write(f"stale SAFELIST entry, delete it: {key}\n")
+
+    if diagnostics or (stale and checked_everything):
+        sys.stderr.write(
+            "\nFields are withheld from the public schema -- and therefore from every "
+            "generated SDK -- only on purpose. Add a help_text, or use "
+            "@sentry_schema_serializer(omit_from_public_schema={'field': '<why>'}).\n"
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tests/sentry/apidocs/test_check_schema_omissions.py
+++ b/tests/sentry/apidocs/test_check_schema_omissions.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from sentry.apidocs._check_schema_omissions import Diagnostic, check_file
+
+
+def _run(source: str) -> list[Diagnostic]:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".py", delete=False) as f:
+        f.write(source)
+        path = Path(f.name)
+    try:
+        diagnostics, _ = check_file(path)
+        return diagnostics
+    finally:
+        path.unlink()
+
+
+def test_bare_exclude_fields_is_rejected() -> None:
+    out = _run(
+        """
+from drf_spectacular.utils import extend_schema_serializer
+from rest_framework import serializers
+
+@extend_schema_serializer(exclude_fields=["secret"])
+class S(serializers.Serializer):
+    secret = serializers.CharField()
+"""
+    )
+    assert len(out) == 1
+    assert "no recorded reason" in out[0].message
+    assert "omit_from_public_schema" in out[0].message
+
+
+def test_string_valued_exclude_fields_is_rejected() -> None:
+    # a bare string only ever "worked" by substring match
+    out = _run(
+        """
+from drf_spectacular.utils import extend_schema_serializer
+from rest_framework import serializers
+
+@extend_schema_serializer(exclude_fields="secret")
+class S(serializers.Serializer):
+    secret = serializers.CharField()
+"""
+    )
+    assert len(out) == 1
+
+
+def test_omission_with_a_reason_passes() -> None:
+    out = _run(
+        """
+from sentry.apidocs.omissions import sentry_schema_serializer
+from rest_framework import serializers
+
+@sentry_schema_serializer(omit_from_public_schema={"secret": "Internal, not public surface."})
+class S(serializers.Serializer):
+    secret = serializers.CharField()
+"""
+    )
+    assert out == []
+
+
+def test_blank_reason_is_rejected() -> None:
+    out = _run(
+        """
+from sentry.apidocs.omissions import sentry_schema_serializer
+from rest_framework import serializers
+
+@sentry_schema_serializer(omit_from_public_schema={"secret": "   "})
+class S(serializers.Serializer):
+    secret = serializers.CharField()
+"""
+    )
+    assert len(out) == 1
+    assert "needs a reason" in out[0].message
+
+
+def test_entry_naming_a_nonexistent_field_is_reported() -> None:
+    out = _run(
+        """
+from sentry.apidocs.omissions import sentry_schema_serializer
+from rest_framework import serializers
+
+@sentry_schema_serializer(omit_from_public_schema={"ghost": "Internal, not public surface."})
+class S(serializers.Serializer):
+    real = serializers.CharField()
+"""
+    )
+    assert len(out) == 1
+    assert "names no field" in out[0].message
+
+
+def test_field_inherited_from_an_in_file_base_is_found() -> None:
+    out = _run(
+        """
+from sentry.apidocs.omissions import sentry_schema_serializer
+from rest_framework import serializers
+
+class Base(serializers.Serializer):
+    inherited = serializers.CharField()
+
+@sentry_schema_serializer(omit_from_public_schema={"inherited": "Internal, not public surface."})
+class S(Base):
+    own = serializers.CharField()
+"""
+    )
+    assert out == []
+
+
+def test_class_with_an_out_of_file_base_skips_the_existence_check() -> None:
+    # we cannot enumerate fields we cannot see, so do not guess
+    out = _run(
+        """
+from sentry.apidocs.omissions import sentry_schema_serializer
+from elsewhere import SomeBase
+
+@sentry_schema_serializer(omit_from_public_schema={"unknown": "Internal, not public surface."})
+class S(SomeBase):
+    pass
+"""
+    )
+    assert out == []
+
+
+def test_typeddict_response_keys_are_checked() -> None:
+    out = _run(
+        """
+from typing import TypedDict
+from sentry.apidocs.omissions import sentry_schema_serializer
+
+@sentry_schema_serializer(omit_from_public_schema={"ghost": "Internal."})
+class R(TypedDict):
+    real: str
+"""
+    )
+    assert len(out) == 1
+    assert "names no field" in out[0].message

--- a/tests/sentry/apidocs/test_check_schema_omissions.py
+++ b/tests/sentry/apidocs/test_check_schema_omissions.py
@@ -137,3 +137,57 @@ class R(TypedDict):
     )
     assert len(out) == 1
     assert "names no field" in out[0].message
+
+
+def test_meta_fields_all_skips_the_existence_check() -> None:
+    # Meta.fields = "__all__" means the field set comes from the model
+    out = _run(
+        """
+from sentry.apidocs.omissions import sentry_schema_serializer
+from rest_framework import serializers
+
+@sentry_schema_serializer(omit_from_public_schema={"from_model": "Internal."})
+class S(serializers.Serializer):
+    class Meta:
+        fields = "__all__"
+"""
+    )
+    assert out == []
+
+
+def test_meta_fields_list_is_enumerated() -> None:
+    out = _run(
+        """
+from sentry.apidocs.omissions import sentry_schema_serializer
+from rest_framework import serializers
+
+@sentry_schema_serializer(omit_from_public_schema={"ghost": "Internal."})
+class S(serializers.Serializer):
+    class Meta:
+        fields = ["real", "other"]
+"""
+    )
+    assert len(out) == 1
+    assert "names no field" in out[0].message
+
+
+def test_nested_class_does_not_shadow_a_top_level_one() -> None:
+    # `Inner` nested inside Holder must not be mistaken for a base named Inner
+    out = _run(
+        """
+from sentry.apidocs.omissions import sentry_schema_serializer
+from rest_framework import serializers
+
+class Inner(serializers.Serializer):
+    real = serializers.CharField()
+
+class Holder:
+    class Inner(serializers.Serializer):
+        decoy = serializers.CharField()
+
+@sentry_schema_serializer(omit_from_public_schema={"real": "Internal."})
+class S(Inner):
+    pass
+"""
+    )
+    assert out == []


### PR DESCRIPTION
Closes the door behind the rest of this stack. Withholding a field from the generated schema removes it from every generated SDK, so it has to be a deliberate decision rather than the cheapest way past a failing docs build.

The check rejects bare `exclude_fields`, blank reasons, and entries naming a field that does not exist on the decorated class. It also fails on safelist entries that no longer match, so the list cannot rot.

`SAFELIST` starts **empty**: every exclusion in the tree has been converted by the rest of the stack, so this is a pure ratchet rather than a registry of debt. That is also why it must land last — until the others merge, this check reports the exclusions still on master, which is the correct signal rather than a bug.

Depends on all of: https://github.com/getsentry/sentry/pull/123462, https://github.com/getsentry/sentry/pull/123463, https://github.com/getsentry/sentry/pull/123467, https://github.com/getsentry/sentry/pull/123483, https://github.com/getsentry/sentry/pull/123484, https://github.com/getsentry/sentry/pull/123485, https://github.com/getsentry/sentry/pull/123486, https://github.com/getsentry/sentry/pull/123487, https://github.com/getsentry/sentry/pull/123488, https://github.com/getsentry/sentry/pull/123489