### PR TITLE
perf(warmup): Deduplicate locale URL resolver caches

### DIFF
--- a/src/sentry/api/endpoints/warmup.py
+++ b/src/sentry/api/endpoints/warmup.py
@@ -1,8 +1,10 @@
+from collections.abc import Iterator
+
 import django.contrib.messages.storage.fallback
 import django.contrib.sessions.serializers
 import django.db.models.sql.compiler  # NOQA
 from django.conf import settings
-from django.urls import reverse
+from django.urls import URLResolver, get_resolver, reverse
 from django.utils import translation
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -19,6 +21,44 @@ from sentry.api.base import Endpoint, all_silo_endpoint
 from sentry.ratelimits.config import RateLimitConfig
 
 
+def _iter_url_resolvers(resolver: URLResolver) -> Iterator[URLResolver]:
+    """Walk nested URL includes once, including repeated or recursive resolvers."""
+    pending = [resolver]
+    seen: set[int] = set()
+    while pending:
+        resolver = pending.pop()
+        if id(resolver) in seen:
+            continue
+        seen.add(id(resolver))
+        yield resolver
+        pending.extend(
+            pattern for pattern in resolver.url_patterns if isinstance(pattern, URLResolver)
+        )
+
+
+def _warm_up_url_resolver(languages: list[str]) -> None:
+    with translation.override(settings.LANGUAGE_CODE):
+        reverse("sentry-warmup")
+        default_language = translation.get_language()
+
+    resolvers = list(_iter_url_resolvers(get_resolver()))
+    for lang in languages:
+        with translation.override(lang):
+            reverse("sentry-warmup")
+            language = translation.get_language()
+
+        if language == default_language:
+            continue
+
+        # Django stores a complete reverse cache per language, even when URL
+        # patterns are identical. Preserve distinct translated routes while
+        # sharing equal caches. Tests guard this private Django attribute.
+        for resolver in resolvers:
+            cache = resolver._reverse_dict
+            if cache[language] == cache[default_language]:
+                cache[language] = cache[default_language]
+
+
 @all_silo_endpoint
 class WarmupEndpoint(Endpoint):
     publish_status = {
@@ -32,12 +72,8 @@ class WarmupEndpoint(Endpoint):
         languages = [lang for lang, _ in settings.LANGUAGES]
         languages.append(settings.LANGUAGE_CODE)
 
-        # for each possible language we support, warm up the url resolver
-        # this fixes an issue we were seeing where many languages trying
-        # to resolve at once would cause lock contention
-        for lang in languages:
-            with translation.override(lang):
-                reverse("sentry-warmup")
+        # Warm every language to avoid resolver lock contention on requests.
+        _warm_up_url_resolver(languages)
 
         # for each possible language we support, warm up the translations
         # cache for faster access

--- a/tests/sentry/api/endpoints/test_warmup.py
+++ b/tests/sentry/api/endpoints/test_warmup.py
@@ -1,7 +1,20 @@
-from django.urls import reverse
+from django.conf import settings
+from django.conf.urls.i18n import i18n_patterns
+from django.http import HttpRequest, HttpResponse
+from django.test import SimpleTestCase, override_settings
+from django.urls import get_resolver, path, reverse
+from django.utils import translation
 from rest_framework import status
 
+from sentry.api.endpoints.warmup import _iter_url_resolvers, _warm_up_url_resolver
 from sentry.testutils.cases import APITestCase
+
+
+def warmup_view(request: HttpRequest) -> HttpResponse:
+    return HttpResponse()
+
+
+urlpatterns = i18n_patterns(path("_warmup/", warmup_view, name="sentry-warmup"))
 
 
 class WarmupEndpointTest(APITestCase):
@@ -10,3 +23,30 @@ class WarmupEndpointTest(APITestCase):
         response = self.client.get(url)
 
         assert response.status_code == status.HTTP_200_OK
+
+    def test_shares_language_independent_django_url_caches(self) -> None:
+        self.client.get(reverse("sentry-warmup"))
+
+        languages = [lang for lang, _ in settings.LANGUAGES]
+        languages.append(settings.LANGUAGE_CODE)
+        for resolver in _iter_url_resolvers(get_resolver()):
+            cache = resolver._reverse_dict
+            default_cache = cache[settings.LANGUAGE_CODE]
+            assert all(cache[language] is default_cache for language in languages)
+
+
+class LocalizedWarmupTest(SimpleTestCase):
+    @override_settings(
+        ROOT_URLCONF=__name__,
+        LANGUAGE_CODE="en",
+        LANGUAGES=(("en", "English"), ("de", "German")),
+    )
+    def test_keeps_language_dependent_django_url_caches_separate(self) -> None:
+        _warm_up_url_resolver(["en", "de"])
+
+        resolver = get_resolver()
+        assert resolver._reverse_dict["en"] is not resolver._reverse_dict["de"]
+        with translation.override("en"):
+            assert reverse("sentry-warmup") == "/en/_warmup/"
+        with translation.override("de"):
+            assert reverse("sentry-warmup") == "/de/_warmup/"


### PR DESCRIPTION
 Before:
 - Django built same URL lookup table 39 times - once per language.
 - Each worker wasted about 192 MiB storing duplicates.

 Now:
 - Django still builds every table during warmup.
 - We compare each table with English table.
 - If they match, both languages point to same table.
 - If they differ, we keep both.

 This keeps fast warmup and saves about:

 - 192 MiB per worker
 - 0.75 GiB per four-worker pod
 - 1.5 GiB per eight-worker pod

Disclaimer:
This relies on Django's private resolver cache layout. I have added tests to catch future potential regressions of this in case upgrading Django breaks this.
