### PR TITLE
fix(dashboards): use accurate sampling for investigations

### DIFF
--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx
@@ -38,6 +38,7 @@ describe('traceMetricsWidgetQueries', () => {
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events-timeseries/',
+      match: [MockApiClient.matchQuery({sampling: 'NORMAL'})],
       body: {
         timeSeries: [
           {
@@ -80,5 +81,61 @@ describe('traceMetricsWidgetQueries', () => {
     );
 
     expect(await screen.findByText('low:30:true:partial')).toBeInTheDocument();
+  });
+
+  it('uses highest accuracy sampling for investigations metrics', async () => {
+    const widget = WidgetFixture({
+      widgetType: WidgetType.TRACEMETRICS,
+      displayType: DisplayType.LINE,
+      queries: [
+        {
+          name: '',
+          aggregates: ['sum(value, investigations.execution.completed, counter, none)'],
+          fields: ['sum(value, investigations.execution.completed, counter, none)'],
+          columns: [],
+          conditions: '',
+          orderby: '',
+        },
+      ],
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      match: [MockApiClient.matchQuery({sampling: 'HIGHEST_ACCURACY'})],
+      body: {
+        timeSeries: [
+          {
+            yAxis: 'sum(value, investigations.execution.completed, counter, none)',
+            meta: {
+              interval: 3600000,
+              valueType: 'integer',
+              valueUnit: null,
+              dataScanned: 'full',
+            },
+            values: [
+              {
+                timestamp: 1,
+                value: 14,
+                confidence: 'high',
+                sampleCount: 14,
+                sampleRate: 1,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    render(
+      <TraceMetricsWidgetQueries widget={widget} dashboardFilters={{}}>
+        {({confidence, sampleCount, isSampled, dataScanned}) => (
+          <div>
+            {confidence}:{sampleCount}:{String(isSampled)}:{dataScanned}
+          </div>
+        )}
+      </TraceMetricsWidgetQueries>
+    );
+
+    expect(await screen.findByText('high:14:false:full')).toBeInTheDocument();
   });
 });

--- a/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx
@@ -3,11 +3,13 @@ import {useCallback, useState} from 'react';
 import type {PageFilters} from 'sentry/types/core';
 import type {Confidence} from 'sentry/types/organization';
 import type {EventsTableData} from 'sentry/utils/discover/discoverQuery';
+import {explodeFieldString} from 'sentry/utils/discover/fields';
 import {getDynamicText} from 'sentry/utils/getDynamicText';
 import {determineSeriesSampleCountAndIsSampled} from 'sentry/utils/timeSeries/determineSeriesSampleCount';
 import type {EventsTimeSeriesResponse} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
 import {TraceMetricsConfig} from 'sentry/views/dashboards/datasetConfig/traceMetrics';
 import type {DashboardFilters, Widget} from 'sentry/views/dashboards/types';
+import {extractTraceMetricFromColumn} from 'sentry/views/dashboards/widgetBuilder/utils/buildTraceMetricAggregate';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
 import {combineConfidenceForSeries} from 'sentry/views/explore/utils';
 
@@ -19,6 +21,24 @@ import {useGenericWidgetQueries} from './genericWidgetQueries';
 
 type SeriesResult = EventsTimeSeriesResponse;
 type TableResult = EventsTableData;
+
+const INVESTIGATIONS_METRIC_PREFIX = 'investigations.';
+
+function getSamplingMode(widget: Widget) {
+  // Investigations emits sparse operational metrics, so normal downsampling can hide
+  // an entire series even when the underlying events are present.
+  const containsInvestigationsMetric = widget.queries.some(query =>
+    query.aggregates.some(aggregate =>
+      extractTraceMetricFromColumn(explodeFieldString(aggregate))?.name.startsWith(
+        INVESTIGATIONS_METRIC_PREFIX
+      )
+    )
+  );
+
+  return containsInvestigationsMetric
+    ? SAMPLING_MODE.HIGH_ACCURACY
+    : SAMPLING_MODE.NORMAL;
+}
 
 type TraceMetricsWidgetQueriesProps = {
   children: (props: GenericWidgetQueriesResult) => React.JSX.Element;
@@ -117,7 +137,7 @@ function TraceMetricsWidgetQueriesSingleRequestImpl({
     onDataFetched,
     onDataFetchStart,
     afterFetchSeriesData,
-    samplingMode: SAMPLING_MODE.NORMAL,
+    samplingMode: getSamplingMode(widget),
     selection,
     widgetInterval,
     yBuckets,


### PR DESCRIPTION
Investigations lifecycle metrics are sparse enough that the dashboard's normal Trace Metrics sampling can omit entire series and heavily extrapolate the few retained samples. In the production Investigations Health dashboard, normal mode returned only a subset of the metric names, while `HIGHEST_ACCURACY` returned the missing starts, completions, durations, and failure metrics.

This changes Trace Metrics dashboard widgets containing an `investigations.*` aggregate to request `HIGHEST_ACCURACY`. Other Trace Metrics widgets continue to use `NORMAL`, limiting the higher query cost to this low-volume operational telemetry.

Tests cover both sampling paths.

Tested with:
- `pnpm test-ci static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx`
- `pnpm run lint:js static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.tsx static/app/views/dashboards/widgetCard/traceMetricsWidgetQueries.spec.tsx`
- `pnpm run typecheck`
- `prek run -q`