### PR TITLE
feat(derived data): Batch status consistency check

### DIFF
--- a/src/sentry/issues/derived/check.py
+++ b/src/sentry/issues/derived/check.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -11,7 +12,10 @@ from sentry.issues.derived.store import GroupDerivedDataStore
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
 from sentry.models.group import Group, GroupStatus
+from sentry.utils import metrics
 from sentry.workflow_engine.caches.mapping import CacheMapping
+
+logger = logging.getLogger(__name__)
 
 _GROUP_STATUS_TO_DERIVED_STATUS = {
     GroupStatus.UNRESOLVED: IssueStatus.OPEN,
@@ -40,6 +44,45 @@ def check_status_consistency(group: Group, derived: GroupDerivedData) -> StatusI
         return None
 
     return StatusInconsistency(derived=derived_status, actual=actual_status)
+
+
+def record_status_consistency(
+    group: Group, derived: GroupDerivedData, *, source: str
+) -> StatusInconsistency | None:
+    """Record a metric/log for a status consistency check.
+
+    Returns the inconsistency when one is found, otherwise ``None``.
+    """
+    inconsistency = check_status_consistency(group, derived)
+    if inconsistency is None:
+        metrics.incr(
+            "issues.status_reconciliation.checked",
+            sample_rate=1.0,
+            tags={"result": "aligned", "source": source},
+        )
+        return None
+
+    metrics.incr(
+        "issues.status_reconciliation.checked",
+        sample_rate=1.0,
+        tags={
+            "result": "diverged",
+            "derived_status": inconsistency.derived.value,
+            "actual_status": inconsistency.actual.value,
+            "source": source,
+        },
+    )
+    logger.info(
+        "issues.status_reconciliation.diverged",
+        extra={
+            "group_id": group.id,
+            "project_id": group.project_id,
+            "derived_status": inconsistency.derived.value,
+            "actual_status": inconsistency.actual.value,
+            "source": source,
+        },
+    )
+    return inconsistency
 
 
 @dataclass(frozen=True)

--- a/src/sentry/issues/derived/check.py
+++ b/src/sentry/issues/derived/check.py
@@ -89,13 +89,10 @@ def record_status_consistency(
 
 def record_batch_status_consistency(
     derived: GroupDerivedData,
-    groups_by_id: dict[int, Group],
+    group: Group,
     project_should_check: dict[int, bool],
 ) -> None:
     """Observe status consistency for one derived row during a batch check."""
-    group = groups_by_id.get(derived.group_id)
-    if group is None:
-        return
     project_id = group.project_id
     if project_id not in project_should_check:
         try:

--- a/src/sentry/issues/derived/check.py
+++ b/src/sentry/issues/derived/check.py
@@ -7,11 +7,13 @@ from uuid import uuid4
 
 from sentry.issues.derived.features import STATUS, IssueStatus
 from sentry.issues.derived.framework import Feature, Pipeline
+from sentry.issues.derived.gate import derived_should_be_correct
 from sentry.issues.derived.processing import DEFAULT_BATCH_SIZE
 from sentry.issues.derived.store import GroupDerivedDataStore
 from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.issues.models.groupderiveddata import EPOCH, GroupDerivedData
 from sentry.models.group import Group, GroupStatus
+from sentry.models.project import Project
 from sentry.utils import metrics
 from sentry.workflow_engine.caches.mapping import CacheMapping
 
@@ -83,6 +85,39 @@ def record_status_consistency(
         },
     )
     return inconsistency
+
+
+def record_batch_status_consistency(
+    derived: GroupDerivedData,
+    groups_by_id: dict[int, Group],
+    project_should_check: dict[int, bool],
+) -> None:
+    """Observe status consistency for one derived row during a batch check."""
+    group = groups_by_id.get(derived.group_id)
+    if group is None:
+        return
+    project_id = group.project_id
+    if project_id not in project_should_check:
+        try:
+            project = Project.objects.get_from_cache(id=project_id)
+        except Project.DoesNotExist:
+            project_should_check[project_id] = False
+        else:
+            project_should_check[project_id] = derived_should_be_correct(project)
+    if not project_should_check[project_id]:
+        return
+    try:
+        record_status_consistency(group, derived, source="batch_check")
+    except Exception:
+        logger.exception(
+            "check_fresh_derived_data_batch.status_consistency_failed",
+            extra={"group_id": derived.group_id, "project_id": project_id},
+        )
+        metrics.incr(
+            "issues.status_reconciliation.error",
+            sample_rate=1.0,
+            tags={"source": "batch_check"},
+        )
 
 
 @dataclass(frozen=True)

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -600,7 +600,6 @@ def check_fresh_derived_data_batch(
     from sentry.issues.derived.processing import PIPELINE
     from sentry.issues.derived.tasks_util import _record_check_result, _resume_check_id
     from sentry.issues.models.groupderiveddata import GroupDerivedData
-    from sentry.models.group import Group
     from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 
     task_state = current_task()
@@ -626,24 +625,19 @@ def check_fresh_derived_data_batch(
     )
 
     status_check_enabled = options.get("issues.derived.status-consistency-check-enabled")
-    groups_by_id: dict[int, Group] = {}
     project_should_check: dict[int, bool] = {}
-    if status_check_enabled:
-        groups_by_id = {
-            group.id: group
-            for group in Group.objects.filter(id__gte=group_id_start, id__lt=group_id_end)
-        }
-
     derived_rows = GroupDerivedData.objects.filter(
         pipeline_hash=PIPELINE.pipeline_hash,
         group_id__gte=group_id_start,
         group_id__lt=group_id_end,
     ).order_by("group_id")
+    if status_check_enabled:
+        derived_rows = derived_rows.select_related("group")
     start = time.monotonic()
     timeout_seconds = BATCH_RETRIGGER_TIMEOUT.total_seconds()
     for derived in derived_rows.iterator():
         if status_check_enabled:
-            record_batch_status_consistency(derived, groups_by_id, project_should_check)
+            record_batch_status_consistency(derived, derived.group, project_should_check)
         remaining = timedelta(seconds=max(0, timeout_seconds - (time.monotonic() - start)))
         try:
             result = check_derived_data(

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -14,7 +14,6 @@ if TYPE_CHECKING:
     from sentry.db.models.manager.base_query_set import BaseQuerySet
     from sentry.issues.derived.processing import GenerationId
     from sentry.issues.derived.promote import PromotionResult
-    from sentry.issues.models.groupderiveddata import GroupDerivedData
     from sentry.models.group import Group
 
 from sentry.tasks.base import instrumented_task
@@ -101,43 +100,6 @@ def _resume_generation_id(
         datetime.fromisoformat(resume_generated_at).replace(tzinfo=timezone.utc),
         resume_pipeline_hash,
     )
-
-
-def _record_batch_status_consistency(
-    derived: GroupDerivedData,
-    groups_by_id: dict[int, Group],
-    project_should_check: dict[int, bool],
-) -> None:
-    """Observe status consistency for one derived row during a batch check."""
-    from sentry.issues.derived.check import record_status_consistency
-    from sentry.issues.derived.gate import derived_should_be_correct
-    from sentry.models.project import Project
-
-    group = groups_by_id.get(derived.group_id)
-    if group is None:
-        return
-    project_id = group.project_id
-    if project_id not in project_should_check:
-        try:
-            project = Project.objects.get_from_cache(id=project_id)
-        except Project.DoesNotExist:
-            project_should_check[project_id] = False
-        else:
-            project_should_check[project_id] = derived_should_be_correct(project)
-    if not project_should_check[project_id]:
-        return
-    try:
-        record_status_consistency(group, derived, source="batch_check")
-    except Exception:
-        logger.exception(
-            "check_fresh_derived_data_batch.status_consistency_failed",
-            extra={"group_id": derived.group_id, "project_id": project_id},
-        )
-        metrics.incr(
-            "issues.status_reconciliation.error",
-            sample_rate=1.0,
-            tags={"source": "batch_check"},
-        )
 
 
 @instrumented_task(
@@ -633,6 +595,7 @@ def check_fresh_derived_data_batch(
         CheckInvalidated,
         CheckTimeout,
         check_derived_data,
+        record_batch_status_consistency,
     )
     from sentry.issues.derived.processing import PIPELINE
     from sentry.issues.derived.tasks_util import _record_check_result, _resume_check_id
@@ -680,7 +643,7 @@ def check_fresh_derived_data_batch(
     timeout_seconds = BATCH_RETRIGGER_TIMEOUT.total_seconds()
     for derived in derived_rows.iterator():
         if status_check_enabled:
-            _record_batch_status_consistency(derived, groups_by_id, project_should_check)
+            record_batch_status_consistency(derived, groups_by_id, project_should_check)
         remaining = timedelta(seconds=max(0, timeout_seconds - (time.monotonic() - start)))
         try:
             result = check_derived_data(

--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from sentry.db.models.manager.base_query_set import BaseQuerySet
     from sentry.issues.derived.processing import GenerationId
     from sentry.issues.derived.promote import PromotionResult
+    from sentry.issues.models.groupderiveddata import GroupDerivedData
     from sentry.models.group import Group
 
 from sentry.tasks.base import instrumented_task
@@ -100,6 +101,43 @@ def _resume_generation_id(
         datetime.fromisoformat(resume_generated_at).replace(tzinfo=timezone.utc),
         resume_pipeline_hash,
     )
+
+
+def _record_batch_status_consistency(
+    derived: GroupDerivedData,
+    groups_by_id: dict[int, Group],
+    project_should_check: dict[int, bool],
+) -> None:
+    """Observe status consistency for one derived row during a batch check."""
+    from sentry.issues.derived.check import record_status_consistency
+    from sentry.issues.derived.gate import derived_should_be_correct
+    from sentry.models.project import Project
+
+    group = groups_by_id.get(derived.group_id)
+    if group is None:
+        return
+    project_id = group.project_id
+    if project_id not in project_should_check:
+        try:
+            project = Project.objects.get_from_cache(id=project_id)
+        except Project.DoesNotExist:
+            project_should_check[project_id] = False
+        else:
+            project_should_check[project_id] = derived_should_be_correct(project)
+    if not project_should_check[project_id]:
+        return
+    try:
+        record_status_consistency(group, derived, source="batch_check")
+    except Exception:
+        logger.exception(
+            "check_fresh_derived_data_batch.status_consistency_failed",
+            extra={"group_id": derived.group_id, "project_id": project_id},
+        )
+        metrics.incr(
+            "issues.status_reconciliation.error",
+            sample_rate=1.0,
+            tags={"source": "batch_check"},
+        )
 
 
 @instrumented_task(
@@ -590,10 +628,16 @@ def check_fresh_derived_data_batch(
     )
     from taskbroker_client.state import current_task
 
-    from sentry.issues.derived.check import CheckInvalidated, CheckTimeout, check_derived_data
+    from sentry import options
+    from sentry.issues.derived.check import (
+        CheckInvalidated,
+        CheckTimeout,
+        check_derived_data,
+    )
     from sentry.issues.derived.processing import PIPELINE
     from sentry.issues.derived.tasks_util import _record_check_result, _resume_check_id
     from sentry.issues.models.groupderiveddata import GroupDerivedData
+    from sentry.models.group import Group
     from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 
     task_state = current_task()
@@ -618,6 +662,15 @@ def check_fresh_derived_data_batch(
         resume_pipeline_hash,
     )
 
+    status_check_enabled = options.get("issues.derived.status-consistency-check-enabled")
+    groups_by_id: dict[int, Group] = {}
+    project_should_check: dict[int, bool] = {}
+    if status_check_enabled:
+        groups_by_id = {
+            group.id: group
+            for group in Group.objects.filter(id__gte=group_id_start, id__lt=group_id_end)
+        }
+
     derived_rows = GroupDerivedData.objects.filter(
         pipeline_hash=PIPELINE.pipeline_hash,
         group_id__gte=group_id_start,
@@ -626,6 +679,8 @@ def check_fresh_derived_data_batch(
     start = time.monotonic()
     timeout_seconds = BATCH_RETRIGGER_TIMEOUT.total_seconds()
     for derived in derived_rows.iterator():
+        if status_check_enabled:
+            _record_batch_status_consistency(derived, groups_by_id, project_should_check)
         remaining = timedelta(seconds=max(0, timeout_seconds - (time.monotonic() - start)))
         try:
             result = check_derived_data(

--- a/src/sentry/issues/endpoints/group_details.py
+++ b/src/sentry/issues/endpoints/group_details.py
@@ -53,7 +53,7 @@ from sentry.issues.constants import (
     cache_key_for_issue_view,
     get_issue_tsdb_group_model,
 )
-from sentry.issues.derived.check import check_status_consistency
+from sentry.issues.derived.check import record_status_consistency
 from sentry.issues.derived.gate import derived_should_be_correct
 from sentry.issues.endpoints.bases.group import GroupEndpoint
 from sentry.issues.escalating.escalating_group_forecast import EscalatingGroupForecast
@@ -136,33 +136,7 @@ class GroupDetailsEndpoint(GroupEndpoint):
         if derived is None:
             return
 
-        inconsistency = check_status_consistency(group, derived)
-        if inconsistency is None:
-            metrics.incr(
-                "issues.status_reconciliation.checked",
-                sample_rate=1.0,
-                tags={"result": "aligned"},
-            )
-            return
-
-        metrics.incr(
-            "issues.status_reconciliation.checked",
-            sample_rate=1.0,
-            tags={
-                "result": "diverged",
-                "derived_status": inconsistency.derived.value,
-                "actual_status": inconsistency.actual.value,
-            },
-        )
-        logger.info(
-            "issues.status_reconciliation.diverged",
-            extra={
-                "group_id": group.id,
-                "project_id": group.project_id,
-                "derived_status": inconsistency.derived.value,
-                "actual_status": inconsistency.actual.value,
-            },
-        )
+        record_status_consistency(group, derived, source="read_path")
 
     @staticmethod
     def __group_hourly_daily_stats(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4371,6 +4371,14 @@ register(
     type=Int,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+# When enabled, check_fresh_derived_data_batch also observes status consistency
+# for projects where derived data should cover full history.
+register(
+    "issues.derived.status-consistency-check-enabled",
+    default=True,
+    type=Bool,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Kill switch for Objectstore Debug Files migration
 register(

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -677,21 +677,6 @@ class CheckFreshDerivedDataBatchTest(DerivedDataTaskTestBase):
 
         mock_record_status.assert_called_once()
 
-    def test_status_check_tolerates_missing_group(self) -> None:
-        group = self.create_unprocessed_groups(1)[0]
-        process_group_log(group.id)
-        group_id = group.id
-        self.project.update_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION, True)
-        Group.objects.filter(id=group_id).delete()
-
-        with patch("sentry.issues.derived.check.record_status_consistency") as mock_record_status:
-            check_fresh_derived_data_batch(
-                group_id_start=group_id,
-                group_id_end=group_id + 1,
-            )
-
-        mock_record_status.assert_not_called()
-
 
 @with_feature("projects:issue-action-log-write-to-db")
 class PickRandomFreshGroupRangesTest(DerivedDataTaskTestBase):

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -5,6 +5,7 @@ from unittest.mock import call, patch
 from sentry.issues.action_log.publish import publish_action
 from sentry.issues.action_log.types import ActionSource, GroupActionActor, ViewAction
 from sentry.issues.derived.check import CheckId, CheckTimeout
+from sentry.issues.derived.gate import GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION
 from sentry.issues.derived.processing import PIPELINE, GroupLogTimeout, process_group_log
 from sentry.issues.derived.tasks import (
     BATCH_RETRIGGER_TIMEOUT,
@@ -20,7 +21,7 @@ from sentry.issues.derived.tasks_util import (
     group_id_ranges_for_hash,
 )
 from sentry.issues.models.groupderiveddata import GroupDerivedData
-from sentry.models.group import Group
+from sentry.models.group import Group, GroupStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
@@ -585,6 +586,111 @@ class CheckFreshDerivedDataBatchTest(DerivedDataTaskTestBase):
             sample_rate=1.0,
             tags={"result": "no_result"},
         )
+
+    def test_records_status_inconsistency_for_backfilled_project(self) -> None:
+        group = self.create_unprocessed_groups(1)[0]
+        process_group_log(group.id)
+        group.update(status=GroupStatus.IGNORED)
+        self.project.update_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION, True)
+        GroupDerivedData.objects.filter(group_id=group.id).update(
+            data={"status": "open"},
+        )
+
+        with patch("sentry.issues.derived.check.metrics.incr") as mock_incr:
+            check_fresh_derived_data_batch(
+                group_id_start=group.id,
+                group_id_end=group.id + 1,
+            )
+
+        assert (
+            call(
+                "issues.status_reconciliation.checked",
+                sample_rate=1.0,
+                tags={
+                    "result": "diverged",
+                    "derived_status": "open",
+                    "actual_status": "closed",
+                    "source": "batch_check",
+                },
+            )
+            in mock_incr.call_args_list
+        )
+
+    def test_skips_status_check_when_not_derived_should_be_correct(self) -> None:
+        group = self.create_unprocessed_groups(1)[0]
+        process_group_log(group.id)
+        group.update(status=GroupStatus.IGNORED)
+        GroupDerivedData.objects.filter(group_id=group.id).update(data={"status": "open"})
+
+        with patch("sentry.issues.derived.check.record_status_consistency") as mock_record_status:
+            check_fresh_derived_data_batch(
+                group_id_start=group.id,
+                group_id_end=group.id + 1,
+            )
+
+        mock_record_status.assert_not_called()
+
+    @override_options({"issues.derived.status-consistency-check-enabled": False})
+    def test_skips_status_check_when_option_disabled(self) -> None:
+        group = self.create_unprocessed_groups(1)[0]
+        process_group_log(group.id)
+        group.update(status=GroupStatus.IGNORED)
+        self.project.update_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION, True)
+        GroupDerivedData.objects.filter(group_id=group.id).update(data={"status": "open"})
+
+        with patch("sentry.issues.derived.check.record_status_consistency") as mock_record_status:
+            check_fresh_derived_data_batch(
+                group_id_start=group.id,
+                group_id_end=group.id + 1,
+            )
+
+        mock_record_status.assert_not_called()
+
+    def test_status_check_runs_before_derived_check_timeout(self) -> None:
+        group = self.create_unprocessed_groups(1)[0]
+        derived = process_group_log(group.id)
+        assert derived.pipeline_hash is not None
+        group.update(status=GroupStatus.IGNORED)
+        self.project.update_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION, True)
+        GroupDerivedData.objects.filter(group_id=group.id).update(data={"status": "open"})
+        check_id = CheckId(
+            "invocation-id",
+            group.id,
+            derived.generated_at,
+            derived.cursor_date,
+            derived.cursor_id,
+            derived.pipeline_hash,
+        )
+
+        with (
+            patch(
+                "sentry.issues.derived.check.check_derived_data",
+                side_effect=CheckTimeout(check_id),
+            ),
+            patch.object(check_fresh_derived_data_batch, "delay"),
+            patch("sentry.issues.derived.check.record_status_consistency") as mock_record_status,
+        ):
+            check_fresh_derived_data_batch(
+                group_id_start=group.id,
+                group_id_end=group.id + 1,
+            )
+
+        mock_record_status.assert_called_once()
+
+    def test_status_check_tolerates_missing_group(self) -> None:
+        group = self.create_unprocessed_groups(1)[0]
+        process_group_log(group.id)
+        group_id = group.id
+        self.project.update_option(GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION, True)
+        Group.objects.filter(id=group_id).delete()
+
+        with patch("sentry.issues.derived.check.record_status_consistency") as mock_record_status:
+            check_fresh_derived_data_batch(
+                group_id_start=group_id,
+                group_id_end=group_id + 1,
+            )
+
+        mock_record_status.assert_not_called()
 
 
 @with_feature("projects:issue-action-log-write-to-db")

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -506,8 +506,8 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.content
 
     @with_feature("projects:issue-status-reconciliation")
-    @mock.patch("sentry.issues.endpoints.group_details.metrics")
-    @mock.patch("sentry.issues.endpoints.group_details.logger")
+    @mock.patch("sentry.issues.derived.check.metrics")
+    @mock.patch("sentry.issues.derived.check.logger")
     def test_diverged_closed_logs_and_skips_action(
         self, mock_logger: mock.MagicMock, mock_metrics: mock.MagicMock
     ) -> None:
@@ -525,6 +525,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
                 "project_id": group.project_id,
                 "derived_status": "open",
                 "actual_status": "closed",
+                "source": "read_path",
             },
         )
         mock_metrics.incr.assert_any_call(
@@ -534,12 +535,13 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
                 "result": "diverged",
                 "derived_status": "open",
                 "actual_status": "closed",
+                "source": "read_path",
             },
         )
 
     @with_feature("projects:issue-status-reconciliation")
-    @mock.patch("sentry.issues.endpoints.group_details.metrics")
-    @mock.patch("sentry.issues.endpoints.group_details.logger")
+    @mock.patch("sentry.issues.derived.check.metrics")
+    @mock.patch("sentry.issues.derived.check.logger")
     def test_diverged_open_logs_and_skips_action(
         self, mock_logger: mock.MagicMock, mock_metrics: mock.MagicMock
     ) -> None:
@@ -557,6 +559,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
                 "project_id": group.project_id,
                 "derived_status": "closed",
                 "actual_status": "open",
+                "source": "read_path",
             },
         )
         mock_metrics.incr.assert_any_call(
@@ -566,11 +569,12 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
                 "result": "diverged",
                 "derived_status": "closed",
                 "actual_status": "open",
+                "source": "read_path",
             },
         )
 
     @with_feature("projects:issue-status-reconciliation")
-    @mock.patch("sentry.issues.endpoints.group_details.metrics")
+    @mock.patch("sentry.issues.derived.check.metrics")
     def test_aligned_status_skips(self, mock_metrics: mock.MagicMock) -> None:
         group = self.create_group(status=GroupStatus.RESOLVED, substatus=None)
         self.create_group_derived_data(group=group, data={"status": "closed"})
@@ -582,7 +586,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
         mock_metrics.incr.assert_any_call(
             "issues.status_reconciliation.checked",
             sample_rate=1.0,
-            tags={"result": "aligned"},
+            tags={"result": "aligned", "source": "read_path"},
         )
 
     @with_feature("projects:issue-status-reconciliation")
@@ -615,7 +619,7 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
             "projects:issue-action-log-write-to-db": True,
         }
     )
-    @mock.patch("sentry.issues.endpoints.group_details.logger")
+    @mock.patch("sentry.issues.derived.check.logger")
     def test_backfilled_project_logs_without_reconciliation_flag(
         self, mock_logger: mock.MagicMock
     ) -> None:
@@ -632,12 +636,13 @@ class GroupDetailsReconcileStatusTest(APITestCase, SnubaTestCase):
                 "project_id": group.project_id,
                 "derived_status": "closed",
                 "actual_status": "open",
+                "source": "read_path",
             },
         )
 
     @override_options({"issues.derived_data.read_path_checks.killswitch": True})
     @with_feature("projects:issue-status-reconciliation")
-    @mock.patch("sentry.issues.endpoints.group_details.logger")
+    @mock.patch("sentry.issues.derived.check.logger")
     def test_read_path_checks_killswitch(self, mock_logger: mock.MagicMock) -> None:
         group = self.create_group(status=GroupStatus.UNRESOLVED, substatus=GroupSubStatus.ONGOING)
         self.create_group_derived_data(group=group, data={"status": "closed"})


### PR DESCRIPTION
Move the status consistency check from the read endpoint into our check module, and use it in our background validations to measure divergence more broadly.