### PR TITLE
feat(event formatter): add json output to the shared formatter

### DIFF
--- a/src/sentry/issues/formatting/autofix.py
+++ b/src/sentry/issues/formatting/autofix.py
@@ -1,5 +1,8 @@
-"""Renders a serialized autofix (Seer Issue Fix) state response into text, reusing the shared
-formatter primitives. Delivered over REST via ``FormattableResponseMixin`` on the autofix endpoint.
+"""Builds the sections for a serialized autofix (Seer Issue Fix) state response, reusing the
+shared formatter. Delivered over REST via ``FormattableResponseMixin`` on the autofix endpoint.
+
+Like the event sections, these describe what to render and let the formatter decide how, so the
+autofix response is available in every format the event response is.
 """
 
 from __future__ import annotations
@@ -7,7 +10,15 @@ from __future__ import annotations
 from collections.abc import Mapping
 from typing import Any
 
-from sentry.issues.formatting.formatter import Consumer, Format, Formatter, get_formatter
+from sentry.issues.formatting.formatter import (
+    Consumer,
+    Field,
+    Format,
+    Group,
+    Section,
+    Text,
+    get_formatter,
+)
 
 
 def _artifacts(autofix: Mapping[str, Any]) -> dict[str, Any]:
@@ -21,49 +32,51 @@ def _artifacts(autofix: Mapping[str, Any]) -> dict[str, Any]:
     return result
 
 
-def _root_cause(data: Any, fmt: Formatter) -> str:
+def _root_cause(data: Any) -> Section | None:
     if not data:
-        return ""
-    parts: list[str] = []
+        return None
+    groups: list[Group] = []
     if data.get("one_line_description"):
-        parts.append(data["one_line_description"])
+        groups.append(Group(items=(Text(data["one_line_description"]),)))
     whys = data.get("five_whys") or []
     if whys:
-        parts.append("\n".join(f"{i}. {why}" for i, why in enumerate(whys, 1)))
+        groups.append(
+            Group(items=(Text("\n".join(f"{i}. {why}" for i, why in enumerate(whys, 1))),))
+        )
     steps = data.get("reproduction_steps") or []
     if steps:
-        parts.append("\n".join(f"- {step}" for step in steps))
-    return fmt.block("Root Cause", "\n\n".join(parts)) if parts else ""
+        groups.append(Group(items=(Text("\n".join(f"- {step}" for step in steps)),)))
+    return Section(title="Root Cause", groups=tuple(groups)) if groups else None
 
 
-def _solution(data: Any, fmt: Formatter) -> str:
+def _solution(data: Any) -> Section | None:
     if not data:
-        return ""
-    parts: list[str] = []
+        return None
+    groups: list[Group] = []
     if data.get("one_line_summary"):
-        parts.append(data["one_line_summary"])
-    steps = [
-        fmt.field(step.get("title") or "Step", step.get("description") or "")
+        groups.append(Group(items=(Text(data["one_line_summary"]),)))
+    steps = tuple(
+        Field(step.get("title") or "Step", step.get("description") or "")
         for step in data.get("steps") or []
-    ]
+    )
     if steps:
-        parts.append("\n".join(steps))
-    return fmt.block("Solution", "\n\n".join(parts)) if parts else ""
+        groups.append(Group(items=steps))
+    return Section(title="Solution", groups=tuple(groups)) if groups else None
 
 
-def _pull_requests(autofix: Mapping[str, Any], fmt: Formatter) -> str:
-    lines = [
-        f"- {repo}: {pr['pr_url']}"
+def _pull_requests(autofix: Mapping[str, Any]) -> Section | None:
+    lines = tuple(
+        Text(f"- {repo}: {pr['pr_url']}")
         for repo, pr in (autofix.get("repo_pr_states") or {}).items()
         if pr.get("pr_url")
-    ]
-    return fmt.block("Pull Requests", "\n".join(lines)) if lines else ""
+    )
+    return Section(title="Pull Requests", groups=(Group(items=lines),)) if lines else None
 
 
 def format_autofix(
     data: Mapping[str, Any], format: Format = "markdown", consumer: Consumer = "ui"
 ) -> str:
-    """Render a serialized autofix state response (``{"autofix": {...}}``) into text.
+    """Render a serialized autofix state response (``{"autofix": {...}}``) into text or JSON.
 
     Takes ``consumer`` to satisfy the adapter signature; the autofix body is the same for the UI
     and for API clients, so nothing varies on it yet.
@@ -73,9 +86,10 @@ def format_autofix(
         return ""
     fmt = get_formatter(format)
     artifacts = _artifacts(autofix)
-    parts = [
-        _root_cause(artifacts.get("root_cause"), fmt),
-        _solution(artifacts.get("solution"), fmt),
-        _pull_requests(autofix, fmt),
+    sections = [
+        _root_cause(artifacts.get("root_cause")),
+        _solution(artifacts.get("solution")),
+        _pull_requests(autofix),
     ]
-    return "\n\n".join(part for part in parts if part)
+    rendered = [fmt.render_section(s) for s in sections if s is not None]
+    return fmt.join([part for part in rendered if part])

--- a/src/sentry/issues/formatting/autofix.py
+++ b/src/sentry/issues/formatting/autofix.py
@@ -81,10 +81,12 @@ def format_autofix(
     Takes ``consumer`` to satisfy the adapter signature; the autofix body is the same for the UI
     and for API clients, so nothing varies on it yet.
     """
+    fmt = get_formatter(format)
     autofix = data.get("autofix")
     if not autofix:  # no autofix run on this issue yet
