### PR TITLE
feat(seer): Add experimental Autofix onboarding modal and scenario lab (experimental, no review)

### DIFF
--- a/static/app/components/seer/onboarding/scenarios.ts
+++ b/static/app/components/seer/onboarding/scenarios.ts
@@ -1,0 +1,197 @@
+import type {
+  SeerOnboardingProject,
+  SeerOnboardingRepo,
+  SeerOnboardingState,
+} from 'sentry/components/seer/onboarding/types';
+import {t} from 'sentry/locale';
+
+const REPOS: SeerOnboardingRepo[] = [
+  {id: 'repo-1', name: 'acme/web'},
+  {id: 'repo-2', name: 'acme/api'},
+  {id: 'repo-3', name: 'acme/checkout-service'},
+  {id: 'repo-4', name: 'acme/mobile'},
+];
+
+const PROJECTS: SeerOnboardingProject[] = [
+  {id: 'project-1', slug: 'frontend'},
+  {id: 'project-2', slug: 'backend'},
+  {id: 'project-3', slug: 'mobile'},
+];
+
+/**
+ * An organization that has cleared every gate: background triage runs and opens PRs.
+ * Every other scenario is described as a diff against this.
+ */
+const CONFIGURED: SeerOnboardingState = {
+  availableProjects: PROJECTS,
+  availableRepos: REPOS,
+  canWriteOrgSettings: true,
+  enableSeerCoding: true,
+  entitlement: 'seat-based',
+  hasAutofixBudget: true,
+  hasScmWriteAccess: true,
+  hasSupportedScmIntegration: true,
+  hideAiFeatures: false,
+  isCodingSettingManaged: false,
+  repoLinks: [
+    {id: 'link-1', repoId: 'repo-1', projectId: 'project-1'},
+    {id: 'link-2', repoId: 'repo-2', projectId: 'project-2'},
+  ],
+  stoppingPoints: {'project-1': 'create_pr', 'project-2': 'create_pr'},
+};
+
+/** Nothing wired up yet: no integration, no repositories, no automation. */
+const NOTHING_SET_UP = {
+  hasSupportedScmIntegration: false,
+  repoLinks: [],
+  stoppingPoints: {},
+} satisfies Partial<SeerOnboardingState>;
+
+export interface SeerOnboardingScenario {
+  /** Why this scenario is worth looking at. */
+  description: string;
+  key: string;
+  label: string;
+  state: SeerOnboardingState;
+}
+
+/**
+ * The onboarding states real users land in, in roughly the order they hit them.
+ *
+ * Shared between the onboarding lab and the modal's tests so both exercise the
+ * same fixtures.
+ */
+export const SEER_ONBOARDING_SCENARIOS: SeerOnboardingScenario[] = [
+  {
+    key: 'brand-new',
+    label: t('Brand new org (no Seer)'),
+    description: t(
+      'No Seer plan and nothing configured. Setup is not gated on billing, so they walk every step and Autofix starts the moment Seer is added.'
+    ),
+    state: {
+      ...CONFIGURED,
+      ...NOTHING_SET_UP,
+      entitlement: 'none',
+      hasAutofixBudget: false,
+    },
+  },
+  {
+    key: 'unpaid-configured',
+    label: t('Set up, but no Seer plan'),
+    description: t(
+      'Every step finished ahead of buying. The modal should say Autofix is ready and waiting, and offer to add Seer.'
+    ),
+    state: {...CONFIGURED, entitlement: 'none', hasAutofixBudget: false},
+  },
+  {
+    key: 'gen-ai-disabled',
+    label: t('Seer on, generative AI disabled'),
+    description: t(
+      'Someone turned off AI features org-wide. This is the only case where the wizard shows a "Turn on generative AI" step — the option defaults to on, so it is an exception rather than a step.'
+    ),
+    state: {...CONFIGURED, ...NOTHING_SET_UP, hideAiFeatures: true},
+  },
+  {
+    key: 'no-scm',
+    label: t('No source code connected'),
+    description: t('Seer is paid for but has never seen the code.'),
+    state: {...CONFIGURED, ...NOTHING_SET_UP},
+  },
+  {
+    key: 'scm-no-repos',
+    label: t('GitHub connected, no repos linked'),
+    description: t(
+      'The integration is installed but no project has a repository attached, so Autofix has no context.'
+    ),
+    state: {...CONFIGURED, repoLinks: [], stoppingPoints: {}},
+  },
+  {
+    key: 'half-linked',
+    label: t('One repo linked, one row half-filled'),
+    description: t(
+      'A partially filled row should not count as linked, and should not block the rest of the form.'
+    ),
+    state: {
+      ...CONFIGURED,
+      repoLinks: [
+        {id: 'link-1', repoId: 'repo-1', projectId: 'project-1'},
+        {id: 'link-2', repoId: 'repo-3', projectId: ''},
+      ],
+      stoppingPoints: {'project-1': 'off'},
+    },
+  },
+  {
+    key: 'repos-automation-off',
+    label: t('Repos linked, automation off'),
+    description: t('Everything is wired up but nothing runs in the background.'),
+    state: {
+      ...CONFIGURED,
+      stoppingPoints: {'project-1': 'off', 'project-2': 'off'},
+    },
+  },
+  {
+    key: 'stops-at-plan',
+    label: t('Automation stops at Plan'),
+    description: t('Triage runs in the background but never drafts a pull request.'),
+    state: {
+      ...CONFIGURED,
+      stoppingPoints: {'project-1': 'plan', 'project-2': 'root_cause'},
+    },
+  },
+  {
+    key: 'coding-disabled',
+    label: t('Code generation disabled'),
+    description: t(
+      'Projects are set to "create PR" but code generation is off, so no PR can be written.'
+    ),
+    state: {...CONFIGURED, enableSeerCoding: false},
+  },
+  {
+    key: 'coding-managed',
+    label: t('Code generation managed by org'),
+    description: t('Code generation is force-disabled and the user cannot change it.'),
+    state: {...CONFIGURED, enableSeerCoding: false, isCodingSettingManaged: true},
+  },
+  {
+    key: 'read-only-member',
+    label: t('Read-only member'),
+    description: t(
+      'AI is off and nothing is connected, but the viewer can only look — every control should be disabled and point at an admin.'
+    ),
+    state: {
+      ...CONFIGURED,
+      ...NOTHING_SET_UP,
+      canWriteOrgSettings: false,
+      hideAiFeatures: true,
+    },
+  },
+  {
+    key: 'no-scm-write-access',
+    label: t('SCM app missing write access'),
+    description: t(
+      'Runs complete but pushing a branch fails. Not handled by the modal yet.'
+    ),
+    state: {...CONFIGURED, hasScmWriteAccess: false},
+  },
+  {
+    key: 'no-budget',
+    label: t('Out of Seer budget'),
+    description: t(
+      'Quota exhausted mid-month. Runs are paused but setup changes still stick.'
+    ),
+    state: {...CONFIGURED, hasAutofixBudget: false},
+  },
+  {
+    key: 'fully-configured',
+    label: t('Fully configured'),
+    description: t('Nothing left to do. The modal should say so and get out of the way.'),
+    state: CONFIGURED,
+  },
+];
+
+export function getSeerOnboardingScenario(key: string): SeerOnboardingScenario {
+  return (
+    SEER_ONBOARDING_SCENARIOS.find(scenario => scenario.key === key) ??
+    SEER_ONBOARDING_SCENARIOS[0]!
+  );
+}