-        return ""
-    fmt = get_formatter(format)
+        # empty has to be valid for the format asked for: "" for the text formats, "{}" for
+        # json. A caller that json.loads the content hits this on every no-run autofix GET.
+        return fmt.join([])
     artifacts = _artifacts(autofix)
     sections = [
         _root_cause(artifacts.get("root_cause")),

--- a/src/sentry/issues/formatting/autofix.py
+++ b/src/sentry/issues/formatting/autofix.py
@@ -1,8 +1,6 @@
 """Builds the sections for a serialized autofix (Seer Issue Fix) state response, reusing the
 shared formatter. Delivered over REST via ``FormattableResponseMixin`` on the autofix endpoint.
-
-Like the event sections, these describe what to render and let the formatter decide how, so the
-autofix response is available in every format the event response is.
+Like the event sections, these describe what to render and let the formatter decide how.
 """
 
 from __future__ import annotations
@@ -84,8 +82,7 @@ def format_autofix(
     fmt = get_formatter(format)
     autofix = data.get("autofix")
     if not autofix:  # no autofix run on this issue yet
-        # empty has to be valid for the format asked for: "" for the text formats, "{}" for
-        # json. A caller that json.loads the content hits this on every no-run autofix GET.
+        # empty still has to parse: "" for the text formats, "{}" for json
         return fmt.join([])
     artifacts = _artifacts(autofix)
     sections = [

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -1,14 +1,8 @@
 """Renders the event model into text or JSON.
 
-Sections return a structured ``Section`` (see ``sections.py``) describing *what* to render;
-formatters decide *how*. Text formats (markdown, xml) supply the syntax primitives
-(``block``/``field``/``code_block``); the JSON format serializes the same structure instead.
-One section list drives every format, so the data a caller gets is identical whichever
-format they ask for -- only the syntax differs.
-
-Size caps live on the structure rather than in the sections, because the two families apply
-them differently: text formats cut a joined body mid-string, JSON drops whole items so the
-result stays parseable.
+Sections describe *what* to render (``sections.py``); formatters decide *how*. One section
+list drives every format, so only the syntax differs between them. Caps live on the structure
+because the families spend them differently: text cuts a joined body, JSON drops whole items.
 """
 
 from __future__ import annotations
@@ -28,10 +22,8 @@ logger = logging.getLogger(__name__)
 
 _TRUNCATED = "... (truncated)"
 
-# ``sentry.utils.json.dumps`` escapes non-ascii, which would make an accented character cost
-# six against the same cap the text formats spend one on -- international events would lose
-# whole sections that an ascii event of the same size keeps. It also leaves the content string
-# full of \uXXXX for anything that reads it without parsing first.
+# ``sentry.utils.json.dumps`` escapes non-ascii, which would spend six of the cap on a
+# character the text formats spend one on, and leave \uXXXX through the content string.
 _ENCODER = json.JSONEncoder(separators=(",", ":"), ignore_nan=True, ensure_ascii=False)
 
 
@@ -78,11 +70,7 @@ def truncate_items(items: Sequence[str], sep: str, max_chars: int | None) -> str
 
 
 def _keep_within(items: Sequence[Any], costs: Sequence[int], max_chars: int | None) -> list[Any]:
-    """The item-dropping half of ``truncate_items``, for formats that keep structure.
-
-    Mirrors its accounting exactly (first item always kept, separator charged from the second
-    on) so JSON drops at the same boundary the text formats do.
-    """
+    """The item-dropping half of ``truncate_items``, for formats that keep structure."""
     if max_chars is None:
         return list(items)
 
@@ -122,7 +110,7 @@ Item = Union[Field, Code, Text]
 
 
 def _item_cost(item: Item) -> int:
-    """Roughly what one item costs in the rendered output, for the drop-whole-items caps."""
+    """Roughly what an item costs once rendered, for the drop-whole-items caps."""
     if isinstance(item, Field):
         return len(item.key) + len(item.value) + 2
     return len(item.text) + 1
@@ -130,15 +118,13 @@ def _item_cost(item: Item) -> int:
 
 @dataclass(frozen=True)
 class Group:
-    """One sub-block of a section: a single exception, a single thread, or the whole body of a
-    section that has no repeating structure. Items render one per line.
+    """One sub-block: a single exception or thread, or a whole body with no repeating
+    structure. Items render one per line.
     """
 
     items: tuple[Item, ...]
-    # cut the joined body at this many characters (text formats) / drop whole items (JSON)
-    max_chars: int | None = None
-    # drop whole items rather than cutting the join, in both families
-    max_item_chars: int | None = None
+    max_chars: int | None = None  # cut the joined body here
+    max_item_chars: int | None = None  # drop whole items instead
 
 
 @dataclass(frozen=True)
@@ -147,10 +133,8 @@ class Section:
 
     title: str
     groups: tuple[Group, ...] = ()
-    # cut the joined body at this many characters (text formats) / drop whole groups (JSON)
-    max_chars: int | None = None
-    # drop whole groups rather than cutting the join, in both families
-    max_group_chars: int | None = None
+    max_chars: int | None = None  # cut the joined body here
+    max_group_chars: int | None = None  # drop whole groups instead
 
 
 SectionFn = Callable[["EventObject", Limits], Union[Section, None]]
@@ -263,15 +247,13 @@ class XmlFormatter(TextFormatter):
 class JsonFormatter(Formatter):
     """Serializes the section structure instead of rendering it to lines.
 
-    A group becomes an object: fields keyed by their slugged name, bare lines under ``text``,
-    preformatted content under ``code``. A section with one group is that object; a section
-    with several (exceptions, threads) is a list of them, so the repeating shape is visible to
-    a consumer rather than implied by blank lines.
+    A group becomes an object: fields under their slugged name, bare lines under ``text``,
+    preformatted content under ``code``. Sections with several groups (exceptions, threads)
+    become a list, so the repeating shape is visible rather than implied by blank lines.
     """
 
     def join(self, sections: Sequence[str]) -> str:
-        # every entry is already a serialized ``{"key": {...}}`` fragment; merging the parsed
-        # objects keeps section order while producing one top-level object
+        # each entry is a serialized ``{"key": {...}}``; merging keeps section order
         merged: dict[str, Any] = {}
         for part in sections:
             merged.update(json.loads(part))
@@ -294,9 +276,8 @@ class JsonFormatter(Formatter):
         return _ENCODER.encode({slug(section.title): payload})
 
     def render_group_object(self, group: Group) -> dict[str, Any]:
-        # drop whole items once the cap is hit, across every item kind. Capping only the free
-        # text would leave an open-ended field list (evidence builds one from
-        # occurrence.evidenceDisplay) unbounded in json while the text formats bound it.
+        # every item kind, not just text: evidence builds an open-ended field list from
+        # occurrence.evidenceDisplay, which the text formats bound and json otherwise would not
         items = [i for i in group.items if not (isinstance(i, Text) and not i.text)]
         cap = group.max_item_chars if group.max_item_chars is not None else group.max_chars
         if cap is not None:

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -28,6 +28,12 @@ logger = logging.getLogger(__name__)
 
 _TRUNCATED = "... (truncated)"
 
+# ``sentry.utils.json.dumps`` escapes non-ascii, which would make an accented character cost
+# six against the same cap the text formats spend one on -- international events would lose
+# whole sections that an ascii event of the same size keeps. It also leaves the content string
+# full of \uXXXX for anything that reads it without parsing first.
+_ENCODER = json.JSONEncoder(separators=(",", ":"), ignore_nan=True, ensure_ascii=False)
+
 
 def slug(title: str) -> str:
     """Turn a human title (e.g. "HTTP Request") into an xml-safe tag ("http_request")."""
@@ -269,7 +275,7 @@ class JsonFormatter(Formatter):
         merged: dict[str, Any] = {}
         for part in sections:
             merged.update(json.loads(part))
-        return json.dumps(merged)
+        return _ENCODER.encode(merged)
 
     def render_section(self, section: Section) -> str:
         groups = [self.render_group_object(group) for group in section.groups]
@@ -279,13 +285,13 @@ class JsonFormatter(Formatter):
 
         cap = section.max_group_chars if section.max_group_chars is not None else section.max_chars
         if cap is not None:
-            costs = [len(json.dumps(g)) for g in groups]
+            costs = [len(_ENCODER.encode(g)) for g in groups]
             groups = _keep_within(groups, costs, cap)
         if not groups:
             return ""
 
         payload: Any = groups[0] if len(groups) == 1 else groups
-        return json.dumps({slug(section.title): payload})
+        return _ENCODER.encode({slug(section.title): payload})
 
     def render_group_object(self, group: Group) -> dict[str, Any]:
         # drop whole items once the cap is hit, across every item kind. Capping only the free

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -1,22 +1,32 @@
-"""Renders the event model into text. Subclasses supply the per-format syntax primitives
-(``block``/``field``/``code_block``); the section list decides what is rendered, so one
-section list drives every format. Sections live in ``sections.py``.
+"""Renders the event model into text or JSON.
+
+Sections return a structured ``Section`` (see ``sections.py``) describing *what* to render;
+formatters decide *how*. Text formats (markdown, xml) supply the syntax primitives
+(``block``/``field``/``code_block``); the JSON format serializes the same structure instead.
+One section list drives every format, so the data a caller gets is identical whichever
+format they ask for -- only the syntax differs.
+
+Size caps live on the structure rather than in the sections, because the two families apply
+them differently: text formats cut a joined body mid-string, JSON drops whole items so the
+result stays parseable.
 """
 
 from __future__ import annotations
 
+import json
 import logging
 import re
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Sequence
-from typing import Literal, TypedDict
+from dataclasses import dataclass
+from typing import Any, Literal, TypedDict, Union
 
 from sentry.issues.formatting.limits import Limits
 from sentry.issues.formatting.models import EventObject
 
 logger = logging.getLogger(__name__)
 
-SectionFn = Callable[["EventObject", "Formatter", Limits], str]
+_TRUNCATED = "... (truncated)"
 
 
 def slug(title: str) -> str:
@@ -29,12 +39,116 @@ def slug(title: str) -> str:
     return name
 
 
+def truncate(text: str, max_chars: int | None) -> str:
+    """Cap a run of plain text. Only for content the formatter has not marked up yet -- use
+    ``truncate_items`` once a body is a join of rendered pieces.
+    """
+    if max_chars is None or len(text) <= max_chars:
+        return text
+    return text[:max_chars].rstrip() + f"\n{_TRUNCATED}"
+
+
+def truncate_items(items: Sequence[str], sep: str, max_chars: int | None) -> str:
+    """Join rendered pieces, dropping whole ones once the cap is hit.
+
+    Slicing a joined body mid-way would cut through a tag a section already emitted and leave
+    the output unparseable, so entire items go instead.
+    """
+    if max_chars is None:
+        return sep.join(items)
+
+    kept: list[str] = []
+    total = 0
+    for item in items:
+        cost = len(item) + (len(sep) if kept else 0)
+        # always keep the first piece: a section rendering nothing but "(truncated)" has lost
+        # its content entirely, which is worse than overshooting the cap once
+        if kept and total + cost > max_chars:
+            kept.append(_TRUNCATED)
+            break
+        kept.append(item)
+        total += cost
+    return sep.join(kept)
+
+
+def _keep_within(items: Sequence[Any], costs: Sequence[int], max_chars: int | None) -> list[Any]:
+    """The item-dropping half of ``truncate_items``, for formats that keep structure.
+
+    Mirrors its accounting exactly (first item always kept, separator charged from the second
+    on) so JSON drops at the same boundary the text formats do.
+    """
+    if max_chars is None:
+        return list(items)
+
+    kept: list[Any] = []
+    total = 0
+    for item, cost in zip(items, costs):
+        if kept and total + cost > max_chars:
+            break
+        kept.append(item)
+        total += cost
+    return kept
+
+
+@dataclass(frozen=True)
+class Field:
+    """A key/value pair. ``**Key:** value`` in markdown, ``<key>value</key>`` in xml."""
+
+    key: str
+    value: str
+
+
+@dataclass(frozen=True)
+class Code:
+    """Preformatted content -- a stacktrace, a request body."""
+
+    text: str
+
+
+@dataclass(frozen=True)
+class Text:
+    """A bare line carrying no key of its own (an exception header, a breadcrumb)."""
+
+    text: str
+
+
+Item = Union[Field, Code, Text]
+
+
+@dataclass(frozen=True)
+class Group:
+    """One sub-block of a section: a single exception, a single thread, or the whole body of a
+    section that has no repeating structure. Items render one per line.
+    """
+
+    items: tuple[Item, ...]
+    # cut the joined body at this many characters (text formats) / drop whole items (JSON)
+    max_chars: int | None = None
+    # drop whole items rather than cutting the join, in both families
+    max_item_chars: int | None = None
+
+
+@dataclass(frozen=True)
+class Section:
+    """One titled block of output. Groups render separated by a blank line."""
+
+    title: str
+    groups: tuple[Group, ...] = ()
+    # cut the joined body at this many characters (text formats) / drop whole groups (JSON)
+    max_chars: int | None = None
+    # drop whole groups rather than cutting the join, in both families
+    max_group_chars: int | None = None
+
+
+SectionFn = Callable[["EventObject", Limits], Union[Section, None]]
+
+
 class Formatter(ABC):
     def render(self, model: EventObject, sections: Sequence[SectionFn], limits: Limits) -> str:
-        parts: list[str] = []
+        rendered: list[str] = []
         for section in sections:
             try:
-                body = section(model, self, limits)
+                built = section(model, limits)
             except Exception:
                 # one malformed section must not sink the whole output, so this handler must
                 # not raise either: a section need only be callable, not a named function
@@ -43,11 +157,58 @@ class Formatter(ABC):
                     extra={"section": getattr(section, "__name__", repr(section))},
                 )
                 continue
+            if built is None or not built.groups:
+                continue
+            try:
+                body = self.render_section(built)
+            except Exception:
+                logger.exception("formatter.section_render_failed", extra={"section": built.title})
+                continue
             if body:
-                parts.append(body)
-        return "\n\n".join(parts)
+                rendered.append(body)
+        return self.join(rendered)
 
-    # syntax primitives: the only thing that differs per format
+    @abstractmethod
+    def render_section(self, section: Section) -> str: ...
+
+    @abstractmethod
+    def join(self, sections: Sequence[str]) -> str: ...
+
+
+class TextFormatter(Formatter):
+    """Shared assembly for the line-oriented formats. Subclasses supply only the syntax."""
+
+    def join(self, sections: Sequence[str]) -> str:
+        return "\n\n".join(sections)
+
+    def render_section(self, section: Section) -> str:
+        groups = [self.render_group(group) for group in section.groups]
+        groups = [g for g in groups if g]
+        if not groups:
+            return ""
+        if section.max_group_chars is not None:
+            body = truncate_items(groups, "\n\n", section.max_group_chars)
+        else:
+            body = truncate("\n\n".join(groups), section.max_chars)
+        return self.block(section.title, body)
+
+    def render_group(self, group: Group) -> str:
+        lines = [self.render_item(item) for item in group.items]
+        lines = [line for line in lines if line]
+        if not lines:
+            return ""
+        if group.max_item_chars is not None:
+            return truncate_items(lines, "\n", group.max_item_chars)
+        return truncate("\n".join(lines), group.max_chars)
+
+    def render_item(self, item: Item) -> str:
+        if isinstance(item, Field):
+            return self.field(item.key, item.value)
+        if isinstance(item, Code):
+            return self.code_block(item.text)
+        return item.text
+
+    # syntax primitives: the only thing that differs per text format
     @abstractmethod
     def block(self, title: str, body: str) -> str: ...
 
@@ -58,7 +219,7 @@ class Formatter(ABC):
     def code_block(self, text: str) -> str: ...
 
 
-class MarkdownFormatter(Formatter):
+class MarkdownFormatter(TextFormatter):
     def block(self, title: str, body: str) -> str:
         return f"## {title}\n{body}"
 
@@ -73,7 +234,7 @@ class MarkdownFormatter(Formatter):
         return f"{fence}\n{text}\n{fence}"
 
 
-class XmlFormatter(Formatter):
+class XmlFormatter(TextFormatter):
     def block(self, title: str, body: str) -> str:
         tag = slug(title)
         return f"<{tag}>\n{body}\n</{tag}>"
@@ -86,7 +247,67 @@ class XmlFormatter(Formatter):
         return f"<code>{text}</code>"
 
 
-Format = Literal["markdown", "xml"]
+class JsonFormatter(Formatter):
+    """Serializes the section structure instead of rendering it to lines.
+
+    A group becomes an object: fields keyed by their slugged name, bare lines under ``text``,
+    preformatted content under ``code``. A section with one group is that object; a section
+    with several (exceptions, threads) is a list of them, so the repeating shape is visible to
+    a consumer rather than implied by blank lines.
+    """
+
+    def join(self, sections: Sequence[str]) -> str:
+        # every entry is already a serialized ``{"key": {...}}`` fragment; merging the parsed
+        # objects keeps section order while producing one top-level object
+        merged: dict[str, Any] = {}
+        for part in sections:
+            merged.update(json.loads(part))
+        return json.dumps(merged, ensure_ascii=False)
+
+    def render_section(self, section: Section) -> str:
+        groups = [self.render_group_object(group) for group in section.groups]
+        groups = [g for g in groups if g]
+        if not groups:
+            return ""
+
+        cap = section.max_group_chars if section.max_group_chars is not None else section.max_chars
+        if cap is not None:
+            costs = [len(json.dumps(g, ensure_ascii=False)) for g in groups]
+            groups = _keep_within(groups, costs, cap)
+        if not groups:
+            return ""
+
+        payload: Any = groups[0] if len(groups) == 1 else groups
+        return json.dumps({slug(section.title): payload}, ensure_ascii=False)
+
+    def render_group_object(self, group: Group) -> dict[str, Any]:
+        fields: dict[str, Any] = {}
+        text: list[str] = []
+        code: list[str] = []
+        for item in group.items:
+            if isinstance(item, Field):
+                fields[slug(item.key)] = item.value
+            elif isinstance(item, Code):
+                code.append(item.text)
+            elif item.text:
+                text.append(item.text)
+
+        cap = group.max_item_chars if group.max_item_chars is not None else group.max_chars
+        if cap is not None and text:
+            # only the free-text runs are open-ended enough to need the cap; fields and code
+            # are already bounded by the section that built them
+            costs = [len(line) + 1 for line in text]
+            text = _keep_within(text, costs, cap)
+
+        obj: dict[str, Any] = dict(fields)
+        if text:
+            obj["text"] = text[0] if len(text) == 1 else text
+        if code:
+            obj["code"] = code[0] if len(code) == 1 else code
+        return obj
+
+
+Format = Literal["markdown", "xml", "json"]
 
 # Who the output is being rendered for. The UI and API clients ramp on separate features and
 # want different sections from the same endpoint, so adapters take this alongside the format.
@@ -94,7 +315,11 @@ Consumer = Literal["ui", "api"]
 
 
 class FormattedResponse(TypedDict):
-    """The ``formatted`` field the mixin adds to a response when ``?llmFormat`` is requested."""
+    """The ``formatted`` field the mixin adds to a response when ``?llmFormat`` is requested.
+
+    ``content`` is text for the text formats and a serialized JSON object for ``json``, so the
+    response shape is the same whichever format a caller asks for.
+    """
 
     format: Format
     content: str
@@ -103,6 +328,7 @@ class FormattedResponse(TypedDict):
 _FORMATTERS: dict[Format, type[Formatter]] = {
     "markdown": MarkdownFormatter,
     "xml": XmlFormatter,
+    "json": JsonFormatter,
 }
 
 

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -115,6 +115,13 @@ class Text:
 Item = Union[Field, Code, Text]
 
 
+def _item_cost(item: Item) -> int:
+    """Roughly what one item costs in the rendered output, for the drop-whole-items caps."""
+    if isinstance(item, Field):
+        return len(item.key) + len(item.value) + 2
+    return len(item.text) + 1
+
+
 @dataclass(frozen=True)
 class Group:
     """One sub-block of a section: a single exception, a single thread, or the whole body of a
@@ -281,23 +288,24 @@ class JsonFormatter(Formatter):
         return json.dumps({slug(section.title): payload})
 
     def render_group_object(self, group: Group) -> dict[str, Any]:
+        # drop whole items once the cap is hit, across every item kind. Capping only the free
+        # text would leave an open-ended field list (evidence builds one from
+        # occurrence.evidenceDisplay) unbounded in json while the text formats bound it.
+        items = [i for i in group.items if not (isinstance(i, Text) and not i.text)]
+        cap = group.max_item_chars if group.max_item_chars is not None else group.max_chars
+        if cap is not None:
+            items = _keep_within(items, [_item_cost(i) for i in items], cap)
+
         fields: dict[str, Any] = {}
         text: list[str] = []
         code: list[str] = []
-        for item in group.items:
+        for item in items:
             if isinstance(item, Field):
                 fields[slug(item.key)] = item.value
             elif isinstance(item, Code):
                 code.append(item.text)
-            elif item.text:
+            else:
                 text.append(item.text)
-
-        cap = group.max_item_chars if group.max_item_chars is not None else group.max_chars
-        if cap is not None and text:
-            # only the free-text runs are open-ended enough to need the cap; fields and code
-            # are already bounded by the section that built them
-            costs = [len(line) + 1 for line in text]
-            text = _keep_within(text, costs, cap)
 
         obj: dict[str, Any] = dict(fields)
         if text:

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -13,7 +13,6 @@ result stays parseable.
 
 from __future__ import annotations
 
-import json
 import logging
 import re
 from abc import ABC, abstractmethod
@@ -23,6 +22,7 @@ from typing import Any, Literal, TypedDict, Union
 
 from sentry.issues.formatting.limits import Limits
 from sentry.issues.formatting.models import EventObject
+from sentry.utils import json
 
 logger = logging.getLogger(__name__)
 
@@ -262,7 +262,7 @@ class JsonFormatter(Formatter):
         merged: dict[str, Any] = {}
         for part in sections:
             merged.update(json.loads(part))
-        return json.dumps(merged, ensure_ascii=False)
+        return json.dumps(merged)
 
     def render_section(self, section: Section) -> str:
         groups = [self.render_group_object(group) for group in section.groups]
@@ -272,13 +272,13 @@ class JsonFormatter(Formatter):
 
         cap = section.max_group_chars if section.max_group_chars is not None else section.max_chars
         if cap is not None:
-            costs = [len(json.dumps(g, ensure_ascii=False)) for g in groups]
+            costs = [len(json.dumps(g)) for g in groups]
             groups = _keep_within(groups, costs, cap)
         if not groups:
             return ""
 
         payload: Any = groups[0] if len(groups) == 1 else groups
-        return json.dumps({slug(section.title): payload}, ensure_ascii=False)
+        return json.dumps({slug(section.title): payload})
 
     def render_group_object(self, group: Group) -> dict[str, Any]:
         fields: dict[str, Any] = {}

--- a/src/sentry/issues/formatting/sections.py
+++ b/src/sentry/issues/formatting/sections.py
@@ -1,9 +1,6 @@
 """Section functions (each builds one block), the default section order (``EVENT_SECTIONS``),
-and the public ``format_issue`` entry point.
-
-Sections decide *what* goes in a block and how much of it; the formatter decides how that
-renders. A section returns ``None`` when it has nothing to say, so the same list can drive
-every format without each one re-deciding what to include.
+and the public ``format_issue`` entry point. Sections decide what goes in a block and how much
+of it; the formatter decides how it renders. A section with nothing to say returns ``None``.
 """
 
 from __future__ import annotations
@@ -293,10 +290,9 @@ def spans_section(model: EventObject, limits: Limits) -> Section | None:
 def evidence_section(model: EventObject, limits: Limits) -> Section | None:
     if not model.evidence:
         return None
-    # occurrence.evidenceDisplay is an arbitrary-length list of arbitrary-length pairs, so it
-    # needs the same cap the other open-ended sections get.
-    # Cap each value before marking it up -- the item cap always keeps the first piece, so a
-    # single oversized value would otherwise carry the whole section past the cap.
+    # evidenceDisplay is arbitrary-length pairs, so it needs the same cap the other open-ended
+    # sections get. Cap each value first: the item cap always keeps the first piece, so one
+    # oversized value would otherwise carry the section past the cap.
     items = tuple(
         Field(name, truncate(value, limits.max_evidence_chars)) for name, value in model.evidence
     )
@@ -371,7 +367,6 @@ def format_issue(
         model = event_response_to_model(data)
     except Exception:
         logger.exception("formatter.adapter_failed")
-        # same as the per-section handler: degrade to an empty render, but one the requested
-        # format can actually parse
+        # degrade to an empty render the requested format can still parse
         return formatter.join([])
     return formatter.render(model, sections, limits)

--- a/src/sentry/issues/formatting/sections.py
+++ b/src/sentry/issues/formatting/sections.py
@@ -371,5 +371,7 @@ def format_issue(
         model = event_response_to_model(data)
     except Exception:
         logger.exception("formatter.adapter_failed")
-        return ""
+        # same as the per-section handler: degrade to an empty render, but one the requested
+        # format can actually parse
+        return formatter.join([])
     return formatter.render(model, sections, limits)

--- a/src/sentry/issues/formatting/sections.py
+++ b/src/sentry/issues/formatting/sections.py
@@ -1,5 +1,9 @@
-"""Section functions (each renders one block), the default section order (``EVENT_SECTIONS``),
-and the public ``format_issue`` entry point. Sections apply the size caps as they render.
+"""Section functions (each builds one block), the default section order (``EVENT_SECTIONS``),
+and the public ``format_issue`` entry point.
+
+Sections decide *what* goes in a block and how much of it; the formatter decides how that
+renders. A section returns ``None`` when it has nothing to say, so the same list can drive
+every format without each one re-deciding what to include.
 """
 
 from __future__ import annotations
@@ -10,46 +14,21 @@ from datetime import UTC
 from typing import Any
 
 from sentry.issues.formatting.adapter import event_response_to_model
-from sentry.issues.formatting.formatter import Format, Formatter, SectionFn, get_formatter
+from sentry.issues.formatting.formatter import (
+    Code,
+    Field,
+    Format,
+    Group,
+    Section,
+    SectionFn,
+    Text,
+    get_formatter,
+    truncate,
+)
 from sentry.issues.formatting.limits import LIMITS_DEFAULT, Limits
 from sentry.issues.formatting.models import EventObject, Frame, Stacktrace, contains_filtered
 
 logger = logging.getLogger(__name__)
-
-
-_TRUNCATED = "... (truncated)"
-
-
-def _truncate(text: str, max_chars: int | None) -> str:
-    """Cap a run of plain text. Only for content the formatter has not marked up yet -- use
-    ``_truncate_items`` once a body is a join of rendered pieces.
-    """
-    if max_chars is None or len(text) <= max_chars:
-        return text
-    return text[:max_chars].rstrip() + f"\n{_TRUNCATED}"
-
-
-def _truncate_items(items: Sequence[str], sep: str, max_chars: int | None) -> str:
-    """Join rendered pieces, dropping whole ones once the cap is hit.
-
-    Slicing a joined body mid-way would cut through a tag a section already emitted and leave
-    the output unparseable, so entire items go instead.
-    """
-    if max_chars is None:
-        return sep.join(items)
-
-    kept: list[str] = []
-    total = 0
-    for item in items:
-        cost = len(item) + (len(sep) if kept else 0)
-        # always keep the first piece: a section rendering nothing but "(truncated)" has lost
-        # its content entirely, which is worse than overshooting the cap once
-        if kept and total + cost > max_chars:
-            kept.append(_TRUNCATED)
-            break
-        kept.append(item)
-        total += cost
-    return sep.join(kept)
 
 
 def _render_frame(frame: Frame) -> str:
@@ -114,76 +93,88 @@ def _render_stacktrace(stacktrace: Stacktrace, limits: Limits) -> str:
     # most-recent frame first, capped to max_frames
     frames = reversed(_select_frames(stacktrace.frames, limits.max_frames))
     body = "\n------\n".join(_render_frame(f) for f in frames)
-    return _truncate(body, limits.max_stacktrace_chars)
+    return truncate(body, limits.max_stacktrace_chars)
 
 
-def exceptions_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def exceptions_section(model: EventObject, limits: Limits) -> Section | None:
     if not model.exceptions:
-        return ""
+        return None
 
-    blocks: list[str] = []
+    groups: list[Group] = []
     for exc in model.exceptions:
         header = ": ".join(p for p in (exc.type, exc.value) if p) or "Error"
-        parts = [header]
+        items: list[Any] = [Text(header)]
         if exc.is_handled is not None:
-            parts.append(fmt.field("Handled", "Yes" if exc.is_handled else "No"))
+            items.append(Field("Handled", "Yes" if exc.is_handled else "No"))
         if exc.stacktrace and exc.stacktrace.frames:
-            parts.append(fmt.code_block(_render_stacktrace(exc.stacktrace, limits)))
-        blocks.append("\n".join(parts))
+            items.append(Code(_render_stacktrace(exc.stacktrace, limits)))
+        groups.append(Group(items=tuple(items)))
 
-    body = _truncate_items(blocks, "\n\n", limits.max_exceptions_chars)
-    return fmt.block("Exception", body)
+    return Section(
+        title="Exception",
+        groups=tuple(groups),
+        max_group_chars=limits.max_exceptions_chars,
+    )
 
 
-def stacktrace_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def stacktrace_section(model: EventObject, limits: Limits) -> Section | None:
     # frames from a bare ``stacktrace`` entry; exception-owned stacktraces render above
     st = model.stacktrace
     if not (st and st.frames):
-        return ""
-    return fmt.block("Stacktrace", fmt.code_block(_render_stacktrace(st, limits)))
+        return None
+    return Section(
+        title="Stacktrace",
+        groups=(Group(items=(Code(_render_stacktrace(st, limits)),)),),
+    )
 
 
-def title_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def title_section(model: EventObject, limits: Limits) -> Section | None:
     # transaction and date belong on the title line rather than blocks of their own
-    lines = [model.title]
+    items: list[Any] = [Text(model.title)]
     if model.transaction_name:
-        lines.append(fmt.field("Transaction", model.transaction_name))
+        items.append(Field("Transaction", model.transaction_name))
     if model.culprit:
-        lines.append(fmt.field("Culprit", model.culprit))
+        items.append(Field("Culprit", model.culprit))
     if model.timestamp:
-        lines.append(
-            fmt.field("Date", model.timestamp.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC"))
+        items.append(
+            Field("Date", model.timestamp.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC"))
         )
-    return fmt.block("Title", "\n".join(lines))
+    return Section(title="Title", groups=(Group(items=tuple(items)),))
 
 
-def message_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def message_section(model: EventObject, limits: Limits) -> Section | None:
     # only render the message when it adds something beyond the title
     if not model.message or model.message in model.title:
-        return ""
-    return fmt.block("Message", model.message)
+        return None
+    return Section(title="Message", groups=(Group(items=(Text(model.message),)),))
 
 
-def detection_context_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def detection_context_section(model: EventObject, limits: Limits) -> Section | None:
     # why a detector opened the issue; only detector-backed issue types carry it
     if not model.detection_context:
-        return ""
-    return fmt.block("Detection Context", model.detection_context)
+        return None
+    return Section(
+        title="Detection Context",
+        groups=(Group(items=(Text(model.detection_context),)),),
+    )
 
 
-def troubleshooting_hint_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def troubleshooting_hint_section(model: EventObject, limits: Limits) -> Section | None:
     if not model.troubleshooting_hint:
-        return ""
-    return fmt.block("Troubleshooting Hint", model.troubleshooting_hint)
+        return None
+    return Section(
+        title="Troubleshooting Hint",
+        groups=(Group(items=(Text(model.troubleshooting_hint),)),),
+    )
 
 
-def breadcrumbs_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def breadcrumbs_section(model: EventObject, limits: Limits) -> Section | None:
     # a zero cap has to bail here: the slice below is ``[-0:]`` at that point, which is ``[0:]``
     # and would render every breadcrumb instead of none
     if not model.breadcrumbs or not limits.max_breadcrumbs:
-        return ""
+        return None
 
-    lines: list[str] = []
+    lines: list[Any] = []
     for crumb in model.breadcrumbs[-limits.max_breadcrumbs :]:  # most recent N
         if contains_filtered(crumb.message) or contains_filtered(crumb.data):
             continue
@@ -193,71 +184,74 @@ def breadcrumbs_section(model: EventObject, fmt: Formatter, limits: Limits) -> s
         if crumb.data:
             line += f" {crumb.data}"
         if line:
-            lines.append(_truncate(line, limits.max_single_breadcrumb_chars))
+            lines.append(Text(truncate(line, limits.max_single_breadcrumb_chars)))
 
     if not lines:
-        return ""
-    return fmt.block("Breadcrumbs", _truncate("\n".join(lines), limits.max_breadcrumbs_chars))
+        return None
+    return Section(
+        title="Breadcrumbs",
+        groups=(Group(items=tuple(lines), max_chars=limits.max_breadcrumbs_chars),),
+    )
 
 
-def request_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def request_section(model: EventObject, limits: Limits) -> Section | None:
     req = model.request
     if not req or not (req.method or req.url or req.data):
-        return ""
+        return None
 
-    parts: list[str] = []
+    items: list[Any] = []
     if req.method or req.url:
-        parts.append(f"{req.method or ''} {req.url or ''}".strip())
+        items.append(Text(f"{req.method or ''} {req.url or ''}".strip()))
     if req.data:
-        parts.append(fmt.code_block(_truncate(str(req.data), limits.max_request_chars)))
-    return fmt.block("Request", "\n".join(parts))
+        items.append(Code(truncate(str(req.data), limits.max_request_chars)))
+    return Section(title="Request", groups=(Group(items=tuple(items)),))
 
 
-def csp_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def csp_section(model: EventObject, limits: Limits) -> Section | None:
     csp = model.csp
     if not csp:
-        return ""
+        return None
     fields = {
         "Blocked": csp.blocked_uri,
         "Directive": csp.effective_directive,
         "Document": csp.document_uri,
     }
-    present = [fmt.field(k, v) for k, v in fields.items() if v]
+    present = tuple(Field(k, v) for k, v in fields.items() if v)
     if not present:
-        return ""
-    return fmt.block("CSP", "\n".join(present))
+        return None
+    return Section(title="CSP", groups=(Group(items=present),))
 
 
-def tags_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def tags_section(model: EventObject, limits: Limits) -> Section | None:
     # ingest derives a `sentry:user` tag from the EventUser and the serializer exposes it as
     # plain `user` ("email:someone@example.com"), so leaving it here would put an identifier in
     # the default output that ``user_section`` is held back to keep out. It carries nothing
     # ``user_section`` doesn't render properly for the callers that do opt in.
     tags = [(key, value) for key, value in model.tags if key != "user"]
     if not tags:
-        return ""
-    body = "\n".join(fmt.field(key, value or "") for key, value in tags)
-    return fmt.block("Tags", body)
+        return None
+    items = tuple(Field(key, value or "") for key, value in tags)
+    return Section(title="Tags", groups=(Group(items=items),))
 
 
-def user_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def user_section(model: EventObject, limits: Limits) -> Section | None:
     user = model.user
     if not user:
-        return ""
+        return None
     fields = {
         "ID": user.id,
         "Email": user.email,
         "Username": user.username,
         "IP": user.ip_address,
     }
-    present = [fmt.field(k, v) for k, v in fields.items() if v]
+    present = tuple(Field(k, v) for k, v in fields.items() if v)
     if not present:
-        return ""
-    return fmt.block("User", "\n".join(present))
+        return None
+    return Section(title="User", groups=(Group(items=present),))
 
 
-def threads_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
-    blocks: list[str] = []
+def threads_section(model: EventObject, limits: Limits) -> Section | None:
+    groups: list[Group] = []
     for thread in model.threads:
         # only threads that carry a stacktrace are worth rendering
         st = thread.stacktrace
@@ -265,58 +259,67 @@ def threads_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
             continue
         # checked before appending, not after: testing at the bottom lets a zero cap through
         # with one thread already rendered
-        if len(blocks) >= limits.max_threads:  # bound total output by thread count
+        if len(groups) >= limits.max_threads:  # bound total output by thread count
             break
         label = thread.name or (str(thread.id) if thread.id is not None else "Thread")
-        parts = [label]
+        items: list[Any] = [Text(label)]
         if thread.crashed:
-            parts.append(fmt.field("Crashed", "Yes"))
-        parts.append(fmt.code_block(_render_stacktrace(st, limits)))
-        blocks.append("\n".join(parts))
+            items.append(Field("Crashed", "Yes"))
+        items.append(Code(_render_stacktrace(st, limits)))
+        groups.append(Group(items=tuple(items)))
 
-    if not blocks:
-        return ""
-    return fmt.block("Threads", "\n\n".join(blocks))
+    if not groups:
+        return None
+    return Section(title="Threads", groups=tuple(groups))
 
 
-def spans_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
-    lines: list[str] = []
+def spans_section(model: EventObject, limits: Limits) -> Section | None:
+    lines: list[Any] = []
     for span in model.spans:
         label = ": ".join(p for p in (span.op, span.description) if p)
         timing = f" ({span.exclusive_time}ms)" if span.exclusive_time is not None else ""
         line = f"{label}{timing}".strip()
         if line:
-            lines.append(line)
+            lines.append(Text(line))
 
     if not lines:
-        return ""
-    return fmt.block("Span Evidence", _truncate("\n".join(lines), limits.max_spans_chars))
+        return None
+    return Section(
+        title="Span Evidence",
+        groups=(Group(items=tuple(lines), max_chars=limits.max_spans_chars),),
+    )
 
 
-def evidence_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+def evidence_section(model: EventObject, limits: Limits) -> Section | None:
     if not model.evidence:
-        return ""
+        return None
     # occurrence.evidenceDisplay is an arbitrary-length list of arbitrary-length pairs, so it
     # needs the same cap the other open-ended sections get.
-    # Cap each value before marking it up -- _truncate_items always keeps the first piece, so a
+    # Cap each value before marking it up -- the item cap always keeps the first piece, so a
     # single oversized value would otherwise carry the whole section past the cap.
-    rendered = [
-        fmt.field(name, _truncate(value, limits.max_evidence_chars))
-        for name, value in model.evidence
-    ]
-    return fmt.block("Evidence", _truncate_items(rendered, "\n", limits.max_evidence_chars))
+    items = tuple(
+        Field(name, truncate(value, limits.max_evidence_chars)) for name, value in model.evidence
+    )
+    return Section(
+        title="Evidence",
+        groups=(Group(items=items, max_item_chars=limits.max_evidence_chars),),
+    )
 
 
-def contexts_section(model: EventObject, fmt: Formatter, limits: Limits) -> str:
-    groups: list[str] = []
+def contexts_section(model: EventObject, limits: Limits) -> Section | None:
+    groups: list[Group] = []
     for name, data in model.contexts.items():
         # drop the redundant "type" key each context echoes (e.g. browser -> type: "browser")
         fields = [f"{key}: {value}" for key, value in data.items() if key != "type"]
         if fields:
-            groups.append("\n".join([name, *fields]))
+            groups.append(Group(items=(Text(name), *(Text(f) for f in fields))))
     if not groups:
-        return ""
-    return fmt.block("Contexts", _truncate("\n\n".join(groups), limits.max_contexts_chars))
+        return None
+    return Section(
+        title="Contexts",
+        groups=tuple(groups),
+        max_chars=limits.max_contexts_chars,
+    )
 
 
 # every section in render order, including the user identifiers that ``EVENT_SECTIONS`` holds
@@ -358,7 +361,7 @@ def format_issue(
     sections: Sequence[SectionFn] = EVENT_SECTIONS,
     limits: Limits = LIMITS_DEFAULT,
 ) -> str:
-    """Render a serialized event into text. The single path used by every consumer.
+    """Render a serialized event into text or JSON. The single path used by every consumer.
 
     Returns "" when the payload can't be adapted, matching how ``Formatter.render`` absorbs
     per-section failures, so a malformed event never takes down the caller.

--- a/tests/sentry/issues/formatting/test_autofix.py
+++ b/tests/sentry/issues/formatting/test_autofix.py
@@ -94,3 +94,10 @@ def test_latest_artifact_per_key_wins() -> None:
     out = format_autofix(data)
     assert "new" in out
     assert "old" not in out
+
+
+def test_no_autofix_run_still_renders_valid_json() -> None:
+    # the common no-run GET: "" is not parseable json, so a caller that json.loads the
+    # formatted content would fail on it
+    assert format_autofix({}, "json") == "{}"
+    assert format_autofix({}, "markdown") == ""

--- a/tests/sentry/issues/formatting/test_formatter.py
+++ b/tests/sentry/issues/formatting/test_formatter.py
@@ -11,6 +11,7 @@ from sentry.issues.formatting.formatter import (
     JsonFormatter,
     MarkdownFormatter,
     Section,
+    SectionFn,
     Text,
     XmlFormatter,
     slug,
@@ -243,7 +244,7 @@ def test_json_does_not_escape_non_ascii() -> None:
 
 def test_unicode_costs_the_same_against_the_cap_as_ascii() -> None:
     # the cap is a character budget; a format must not count one character as six
-    def section(chars: str):
+    def section(chars: str) -> SectionFn:
         return lambda model, limits: Section(
             title="Evidence",
             groups=tuple(Group(items=(Field(f"k{i}", chars * 10),)) for i in range(20)),

--- a/tests/sentry/issues/formatting/test_formatter.py
+++ b/tests/sentry/issues/formatting/test_formatter.py
@@ -1,11 +1,17 @@
 import functools
+import json
 from xml.etree import ElementTree
 
 import pytest
 
 from sentry.issues.formatting.formatter import (
-    Formatter,
+    Code,
+    Field,
+    Group,
+    JsonFormatter,
     MarkdownFormatter,
+    Section,
+    Text,
     XmlFormatter,
     slug,
 )
@@ -15,15 +21,15 @@ from sentry.issues.formatting.models import (
 )
 
 
-def title_section(model: EventObject, fmt: Formatter, limits: object) -> str:
-    return fmt.block("Title", model.title)
+def title_section(model: EventObject, limits: object) -> Section | None:
+    return Section(title="Title", groups=(Group(items=(Text(model.title),)),))
 
 
-def empty_section(model: EventObject, fmt: Formatter, limits: object) -> str:
-    return ""
+def empty_section(model: EventObject, limits: object) -> Section | None:
+    return None
 
 
-def boom_section(model: EventObject, fmt: Formatter, limits: object) -> str:
+def boom_section(model: EventObject, limits: object) -> Section | None:
     raise ValueError("boom")
 
 
@@ -91,16 +97,16 @@ def test_code_fence_outruns_backticks_in_content(text: str, expected_fence: str)
 def test_failing_section_without_a_name_does_not_escape() -> None:
     # the handler exists so one bad section can't sink the render; reading __name__ off an
     # arbitrary callable would make the handler itself raise
-    def boom(model: EventObject, fmt: Formatter, limits: Limits) -> str:
+    def boom(model: EventObject, limits: Limits) -> Section | None:
         raise ValueError("boom")
 
-    def ok(model: EventObject, fmt: Formatter, limits: Limits) -> str:
-        return "survived"
+    def ok(model: EventObject, limits: Limits) -> Section | None:
+        return Section(title="Ok", groups=(Group(items=(Text("survived"),)),))
 
     out = MarkdownFormatter().render(
         EventObject(title="t"), [functools.partial(boom), ok], LIMITS_DEFAULT
     )
-    assert out == "survived"
+    assert out == "## Ok\nsurvived"
 
 
 @pytest.mark.parametrize("key", ["123abc", "\U0001f525", "###", "", "  ", "-x-"])
@@ -109,3 +115,69 @@ def test_slug_always_yields_a_legal_xml_name(key: str) -> None:
     # start with a digit; either would emit <> or <123> and break the parse
     out = XmlFormatter().field(key, "v")
     ElementTree.fromstring(f"<r>{out}</r>")
+
+
+def _fields_section(model: EventObject, limits: object) -> Section | None:
+    return Section(
+        title="HTTP Request",
+        groups=(Group(items=(Text("GET /x"), Field("Method", "GET"), Code("body"))),),
+    )
+
+
+def _repeating_section(model: EventObject, limits: object) -> Section | None:
+    return Section(
+        title="Exception",
+        groups=(
+            Group(items=(Text("ValueError: a"),)),
+            Group(items=(Text("KeyError: b"),)),
+        ),
+    )
+
+
+def test_json_renders_a_section_as_an_object() -> None:
+    out = JsonFormatter().render(EventObject(title="t"), [_fields_section], LIMITS_DEFAULT)
+    assert json.loads(out) == {"http_request": {"method": "GET", "text": "GET /x", "code": "body"}}
+
+
+def test_json_renders_repeating_groups_as_a_list() -> None:
+    # the shape a consumer keys off has to be visible, not implied by blank lines the way it is
+    # in the text formats
+    out = JsonFormatter().render(EventObject(title="t"), [_repeating_section], LIMITS_DEFAULT)
+    assert json.loads(out) == {"exception": [{"text": "ValueError: a"}, {"text": "KeyError: b"}]}
+
+
+def test_json_merges_sections_into_one_object() -> None:
+    out = JsonFormatter().render(
+        EventObject(title="boom"), [title_section, _fields_section], LIMITS_DEFAULT
+    )
+    parsed = json.loads(out)
+    assert list(parsed) == ["title", "http_request"]  # section order preserved
+
+
+def test_json_skips_empty_and_failing_sections() -> None:
+    out = JsonFormatter().render(
+        EventObject(title="t"), [empty_section, boom_section, title_section], LIMITS_DEFAULT
+    )
+    assert json.loads(out) == {"title": {"text": "t"}}
+
+
+def test_json_output_is_always_parseable() -> None:
+    # the text formats degrade to a truncated string; json has to stay valid or the consumer
+    # can't read any of it
+    out = JsonFormatter().render(EventObject(title="t"), [], LIMITS_DEFAULT)
+    assert json.loads(out) == {}
+
+
+def test_every_format_sees_the_same_sections() -> None:
+    # the point of the split: one section list, three renderings. If a format could change
+    # which sections run, comparing them would be measuring the wrong thing.
+    event = EventObject(title="boom")
+    sections = [title_section, _fields_section, _repeating_section]
+    rendered = {
+        "markdown": MarkdownFormatter().render(event, sections, LIMITS_DEFAULT),
+        "xml": XmlFormatter().render(event, sections, LIMITS_DEFAULT),
+        "json": JsonFormatter().render(event, sections, LIMITS_DEFAULT),
+    }
+    for out in rendered.values():
+        assert "boom" in out and "GET /x" in out and "KeyError: b" in out
+    assert set(json.loads(rendered["json"])) == {"title", "http_request", "exception"}

--- a/tests/sentry/issues/formatting/test_formatter.py
+++ b/tests/sentry/issues/formatting/test_formatter.py
@@ -171,8 +171,8 @@ def test_json_output_is_always_parseable() -> None:
 
 
 def test_every_format_sees_the_same_sections() -> None:
-    # the point of the split: one section list, three renderings. If a format could change
-    # which sections run, comparing them would be measuring the wrong thing.
+    # one section list, three renderings: if a format could change which sections run,
+    # comparing them would measure the wrong thing
     event = EventObject(title="boom")
     sections = [title_section, _fields_section, _repeating_section]
     rendered = {
@@ -186,8 +186,7 @@ def test_every_format_sees_the_same_sections() -> None:
 
 
 def _many_fields_section(model: EventObject, limits: object) -> Section | None:
-    # what evidence_section builds from occurrence.evidenceDisplay: an open-ended field list
-    # bounded only by the group cap
+    # what evidence_section builds: an open-ended field list bounded only by the cap
     return Section(
         title="Evidence",
         groups=(
@@ -200,9 +199,8 @@ def _many_fields_section(model: EventObject, limits: object) -> Section | None:
 
 
 def test_json_applies_the_item_cap_to_fields_not_just_text() -> None:
-    # capping only the free text would let an open-ended field list grow unbounded in json
-    # while the text formats bound it, so asking for a different format would change how much
-    # data a caller gets
+    # capping only free text would leave an open-ended field list unbounded in json, so the
+    # format a caller asked for would change how much data they got
     event = EventObject(title="t")
     rendered = {
         fmt: fmt.render(event, [_many_fields_section], LIMITS_DEFAULT)
@@ -211,9 +209,8 @@ def test_json_applies_the_item_cap_to_fields_not_just_text() -> None:
     kept = json.loads(rendered[next(f for f in rendered if isinstance(f, JsonFormatter))])
     assert len(kept["evidence"]) < 50  # dropped whole pairs rather than keeping all of them
 
-    # the cap is a character budget, so every format lands in the same envelope. Item counts
-    # differ slightly because the per-item syntax costs differ (markdown spends 8 characters
-    # on "**k0:** " that json does not), which is fine; an unbounded format is not.
+    # the cap is a character budget, so every format lands in the same envelope. Counts differ
+    # slightly because the syntax costs differ, which is fine; an unbounded format is not.
     for out in rendered.values():
         assert len(out) < 2 * 100
 
@@ -223,8 +220,7 @@ def test_json_applies_the_item_cap_to_fields_not_just_text() -> None:
     [(MarkdownFormatter(), ""), (XmlFormatter(), ""), (JsonFormatter(), "{}")],
 )
 def test_empty_render_is_valid_for_the_requested_format(fmt: Formatter, expected: str) -> None:
-    # an empty json render still has to parse: callers json.loads the content, and the no-run
-    # autofix GET takes this path routinely
+    # callers json.loads the content, and the no-run autofix GET takes this path routinely
     assert fmt.render(EventObject(title="t"), [], LIMITS_DEFAULT) == expected
 
 
@@ -233,9 +229,8 @@ def _unicode_section(model: EventObject, limits: object) -> Section | None:
 
 
 def test_json_does_not_escape_non_ascii() -> None:
-    # escaping would spend six characters of the cap on one accented character, so an
-    # international event would lose sections an ascii event of the same size keeps. It also
-    # leaves \uXXXX in the content string for anything that reads it without parsing.
+    # escaping would spend six of the cap on one accented character, so an international event
+    # would lose sections an ascii event of the same size keeps
     out = JsonFormatter().render(EventObject(title="t"), [_unicode_section], LIMITS_DEFAULT)
     assert "café ünïcode" in out
     assert "\\u" not in out

--- a/tests/sentry/issues/formatting/test_formatter.py
+++ b/tests/sentry/issues/formatting/test_formatter.py
@@ -1,5 +1,4 @@
 import functools
-import json
 from xml.etree import ElementTree
 
 import pytest
@@ -19,6 +18,7 @@ from sentry.issues.formatting.limits import LIMITS_DEFAULT, Limits
 from sentry.issues.formatting.models import (
     EventObject,
 )
+from sentry.utils import json
 
 
 def title_section(model: EventObject, limits: object) -> Section | None:

--- a/tests/sentry/issues/formatting/test_formatter.py
+++ b/tests/sentry/issues/formatting/test_formatter.py
@@ -6,6 +6,7 @@ import pytest
 from sentry.issues.formatting.formatter import (
     Code,
     Field,
+    Formatter,
     Group,
     JsonFormatter,
     MarkdownFormatter,
@@ -181,3 +182,46 @@ def test_every_format_sees_the_same_sections() -> None:
     for out in rendered.values():
         assert "boom" in out and "GET /x" in out and "KeyError: b" in out
     assert set(json.loads(rendered["json"])) == {"title", "http_request", "exception"}
+
+
+def _many_fields_section(model: EventObject, limits: object) -> Section | None:
+    # what evidence_section builds from occurrence.evidenceDisplay: an open-ended field list
+    # bounded only by the group cap
+    return Section(
+        title="Evidence",
+        groups=(
+            Group(
+                items=tuple(Field(f"k{i}", "v" * 20) for i in range(50)),
+                max_item_chars=100,
+            ),
+        ),
+    )
+
+
+def test_json_applies_the_item_cap_to_fields_not_just_text() -> None:
+    # capping only the free text would let an open-ended field list grow unbounded in json
+    # while the text formats bound it, so asking for a different format would change how much
+    # data a caller gets
+    event = EventObject(title="t")
+    rendered = {
+        fmt: fmt.render(event, [_many_fields_section], LIMITS_DEFAULT)
+        for fmt in (MarkdownFormatter(), XmlFormatter(), JsonFormatter())
+    }
+    kept = json.loads(rendered[next(f for f in rendered if isinstance(f, JsonFormatter))])
+    assert len(kept["evidence"]) < 50  # dropped whole pairs rather than keeping all of them
+
+    # the cap is a character budget, so every format lands in the same envelope. Item counts
+    # differ slightly because the per-item syntax costs differ (markdown spends 8 characters
+    # on "**k0:** " that json does not), which is fine; an unbounded format is not.
+    for out in rendered.values():
+        assert len(out) < 2 * 100
+
+
+@pytest.mark.parametrize(
+    "fmt,expected",
+    [(MarkdownFormatter(), ""), (XmlFormatter(), ""), (JsonFormatter(), "{}")],
+)
+def test_empty_render_is_valid_for_the_requested_format(fmt: Formatter, expected: str) -> None:
+    # an empty json render still has to parse: callers json.loads the content, and the no-run
+    # autofix GET takes this path routinely
+    assert fmt.render(EventObject(title="t"), [], LIMITS_DEFAULT) == expected

--- a/tests/sentry/issues/formatting/test_formatter.py
+++ b/tests/sentry/issues/formatting/test_formatter.py
@@ -225,3 +225,36 @@ def test_empty_render_is_valid_for_the_requested_format(fmt: Formatter, expected
     # an empty json render still has to parse: callers json.loads the content, and the no-run
     # autofix GET takes this path routinely
     assert fmt.render(EventObject(title="t"), [], LIMITS_DEFAULT) == expected
+
+
+def _unicode_section(model: EventObject, limits: object) -> Section | None:
+    return Section(title="Tags", groups=(Group(items=(Field("ville", "café ünïcode"),)),))
+
+
+def test_json_does_not_escape_non_ascii() -> None:
+    # escaping would spend six characters of the cap on one accented character, so an
+    # international event would lose sections an ascii event of the same size keeps. It also
+    # leaves \uXXXX in the content string for anything that reads it without parsing.
+    out = JsonFormatter().render(EventObject(title="t"), [_unicode_section], LIMITS_DEFAULT)
+    assert "café ünïcode" in out
+    assert "\\u" not in out
+    assert json.loads(out)["tags"]["ville"] == "café ünïcode"
+
+
+def test_unicode_costs_the_same_against_the_cap_as_ascii() -> None:
+    # the cap is a character budget; a format must not count one character as six
+    def section(chars: str):
+        return lambda model, limits: Section(
+            title="Evidence",
+            groups=tuple(Group(items=(Field(f"k{i}", chars * 10),)) for i in range(20)),
+            max_group_chars=200,
+        )
+
+    event = EventObject(title="t")
+    ascii_kept = len(
+        json.loads(JsonFormatter().render(event, [section("a")], LIMITS_DEFAULT))["evidence"]
+    )
+    accented_kept = len(
+        json.loads(JsonFormatter().render(event, [section("é")], LIMITS_DEFAULT))["evidence"]
+    )
+    assert ascii_kept == accented_kept

--- a/tests/sentry/issues/formatting/test_sections.py
+++ b/tests/sentry/issues/formatting/test_sections.py
@@ -49,10 +49,8 @@ MD = MarkdownFormatter()
 
 
 def _render(section_fn: SectionFn, model: EventObject, fmt: Formatter, limits: Limits) -> str:
-    """Build a section and render it, mirroring what ``Formatter.render`` does per section.
-
-    Sections return structure now, so a test that wants text goes through the formatter. An
-    empty section is ``None``, which renders as "" the way the old string-returning sections did.
+    """Build a section and render it, as ``Formatter.render`` does per section. A section with
+    nothing to say is ``None``, which renders as "".
     """
     built = section_fn(model, limits)
     return fmt.render_section(built) if built is not None else ""

--- a/tests/sentry/issues/formatting/test_sections.py
+++ b/tests/sentry/issues/formatting/test_sections.py
@@ -5,8 +5,13 @@ from xml.etree import ElementTree
 
 import pytest
 
-from sentry.issues.formatting.formatter import MarkdownFormatter, SectionFn, XmlFormatter
-from sentry.issues.formatting.limits import LIMITS_DEFAULT
+from sentry.issues.formatting.formatter import (
+    Formatter,
+    MarkdownFormatter,
+    SectionFn,
+    XmlFormatter,
+)
+from sentry.issues.formatting.limits import LIMITS_DEFAULT, Limits
 from sentry.issues.formatting.models import (
     Breadcrumb,
     CspDetails,
@@ -43,12 +48,22 @@ from sentry.issues.formatting.sections import (
 MD = MarkdownFormatter()
 
 
+def _render(section_fn: SectionFn, model: EventObject, fmt: Formatter, limits: Limits) -> str:
+    """Build a section and render it, mirroring what ``Formatter.render`` does per section.
+
+    Sections return structure now, so a test that wants text goes through the formatter. An
+    empty section is ``None``, which renders as "" the way the old string-returning sections did.
+    """
+    built = section_fn(model, limits)
+    return fmt.render_section(built) if built is not None else ""
+
+
 def _event_with_exception(**exc_kwargs: Any) -> EventObject:
     return EventObject(title="t", exceptions=[ExceptionDetails(**exc_kwargs)])
 
 
 def test_no_exceptions_renders_nothing() -> None:
-    out = exceptions_section(EventObject(title="t"), MarkdownFormatter(), LIMITS_DEFAULT)
+    out = _render(exceptions_section, EventObject(title="t"), MarkdownFormatter(), LIMITS_DEFAULT)
     assert out == ""
 
 
@@ -69,7 +84,7 @@ def test_basic_exception_with_handled_and_frame() -> None:
             ]
         ),
     )
-    out = exceptions_section(event, MarkdownFormatter(), LIMITS_DEFAULT)
+    out = _render(exceptions_section, event, MarkdownFormatter(), LIMITS_DEFAULT)
     assert out.startswith("## Exception\n")
     assert "ValueError: boom" in out
     assert "**Handled:** No" in out
@@ -80,14 +95,14 @@ def test_basic_exception_with_handled_and_frame() -> None:
 
 def test_handled_omitted_when_none() -> None:
     event = _event_with_exception(type="ValueError", value="boom")  # is_handled defaults None
-    out = exceptions_section(event, MarkdownFormatter(), LIMITS_DEFAULT)
+    out = _render(exceptions_section, event, MarkdownFormatter(), LIMITS_DEFAULT)
     assert "Handled" not in out
 
 
 def test_frames_capped_and_most_recent_first() -> None:
     frames = [Frame(function=f"f{i}", filename="a.py", line_no=i) for i in range(20)]
     event = _event_with_exception(type="E", stacktrace=Stacktrace(frames=frames))
-    out = exceptions_section(event, MarkdownFormatter(), LIMITS_DEFAULT)
+    out = _render(exceptions_section, event, MarkdownFormatter(), LIMITS_DEFAULT)
     # default cap is 16 frames; with no app frames, the head and tail of the system frames
     # are kept (f0..f7 + f12..f19), most-recent first
     assert out.count(" in a.py ") == 16
@@ -106,7 +121,7 @@ def test_frame_cap_keeps_app_frames(app_frame_count: int) -> None:
     ]
     frames += [Frame(function=f"lib{i}", filename="v.py") for i in range(50)]
     event = _event_with_exception(type="E", stacktrace=Stacktrace(frames=frames))
-    out = exceptions_section(event, MarkdownFormatter(), LIMITS_DEFAULT)
+    out = _render(exceptions_section, event, MarkdownFormatter(), LIMITS_DEFAULT)
     for i in range(app_frame_count):
         assert f"app{i} in a.py" in out
     assert out.count(" [Line: Unknown] ") == 16  # cap is filled exactly, never under
@@ -116,13 +131,13 @@ def test_stacktrace_char_truncation() -> None:
     frames = [Frame(function="f", filename="a.py", line_no=1)]
     event = _event_with_exception(type="E", stacktrace=Stacktrace(frames=frames))
     tight = dataclasses.replace(LIMITS_DEFAULT, max_stacktrace_chars=10)
-    out = exceptions_section(event, MarkdownFormatter(), tight)
+    out = _render(exceptions_section, event, MarkdownFormatter(), tight)
     assert "(truncated)" in out
 
 
 def test_xml_output() -> None:
     event = _event_with_exception(type="ValueError", value="boom")
-    out = exceptions_section(event, XmlFormatter(), LIMITS_DEFAULT)
+    out = _render(exceptions_section, event, XmlFormatter(), LIMITS_DEFAULT)
     assert out.startswith("<exception>\n")
     assert out.endswith("\n</exception>")
     assert "ValueError: boom" in out
@@ -130,7 +145,7 @@ def test_xml_output() -> None:
 
 def test_title_with_culprit() -> None:
     event = EventObject(title="ValueError: boom", culprit="app.views.checkout")
-    out = title_section(event, MD, LIMITS_DEFAULT)
+    out = _render(title_section, event, MD, LIMITS_DEFAULT)
     assert "ValueError: boom" in out
     assert "**Culprit:** app.views.checkout" in out
 
@@ -141,13 +156,13 @@ def test_title_with_transaction_and_date() -> None:
         transaction_name="/api/checkout",
         timestamp=datetime(2026, 7, 29, 10, 11, 12, tzinfo=timezone.utc),
     )
-    out = title_section(event, MD, LIMITS_DEFAULT)
+    out = _render(title_section, event, MD, LIMITS_DEFAULT)
     assert "**Transaction:** /api/checkout" in out
     assert "**Date:** 2026-07-29 10:11:12 UTC" in out
 
 
 def test_title_omits_absent_fields() -> None:
-    out = title_section(EventObject(title="just a title"), MD, LIMITS_DEFAULT)
+    out = _render(title_section, EventObject(title="just a title"), MD, LIMITS_DEFAULT)
     assert out == "## Title\njust a title"
 
 
@@ -166,7 +181,7 @@ def test_frame_vars_trimmed_to_context_and_scrubbed() -> None:
         },
     )
     event = _event_with_exception(type="E", stacktrace=Stacktrace(frames=[frame]))
-    out = exceptions_section(event, MD, LIMITS_DEFAULT)
+    out = _render(exceptions_section, event, MD, LIMITS_DEFAULT)
     assert "[Filtered]" not in out
     # only the unscrubbed part of the one mentioned var survives; the source lines still render
     assert "vars: user={'id': 7}, missing=None" in out
@@ -178,7 +193,7 @@ def test_frame_vars_scrubbed_without_context() -> None:
     # no source context to narrow against, so vars are kept -- but still never scrubbed values
     frame = Frame(function="f", filename="a.py", vars={"token": "[Filtered]", "count": 3})
     event = _event_with_exception(type="E", stacktrace=Stacktrace(frames=[frame]))
-    out = exceptions_section(event, MD, LIMITS_DEFAULT)
+    out = _render(exceptions_section, event, MD, LIMITS_DEFAULT)
     assert "[Filtered]" not in out
     assert "token" not in out
     assert "count=3" in out
@@ -193,7 +208,7 @@ def test_frame_vars_keep_containers_that_arrived_empty() -> None:
         vars={"items": [], "opts": {}, "scrubbed": {"token": "[Filtered]"}},
     )
     event = _event_with_exception(type="E", stacktrace=Stacktrace(frames=[frame]))
-    out = exceptions_section(event, MD, LIMITS_DEFAULT)
+    out = _render(exceptions_section, event, MD, LIMITS_DEFAULT)
     assert "items=[]" in out
     assert "opts={}" in out
     assert "scrubbed" not in out
@@ -202,11 +217,15 @@ def test_frame_vars_keep_containers_that_arrived_empty() -> None:
 def test_message_deduped_against_title() -> None:
     # message that is a substring of the title renders nothing
     assert (
-        message_section(EventObject(title="boom happened", message="boom"), MD, LIMITS_DEFAULT)
+        _render(
+            message_section, EventObject(title="boom happened", message="boom"), MD, LIMITS_DEFAULT
+        )
         == ""
     )
     # distinct message renders
-    out = message_section(EventObject(title="t", message="something else"), MD, LIMITS_DEFAULT)
+    out = _render(
+        message_section, EventObject(title="t", message="something else"), MD, LIMITS_DEFAULT
+    )
     assert "something else" in out
 
 
@@ -214,7 +233,7 @@ def test_breadcrumbs_last_n_and_skip_filtered() -> None:
     crumbs = [Breadcrumb(message=f"crumb-{i}") for i in range(15)]
     crumbs.append(Breadcrumb(message="[Filtered]"))
     event = EventObject(title="t", breadcrumbs=crumbs)
-    out = breadcrumbs_section(event, MD, LIMITS_DEFAULT)  # max_breadcrumbs=10
+    out = _render(breadcrumbs_section, event, MD, LIMITS_DEFAULT)  # max_breadcrumbs=10
     assert "[Filtered]" not in out  # filtered crumb skipped
     assert "crumb-14" in out  # most recent kept
     assert "crumb-6" in out  # boundary of the last-10 window (indices 6..15)
@@ -230,9 +249,12 @@ def test_threads_zero_cap_renders_nothing() -> None:
         title="t",
         threads=[ThreadDetails(name=f"T{i}", stacktrace=stacktrace) for i in range(5)],
     )
-    assert threads_section(event, MD, dataclasses.replace(LIMITS_DEFAULT, max_threads=0)) == ""
+    assert (
+        _render(threads_section, event, MD, dataclasses.replace(LIMITS_DEFAULT, max_threads=0))
+        == ""
+    )
     # and the cap is still filled exactly when it is non-zero
-    out = threads_section(event, MD, dataclasses.replace(LIMITS_DEFAULT, max_threads=2))
+    out = _render(threads_section, event, MD, dataclasses.replace(LIMITS_DEFAULT, max_threads=2))
     assert [f"T{i}" in out for i in range(5)] == [True, True, False, False, False]
 
 
@@ -240,31 +262,33 @@ def test_breadcrumbs_zero_cap_renders_nothing() -> None:
     # the window is a negative slice, so a zero cap becomes [0:] and would render every
     # breadcrumb -- the exact opposite of what the cap asks for
     event = EventObject(title="t", breadcrumbs=[Breadcrumb(message=f"c{i}") for i in range(5)])
-    out = breadcrumbs_section(event, MD, dataclasses.replace(LIMITS_DEFAULT, max_breadcrumbs=0))
+    out = _render(
+        breadcrumbs_section, event, MD, dataclasses.replace(LIMITS_DEFAULT, max_breadcrumbs=0)
+    )
     assert out == ""
 
 
 def test_breadcrumbs_all_filtered_renders_nothing() -> None:
     event = EventObject(title="t", breadcrumbs=[Breadcrumb(message="[Filtered]")])
-    assert breadcrumbs_section(event, MD, LIMITS_DEFAULT) == ""
+    assert _render(breadcrumbs_section, event, MD, LIMITS_DEFAULT) == ""
 
 
 def test_request_method_url_and_body() -> None:
     event = EventObject(
         title="t", request=RequestDetails(method="POST", url="https://x.com", data={"a": 1})
     )
-    out = request_section(event, MD, LIMITS_DEFAULT)
+    out = _render(request_section, event, MD, LIMITS_DEFAULT)
     assert "POST https://x.com" in out
     assert "{'a': 1}" in out
 
 
 def test_request_none_renders_nothing() -> None:
-    assert request_section(EventObject(title="t"), MD, LIMITS_DEFAULT) == ""
+    assert _render(request_section, EventObject(title="t"), MD, LIMITS_DEFAULT) == ""
 
 
 def test_tags_section() -> None:
     event = EventObject(title="t", tags=[("environment", "prod"), ("release", None)])
-    out = tags_section(event, MD, LIMITS_DEFAULT)
+    out = _render(tags_section, event, MD, LIMITS_DEFAULT)
     assert "**environment:** prod" in out
     assert "**release:** " in out
 
@@ -281,12 +305,15 @@ def test_tags_section_drops_the_derived_user_tag() -> None:
     assert "someone@example.com" not in out
     assert "**browser:** Chrome" in out
     # a tags block with nothing but the user tag renders nothing at all
-    assert tags_section(EventObject(title="t", tags=[("user", "id:7")]), MD, LIMITS_DEFAULT) == ""
+    assert (
+        _render(tags_section, EventObject(title="t", tags=[("user", "id:7")]), MD, LIMITS_DEFAULT)
+        == ""
+    )
 
 
 def test_user_only_present_fields() -> None:
     event = EventObject(title="t", user=UserDetails(email="user@example.com"))
-    out = user_section(event, MD, LIMITS_DEFAULT)
+    out = _render(user_section, event, MD, LIMITS_DEFAULT)
     assert "**Email:** user@example.com" in out
     assert "ID" not in out
 
@@ -299,7 +326,7 @@ def test_contexts_renders_groups_and_skips_type() -> None:
             "os": {"type": "os", "name": "Windows"},
         },
     )
-    out = contexts_section(event, MD, LIMITS_DEFAULT)
+    out = _render(contexts_section, event, MD, LIMITS_DEFAULT)
     assert "## Contexts" in out
     assert "browser\nname: Chrome\nversion: 28" in out
     assert "os\nname: Windows" in out
@@ -313,7 +340,7 @@ def test_csp_section() -> None:
             effective_directive="img-src", blocked_uri="blob", document_uri="https://x.com"
         ),
     )
-    out = csp_section(event, MD, LIMITS_DEFAULT)
+    out = _render(csp_section, event, MD, LIMITS_DEFAULT)
     assert "## CSP" in out
     assert "**Blocked:** blob" in out
     assert "**Directive:** img-src" in out
@@ -325,7 +352,7 @@ def test_evidence_section() -> None:
         title="t",
         evidence=[("Regression", "duration increased"), ("Transaction", "POST /oauth/token")],
     )
-    out = evidence_section(event, MD, LIMITS_DEFAULT)
+    out = _render(evidence_section, event, MD, LIMITS_DEFAULT)
     assert "## Evidence" in out
     assert "**Regression:** duration increased" in out
     assert "**Transaction:** POST /oauth/token" in out
@@ -333,7 +360,7 @@ def test_evidence_section() -> None:
 
 @pytest.mark.parametrize("section", [csp_section, evidence_section, contexts_section])
 def test_section_empty_renders_nothing(section: SectionFn) -> None:
-    assert section(EventObject(title="t"), MD, LIMITS_DEFAULT) == ""
+    assert _render(section, EventObject(title="t"), MD, LIMITS_DEFAULT) == ""
 
 
 def test_threads_only_with_stacktrace() -> None:
@@ -342,7 +369,7 @@ def test_threads_only_with_stacktrace() -> None:
     )
     without_st = ThreadDetails(name="worker")
     event = EventObject(title="t", threads=[with_st, without_st])
-    out = threads_section(event, MD, LIMITS_DEFAULT)
+    out = _render(threads_section, event, MD, LIMITS_DEFAULT)
     assert "main" in out
     assert "**Crashed:** Yes" in out
     assert "worker" not in out
@@ -356,7 +383,7 @@ def test_threads_capped_by_max_threads() -> None:
     ]
     event = EventObject(title="t", threads=threads)
     tight = dataclasses.replace(LIMITS_DEFAULT, max_threads=3)
-    out = threads_section(event, MD, tight)
+    out = _render(threads_section, event, MD, tight)
     assert out.count("```") == 3 * 2  # one fenced stacktrace per rendered thread, capped at 3
     assert "t0" in out and "t2" in out
     assert "t3" not in out
@@ -366,19 +393,19 @@ def test_spans_section() -> None:
     event = EventObject(
         title="t", spans=[EvidenceSpan(op="db", description="SELECT 1", exclusive_time=12.5)]
     )
-    out = spans_section(event, MD, LIMITS_DEFAULT)
+    out = _render(spans_section, event, MD, LIMITS_DEFAULT)
     assert "db: SELECT 1 (12.5ms)" in out
 
 
 def test_spans_all_blank_renders_nothing() -> None:
     # spans present but every field empty -> no empty "## Span Evidence" block
     event = EventObject(title="t", spans=[EvidenceSpan(), EvidenceSpan()])
-    assert spans_section(event, MD, LIMITS_DEFAULT) == ""
+    assert _render(spans_section, event, MD, LIMITS_DEFAULT) == ""
 
 
 def test_breadcrumbs_all_blank_renders_nothing() -> None:
     event = EventObject(title="t", breadcrumbs=[Breadcrumb(), Breadcrumb()])
-    assert breadcrumbs_section(event, MD, LIMITS_DEFAULT) == ""
+    assert _render(breadcrumbs_section, event, MD, LIMITS_DEFAULT) == ""
 
 
 def _serialized_event() -> dict[str, Any]:
@@ -429,9 +456,11 @@ def test_detector_sections_render_when_present() -> None:
         detection_context="Opened by a Sentry detector, not an exception.",
         troubleshooting_hint="Remove the manually instrumented span.",
     )
-    assert "Opened by a Sentry detector" in detection_context_section(event, MD, LIMITS_DEFAULT)
-    assert "Remove the manually instrumented" in troubleshooting_hint_section(
-        event, MD, LIMITS_DEFAULT
+    assert "Opened by a Sentry detector" in _render(
+        detection_context_section, event, MD, LIMITS_DEFAULT
+    )
+    assert "Remove the manually instrumented" in _render(
+        troubleshooting_hint_section, event, MD, LIMITS_DEFAULT
     )
     out = format_issue({"title": "t", "detectionContext": "why", "troubleshootingHint": "how"})
     assert "why" in out and "how" in out
@@ -441,7 +470,7 @@ def test_detector_sections_render_when_present() -> None:
 @pytest.mark.parametrize("value", [None, ""])
 def test_detector_sections_skipped_when_blank(section: Any, value: str | None) -> None:
     event = EventObject(title="t", detection_context=value, troubleshooting_hint=value)
-    assert section(event, MD, LIMITS_DEFAULT) == ""
+    assert _render(section, event, MD, LIMITS_DEFAULT) == ""
 
 
 def test_invalid_format_raises() -> None:
@@ -504,15 +533,15 @@ def test_bare_stacktrace_entry_renders() -> None:
         title="t",
         stacktrace=Stacktrace(frames=[Frame(function="do_thing", filename="app.py", line_no=12)]),
     )
-    out = stacktrace_section(event, MD, LIMITS_DEFAULT)
+    out = _render(stacktrace_section, event, MD, LIMITS_DEFAULT)
     assert out.startswith("## Stacktrace")
     assert "do_thing in app.py [Line 12]" in out
 
 
 def test_bare_stacktrace_skipped_when_empty() -> None:
-    assert stacktrace_section(EventObject(title="t"), MD, LIMITS_DEFAULT) == ""
+    assert _render(stacktrace_section, EventObject(title="t"), MD, LIMITS_DEFAULT) == ""
     event = EventObject(title="t", stacktrace=Stacktrace(frames=[]))
-    assert stacktrace_section(event, MD, LIMITS_DEFAULT) == ""
+    assert _render(stacktrace_section, event, MD, LIMITS_DEFAULT) == ""
 
 
 def test_exception_stacktrace_not_duplicated() -> None:
@@ -543,7 +572,7 @@ def test_exception_stacktrace_not_duplicated() -> None:
     )
     assert "## Exception" in out
     assert "## Stacktrace" not in out
-    assert stacktrace_section(event, MD, LIMITS_DEFAULT) == ""
+    assert _render(stacktrace_section, event, MD, LIMITS_DEFAULT) == ""
 
 
 def test_truncating_a_rendered_body_never_splits_markup() -> None:
@@ -556,8 +585,11 @@ def test_truncating_a_rendered_body_never_splits_markup() -> None:
         ],
     )
     for cap in range(20, 260):
-        out = exceptions_section(
-            event, XmlFormatter(), dataclasses.replace(LIMITS_DEFAULT, max_exceptions_chars=cap)
+        out = _render(
+            exceptions_section,
+            event,
+            XmlFormatter(),
+            dataclasses.replace(LIMITS_DEFAULT, max_exceptions_chars=cap),
         )
         ElementTree.fromstring(out)  # raises if a tag was split
 
@@ -577,8 +609,11 @@ def test_truncating_a_rendered_body_keeps_markdown_fences_balanced() -> None:
         ],
     )
     for cap in range(20, 600):
-        out = exceptions_section(
-            event, MD, dataclasses.replace(LIMITS_DEFAULT, max_exceptions_chars=cap)
+        out = _render(
+            exceptions_section,
+            event,
+            MD,
+            dataclasses.replace(LIMITS_DEFAULT, max_exceptions_chars=cap),
         )
         fences = [line for line in out.splitlines() if line and set(line) == {"`"}]
         assert len(fences) % 2 == 0, f"unbalanced fence at cap={cap}"
@@ -588,8 +623,8 @@ def test_capping_a_rendered_body_keeps_the_first_piece() -> None:
     # dropping every piece would leave a section carrying nothing but "(truncated)"; overshooting
     # the cap once beats losing the content the section exists to render
     event = EventObject(title="t", exceptions=[ExceptionDetails(type="E", value="v" * 200)])
-    out = exceptions_section(
-        event, MD, dataclasses.replace(LIMITS_DEFAULT, max_exceptions_chars=10)
+    out = _render(
+        exceptions_section, event, MD, dataclasses.replace(LIMITS_DEFAULT, max_exceptions_chars=10)
     )
     assert "E: " + "v" * 200 in out
 
@@ -598,14 +633,14 @@ def test_evidence_section_is_capped() -> None:
     # evidenceDisplay carries whatever pairs an occurrence defines, so it needs a cap like the
     # other open-ended sections rather than rendering unbounded
     event = EventObject(title="t", evidence=[("Regression", "x" * 10_000)])
-    out = evidence_section(event, MD, LIMITS_DEFAULT)
+    out = _render(evidence_section, event, MD, LIMITS_DEFAULT)
     assert "... (truncated)" in out
     assert len(out) < 6_000  # max_evidence_chars=5_000, plus the surrounding block
 
 
 def test_contexts_render_key_value_pairs() -> None:
     event = EventObject(title="t", contexts={"browser": {"type": "browser", "name": "Chrome"}})
-    out = contexts_section(event, XmlFormatter(), LIMITS_DEFAULT)
+    out = _render(contexts_section, event, XmlFormatter(), LIMITS_DEFAULT)
     assert "name: Chrome" in out
     assert "type: browser" not in out  # the redundant echo is dropped
 
@@ -615,7 +650,10 @@ def test_evidence_truncation_never_splits_markup() -> None:
     # an unclosed tag
     event = EventObject(title="t", evidence=[("regression", "x" * 200), ("other", "y" * 200)])
     for cap in range(20, 400):
-        out = evidence_section(
-            event, XmlFormatter(), dataclasses.replace(LIMITS_DEFAULT, max_evidence_chars=cap)
+        out = _render(
+            evidence_section,
+            event,
+            XmlFormatter(),
+            dataclasses.replace(LIMITS_DEFAULT, max_evidence_chars=cap),
         )
         ElementTree.fromstring(out)  # raises if a tag was split


### PR DESCRIPTION
Adds json as a third output format for the shared issue and event formatter, alongside markdown and xml.

Sections used to return rendered strings, so the output format was baked into selection. They now return a Section describing what to render (groups of Field, Code and Text items) and the formatter decides how. MarkdownFormatter and XmlFormatter move under a shared TextFormatter that assembles lines from the same syntax primitives as before. JsonFormatter serializes that same structure instead.

Markdown and xml output is unchanged. The existing section tests assert the same strings they did before and pass untouched, which is the parity check. Only their call sites moved, through a _render helper.

Size caps move onto Section and Group because the two families apply them differently. Text formats cut a joined body mid string, while json drops whole items so the result stays parseable.

?llmFormat=json needs no new plumbing. VALID_FORMATS is get_args(Format), so extending the literal covers both the REST mixin and the Seer RPC, and FormattedResponse.content stays a string carrying serialized json. That means no schema change is needed in the MCP to consume it.

Autofix sections move to the same structure, so the autofix endpoint serves json alongside the event endpoint