--- a/static/app/components/seer/onboarding/seerOnboardingModal.spec.tsx
+++ b/static/app/components/seer/onboarding/seerOnboardingModal.spec.tsx
@@ -1,0 +1,326 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  makeClosableHeader,
+  makeCloseButton,
+  ModalBody,
+  ModalFooter,
+} from '@sentry/scraps/modal';
+
+import {getSeerOnboardingScenario} from 'sentry/components/seer/onboarding/scenarios';
+import {SeerOnboardingModal} from 'sentry/components/seer/onboarding/seerOnboardingModal';
+import type {
+  SeerOnboardingActions,
+  SeerOnboardingState,
+} from 'sentry/components/seer/onboarding/types';
+
+const organization = OrganizationFixture({features: ['seat-based-seer-enabled']});
+
+function makeActions(): SeerOnboardingActions {
+  return {
+    activateSeer: jest.fn(),
+    addRepoLink: jest.fn(),
+    connectScm: jest.fn(),
+    enableAiFeatures: jest.fn(),
+    removeRepoLink: jest.fn(),
+    setEnableSeerCoding: jest.fn(),
+    setLinkProject: jest.fn(),
+    setLinkRepo: jest.fn(),
+    setProjectStoppingPoint: jest.fn(),
+  };
+}
+
+function renderModal(
+  scenarioKey: string,
+  actions = makeActions(),
+  stateOverrides: Partial<SeerOnboardingState> = {}
+) {
+  const closeModal = jest.fn();
+  render(
+    <SeerOnboardingModal
+      Header={makeClosableHeader(closeModal)}
+      Body={ModalBody}
+      Footer={ModalFooter}
+      CloseButton={makeCloseButton(closeModal)}
+      closeModal={closeModal}
+      actions={actions}
+      state={{...getSeerOnboardingScenario(scenarioKey).state, ...stateOverrides}}
+    />,
+    {organization}
+  );
+  return {actions, closeModal};
+}
+
+describe('SeerOnboardingModal', () => {
+  it('celebrates a fully configured organization instead of showing the wizard', () => {
+    renderModal('fully-configured');
+
+    expect(screen.getByText('Autofix is ready')).toBeInTheDocument();
+    expect(screen.queryByText('Connect your source code')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Done'})).toBeInTheDocument();
+  });
+
+  it('omits the generative AI step when it is not blocking anything', () => {
+    renderModal('no-scm');
+
+    // Generative AI is on by default, so it is not a step — connecting the SCM is.
+    expect(screen.queryByText('Turn on generative AI')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Connect GitHub'})).toBeInTheDocument();
+  });
+
+  it('surfaces the generative AI step only when AI is actually disabled', () => {
+    renderModal('gen-ai-disabled');
+
+    expect(screen.getByText('Turn on generative AI')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Enable Generative AI Features'})
+    ).toBeInTheDocument();
+  });
+
+  it('asks for the SCM connection through the provided action', async () => {
+    const {actions} = renderModal('no-scm');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Connect GitHub'}));
+
+    expect(actions.connectScm).toHaveBeenCalled();
+  });
+
+  it('renders a custom scmButton in place of the default', () => {
+    const closeModal = jest.fn();
+    render(
+      <SeerOnboardingModal
+        Header={makeClosableHeader(closeModal)}
+        Body={ModalBody}
+        Footer={ModalFooter}
+        CloseButton={makeCloseButton(closeModal)}
+        closeModal={closeModal}
+        actions={makeActions()}
+        state={getSeerOnboardingScenario('no-scm').state}
+        scmButton={<button type="button">Install the real thing</button>}
+      />,
+      {organization}
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Install the real thing'})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Connect GitHub'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('tells a read-only member to find an admin', () => {
+    renderModal('read-only-member');
+
+    expect(
+      screen.getByText(
+        'You need an admin to enable generative AI features before Seer can do anything here.'
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Enable Generative AI Features'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('locks the code generation switch when the org manages it', async () => {
+    renderModal('coding-managed');
+
+    expect(await screen.findByRole('checkbox')).toBeDisabled();
+    expect(
+      screen.getByText('Code generation is managed by your organization.')
+    ).toBeInTheDocument();
+  });
+
+  it('sets the stopping point per project, in user-facing terms', async () => {
+    const {actions} = renderModal('repos-automation-off');
+
+    // Both linked projects get their own control; change the first one.
+    const selects = await screen.findAllByRole('button', {name: 'No Automation'});
+    expect(selects).toHaveLength(2);
+
+    await userEvent.click(selects[0]!);
+    await userEvent.click(screen.getByRole('option', {name: 'Stop after PR drafted'}));
+
+    expect(actions.setProjectStoppingPoint).toHaveBeenCalledWith(
+      'project-1',
+      'create_pr'
+    );
+  });
+
+  it('lists one row per repository/project pairing', async () => {
+    renderModal('half-linked');
+
+    // One project is already linked, so the wizard opens past this step.
+    await userEvent.click(screen.getByRole('button', {name: 'Back'}));
+
+    expect(screen.getByRole('button', {name: 'acme/web'})).toBeInTheDocument();
+    // The half-filled row keeps its repo but still prompts for a project.
+    expect(
+      screen.getByRole('button', {name: 'acme/checkout-service'})
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Select a project'})).toBeInTheDocument();
+  });
+
+  it('starts a new repository row', async () => {
+    const {actions} = renderModal('scm-no-repos');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Connect a repository'}));
+
+    expect(actions.addRepoLink).toHaveBeenCalled();
+  });
+
+  it('removes a repository row', async () => {
+    const {actions} = renderModal('half-linked');
+    await userEvent.click(screen.getByRole('button', {name: 'Back'}));
+
+    await userEvent.click(screen.getAllByRole('button', {name: 'Remove repository'})[0]!);
+
+    expect(actions.removeRepoLink).toHaveBeenCalledWith('link-1');
+  });
+
+  it('picks a repository and a project for a row', async () => {
+    const {actions} = renderModal('scm-no-repos', undefined, {
+      repoLinks: [{id: 'link-x', repoId: '', projectId: ''}],
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Select a repository'}));
+    await userEvent.click(screen.getByRole('option', {name: 'acme/api'}));
+    expect(actions.setLinkRepo).toHaveBeenCalledWith('link-x', 'repo-2');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Select a project'}));
+    await userEvent.click(screen.getByRole('option', {name: 'backend'}));
+    expect(actions.setLinkProject).toHaveBeenCalledWith('link-x', 'project-2');
+  });
+
+  it('has nothing to automate until a repository is linked', async () => {
+    renderModal('scm-no-repos');
+
+    await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+    expect(
+      screen.getByText(
+        'Link a repository to a project first — there is nothing to automate yet.'
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('replaces the wizard with a named blocker for a genuine setup problem', () => {
+    renderModal('no-scm-write-access');
+
+    expect(screen.getByText('Missing repository write access')).toBeInTheDocument();
+    expect(screen.queryByText('Connect your source code')).not.toBeInTheDocument();
+  });
+
+  it('starts a brand new org on the first real step, with nothing done', () => {
+    renderModal('brand-new');
+
+    expect(screen.queryByText('Turn on generative AI')).not.toBeInTheDocument();
+    expect(screen.getByText('Connect your source code')).toBeInTheDocument();
+    expect(screen.getByText('Let Seer open pull requests')).toBeInTheDocument();
+    // Step one is open and actionable, not pre-ticked.
+    expect(screen.getByRole('button', {name: 'Connect GitHub'})).toBeInTheDocument();
+  });
+
+  it('explains why nothing is running yet for an org without Seer', async () => {
+    const {actions} = renderModal('brand-new');
+
+    expect(
+      screen.getByText(
+        'Seer is not on this plan yet. You can still set everything up now — Autofix will start running as soon as Seer is added.'
+      )
+    ).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add Seer'}));
+    expect(actions.activateSeer).toHaveBeenCalled();
+  });
+
+  it('tells an org that finished setup without paying that Autofix is waiting', async () => {
+    const {actions} = renderModal('unpaid-configured');
+
+    expect(screen.getByText('Autofix is ready and waiting')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Add Seer to your plan'}));
+    expect(actions.activateSeer).toHaveBeenCalled();
+  });
+
+  it('offers budget rather than a plan when the org already pays for Seer', () => {
+    renderModal('no-budget');
+
+    expect(screen.getByText('Autofix is ready and waiting')).toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Add Seer budget'})).toBeInTheDocument();
+  });
+
+  it('jumps straight to a step from any row', async () => {
+    renderModal('half-linked');
+
+    // Opens on the last step, since the earlier ones are satisfied.
+    expect(screen.getByRole('button', {name: 'No Automation'})).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Go to “Connect your source code”'})
+    );
+
+    expect(screen.getByRole('button', {name: 'Connect GitHub'})).toBeInTheDocument();
+
+    // ...and back down again, without walking through the step between.
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Go to “Let Seer open pull requests”'})
+    );
+    expect(screen.getByRole('button', {name: 'No Automation'})).toBeInTheDocument();
+  });
+
+  it('points every step at the setting that owns it', async () => {
+    renderModal('gen-ai-disabled');
+
+    // Step 1 — generative AI lives on organization general settings.
+    expect(
+      screen.getByRole('link', {name: 'Show Generative AI Features'})
+    ).toHaveAttribute('href', '/settings/org-slug/#hideAiFeatures');
+
+    // Step 2 — the integration itself.
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Go to “Connect your source code”'})
+    );
+    expect(screen.getByRole('link', {name: 'Integrations'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/integrations/github/'
+    );
+
+    // Step 3 — repository wiring.
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Go to “Link a repository to a project”'})
+    );
+    expect(screen.getByRole('link', {name: 'Autofix settings'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/seer/projects/'
+    );
+
+    // Step 4 — automation and code generation are two different pages.
+    await userEvent.click(
+      screen.getByRole('button', {name: 'Go to “Let Seer open pull requests”'})
+    );
+    expect(screen.getByRole('link', {name: 'Autofix settings'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/seer/projects/'
+    );
+    expect(screen.getByRole('link', {name: 'Defaults'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/seer/projects/defaults/'
+    );
+    expect(screen.getByRole('link', {name: 'Advanced settings'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/seer/advanced/#enableSeerCoding'
+    );
+  });
+
+  it('points the finished state back at Seer settings', () => {
+    renderModal('fully-configured');
+
+    expect(screen.getByRole('link', {name: 'Seer settings'})).toHaveAttribute(
+      'href',
+      '/settings/org-slug/seer/projects/'
+    );
+  });
+});

--- a/static/app/components/seer/onboarding/seerOnboardingModal.tsx
+++ b/static/app/components/seer/onboarding/seerOnboardingModal.tsx
@@ -1,0 +1,647 @@
+import {Fragment, useState} from 'react';
+
+import seerConfigBug1 from 'sentry-images/spot/seer-config-bug-1.svg';
+import seerConfigCheck from 'sentry-images/spot/seer-config-check.svg';
+
+import {Alert} from '@sentry/scraps/alert';
+import {Button} from '@sentry/scraps/button';
+import {CompactSelect} from '@sentry/scraps/compactSelect';
+import {Image} from '@sentry/scraps/image';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {ExternalLink, Link} from '@sentry/scraps/link';
+import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
+import {Switch} from '@sentry/scraps/switch';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {
+  GuidedSteps,
+  useGuidedStepsContext,
+} from 'sentry/components/guidedSteps/guidedSteps';
+import type {
+  SeerOnboardingActions,
+  SeerOnboardingProject,
+  SeerOnboardingState,
+  SeerRepoLink,
+} from 'sentry/components/seer/onboarding/types';
+import {
+  getLinkedProjects,
+  willOpenPullRequests,
+} from 'sentry/components/seer/onboarding/types';
+import {IconAdd, IconChevron, IconDelete} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {useStoppingPointSelectOptions} from 'sentry/utils/seer/stoppingPoint';
+import type {SeerAutofixStoppingPoint} from 'sentry/utils/seer/types';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+const AUTOFIX_DOCS = 'https://docs.sentry.io/product/ai-in-sentry/seer/autofix/';
+const AUTOMATION_DOCS = `${AUTOFIX_DOCS}#how-issue-autofix-works`;
+const CODE_GENERATION_DOCS = `${AUTOFIX_DOCS}#code-generation`;
+const AI_FEATURES_DOCS =
+  'https://docs.sentry.io/product/ai-in-sentry/#ai-powered-features';
+
+interface StepProps {
+  actions: SeerOnboardingActions;
+  state: SeerOnboardingState;
+}
+
+/**
+ * The user-facing stopping point the modal is steering towards. Only this value
+ * produces a pull request from an automated run.
+ */
+const PR_STOPPING_POINT = 'create_pr';
+
+/**
+ * `useStoppingPointSelectOptions` speaks the backend vocabulary; the modal (and
+ * `SeerOnboardingState`) speaks the user-facing one. Both name the same four
+ * choices, so map between them rather than duplicating the option list.
+ */
+function toUserFacing(value: SeerAutofixStoppingPoint) {
+  switch (value) {
+    case 'root_cause':
+      return 'root_cause' as const;
+    case 'solution':
+    case 'code_changes':
+      return 'plan' as const;
+    case 'open_pr':
+      return PR_STOPPING_POINT;
+    default:
+      return 'off' as const;
+  }
+}
+
+/**
+ * Every step configures something the user can revisit. Saying so — and linking
+ * straight at it — keeps the modal from feeling like a one-shot decision.
+ *
+ * Rendered below the step's buttons so it reads as a footnote rather than
+ * splitting the actions apart.
+ *
+ * The `#fieldName` anchors are honoured by the form system: `useScrollToHash`
+ * in `core/form/field/baseField.tsx` scrolls to, focuses and highlights the
+ * matching field.
+ */
+function SettingsHint({children}: {children: React.ReactNode}) {
+  return (
+    <Text as="p" size="sm" variant="muted">
+      {children}
+    </Text>
+  );
+}
+
+function StepDescription({children}: {children: React.ReactNode}) {
+  return (
+    <Text as="p" variant="muted">
+      {children}
+    </Text>
+  );
+}
+
+function EnableAiStep({actions, state}: StepProps) {
+  return (
+    <Stack gap="lg" align="start">
+      <StepDescription>
+        {tct(
+          'Seer is part of your plan, but generative AI features are turned off for this organization. Read more about [ai:generative AI features] in the docs.',
+          {ai: <ExternalLink href={AI_FEATURES_DOCS} />}
+        )}
+      </StepDescription>
+      {state.canWriteOrgSettings ? (
+        <Button variant="primary" size="sm" onClick={actions.enableAiFeatures}>
+          {t('Enable Generative AI Features')}
+        </Button>
+      ) : (
+        <Alert variant="warning">
+          {t(
+            'You need an admin to enable generative AI features before Seer can do anything here.'
+          )}
+        </Alert>
+      )}
+    </Stack>
+  );
+}
+
+function ConnectScmStep({
+  actions,
+  scmButton,
+  state,
+}: StepProps & {scmButton?: React.ReactNode}) {
+  return (
+    <Stack gap="lg" align="start">
+      <StepDescription>
+        {t(
+          'Autofix reads your source code to find the root cause, write a fix, and open the pull request. Connect GitHub to give it access.'
+        )}
+      </StepDescription>
+      {state.canWriteOrgSettings ? (
+        (scmButton ?? (
+          <Button variant="primary" size="sm" onClick={actions.connectScm}>
+            {t('Connect GitHub')}
+          </Button>
+        ))
+      ) : (
+        <Alert variant="warning">
+          {t('You need an admin to install the GitHub integration.')}
+        </Alert>
+      )}
+    </Stack>
+  );
+}
+
+function RepoLinkRow({actions, link, state}: StepProps & {link: SeerRepoLink}) {
+  // A repository can only back one project here, so hide the ones already spoken
+  // for by another row.
+  const takenRepoIds = new Set(
+    state.repoLinks.filter(other => other.id !== link.id).map(other => other.repoId)
+  );
+
+  return (
+    <Flex gap="md" align="center" wrap="wrap">
+      <CompactSelect
+        size="sm"
+        disabled={!state.canWriteOrgSettings}
+        value={link.repoId}
+        menuTitle={t('Repository')}
+        options={state.availableRepos
+          .filter(repo => !takenRepoIds.has(repo.id))
+          .map(repo => ({value: repo.id, label: repo.name}))}
+        onChange={option => actions.setLinkRepo(link.id, String(option.value))}
+        trigger={triggerProps => (
+          <OverlayTrigger.Button {...triggerProps}>
+            {state.availableRepos.find(repo => repo.id === link.repoId)?.name ??
+              t('Select a repository')}
+          </OverlayTrigger.Button>
+        )}
+      />
+      <Text variant="muted">{'\u2192'}</Text>
+      <CompactSelect
+        size="sm"
+        disabled={!state.canWriteOrgSettings}
+        value={link.projectId}
+        menuTitle={t('Project')}
+        options={state.availableProjects.map(project => ({
+          value: project.id,
+          label: project.slug,
+        }))}
+        onChange={option => actions.setLinkProject(link.id, String(option.value))}
+        trigger={triggerProps => (
+          <OverlayTrigger.Button {...triggerProps}>
+            {state.availableProjects.find(project => project.id === link.projectId)
+              ?.slug ?? t('Select a project')}
+          </OverlayTrigger.Button>
+        )}
+      />
+      <Button
+        size="sm"
+        variant="transparent"
+        icon={<IconDelete />}
+        aria-label={t('Remove repository')}
+        disabled={!state.canWriteOrgSettings}
+        onClick={() => actions.removeRepoLink(link.id)}
+      />
+    </Flex>
+  );
+}
+
+function LinkReposStep({actions, state}: StepProps) {
+  return (
+    <Stack gap="lg" align="start">
+      <StepDescription>
+        {t(
+          'Pick the repository each project ships from. Without one, Autofix can triage an issue but has nothing to write a fix against.'
+        )}
+      </StepDescription>
+
+      {state.repoLinks.length > 0 ? (
+        <Stack gap="md">
+          {state.repoLinks.map(link => (
+            <RepoLinkRow key={link.id} link={link} actions={actions} state={state} />
+          ))}
+        </Stack>
+      ) : null}
+
+      <Button
+        size="sm"
+        icon={<IconAdd />}
+        disabled={!state.canWriteOrgSettings}
+        onClick={actions.addRepoLink}
+        variant={state.repoLinks.length > 0 ? 'secondary' : 'primary'}
+      >
+        {state.repoLinks.length > 0 ? t('Add another') : t('Connect a repository')}
+      </Button>
+    </Stack>
+  );
+}
+
+function ProjectAutomationRow({
+  actions,
+  project,
+  state,
+}: StepProps & {project: SeerOnboardingProject}) {
+  const stoppingPointOptions = useStoppingPointSelectOptions();
+  const current = state.stoppingPoints[project.id] ?? 'off';
+  const selectedOption = stoppingPointOptions.find(
+    option => toUserFacing(option.value) === current
+  );
+
+  return (
+    <Flex gap="md" align="center" justify="between" wrap="wrap">
+      <Text bold>{project.slug}</Text>
+      <CompactSelect
+        size="sm"
+        disabled={!state.canWriteOrgSettings}
+        value={selectedOption?.value ?? 'off'}
+        options={stoppingPointOptions}
+        onChange={option =>
+          actions.setProjectStoppingPoint(project.id, toUserFacing(option.value))
+        }
+      />
+    </Flex>
+  );
+}
+
+function EnablePrsStep({actions, state}: StepProps) {
+  const linkedProjects = getLinkedProjects(state);
+
+  return (
+    <Stack gap="xl" align="start">
+      <StepDescription>
+        {tct(
+          'Choose how far an automated run should go for each project. "Stop after PR drafted" lets Seer triage new issues in the background and open a pull request for the [actionable:most actionable] ones.',
+          {actionable: <ExternalLink href={AUTOMATION_DOCS} />}
+        )}
+      </StepDescription>
+
+      {linkedProjects.length > 0 ? (
+        <Stack gap="md" width="100%" maxWidth="440px">
+          {linkedProjects.map(project => (
+            <ProjectAutomationRow
+              key={project.id}
+              project={project}
+              actions={actions}
+              state={state}
+            />
+          ))}
+        </Stack>
+      ) : (
+        <Alert variant="info">
+          {t('Link a repository to a project first — there is nothing to automate yet.')}
+        </Alert>
+      )}
+
+      <Stack gap="sm">
+        <Flex align="center" gap="md">
+          <Switch
+            checked={state.enableSeerCoding}
+            disabled={!state.canWriteOrgSettings || state.isCodingSettingManaged}
+            onChange={event => actions.setEnableSeerCoding(event.target.checked)}
+          />
+          <Text bold>{t('Enable Code Generation')}</Text>
+        </Flex>
+        <Text size="sm" variant="muted">
+          {tct(
+            'Allow Seer to create PRs or branches in your repositories. [docs:Read the docs] to learn more.',
+            {docs: <ExternalLink href={CODE_GENERATION_DOCS} />}
+          )}
+        </Text>
+        {state.isCodingSettingManaged ? (
+          <Alert variant="info">
+            {t('Code generation is managed by your organization.')}
+          </Alert>
+        ) : null}
+      </Stack>
+    </Stack>
+  );
+}
+
+/**
+ * Setup is deliberately not gated on billing: an organization can wire every step
+ * up before it pays, so Autofix starts working the moment Seer is switched on.
+ * Returns why nothing is running yet, or null when Seer is live.
+ */
+function getInactiveReason(state: SeerOnboardingState) {
+  if (state.entitlement === 'none') {
+    return {
+      ctaLabel: t('Add Seer to your plan'),
+      shortCtaLabel: t('Add Seer'),
+      notice: t(
+        'Seer is not on this plan yet. You can still set everything up now — Autofix will start running as soon as Seer is added.'
+      ),
+      readyDescription: t(
+        'Everything is configured. Add Seer and it will start triaging new issues, working out the root cause, and opening pull requests for the most actionable ones.'
+      ),
+    };
+  }
+  if (!state.hasAutofixBudget) {
+    return {
+      ctaLabel: t('Add Seer budget'),
+      shortCtaLabel: t('Add budget'),
+      notice: t(
+        'This organization is out of Seer budget, so automated runs are paused. Setup changes still stick.'
+      ),
+      readyDescription: t(
+        'Everything is configured. Automated runs resume as soon as this organization has Seer budget again.'
+      ),
+    };
+  }
+  return null;
+}
+
+type InactiveReason = NonNullable<ReturnType<typeof getInactiveReason>>;
+
+function AllSetPanel({
+  actions,
+  inactiveReason,
+}: {
+  actions: SeerOnboardingActions;
+  inactiveReason: InactiveReason | null;
+}) {
+  const organization = useOrganization();
+
+  return (
+    <Flex align="center" gap="2xl">
+      <Image src={seerConfigCheck} alt="" height="112px" />
+      <Stack gap="md" align="start">
+        <Heading as="h3" size="lg">
+          {inactiveReason ? t('Autofix is ready and waiting') : t('Autofix is ready')}
+        </Heading>
+        <Text variant="muted">
+          {inactiveReason
+            ? inactiveReason.readyDescription
+            : t(
+                'Seer will triage new issues as they arrive, work out the root cause, write a fix, and open a pull request for the most actionable ones.'
+              )}
+        </Text>
+        <Text variant="muted">
+          {tct(
+            '[settings:Seer settings] holds everything you just set up, plus per-repository branches and instructions. [docs:Read the docs].',
+            {
+              settings: <Link to={`/settings/${organization.slug}/seer/projects/`} />,
+              docs: <ExternalLink href={AUTOFIX_DOCS} />,
+            }
+          )}
+        </Text>
+        {inactiveReason ? (
+          <Button variant="primary" size="sm" onClick={actions.activateSeer}>
+            {inactiveReason.ctaLabel}
+          </Button>
+        ) : null}
+      </Stack>
+    </Flex>
+  );
+}
+
+function SeerInactiveNotice({
+  actions,
+  inactiveReason,
+}: {
+  actions: SeerOnboardingActions;
+  inactiveReason: InactiveReason;
+}) {
+  return (
+    <Alert
+      variant="info"
+      trailingItems={
+        <Button size="xs" onClick={actions.activateSeer}>
+          {inactiveReason.shortCtaLabel}
+        </Button>
+      }
+    >
+      {inactiveReason.notice}
+    </Alert>
+  );
+}
+
+/**
+ * A gate the modal deliberately does not try to resolve yet — it names what is
+ * wrong instead of pretending to fix it. The real upsell and permission flows
+ * already exist elsewhere and should be wired in when this modal goes live.
+ */
+function BlockedPanel({
+  description,
+  title,
+}: {
+  description: React.ReactNode;
+  title: string;
+}) {
+  return (
+    <Flex align="center" gap="2xl">
+      <Image src={seerConfigBug1} alt="" height="112px" />
+      <Stack gap="md">
+        <Heading as="h3" size="lg">
+          {title}
+        </Heading>
+        <Text variant="muted">{description}</Text>
+      </Stack>
+    </Flex>
+  );
+}
+
+function getBlocker(state: SeerOnboardingState) {
+  if (!state.hasScmWriteAccess) {
+    return {
+      title: t('Missing repository write access'),
+      description: t(
+        'Seer can read your code but cannot push a branch, so it will stop short of opening a pull request. Update the GitHub app permissions to continue.'
+      ),
+    };
+  }
+  return null;
+}
+
+/**
+ * A step you can jump straight to, instead of clicking Back and Next through
+ * everything in between.
+ *
+ * `GuidedSteps.Step` renders its own header as a permanently disabled button and
+ * exposes no click handler, so the affordance goes in `trailingItems` — which is
+ * the one slot that renders for collapsed steps too. Jumping needs
+ * `useGuidedStepsContext`, which only resolves inside `<GuidedSteps>`, hence the
+ * wrapper.
+ */
+function JumpableStep({
+  children,
+  isCompleted,
+  settingsHint,
+  stepKey,
+  title,
+}: {
+  children: React.ReactNode;
+  isCompleted: boolean;
+  settingsHint: React.ReactNode;
+  stepKey: string;
+  title: string;
+}) {
+  const {getStepNumber, setCurrentStep} = useGuidedStepsContext();
+
+  return (
+    <GuidedSteps.Step
+      stepKey={stepKey}
+      title={title}
+      isCompleted={isCompleted}
+      trailingItems={
+        <Button
+          size="xs"
+          variant="transparent"
+          icon={<IconChevron direction="right" />}
+          aria-label={t('Go to “%s”', title)}
+          // `getStepNumber` reads the registry at call time, so this resolves
+          // correctly even though steps register after the first render.
+          onClick={() => setCurrentStep(getStepNumber(stepKey))}
+        />
+      }
+    >
+      {children}
+      <GuidedSteps.StepButtons />
+      <Container paddingTop="lg">{settingsHint}</Container>
+    </GuidedSteps.Step>
+  );
+}
+
+interface SeerOnboardingModalProps extends ModalRenderProps {
+  actions: SeerOnboardingActions;
+  state: SeerOnboardingState;
+  /**
+   * Rendered in place of the default "Connect GitHub" button. Exists so a
+   * caller can supply the real integration install button without this
+   * component reaching into getsentry.
+   */
+  scmButton?: React.ReactNode;
+}
+
+export function SeerOnboardingModal({
+  Body,
+  Footer,
+  Header,
+  actions,
+  closeModal,
+  scmButton,
+  state,
+}: SeerOnboardingModalProps) {
+  const orgSlug = useOrganization().slug;
+  const blocker = getBlocker(state);
+
+  const aiEnabled = !state.hideAiFeatures;
+  // Generative AI is on by default, so for almost every org this is not a setup
+  // step at all — it is an exception. Only show it when it is actually blocking.
+  // Decided once on open: GuidedSteps fixes step order at mount, and the step
+  // must not vanish from under someone who has just used it.
+  const [showAiStep] = useState(() => state.hideAiFeatures);
+  const scmConnected = state.hasSupportedScmIntegration;
+  const reposLinked = getLinkedProjects(state).length > 0;
+  const prsEnabled = willOpenPullRequests(state);
+  const isComplete = aiEnabled && scmConnected && reposLinked && prsEnabled;
+  // Billing is not a setup step. An unpaid org walks the same four steps and
+  // simply has nothing running at the end of them.
+  const inactiveReason = getInactiveReason(state);
+
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Heading as="h2" size="xl">
+          {t('Set up Seer Autofix')}
+        </Heading>
+      </Header>
+      <Body>
+        {blocker ? (
+          <BlockedPanel title={blocker.title} description={blocker.description} />
+        ) : isComplete ? (
+          <AllSetPanel actions={actions} inactiveReason={inactiveReason} />
+        ) : (
+          <Stack gap="xl">
+            {inactiveReason ? (
+              <SeerInactiveNotice actions={actions} inactiveReason={inactiveReason} />
+            ) : null}
+            <Text variant="muted">
+              {t(
+                'A few things have to be true before Seer can triage issues in the background and open a pull request for you.'
+              )}
+            </Text>
+            <GuidedSteps>
+              {showAiStep ? (
+                <JumpableStep
+                  stepKey="enable-ai"
+                  title={t('Turn on generative AI')}
+                  isCompleted={aiEnabled}
+                  settingsHint={
+                    <SettingsHint>
+                      {tct(
+                        'Change this later under [link:Show Generative AI Features].',
+                        {link: <Link to={`/settings/${orgSlug}/#hideAiFeatures`} />}
+                      )}
+                    </SettingsHint>
+                  }
+                >
+                  <EnableAiStep actions={actions} state={state} />
+                </JumpableStep>
+              ) : null}
+              <JumpableStep
+                stepKey="connect-scm"
+                title={t('Connect your source code')}
+                isCompleted={scmConnected}
+                settingsHint={
+                  <SettingsHint>
+                    {tct(
+                      'Repository access and permissions are managed under [link:Integrations].',
+                      {link: <Link to={`/settings/${orgSlug}/integrations/github/`} />}
+                    )}
+                  </SettingsHint>
+                }
+              >
+                <ConnectScmStep actions={actions} state={state} scmButton={scmButton} />
+              </JumpableStep>
+              <JumpableStep
+                stepKey="link-repos"
+                title={t('Link a repository to a project')}
+                isCompleted={reposLinked}
+                settingsHint={
+                  <SettingsHint>
+                    {tct(
+                      'Change these later in [link:Autofix settings], along with each repository’s working branch and instructions.',
+                      {link: <Link to={`/settings/${orgSlug}/seer/projects/`} />}
+                    )}
+                  </SettingsHint>
+                }
+              >
+                <LinkReposStep actions={actions} state={state} />
+              </JumpableStep>
+              <JumpableStep
+                stepKey="enable-prs"
+                title={t('Let Seer open pull requests')}
+                isCompleted={prsEnabled}
+                settingsHint={
+                  <SettingsHint>
+                    {tct(
+                      'Change these later in [link:Autofix settings], set the default for new projects under [defaults:Defaults], or manage code generation in [advanced:Advanced settings].',
+                      {
+                        link: <Link to={`/settings/${orgSlug}/seer/projects/`} />,
+                        defaults: (
+                          <Link to={`/settings/${orgSlug}/seer/projects/defaults/`} />
+                        ),
+                        advanced: (
+                          <Link
+                            to={`/settings/${orgSlug}/seer/advanced/#enableSeerCoding`}
+                          />
+                        ),
+                      }
+                    )}
+                  </SettingsHint>
+                }
+              >
+                <EnablePrsStep actions={actions} state={state} />
+              </JumpableStep>
+            </GuidedSteps>
+          </Stack>
+        )}
+      </Body>
+      <Footer>
+        <Button
+          variant={isComplete || blocker ? 'primary' : 'secondary'}
+          onClick={closeModal}
+        >
+          {isComplete || blocker ? t('Done') : t('Finish later')}
+        </Button>
+      </Footer>
+    </Fragment>
+  );
+}

--- a/static/app/components/seer/onboarding/types.ts
+++ b/static/app/components/seer/onboarding/types.ts
@@ -1,0 +1,102 @@
+import type {UserFacingStoppingPoint} from 'sentry/utils/seer/types';
+
+export interface SeerOnboardingRepo {
+  id: string;
+  /** Display name, in `owner/name` form. */
+  name: string;
+}
+
+export interface SeerOnboardingProject {
+  id: string;
+  slug: string;
+}
+
+/**
+ * One repository attached to one project. Mirrors a `SeerProjectRepository` row,
+ * which is what Autofix actually reads — code mappings are only suggestions.
+ */
+export interface SeerRepoLink {
+  id: string;
+  /** Empty until the row is filled in. */
+  projectId: string;
+  repoId: string;
+}
+
+/**
+ * Everything the Seer onboarding modal needs to know, flattened into plain data.
+ *
+ * The modal is intentionally presentational: it never queries or mutates. Production
+ * callsites derive this from the API (`seer/onboarding-check/`, `seer/setup-check/`,
+ * `/organizations/{org}/repos/`, project settings, ...) while the onboarding lab hands
+ * it fabricated values, so every scenario is reachable without touching a real
+ * organization.
+ */
+export interface SeerOnboardingState {
+  /** Projects the user could attach a repository to. */
+  availableProjects: SeerOnboardingProject[];
+  /** Repositories visible through the connected SCM integration. */
+  availableRepos: SeerOnboardingRepo[];
+  /** `org:write` — required to change any of the settings below. */
+  canWriteOrgSettings: boolean;
+  /** Org option `sentry:enable_seer_coding`. Without it Seer never writes code. */
+  enableSeerCoding: boolean;
+  /** Which Seer plan the org is on, if any. */
+  entitlement: 'none' | 'legacy' | 'seat-based';
+  /** Whether the org has `SEER_AUTOFIX` / `SEER_SCANNER` budget left. */
+  hasAutofixBudget: boolean;
+  /** Whether the SCM app still has write permission — PRs fail without it. */
+  hasScmWriteAccess: boolean;
+  /** An active GitHub, GitHub Enterprise or (flagged) GitLab integration. */
+  hasSupportedScmIntegration: boolean;
+  /** Org option `sentry:hide_ai_features`. */
+  hideAiFeatures: boolean;
+  /** `organizations:seer-disable-coding-setting` — code generation is org-managed. */
+  isCodingSettingManaged: boolean;
+  /** Repository/project pairings, one row per pairing. */
+  repoLinks: SeerRepoLink[];
+  /**
+   * Where automated runs stop, per project. Only `create_pr` produces a pull
+   * request. Projects missing from this map have never been configured.
+   */
+  stoppingPoints: Record<string, UserFacingStoppingPoint>;
+}
+
+/**
+ * The writes the modal can ask for. Production supplies real mutations; the
+ * onboarding lab supplies simulated ones that mutate local state.
+ */
+export interface SeerOnboardingActions {
+  /** Send the user off to buy or trial Seer. Setup itself never waits on this. */
+  activateSeer(): void;
+  /** Start a new, empty repository/project row. */
+  addRepoLink(): void;
+  connectScm(): void;
+  enableAiFeatures(): void;
+  removeRepoLink(linkId: string): void;
+  setEnableSeerCoding(value: boolean): void;
+  setLinkProject(linkId: string, projectId: string): void;
+  setLinkRepo(linkId: string, repoId: string): void;
+  setProjectStoppingPoint(projectId: string, value: UserFacingStoppingPoint): void;
+}
+
+/** Projects that have at least one repository attached. */
+export function getLinkedProjects(state: SeerOnboardingState): SeerOnboardingProject[] {
+  const linkedIds = new Set(
+    state.repoLinks.filter(link => link.projectId && link.repoId).map(l => l.projectId)
+  );
+  return state.availableProjects.filter(project => linkedIds.has(project.id));
+}
+
+/**
+ * Autofix needs at least one project that is wired end to end: a repository to
+ * work in, permission to write code, and an automated run that goes as far as
+ * opening the pull request.
+ */
+export function willOpenPullRequests(state: SeerOnboardingState): boolean {
+  return (
+    state.enableSeerCoding &&
+    getLinkedProjects(state).some(
+      project => state.stoppingPoints[project.id] === 'create_pr'
+    )
+  );
+}

--- a/static/gsApp/overrides/seerSettingsRoutes.ts
+++ b/static/gsApp/overrides/seerSettingsRoutes.ts
@@ -26,6 +26,13 @@ export const seerSettingsRoutes = (): SentryRouteObject => ({
       component: make(() => import('getsentry/views/seerAutomation/connectors')),
     },
     {
+      // Employee-only harness for the Seer onboarding modal. Intentionally not in
+      // the Seer sub-nav; reachable by URL only.
+      path: 'onboarding-lab/',
+      name: t('Onboarding Lab'),
+      component: make(() => import('getsentry/views/seerAutomation/onboardingLab')),
+    },
+    {
       // Legacy autofix page, redirects to /seer/projects/ if seat-based is active
       index: true,
       name: t('Seer Automation'),

--- a/static/gsApp/views/seerAutomation/onboardingLab.spec.tsx
+++ b/static/gsApp/views/seerAutomation/onboardingLab.spec.tsx
@@ -1,0 +1,177 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+  within,
+} from 'sentry-test/reactTestingLibrary';
+
+import SeerOnboardingLab from 'getsentry/views/seerAutomation/onboardingLab';
+
+const superuserOrganization = OrganizationFixture({
+  access: ['org:read', 'org:write', 'org:superuser'],
+  features: ['seat-based-seer-enabled'],
+});
+
+/** Re-read the dialog: the install pipeline tears the onboarding modal down. */
+function dialog() {
+  return screen.getByRole('dialog');
+}
+
+describe('SeerOnboardingLab', () => {
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    // No connected repos, so the lab falls back to the fixture catalogue and the
+    // scenarios stay deterministic.
+    MockApiClient.addMockResponse({url: '/organizations/org-slug/repos/', body: []});
+  });
+
+  it('hides itself from users without superuser access', () => {
+    render(<SeerOnboardingLab />, {organization: OrganizationFixture()});
+
+    expect(screen.getByText("You don't have access to this feature")).toBeInTheDocument();
+    expect(screen.queryByText('Seer Onboarding Lab')).not.toBeInTheDocument();
+  });
+
+  it('shows the state of the selected scenario', async () => {
+    render(<SeerOnboardingLab />, {organization: superuserOrganization});
+
+    expect(await screen.findByTestId('lab-state-entitlement')).toHaveTextContent('none');
+
+    await userEvent.click(screen.getByRole('radio', {name: /Fully configured/}));
+
+    expect(screen.getByTestId('lab-state-entitlement')).toHaveTextContent('seat-based');
+    expect(screen.getByTestId('lab-state-stoppingPoints')).toHaveTextContent(
+      'frontend: create_pr, backend: create_pr'
+    );
+    expect(screen.getByTestId('lab-state-repoLinks')).toHaveTextContent(
+      'acme/web → frontend, acme/api → backend'
+    );
+  });
+
+  it('falls back to fixtures when the org has no connected repositories', async () => {
+    render(<SeerOnboardingLab />, {organization: superuserOrganization});
+
+    expect(await screen.findByText(/This org \(0 repos/)).toBeInTheDocument();
+    // The catalogue is empty, so the scenario keeps its fixture repositories.
+    expect(screen.getByTestId('lab-state-repoLinks')).toHaveTextContent('[]');
+
+    await userEvent.click(screen.getByRole('radio', {name: /Fully configured/}));
+    expect(screen.getByTestId('lab-state-repoLinks')).toHaveTextContent('acme/web');
+  });
+
+  it('hands back to onboarding after the install pipeline takes the modal over', async () => {
+    render(<SeerOnboardingLab />, {organization: superuserOrganization});
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('radio', {name: /No source code/}));
+    await userEvent.click(screen.getByRole('button', {name: 'Open modal'}));
+    await userEvent.click(within(dialog()).getByRole('button', {name: 'Connect GitHub'}));
+
+    // The pipeline has replaced the onboarding modal, not stacked on it.
+    expect(within(dialog()).getByText('Add Installation')).toBeInTheDocument();
+    expect(within(dialog()).queryByText('Set up Seer Autofix')).not.toBeInTheDocument();
+
+    await userEvent.click(within(dialog()).getByRole('button', {name: 'Finish install'}));
+
+    // ...and finishing hands us back, past the step we just completed.
+    expect(within(dialog()).getByText('Set up Seer Autofix')).toBeInTheDocument();
+    expect(
+      within(dialog()).getByRole('button', {name: 'Connect a repository'})
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('lab-state-hasSupportedScmIntegration')).toHaveTextContent(
+      'true'
+    );
+  });
+
+  it('abandons nothing when the install pipeline is cancelled', async () => {
+    render(<SeerOnboardingLab />, {organization: superuserOrganization});
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('radio', {name: /No source code/}));
+    await userEvent.click(screen.getByRole('button', {name: 'Open modal'}));
+    await userEvent.click(within(dialog()).getByRole('button', {name: 'Connect GitHub'}));
+    await userEvent.click(within(dialog()).getByRole('button', {name: 'Cancel'}));
+
+    // Cancelling leaves no modal, so the page's Open modal button gets you back.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('lab-state-hasSupportedScmIntegration')).toHaveTextContent(
+      'false'
+    );
+  });
+
+  it('simulates buying Seer from the set-up-but-unpaid scenario', async () => {
+    render(<SeerOnboardingLab />, {organization: superuserOrganization});
+    renderGlobalModal();
+
+    await userEvent.click(
+      await screen.findByRole('radio', {name: /Set up, but no Seer plan/})
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Open modal'}));
+
+    expect(
+      within(dialog()).getByText('Autofix is ready and waiting')
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(dialog()).getByRole('button', {name: 'Add Seer to your plan'})
+    );
+
+    expect(within(dialog()).getByText('Autofix is ready')).toBeInTheDocument();
+    expect(screen.getByTestId('lab-state-entitlement')).toHaveTextContent('seat-based');
+  });
+
+  it('walks an unpaid org all the way from nothing to ready', async () => {
+    render(<SeerOnboardingLab />, {organization: superuserOrganization});
+    renderGlobalModal();
+
+    await userEvent.click(await screen.findByRole('radio', {name: /Brand new org/}));
+    await userEvent.click(screen.getByRole('button', {name: 'Open modal'}));
+
+    // No plan, but setup is not gated on billing.
+    expect(
+      within(dialog()).getByText(/Seer is not on this plan yet/)
+    ).toBeInTheDocument();
+
+    // Connect the SCM integration, through the pipeline hand-off.
+    await userEvent.click(within(dialog()).getByRole('button', {name: 'Connect GitHub'}));
+    await userEvent.click(within(dialog()).getByRole('button', {name: 'Finish install'}));
+
+    // Link a repository to a project.
+    await userEvent.click(
+      within(dialog()).getByRole('button', {name: 'Connect a repository'})
+    );
+    await userEvent.click(
+      within(dialog()).getByRole('button', {name: 'Select a repository'})
+    );
+    await userEvent.click(screen.getByRole('option', {name: 'acme/web'}));
+    await userEvent.click(
+      within(dialog()).getByRole('button', {name: 'Select a project'})
+    );
+    await userEvent.click(screen.getByRole('option', {name: 'frontend'}));
+
+    expect(screen.getByTestId('lab-state-repoLinks')).toHaveTextContent(
+      'acme/web → frontend'
+    );
+
+    // Turn automation up to opening pull requests.
+    await userEvent.click(within(dialog()).getByRole('button', {name: 'No Automation'}));
+    await userEvent.click(screen.getByRole('option', {name: 'Stop after PR drafted'}));
+
+    expect(screen.getByTestId('lab-state-stoppingPoints')).toHaveTextContent(
+      'frontend: create_pr'
+    );
+
+    // Setup is done, but Seer still is not paid for.
+    expect(
+      within(dialog()).getByText('Autofix is ready and waiting')
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      within(dialog()).getByRole('button', {name: 'Add Seer to your plan'})
+    );
+    expect(within(dialog()).getByText('Autofix is ready')).toBeInTheDocument();
+  });
+});

--- a/static/gsApp/views/seerAutomation/onboardingLab.tsx
+++ b/static/gsApp/views/seerAutomation/onboardingLab.tsx
@@ -1,0 +1,522 @@
+import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {css} from '@emotion/react';
+import {useInfiniteQuery} from '@tanstack/react-query';
+
+import {Button} from '@sentry/scraps/button';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {useModal} from '@sentry/scraps/modal';
+import {SegmentedControl} from '@sentry/scraps/segmentedControl';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import type {ModalRenderProps} from 'sentry/actionCreators/modal';
+import {RadioGroup} from 'sentry/components/forms/controls/radioGroup';
+import {NoAccess} from 'sentry/components/noAccess';
+import {Panel} from 'sentry/components/panels/panel';
+import {PanelBody} from 'sentry/components/panels/panelBody';
+import {PanelHeader} from 'sentry/components/panels/panelHeader';
+import {PanelItem} from 'sentry/components/panels/panelItem';
+import {
+  SEER_ONBOARDING_SCENARIOS,
+  getSeerOnboardingScenario,
+} from 'sentry/components/seer/onboarding/scenarios';
+import {SeerOnboardingModal} from 'sentry/components/seer/onboarding/seerOnboardingModal';
+import type {
+  SeerOnboardingActions,
+  SeerOnboardingState,
+} from 'sentry/components/seer/onboarding/types';
+import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {NODE_ENV} from 'sentry/constants/env';
+import {t} from 'sentry/locale';
+import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
+import {
+  organizationRepositoriesInfiniteOptions,
+  selectUniqueRepos,
+} from 'sentry/utils/repositories/repoQueryOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
+import {SettingsPageHeader} from 'sentry/views/settings/components/settingsPageHeader';
+
+import {GithubButton} from 'getsentry/views/seerAutomation/onboarding/githubButton';
+import {SeerOnboardingProvider} from 'getsentry/views/seerAutomation/onboarding/hooks/seerOnboardingContext';
+
+/** Monotonic so a removed row's id is never reused within a session. */
+let nextLinkId = 1000;
+
+const modalCss = css`
+  width: 100%;
+  max-width: 640px;
+`;
+
+type ScmMode = 'standin' | 'real';
+type DataSource = 'live' | 'fixtures';
+
+/**
+ * Stands in for the GitHub install pipeline.
+ *
+ * The real flow calls `openPipelineModal`, and `GlobalModal` is a singleton — so
+ * launching it *replaces* the onboarding modal rather than stacking on it. This
+ * reproduces exactly that takeover, so the hand-back can be exercised without
+ * installing a GitHub app anywhere.
+ */
+function StandInPipelineModal({
+  Header,
+  Body,
+  Footer,
+  closeModal,
+  onComplete,
+}: ModalRenderProps & {
+  onComplete: () => void;
+}) {
+  return (
+    <Fragment>
+      <Header closeButton>
+        <Heading as="h2" size="lg">
+          {t('Add Installation')}
+        </Heading>
+      </Header>
+      <Body>
+        <Stack gap="md">
+          <Text variant="muted">
+            {t(
+              'Stand-in for the GitHub install pipeline. The real one OAuths in a popup and asks which GitHub organization to install into.'
+            )}
+          </Text>
+          <Text variant="muted">
+            {t(
+              'Note that this modal replaced the onboarding modal — finishing here should hand you back to it.'
+            )}
+          </Text>
+        </Stack>
+      </Body>
+      <Footer>
+        <Flex gap="md">
+          <Button onClick={closeModal}>{t('Cancel')}</Button>
+          <Button
+            variant="primary"
+            onClick={() => {
+              closeModal();
+              onComplete();
+            }}
+          >
+            {t('Finish install')}
+          </Button>
+        </Flex>
+      </Footer>
+    </Fragment>
+  );
+}
+
+/**
+ * Owns the mock state for one run through the modal.
+ *
+ * This has to live inside the modal renderer: `GlobalModal` keeps the renderer in
+ * a store, so a closure over the lab page's state would go stale as soon as the
+ * first action fired. `onStateChange` mirrors the state back out so the lab's
+ * state table survives the modal being torn down by the install pipeline.
+ */
+function MockSeerOnboardingModal({
+  initialState,
+  onStateChange,
+  scmButton,
+  ...modalProps
+}: ModalRenderProps & {
+  initialState: SeerOnboardingState;
+  onStateChange: (state: SeerOnboardingState) => void;
+  scmButton: React.ReactNode;
+}) {
+  const [state, setState] = useState(initialState);
+
+  useEffect(() => {
+    onStateChange(state);
+  }, [state, onStateChange]);
+
+  const actions = useMemo<SeerOnboardingActions>(
+    () => ({
+      // Stands in for checkout: the org comes back with a plan and budget.
+      activateSeer: () =>
+        setState(prev => ({...prev, entitlement: 'seat-based', hasAutofixBudget: true})),
+      // Unused here — the SCM step renders a real launcher via `scmButton`.
+      connectScm: () => setState(prev => ({...prev, hasSupportedScmIntegration: true})),
+      enableAiFeatures: () => setState(prev => ({...prev, hideAiFeatures: false})),
+      addRepoLink: () =>
+        setState(prev => ({
+          ...prev,
+          repoLinks: [
+            ...prev.repoLinks,
+            {id: `link-${nextLinkId++}`, repoId: '', projectId: ''},
+          ],
+        })),
+      removeRepoLink: linkId =>
+        setState(prev => ({
+          ...prev,
+          repoLinks: prev.repoLinks.filter(link => link.id !== linkId),
+        })),
+      setLinkRepo: (linkId, repoId) =>
+        setState(prev => ({
+          ...prev,
+          repoLinks: prev.repoLinks.map(link =>
+            link.id === linkId ? {...link, repoId} : link
+          ),
+        })),
+      setLinkProject: (linkId, projectId) =>
+        setState(prev => ({
+          ...prev,
+          repoLinks: prev.repoLinks.map(link =>
+            link.id === linkId ? {...link, projectId} : link
+          ),
+          // A newly attached project starts from the org default, which is off.
+          stoppingPoints: {[projectId]: 'off', ...prev.stoppingPoints},
+        })),
+      setProjectStoppingPoint: (projectId, value) =>
+        setState(prev => ({
+          ...prev,
+          stoppingPoints: {...prev.stoppingPoints, [projectId]: value},
+        })),
+      setEnableSeerCoding: value =>
+        setState(prev => ({...prev, enableSeerCoding: value})),
+    }),
+    []
+  );
+
+  return (
+    <SeerOnboardingModal
+      {...modalProps}
+      state={state}
+      actions={actions}
+      scmButton={scmButton}
+    />
+  );
+}
+
+/**
+ * The gates worth watching, in the order the modal walks them. The repo/project
+ * catalogue is source data, not state, so it is left out.
+ */
+function describeState(state: SeerOnboardingState): Array<[string, string]> {
+  const repoLinks =
+    state.repoLinks.length === 0
+      ? '[]'
+      : state.repoLinks
+          .map(link => {
+            const repo =
+              state.availableRepos.find(r => r.id === link.repoId)?.name ?? '?';
+            const project =
+              state.availableProjects.find(p => p.id === link.projectId)?.slug ?? '?';
+            return `${repo} → ${project}`;
+          })
+          .join(', ');
+
+  const stoppingPoints = Object.entries(state.stoppingPoints);
+
+  return [
+    ['entitlement', state.entitlement],
+    ['hasAutofixBudget', String(state.hasAutofixBudget)],
+    ['hideAiFeatures', String(state.hideAiFeatures)],
+    ['canWriteOrgSettings', String(state.canWriteOrgSettings)],
+    ['hasSupportedScmIntegration', String(state.hasSupportedScmIntegration)],
+    ['hasScmWriteAccess', String(state.hasScmWriteAccess)],
+    ['repoLinks', repoLinks],
+    [
+      'stoppingPoints',
+      stoppingPoints.length === 0
+        ? '{}'
+        : stoppingPoints
+            .map(([projectId, value]) => {
+              const slug =
+                state.availableProjects.find(p => p.id === projectId)?.slug ?? projectId;
+              return `${slug}: ${value}`;
+            })
+            .join(', '),
+    ],
+    ['enableSeerCoding', String(state.enableSeerCoding)],
+    ['isCodingSettingManaged', String(state.isCodingSettingManaged)],
+  ];
+}
+
+function StateRow({label, value}: {label: string; value: string}) {
+  return (
+    <PanelItem>
+      <Grid columns="220px 1fr" gap="md" width="100%">
+        <Text size="sm" variant="muted" monospace>
+          {label}
+        </Text>
+        <Text size="sm" monospace data-test-id={`lab-state-${label}`}>
+          {value}
+        </Text>
+      </Grid>
+    </PanelItem>
+  );
+}
+
+/**
+ * Rehomes a scenario's fixture links onto whatever this organization actually
+ * has, pairing them off by position. Links and stopping points beyond the real
+ * catalogue are dropped rather than left dangling.
+ */
+function withLiveCatalogue(
+  scenarioState: SeerOnboardingState,
+  availableRepos: SeerOnboardingState['availableRepos'],
+  availableProjects: SeerOnboardingState['availableProjects']
+): SeerOnboardingState {
+  const fixtureProjectIds = scenarioState.availableProjects.map(p => p.id);
+
+  const repoLinks = scenarioState.repoLinks
+    .map((link, index) => {
+      const repo = availableRepos[index];
+      const projectIndex = fixtureProjectIds.indexOf(link.projectId);
+      const project = projectIndex >= 0 ? availableProjects[projectIndex] : undefined;
+      if (!repo) {
+        return null;
+      }
+      return {
+        id: link.id,
+        repoId: link.repoId ? repo.id : '',
+        // Preserve a half-filled row as half-filled.
+        projectId: link.projectId ? (project?.id ?? '') : '',
+      };
+    })
+    .filter(link => link !== null);
+
+  const stoppingPoints = Object.fromEntries(
+    Object.entries(scenarioState.stoppingPoints).flatMap(([fixtureId, value]) => {
+      const project = availableProjects[fixtureProjectIds.indexOf(fixtureId)];
+      return project ? [[project.id, value] as const] : [];
+    })
+  );
+
+  return {...scenarioState, availableRepos, availableProjects, repoLinks, stoppingPoints};
+}
+
+export default function SeerOnboardingLab() {
+  const organization = useOrganization();
+  const {openModal} = useModal();
+  const [scenarioKey, setScenarioKey] = useState(SEER_ONBOARDING_SCENARIOS[0]!.key);
+  const [scmMode, setScmMode] = useState<ScmMode>('standin');
+  const [dataSource, setDataSource] = useState<DataSource>('live');
+
+  const {projects, fetching: projectsFetching} = useProjects();
+  const reposResult = useInfiniteQuery({
+    ...organizationRepositoriesInfiniteOptions({
+      organization,
+      query: {per_page: 100},
+      staleTime: 60_000,
+    }),
+    select: selectUniqueRepos,
+  });
+  useFetchAllPages({result: reposResult});
+
+  const liveRepos = useMemo(
+    () =>
+      (reposResult.data ?? [])
+        .filter(repo => repo.externalId)
+        .map(repo => ({id: repo.id, name: repo.name})),
+    [reposResult.data]
+  );
+  const liveProjects = useMemo(
+    () => projects.map(project => ({id: project.id, slug: project.slug})),
+    [projects]
+  );
+  const hasLiveData = liveRepos.length > 0 && liveProjects.length > 0;
+  const useLive = dataSource === 'live' && hasLiveData;
+
+  const buildState = useCallback(
+    (key: string) => {
+      const scenarioState = getSeerOnboardingScenario(key).state;
+      return useLive
+        ? withLiveCatalogue(scenarioState, liveRepos, liveProjects)
+        : scenarioState;
+    },
+    [liveProjects, liveRepos, useLive]
+  );
+
+  const [liveState, setLiveState] = useState(
+    () => getSeerOnboardingScenario(SEER_ONBOARDING_SCENARIOS[0]!.key).state
+  );
+
+  const selectScenario = useCallback(
+    (key: string) => {
+      setScenarioKey(key);
+      setLiveState(buildState(key));
+    },
+    [buildState]
+  );
+
+  // Re-seed when the catalogue arrives or the source is switched, so the table
+  // and the modal never disagree about which repos exist.
+  const lastSourceRef = useRef(useLive);
+  useEffect(() => {
+    if (lastSourceRef.current !== useLive) {
+      lastSourceRef.current = useLive;
+      setLiveState(buildState(scenarioKey));
+    }
+  }, [buildState, scenarioKey, useLive]);
+
+  // The install pipeline tears our modal down, so re-opening has to reach the
+  // freshest state and opener rather than whatever the old closure captured.
+  // Written in an effect below, never during render.
+  const openRef = useRef<(state: SeerOnboardingState) => void>(() => {});
+
+  const openWithState = (state: SeerOnboardingState) => {
+    const handleScmConnected = () => {
+      const next = {...state, hasSupportedScmIntegration: true};
+      setLiveState(next);
+      openRef.current(next);
+    };
+
+    const scmButton =
+      scmMode === 'real' ? (
+        <SeerOnboardingProvider>
+          <GithubButton
+            onAddIntegration={handleScmConnected}
+            analyticsView="seer_onboarding_github"
+          />
+        </SeerOnboardingProvider>
+      ) : (
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() =>
+            openModal(deps => (
+              <StandInPipelineModal {...deps} onComplete={handleScmConnected} />
+            ))
+          }
+        >
+          {t('Connect GitHub')}
+        </Button>
+      );
+
+    openModal(
+      deps => (
+        <MockSeerOnboardingModal
+          {...deps}
+          initialState={state}
+          onStateChange={setLiveState}
+          scmButton={scmButton}
+        />
+      ),
+      {closeEvents: 'escape-key', modalCss}
+    );
+  };
+
+  useEffect(() => {
+    openRef.current = openWithState;
+  });
+
+  // `org:superuser` is only granted while superuser mode is active, so this keeps
+  // the page to employees in production while staying available in local dev.
+  const isSuperuser = organization.access.includes('org:superuser');
+  if (!isSuperuser && NODE_ENV !== 'development') {
+    return <NoAccess />;
+  }
+
+  return (
+    <Fragment>
+      <SentryDocumentTitle title={t('Seer Onboarding Lab')} />
+      <SettingsPageHeader
+        title={t('Seer Onboarding Lab')}
+        subtitle={t(
+          'Drive the Seer Autofix onboarding modal through every state a real organization can be in. Selections are simulated and never written back, but the repository and project lists are this organization’s real ones.'
+        )}
+      />
+
+      <Grid columns={{'screen:xs': '1fr', 'screen:lg': '360px 1fr'}} gap="2xl">
+        <Stack gap="xl">
+          <Panel>
+            <PanelHeader>{t('Scenario')}</PanelHeader>
+            <PanelBody withPadding>
+              <RadioGroup
+                label={t('Scenario')}
+                value={scenarioKey}
+                choices={SEER_ONBOARDING_SCENARIOS.map(
+                  ({key, label, description}) => [key, label, description] as const
+                )}
+                onChange={selectScenario}
+              />
+            </PanelBody>
+          </Panel>
+
+          <Flex gap="md">
+            <Button variant="primary" onClick={() => openWithState(liveState)}>
+              {t('Open modal')}
+            </Button>
+            <Button onClick={() => selectScenario(scenarioKey)}>{t('Reset')}</Button>
+          </Flex>
+        </Stack>
+
+        <Stack gap="xl">
+          <Panel>
+            <PanelHeader>{t('Mock state')}</PanelHeader>
+            <PanelBody>
+              {describeState(liveState).map(([label, value]) => (
+                <StateRow key={label} label={label} value={value} />
+              ))}
+            </PanelBody>
+          </Panel>
+
+          <Stack gap="md">
+            <Heading as="h3" size="sm">
+              {t('Repositories and projects')}
+            </Heading>
+            <SegmentedControl
+              size="sm"
+              value={dataSource}
+              onChange={value => setDataSource(value)}
+            >
+              <SegmentedControl.Item key="live">
+                {t(
+                  'This org (%s repos, %s projects)',
+                  liveRepos.length,
+                  liveProjects.length
+                )}
+              </SegmentedControl.Item>
+              <SegmentedControl.Item key="fixtures">
+                {t('Fixtures')}
+              </SegmentedControl.Item>
+            </SegmentedControl>
+            {dataSource === 'live' && !hasLiveData ? (
+              <Text size="sm" variant="warning">
+                {projectsFetching || reposResult.isFetching
+                  ? t('Loading this organization’s repositories and projects…')
+                  : t(
+                      'This organization has no connected repositories, so the fixture catalogue is being used instead.'
+                    )}
+              </Text>
+            ) : null}
+
+            <Heading as="h3" size="sm">
+              {t('GitHub connection')}
+            </Heading>
+            <SegmentedControl
+              size="sm"
+              value={scmMode}
+              onChange={value => setScmMode(value)}
+            >
+              <SegmentedControl.Item key="standin">{t('Stand-in')}</SegmentedControl.Item>
+              <SegmentedControl.Item key="real">
+                {t('Real install')}
+              </SegmentedControl.Item>
+            </SegmentedControl>
+            <Text size="sm" variant="muted">
+              {scmMode === 'real'
+                ? t(
+                    'Uses the real GithubButton and launches the real install pipeline. This installs the GitHub app on this organization for real.'
+                  )
+                : t(
+                    'Reproduces the modal takeover and hand-back without installing anything.'
+                  )}
+            </Text>
+          </Stack>
+
+          <Stack gap="md">
+            <Heading as="h3" size="sm" variant="muted">
+              {t('About this scenario')}
+            </Heading>
+            <Text variant="muted">
+              {getSeerOnboardingScenario(scenarioKey).description}
+            </Text>
+          </Stack>
+        </Stack>
+      </Grid>
+    </Fragment>
+  );
+}


### PR DESCRIPTION
> **Experiment — not for merge as-is.** Nothing here is wired to a production trigger, the modal runs on mock state rather than the API, and the lab page is reachable by URL only. Opening this for design and direction feedback on the flow.

Sketches a modal-based Seer Autofix onboarding flow, plus an employee-only **Onboarding Lab** at `/settings/:orgSlug/seer/onboarding-lab/` for driving it through every state an organization can land in — without contorting a real org into each one in turn.

The modal walks the gates standing between an org and background triage opening a pull request: generative AI enabled, a supported SCM integration, at least one repository linked to a project, and per-project automation set to draft PRs. Each step links at the setting that owns it, so nothing reads as a one-shot decision.

**Billing does not gate setup**

An org with no Seer plan walks the same steps as one that pays, and finishes on "Autofix is ready and waiting" with an offer to add Seer — rather than a dead end. Out-of-budget behaves the same way. The only hard stop left is missing SCM write access, which is a genuine setup problem rather than a billing one.

**The modal is presentational**

State in, actions out, no queries or mutations:

```ts
interface SeerOnboardingState {
  entitlement: 'none' | 'legacy' | 'seat-based';
  hasSupportedScmIntegration: boolean;
  repoLinks: SeerRepoLink[];                              // ≈ SeerProjectRepository rows
  stoppingPoints: Record<string, UserFacingStoppingPoint>; // per project
  // ...
}
```

That is the seam the lab drives with fabricated state, and the seam a real `useSeerOnboardingState()` hook plugs into later. Completion is derived (`getLinkedProjects`, `willOpenPullRequests`), not stored.

**GlobalModal is a singleton, which shapes the SCM step**

The real GitHub button calls `openPipelineModal` → `openModal`, so launching it from inside the onboarding modal *replaces* the onboarding modal instead of stacking on it; the pipeline then closes itself on completion and leaves nothing on screen. The existing `SeerConnectGitHubBanner` sidesteps this by living on a page and calling `window.location.reload()`, which is not available inside a modal.

So progress is held outside the modal and `onAddIntegration` re-opens it past the completed step. The lab renders the real `GithubButton` behind an explicit opt-in and defaults to a stand-in launcher that reproduces the same takeover and hand-back without installing a GitHub app anywhere.

**Known constraint**

Step rows are jumped to via a `trailingItems` chevron rather than a clickable header: `GuidedSteps.Step` renders its header as a permanently disabled button and no longer accepts `onClick`. Making titles clickable would mean changing the shared `GuidedSteps` component, which felt out of scope for an experiment.

The lab reads the org's real repositories and projects so the pickers show real examples, falling back to synthetic `acme/*` fixtures when there are none. Selections are never written back.