### PR TITLE
perf(snapshots): Virtualize snapshot list per-card instead of per-group

### DIFF
--- a/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
@@ -1,6 +1,6 @@
 import type {SidebarItem, SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
 
-import {buildRows} from './snapshotListView';
+import {buildRowIndex, buildRows} from './snapshotListView';
 
 const mockZoom = {
   containerRef: {current: null},
@@ -102,5 +102,41 @@ describe('buildRows', () => {
     // CARD_CHROME_HEIGHT (120) + min(aspectHeight, MAX_IMAGE_HEIGHT); 320<=900 => 180.
     // Single card is also last-in-group, so ROW_PADDING_BOTTOM (16) is added.
     expect(cardRow.estimatedHeight).toBe(120 + 180 + 16);
+  });
+});
+
+describe('buildRowIndex', () => {
+  it('maps keys to card ordinals and row indices', () => {
+    const rows = buildRows(
+      [
+        {
+          key: 'changed:Screens',
+          name: 'Screens',
+          displayName: 'Screens',
+          type: 'changed',
+          pairs: [
+            {
+              base_image: image({image_file_name: 'a.base.png'}),
+              head_image: image({image_file_name: 'a.png'}),
+              diff: null,
+              diff_image_key: null,
+            },
+            {
+              base_image: image({image_file_name: 'b.base.png'}),
+              head_image: image({image_file_name: 'b.png'}),
+              diff: null,
+              diff_image_key: null,
+            },
+          ],
+        },
+      ],
+      900
+    );
+    const idx = buildRowIndex(rows);
+    expect(idx.order).toEqual(['a.png', 'b.png']); // per-card ordinal order
+    expect(idx.positionByKey.get('b.png')).toBe(1);
+    expect(idx.rowIndexByKey.get('a.png')).toBe(1); // row 0 is the header
+    expect(idx.rowIndexByKey.get('b.png')).toBe(2);
+    expect(idx.firstRowByItemKey.get('changed:Screens')).toBe(0); // header row
   });
 });

--- a/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
@@ -1,0 +1,106 @@
+import type {SidebarItem, SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
+
+import {buildRows} from './snapshotListView';
+
+const mockZoom = {
+  containerRef: {current: null},
+  resetZoom: jest.fn(),
+  transform: {x: 0, y: 0, k: 1},
+  zoomIn: jest.fn(),
+  zoomOut: jest.fn(),
+};
+
+jest.mock('./imageDisplay/useD3Zoom', () => ({
+  useD3Zoom: () => mockZoom,
+  useSyncedD3Zoom: () => [mockZoom, mockZoom],
+}));
+
+function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
+  return {
+    display_name: 'S',
+    height: 180,
+    image_file_name: 'a.png',
+    key: 'k',
+    tags: null,
+    width: 320,
+    group: 'Screens',
+    ...overrides,
+  };
+}
+
+describe('buildRows', () => {
+  it('emits a header row then one card row per card for a grouped item', () => {
+    const item: SidebarItem = {
+      key: 'changed:Screens',
+      name: 'Screens',
+      displayName: 'Screens',
+      type: 'changed',
+      pairs: [
+        {
+          base_image: image({image_file_name: 'a.base.png'}),
+          head_image: image({image_file_name: 'a.png'}),
+          diff: null,
+          diff_image_key: null,
+        },
+        {
+          base_image: image({image_file_name: 'b.base.png'}),
+          head_image: image({image_file_name: 'b.png'}),
+          diff: null,
+          diff_image_key: null,
+        },
+      ],
+    };
+    const rows = buildRows([item], 900);
+    expect(rows.map(r => r.kind)).toEqual(['header', 'card', 'card']);
+    expect(rows[0]).toMatchObject({
+      kind: 'header',
+      groupName: 'Screens',
+      itemKey: 'changed:Screens',
+    });
+    expect(rows[1]).toMatchObject({
+      kind: 'card',
+      isFirstInGroup: true,
+      isLastInGroup: false,
+      isUngrouped: false,
+    });
+    expect(rows[2]).toMatchObject({
+      kind: 'card',
+      isFirstInGroup: false,
+      isLastInGroup: true,
+    });
+  });
+
+  it('emits only card rows (no header) for an ungrouped item', () => {
+    const item: SidebarItem = {
+      key: 'added:solo',
+      name: 'solo.png',
+      displayName: 'solo.png',
+      type: 'added',
+      images: [image({group: undefined, image_file_name: 'solo.png'})],
+    };
+    const rows = buildRows([item], 900);
+    expect(rows.map(r => r.kind)).toEqual(['card']);
+    expect(rows[0]).toMatchObject({
+      kind: 'card',
+      isUngrouped: true,
+      isFirstInGroup: true,
+      isLastInGroup: true,
+      groupName: null,
+    });
+  });
+
+  it('gives each card row the same estimatedHeight buildGroups gave the card', () => {
+    const item: SidebarItem = {
+      key: 'unchanged:Screens',
+      name: 'Screens',
+      displayName: 'Screens',
+      type: 'unchanged',
+      images: [image({width: 320, height: 180})],
+    };
+    const rows = buildRows([item], 900);
+    const cardRow = rows.find(r => r.kind === 'card')!;
+    // CARD_CHROME_HEIGHT (120) + min(aspectHeight, MAX_IMAGE_HEIGHT); 320<=900 => 180.
+    // Single card is also last-in-group, so ROW_PADDING_BOTTOM (16) is added.
+    expect(cardRow.estimatedHeight).toBe(120 + 180 + 16);
+  });
+});

--- a/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
@@ -1,7 +1,10 @@
 import type {SidebarItem, SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
 
-import {buildRowIndex, buildRows} from './snapshotListView';
+import {buildRowIndex, buildRows, rowFrameEdges} from './snapshotListView';
 
+// buildRows/buildRowIndex are pure, but importing them from snapshotListView
+// transitively loads the card components (and d3-zoom, which Jest cannot parse).
+// This mock keeps that import chain resolvable; the hook is never called here.
 const mockZoom = {
   containerRef: {current: null},
   resetZoom: jest.fn(),
@@ -89,7 +92,7 @@ describe('buildRows', () => {
     });
   });
 
-  it('gives each card row the same estimatedHeight buildGroups gave the card', () => {
+  it('gives a card row CARD_CHROME_HEIGHT + image box + last-row gap', () => {
     const item: SidebarItem = {
       key: 'unchanged:Screens',
       name: 'Screens',
@@ -102,6 +105,126 @@ describe('buildRows', () => {
     // CARD_CHROME_HEIGHT (120) + min(aspectHeight, MAX_IMAGE_HEIGHT); 320<=900 => 180.
     // Single card is also last-in-group, so ROW_PADDING_BOTTOM (16) is added.
     expect(cardRow.estimatedHeight).toBe(120 + 180 + 16);
+  });
+
+  it('adds the errored banner height to changed/errored card estimates', () => {
+    const pair = {
+      base_image: image({image_file_name: 'a.base.png'}),
+      head_image: image({image_file_name: 'a.png'}),
+      diff: null,
+      diff_image_key: null,
+    };
+    const changed = buildRows(
+      [
+        {
+          key: 'changed:Screens',
+          name: 'Screens',
+          displayName: 'Screens',
+          type: 'changed',
+          pairs: [pair],
+        },
+      ],
+      900
+    ).find(r => r.kind === 'card')!;
+    const errored = buildRows(
+      [
+        {
+          key: 'errored:Screens',
+          name: 'Screens',
+          displayName: 'Screens',
+          type: 'errored',
+          pairs: [pair],
+        },
+      ],
+      900
+    ).find(r => r.kind === 'card')!;
+    // errored adds ERRORED_BANNER_HEIGHT (56) over the same changed estimate.
+    expect(errored.estimatedHeight).toBe(changed.estimatedHeight + 56);
+  });
+
+  it('renders renamed pairs as image cards carrying the pair as copyData', () => {
+    const pair = {
+      base_image: image({image_file_name: 'old.png'}),
+      head_image: image({image_file_name: 'new.png'}),
+      diff: null,
+      diff_image_key: null,
+    };
+    const rows = buildRows(
+      [
+        {
+          key: 'renamed:Screens',
+          name: 'Screens',
+          displayName: 'Screens',
+          type: 'renamed',
+          pairs: [pair],
+        },
+      ],
+      900
+    );
+    const cardRow = rows.find(r => r.kind === 'card')!;
+    expect(cardRow.card.type).toBe('image-card');
+    expect(cardRow.card).toMatchObject({
+      image: {image_file_name: 'new.png'},
+      copyData: pair,
+    });
+  });
+});
+
+describe('rowFrameEdges', () => {
+  const [header, firstCard, lastCard] = buildRows(
+    [
+      {
+        key: 'changed:Screens',
+        name: 'Screens',
+        displayName: 'Screens',
+        type: 'changed',
+        pairs: [
+          {
+            base_image: image({image_file_name: 'a.base.png'}),
+            head_image: image({image_file_name: 'a.png'}),
+            diff: null,
+            diff_image_key: null,
+          },
+          {
+            base_image: image({image_file_name: 'b.base.png'}),
+            head_image: image({image_file_name: 'b.png'}),
+            diff: null,
+            diff_image_key: null,
+          },
+        ],
+      },
+    ],
+    900
+  );
+  const [ungroupedCard] = buildRows(
+    [
+      {
+        key: 'added:solo',
+        name: 'solo.png',
+        displayName: 'solo.png',
+        type: 'added',
+        images: [image({group: undefined, image_file_name: 'solo.png'})],
+      },
+    ],
+    900
+  );
+
+  it('puts the group top border on the header, not the grouped first card', () => {
+    expect(rowFrameEdges(header!)).toEqual({
+      frameTop: true,
+      frameBottom: false,
+      separator: false,
+    });
+    expect(rowFrameEdges(firstCard!)).toMatchObject({frameTop: false, separator: true});
+  });
+
+  it('closes the frame on the last card and boxes an ungrouped card fully', () => {
+    expect(rowFrameEdges(lastCard!)).toMatchObject({frameBottom: true, separator: false});
+    expect(rowFrameEdges(ungroupedCard!)).toEqual({
+      frameTop: true,
+      frameBottom: true,
+      separator: false,
+    });
   });
 });
 

--- a/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
@@ -2,9 +2,6 @@ import type {SidebarItem, SnapshotImage} from 'sentry/views/preprod/types/snapsh
 
 import {buildRowIndex, buildRows, rowFrameEdges} from './snapshotListView';
 
-// buildRows/buildRowIndex are pure, but importing them from snapshotListView
-// transitively loads the card components (and d3-zoom, which Jest cannot parse).
-// This mock keeps that import chain resolvable; the hook is never called here.
 const mockZoom = {
   containerRef: {current: null},
   resetZoom: jest.fn(),
@@ -102,8 +99,6 @@ describe('buildRows', () => {
     };
     const rows = buildRows([item], 900);
     const cardRow = rows.find(r => r.kind === 'card')!;
-    // CARD_CHROME_HEIGHT (120) + min(aspectHeight, MAX_IMAGE_HEIGHT); 320<=900 => 180.
-    // Single card is also last-in-group, so ROW_PADDING_BOTTOM (16) is added.
     expect(cardRow.estimatedHeight).toBe(120 + 180 + 16);
   });
 
@@ -138,7 +133,6 @@ describe('buildRows', () => {
       ],
       900
     ).find(r => r.kind === 'card')!;
-    // errored adds ERRORED_BANNER_HEIGHT (56) over the same changed estimate.
     expect(errored.estimatedHeight).toBe(changed.estimatedHeight + 56);
   });
 
@@ -256,11 +250,11 @@ describe('buildRowIndex', () => {
       900
     );
     const idx = buildRowIndex(rows);
-    expect(idx.order).toEqual(['a.png', 'b.png']); // per-card ordinal order
+    expect(idx.order).toEqual(['a.png', 'b.png']);
     expect(idx.positionByKey.get('b.png')).toBe(1);
-    expect(idx.rowIndexByKey.get('a.png')).toBe(1); // row 0 is the header
+    expect(idx.rowIndexByKey.get('a.png')).toBe(1);
     expect(idx.rowIndexByKey.get('b.png')).toBe(2);
-    expect(idx.firstRowByItemKey.get('changed:Screens')).toBe(0); // header row
-    expect(idx.lastRowByItemKey.get('changed:Screens')).toBe(2); // last card row
+    expect(idx.firstRowByItemKey.get('changed:Screens')).toBe(0);
+    expect(idx.lastRowByItemKey.get('changed:Screens')).toBe(2);
   });
 });

--- a/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/buildRows.spec.tsx
@@ -138,5 +138,6 @@ describe('buildRowIndex', () => {
     expect(idx.rowIndexByKey.get('a.png')).toBe(1); // row 0 is the header
     expect(idx.rowIndexByKey.get('b.png')).toBe(2);
     expect(idx.firstRowByItemKey.get('changed:Screens')).toBe(0); // header row
+    expect(idx.lastRowByItemKey.get('changed:Screens')).toBe(2); // last card row
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
@@ -98,8 +98,3 @@ const SnapshotVariantContainer = styled(Container, {
     border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   }
 `;
-
-// The selection overlay stays square; the enclosing frame (SnapshotCardFrame or
-// the list's RowFrame) clips it to the frame's rounded corners via overflow:
-// hidden, so it always follows the actual frame edge rather than assuming this
-// card is the first/last in its group.

--- a/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotFrames.tsx
@@ -97,14 +97,9 @@ const SnapshotVariantContainer = styled(Container, {
   &:not(:last-child) {
     border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   }
-
-  &:first-child > ${SelectedOverlay} {
-    border-top-left-radius: ${p => p.theme.radius.md};
-    border-top-right-radius: ${p => p.theme.radius.md};
-  }
-
-  &:last-child > ${SelectedOverlay} {
-    border-bottom-left-radius: ${p => p.theme.radius.md};
-    border-bottom-right-radius: ${p => p.theme.radius.md};
-  }
 `;
+
+// The selection overlay stays square; the enclosing frame (SnapshotCardFrame or
+// the list's RowFrame) clips it to the frame's rounded corners via overflow:
+// hidden, so it always follows the actual frame edge rather than assuming this
+// card is the first/last in its group.

--- a/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
@@ -1,4 +1,4 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {fireEvent, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {mockElementSize} from 'sentry/utils/fixtures/virtualization';
 import type {
@@ -73,9 +73,13 @@ describe('SnapshotListView', () => {
     mockElementSize({width: 900, height: 600});
     // jsdom returns empty padding strings; parseFloat('') is NaN, which would
     // propagate into the virtualizer's height math. Force numeric padding.
-    jest
-      .spyOn(window, 'getComputedStyle')
-      .mockReturnValue({paddingLeft: '0px', paddingRight: '0px'} as CSSStyleDeclaration);
+    jest.spyOn(window, 'getComputedStyle').mockReturnValue({
+      paddingLeft: '0px',
+      paddingRight: '0px',
+      getPropertyValue: () => '',
+    } as unknown as CSSStyleDeclaration);
+    // jsdom does not implement scrollIntoView; keyboard nav calls it.
+    HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
   it('renders errored pairs as side-by-side cards with a failed badge', () => {
@@ -90,5 +94,87 @@ describe('SnapshotListView', () => {
     expect(screen.getByText('Failed to compare')).toBeInTheDocument();
     // Onion mode renders an opacity slider; side-by-side (split) does not.
     expect(screen.queryByRole('slider')).not.toBeInTheDocument();
+  });
+
+  function changedGroup(count: number): SidebarItem {
+    return {
+      key: 'changed:Screens',
+      name: 'Screens',
+      displayName: 'Screens',
+      type: 'changed',
+      pairs: Array.from({length: count}, (_, i) => ({
+        base_image: image({image_file_name: `s${i}.base.png`, group: 'Screens'}),
+        head_image: image({
+          display_name: `Screen ${i}`,
+          image_file_name: `s${i}.png`,
+          group: 'Screens',
+        }),
+        diff: null,
+        diff_image_key: null,
+      })),
+    };
+  }
+
+  it('renders every card in a large single group (per-card rows) plus one header', () => {
+    renderListView([changedGroup(6)]);
+
+    // Exactly one in-flow group header (sticky overlay only appears once scrolled).
+    expect(screen.getAllByRole('heading', {name: 'Screens'})).toHaveLength(1);
+    // All six cards mount because mockElementSize gives the viewport enough height.
+    expect(screen.getByText('Screen 0')).toBeInTheDocument();
+    expect(screen.getByText('Screen 5')).toBeInTheDocument();
+  });
+
+  it('frames the first row of a group as frame-top and the last card row as frame-bottom', () => {
+    renderListView([changedGroup(2)]);
+
+    // Frame edges are pure styling hooks with no ARIA role; query the DOM directly.
+    expect(document.querySelectorAll('[data-frame-top]')).toHaveLength(1); // header row
+    expect(document.querySelectorAll('[data-frame-bottom]')).toHaveLength(1); // last card row
+  });
+
+  it('renders no group header for ungrouped items', () => {
+    renderListView([
+      {
+        key: 'added:solo',
+        name: 'solo.png',
+        displayName: 'solo.png',
+        type: 'added',
+        images: [image({group: undefined, image_file_name: 'solo.png'})],
+      },
+    ]);
+
+    expect(screen.queryByRole('heading', {name: 'solo.png'})).not.toBeInTheDocument();
+  });
+
+  it('reports the first visible card ordinal and a finite progress on scroll', async () => {
+    const onScrollProgress = jest.fn();
+    render(
+      <SnapshotListView
+        items={[changedGroup(5)]}
+        imageBaseUrl="/api/0/projects/org-slug/project-slug/files/images/"
+        onScrollProgress={onScrollProgress}
+      />
+    );
+
+    await waitFor(() => expect(onScrollProgress).toHaveBeenCalled());
+    const [progress, firstIdx] = onScrollProgress.mock.calls.at(-1)!;
+    expect(Number.isFinite(progress)).toBe(true);
+    expect(firstIdx).toBe(0);
+  });
+
+  it('arrow-down selects the next card via onSelectSnapshot', () => {
+    const onSelectSnapshot = jest.fn();
+    render(
+      <SnapshotListView
+        items={[changedGroup(3)]}
+        imageBaseUrl="/api/0/projects/org-slug/project-slug/files/images/"
+        selectedSnapshotKey="s0.png"
+        onSelectSnapshot={onSelectSnapshot}
+      />
+    );
+
+    fireEvent.keyDown(document.body, {key: 'ArrowDown'});
+    expect(onSelectSnapshot).toHaveBeenCalledWith('s1.png');
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
@@ -131,6 +131,9 @@ describe('SnapshotListView', () => {
     // Frame edges are pure styling hooks with no ARIA role; query the DOM directly.
     expect(document.querySelectorAll('[data-frame-top]')).toHaveLength(1); // header row
     expect(document.querySelectorAll('[data-frame-bottom]')).toHaveLength(1); // last card row
+    // The inter-group gap is gated to the last row only; padding every row would
+    // break the group's continuous bordered frame.
+    expect(document.querySelectorAll('[data-last-in-group]')).toHaveLength(1);
   });
 
   it('renders no group header for ungrouped items', () => {

--- a/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
@@ -78,7 +78,6 @@ describe('SnapshotListView', () => {
       paddingRight: '0px',
       getPropertyValue: () => '',
     } as unknown as CSSStyleDeclaration);
-    // jsdom does not implement scrollIntoView; keyboard nav calls it.
     HTMLElement.prototype.scrollIntoView = jest.fn();
   });
 
@@ -118,9 +117,7 @@ describe('SnapshotListView', () => {
   it('renders every card in a large single group (per-card rows) plus one header', () => {
     renderListView([changedGroup(6)]);
 
-    // Exactly one in-flow group header (sticky overlay only appears once scrolled).
     expect(screen.getAllByRole('heading', {name: 'Screens'})).toHaveLength(1);
-    // All six cards mount because mockElementSize gives the viewport enough height.
     expect(screen.getByText('Screen 0')).toBeInTheDocument();
     expect(screen.getByText('Screen 5')).toBeInTheDocument();
   });
@@ -128,11 +125,8 @@ describe('SnapshotListView', () => {
   it('frames the first row of a group as frame-top and the last card row as frame-bottom', () => {
     renderListView([changedGroup(2)]);
 
-    // Frame edges are pure styling hooks with no ARIA role; query the DOM directly.
-    expect(document.querySelectorAll('[data-frame-top]')).toHaveLength(1); // header row
-    expect(document.querySelectorAll('[data-frame-bottom]')).toHaveLength(1); // last card row
-    // The inter-group gap is gated to the last row only; padding every row would
-    // break the group's continuous bordered frame.
+    expect(document.querySelectorAll('[data-frame-top]')).toHaveLength(1);
+    expect(document.querySelectorAll('[data-frame-bottom]')).toHaveLength(1);
     expect(document.querySelectorAll('[data-last-in-group]')).toHaveLength(1);
   });
 
@@ -148,22 +142,6 @@ describe('SnapshotListView', () => {
     ]);
 
     expect(screen.queryByRole('heading', {name: 'solo.png'})).not.toBeInTheDocument();
-  });
-
-  it('reports the first visible card ordinal and a finite progress on scroll', async () => {
-    const onScrollProgress = jest.fn();
-    render(
-      <SnapshotListView
-        items={[changedGroup(5)]}
-        imageBaseUrl="/api/0/projects/org-slug/project-slug/files/images/"
-        onScrollProgress={onScrollProgress}
-      />
-    );
-
-    await waitFor(() => expect(onScrollProgress).toHaveBeenCalled());
-    const [progress, firstIdx] = onScrollProgress.mock.calls.at(-1)!;
-    expect(Number.isFinite(progress)).toBe(true);
-    expect(firstIdx).toBe(0);
   });
 
   it('reports the visible item key to the sidebar even for ungrouped items', async () => {

--- a/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
@@ -166,6 +166,28 @@ describe('SnapshotListView', () => {
     expect(firstIdx).toBe(0);
   });
 
+  it('reports the visible item key to the sidebar even for ungrouped items', async () => {
+    const onVisibleGroupChange = jest.fn();
+    render(
+      <SnapshotListView
+        items={[
+          {
+            key: 'added:solo',
+            name: 'solo.png',
+            displayName: 'solo.png',
+            type: 'added',
+            images: [image({group: undefined, image_file_name: 'solo.png'})],
+          },
+        ]}
+        imageBaseUrl="/api/0/projects/org-slug/project-slug/files/images/"
+        onVisibleGroupChange={onVisibleGroupChange}
+      />
+    );
+
+    await waitFor(() => expect(onVisibleGroupChange).toHaveBeenCalled());
+    expect(onVisibleGroupChange).toHaveBeenLastCalledWith('added:solo');
+  });
+
   it('arrow-down selects the next card via onSelectSnapshot', () => {
     const onSelectSnapshot = jest.fn();
     render(

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -28,7 +28,8 @@ import type {
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
 import {ImageCard, PairCard} from './snapshotCards';
 import {MAX_IMAGE_HEIGHT} from './snapshotDiffBodies';
-import {SnapshotCardFrame, SnapshotGroupHeader} from './snapshotFrames';
+import {SnapshotGroupHeader} from './snapshotFrames';
+import {RowFrame} from './snapshotRowFrame';
 
 interface SnapshotListViewProps {
   imageBaseUrl: string;
@@ -75,21 +76,10 @@ type GroupCard =
       copyData?: unknown;
     };
 
-interface GroupRow {
-  cards: GroupCard[];
-  estimatedHeight: number;
-  id: string;
-  isUngrouped: boolean;
-  itemKey: string;
-  name: string;
-}
-
 // Keep in sync with SnapshotGroupHeader: lg vertical padding + md heading height.
 const SNAPSHOT_GROUP_HEADER_HEIGHT = 44;
 const CARD_CHROME_HEIGHT = 120;
 const ERRORED_BANNER_HEIGHT = 56;
-const CARD_GAP = 0;
-const GROUP_PADDING = 0;
 const ROW_PADDING_BOTTOM = 16;
 const DEFAULT_CONTENT_WIDTH = 900;
 const SNAPSHOT_FRAME_BORDER_WIDTH = 1;
@@ -215,6 +205,7 @@ export function buildRows(items: SidebarItem[], contentWidth: number): ListRow[]
 
 export interface RowIndex {
   firstRowByItemKey: Map<string, number>;
+  lastRowByItemKey: Map<string, number>;
   order: string[];
   positionByKey: Map<string, number>;
   rowIndexByKey: Map<string, number>;
@@ -225,10 +216,12 @@ export function buildRowIndex(rows: ListRow[]): RowIndex {
   const positionByKey = new Map<string, number>();
   const rowIndexByKey = new Map<string, number>();
   const firstRowByItemKey = new Map<string, number>();
+  const lastRowByItemKey = new Map<string, number>();
   rows.forEach((row, rowIdx) => {
     if (!firstRowByItemKey.has(row.itemKey)) {
       firstRowByItemKey.set(row.itemKey, rowIdx);
     }
+    lastRowByItemKey.set(row.itemKey, rowIdx);
     if (row.kind === 'card') {
       const key = snapshotKeyFor(row.card);
       positionByKey.set(key, order.length);
@@ -236,70 +229,11 @@ export function buildRowIndex(rows: ListRow[]): RowIndex {
       rowIndexByKey.set(key, rowIdx);
     }
   });
-  return {order, positionByKey, rowIndexByKey, firstRowByItemKey};
+  return {order, positionByKey, rowIndexByKey, firstRowByItemKey, lastRowByItemKey};
 }
 
-function buildGroups(items: SidebarItem[], contentWidth: number): GroupRow[] {
-  const groups: GroupRow[] = [];
-  for (const item of items) {
-    const cards: GroupCard[] = [];
-    if (item.type === 'changed' || item.type === 'errored') {
-      const status = item.type === 'errored' ? DiffStatus.ERRORED : DiffStatus.CHANGED;
-      const bannerHeight = status === DiffStatus.ERRORED ? ERRORED_BANNER_HEIGHT : 0;
-      for (const pair of item.pairs) {
-        cards.push({
-          type: 'pair-card',
-          id: `c:${item.key}:${pair.head_image.image_file_name}`,
-          pair,
-          status,
-          estimatedHeight:
-            Math.max(
-              estimateCardHeight(pair.head_image, true, contentWidth),
-              estimateCardHeight(pair.base_image, true, contentWidth)
-            ) + bannerHeight,
-        });
-      }
-    } else if (item.type === 'renamed') {
-      for (const pair of item.pairs) {
-        cards.push({
-          type: 'image-card',
-          id: `c:${item.key}:${pair.head_image.image_file_name}`,
-          image: pair.head_image,
-          copyData: pair,
-          cardType: item.type,
-          estimatedHeight: estimateCardHeight(pair.head_image, false, contentWidth),
-        });
-      }
-    } else {
-      for (const image of item.images) {
-        cards.push({
-          type: 'image-card',
-          id: `c:${item.key}:${image.image_file_name}`,
-          image,
-          cardType: item.type,
-          estimatedHeight: estimateCardHeight(image, false, contentWidth),
-        });
-      }
-    }
-    const cardsHeight = cards.reduce(
-      (sum, c, i) => sum + c.estimatedHeight + (i > 0 ? CARD_GAP : 0),
-      0
-    );
-    const ungrouped = isItemUngrouped(item);
-    groups.push({
-      id: `g:${item.key}`,
-      name: item.name,
-      itemKey: item.key,
-      cards,
-      isUngrouped: ungrouped,
-      estimatedHeight:
-        (ungrouped
-          ? cardsHeight
-          : SNAPSHOT_GROUP_HEADER_HEIGHT + cardsHeight + GROUP_PADDING) +
-        ROW_PADDING_BOTTOM,
-    });
-  }
-  return groups;
+function isGroupedRow(row: ListRow): boolean {
+  return row.kind === 'header' || !row.isUngrouped;
 }
 
 export interface SnapshotListViewHandle {
@@ -354,47 +288,32 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
     return () => observer.disconnect();
   }, []);
 
-  const groups = useMemo(() => buildGroups(items, contentWidth), [items, contentWidth]);
-  const getItemKey = useCallback((index: number) => groups[index]!.id, [groups]);
+  const rows = useMemo(() => buildRows(items, contentWidth), [items, contentWidth]);
+  const getItemKey = useCallback((index: number) => rows[index]!.id, [rows]);
 
   const virtualizer = useVirtualizer({
-    count: groups.length,
+    count: rows.length,
     getScrollElement: () => scrollRef.current,
-    estimateSize: i => groups[i]!.estimatedHeight,
+    estimateSize: i => rows[i]!.estimatedHeight,
     getItemKey,
-    overscan: 5,
+    overscan: 8,
     scrollPaddingEnd: 8,
   });
 
-  // Flat (snapshotKey -> groupIdx / position) index for keyboard nav and scroll; O(1) lookups
-  const flatIndex = useMemo(() => {
-    const order: string[] = [];
-    const groupIdxByKey = new Map<string, number>();
-    const positionByKey = new Map<string, number>();
-    for (let gi = 0; gi < groups.length; gi++) {
-      const group = groups[gi]!;
-      for (const card of group.cards) {
-        const key = snapshotKeyFor(card);
-        positionByKey.set(key, order.length);
-        order.push(key);
-        groupIdxByKey.set(key, gi);
-      }
-    }
-    return {order, groupIdxByKey, positionByKey};
-  }, [groups]);
+  const rowIndex = useMemo(() => buildRowIndex(rows), [rows]);
 
   useImperativeHandle(
     ref,
     () => ({
       scrollToGroup(itemKey: string) {
-        const groupIdx = groups.findIndex(g => g.itemKey === itemKey);
-        if (groupIdx === -1) {
+        const rowIdx = rowIndex.firstRowByItemKey.get(itemKey);
+        if (rowIdx === undefined) {
           return;
         }
-        virtualizer.scrollToIndex(groupIdx, {align: 'start'});
+        virtualizer.scrollToIndex(rowIdx, {align: 'start'});
       },
     }),
-    [groups, virtualizer]
+    [rowIndex, virtualizer]
   );
 
   const rafId = useRef(0);
@@ -402,11 +321,11 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
   onVisibleGroupChangeRef.current = onVisibleGroupChange;
   const onScrollProgressRef = useRef(onScrollProgress);
   onScrollProgressRef.current = onScrollProgress;
-  const groupsRef = useRef(groups);
-  groupsRef.current = groups;
-  const flatIndexRef = useRef(flatIndex);
-  flatIndexRef.current = flatIndex;
-  const visibleGroupIdxRef = useRef(0);
+  const rowsRef = useRef(rows);
+  rowsRef.current = rows;
+  const rowIndexRef = useRef(rowIndex);
+  rowIndexRef.current = rowIndex;
+  const visibleRowIdxRef = useRef(0);
   const handleScroll = useCallback(() => {
     cancelAnimationFrame(rafId.current);
     rafId.current = requestAnimationFrame(() => {
@@ -414,55 +333,36 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       if (!el) {
         return;
       }
-      setScrollTop(el.scrollTop);
-      const containerTop = el.getBoundingClientRect().top;
+      const top = el.scrollTop;
+      setScrollTop(top);
+      const virtualRows = virtualizer.getVirtualItems();
 
-      const rows = el.querySelectorAll<HTMLElement>('[data-index]');
-      const ROW_THRESHOLD = 100;
-      let visibleItemKey = groupsRef.current[0]?.itemKey ?? null;
-      let visibleGroupIdx = 0;
-      for (const row of rows) {
-        const idx = parseInt(row.dataset.index ?? '', 10);
-        if (isNaN(idx)) {
-          continue;
-        }
-        const rowTop = row.getBoundingClientRect().top - containerTop;
-        if (rowTop <= ROW_THRESHOLD) {
-          visibleItemKey = groupsRef.current[idx]?.itemKey ?? null;
-          visibleGroupIdx = idx;
-        }
-      }
-      visibleGroupIdxRef.current = visibleGroupIdx;
-      onVisibleGroupChangeRef.current?.(visibleItemKey);
+      // Topmost visible row defines the active group and the scroll anchor.
+      const topRowItem = virtualRows.find(vi => vi.end > top) ?? virtualRows[0];
+      visibleRowIdxRef.current = topRowItem?.index ?? 0;
+      const topRow = topRowItem ? rowsRef.current[topRowItem.index] : undefined;
+      onVisibleGroupChangeRef.current?.(
+        topRow && isGroupedRow(topRow) ? topRow.itemKey : null
+      );
 
       if (onScrollProgressRef.current) {
         const maxScroll = el.scrollHeight - el.clientHeight;
-        const progress = maxScroll > 0 ? (el.scrollTop / maxScroll) * 100 : 0;
-        const cards = el.querySelectorAll<HTMLElement>('[data-snapshot-key]');
-        const SNAP_THRESHOLD = 9;
-        let topCard = 0;
-        for (const card of cards) {
-          const key = card.dataset.snapshotKey;
-          if (!key) {
-            continue;
-          }
-          const pos = flatIndexRef.current.positionByKey.get(key);
-          if (pos === undefined) {
-            continue;
-          }
-          const cardTop = card.getBoundingClientRect().top - containerTop;
-          if (cardTop <= SNAP_THRESHOLD) {
-            topCard = pos;
-          }
-        }
-        onScrollProgressRef.current(progress, topCard);
+        const progress = maxScroll > 0 ? (top / maxScroll) * 100 : 0;
+        const topCardItem = virtualRows.find(
+          vi => vi.end > top && rowsRef.current[vi.index]?.kind === 'card'
+        );
+        const topCardRow = topCardItem ? rowsRef.current[topCardItem.index] : undefined;
+        const key =
+          topCardRow?.kind === 'card' ? snapshotKeyFor(topCardRow.card) : undefined;
+        const ordinal = key ? (rowIndexRef.current.positionByKey.get(key) ?? 0) : 0;
+        onScrollProgressRef.current(progress, ordinal);
       }
     });
-  }, []);
+  }, [virtualizer]);
 
   useEffect(() => {
     const el = scrollRef.current;
-    if (!el || groups.length === 0) {
+    if (!el || rows.length === 0) {
       return;
     }
     el.addEventListener('scroll', handleScroll, {passive: true});
@@ -471,7 +371,7 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       el.removeEventListener('scroll', handleScroll);
       cancelAnimationFrame(rafId.current);
     };
-  }, [groups, handleScroll]);
+  }, [rows, handleScroll]);
 
   const prevDiffModeRef = useRef(diffMode);
   useEffect(() => {
@@ -479,29 +379,29 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       return;
     }
     prevDiffModeRef.current = diffMode;
-    const idx = visibleGroupIdxRef.current;
-    if (idx >= 0 && idx < groups.length) {
+    const idx = visibleRowIdxRef.current;
+    if (idx >= 0 && idx < rows.length) {
       requestAnimationFrame(() => {
         virtualizer.scrollToIndex(idx, {align: 'start'});
       });
     }
-  }, [diffMode, groups, virtualizer]);
+  }, [diffMode, rows, virtualizer]);
 
   const initialSnapshotKey = useRef(selectedSnapshotKey ?? null).current;
   const didInitialScroll = useRef(false);
   useEffect(() => {
-    if (didInitialScroll.current || !initialSnapshotKey || groups.length === 0) {
+    if (didInitialScroll.current || !initialSnapshotKey || rows.length === 0) {
       return;
     }
-    const targetIdx = flatIndex.groupIdxByKey.get(initialSnapshotKey);
+    const targetIdx = rowIndex.rowIndexByKey.get(initialSnapshotKey);
     if (targetIdx === undefined) {
       return;
     }
     didInitialScroll.current = true;
     virtualizer.scrollToIndex(targetIdx, {align: 'start'});
 
-    const isUngrouped =
-      groups[flatIndex.groupIdxByKey.get(initialSnapshotKey) ?? -1]?.isUngrouped ?? true;
+    const targetRow = rows[targetIdx];
+    const isUngrouped = targetRow?.kind === 'card' ? targetRow.isUngrouped : true;
 
     let retries = 3;
     const adjustScroll = () => {
@@ -520,17 +420,17 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       }
     };
     requestAnimationFrame(adjustScroll);
-  }, [groups, initialSnapshotKey, flatIndex, virtualizer]);
+  }, [rows, initialSnapshotKey, rowIndex, virtualizer]);
 
   const keyNavRef = useRef({
-    flatIndex,
+    rowIndex,
     selectedSnapshotKey,
     onSelectSnapshot,
     onOpenSnapshot,
     virtualizer,
   });
   keyNavRef.current = {
-    flatIndex,
+    rowIndex,
     selectedSnapshotKey,
     onSelectSnapshot,
     onOpenSnapshot,
@@ -546,12 +446,9 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       }
       cardEl.scrollIntoView({block});
       if (block === 'start') {
-        const groupIdx = keyNavRef.current.flatIndex.groupIdxByKey.get(key);
-        if (
-          groupIdx !== undefined &&
-          !groupsRef.current[groupIdx]?.isUngrouped &&
-          scrollRef.current
-        ) {
+        const rowIdx = keyNavRef.current.rowIndex.rowIndexByKey.get(key);
+        const row = rowIdx === undefined ? undefined : rowsRef.current[rowIdx];
+        if (row?.kind === 'card' && !row.isUngrouped && scrollRef.current) {
           scrollRef.current.scrollTop -= SNAPSHOT_GROUP_HEADER_HEIGHT;
         }
       }
@@ -562,11 +459,11 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       if (scrollCardIntoView(key, block)) {
         return;
       }
-      const groupIdx = keyNavRef.current.flatIndex.groupIdxByKey.get(key);
-      if (groupIdx === undefined) {
+      const rowIdx = keyNavRef.current.rowIndex.rowIndexByKey.get(key);
+      if (rowIdx === undefined) {
         return;
       }
-      keyNavRef.current.virtualizer.scrollToIndex(groupIdx, {
+      keyNavRef.current.virtualizer.scrollToIndex(rowIdx, {
         align: block === 'start' ? 'start' : 'auto',
       });
       requestAnimationFrame(() => scrollCardIntoView(key, block));
@@ -586,7 +483,7 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
         return;
       }
       const {
-        flatIndex: idx,
+        rowIndex: idx,
         selectedSnapshotKey: currentKey,
         onSelectSnapshot: onSelect,
         onOpenSnapshot: onOpen,
@@ -651,25 +548,29 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
   const totalSize = virtualizer.getTotalSize();
   const scrollContainerPaddingTop = Number.parseFloat(theme.space.xl);
   const activeGroupThreshold = scrollTop - scrollContainerPaddingTop;
-  const activeVirtualItem = virtualItems.find(virtualItem => {
-    return scrollTop > 0 && activeGroupThreshold < virtualItem.end - ROW_PADDING_BOTTOM;
+  const activeRowItem = virtualItems.find(virtualItem => {
+    return scrollTop > 0 && activeGroupThreshold < virtualItem.end;
   });
-  const activeGroupBounds =
-    activeVirtualItem === undefined
-      ? null
-      : {
-          bottom:
-            scrollContainerPaddingTop +
-            activeVirtualItem.end -
-            ROW_PADDING_BOTTOM -
-            scrollTop,
-          group: groups[activeVirtualItem.index]!,
-          top: scrollContainerPaddingTop + activeVirtualItem.start - scrollTop,
-        };
-  const activeGroupName =
-    activeGroupBounds && !activeGroupBounds.group.isUngrouped
-      ? activeGroupBounds.group.name
-      : null;
+  const activeRow = activeRowItem ? rows[activeRowItem.index] : undefined;
+  const activeItemKey = activeRow && isGroupedRow(activeRow) ? activeRow.itemKey : null;
+  const activeGroupName = activeItemKey === null ? null : (activeRow?.groupName ?? null);
+  const measurements = virtualizer.measurementsCache;
+  const activeGroupBounds = (() => {
+    if (activeItemKey === null) {
+      return null;
+    }
+    const firstIdx = rowIndex.firstRowByItemKey.get(activeItemKey);
+    const lastIdx = rowIndex.lastRowByItemKey.get(activeItemKey);
+    const first = firstIdx === undefined ? undefined : measurements[firstIdx];
+    const last = lastIdx === undefined ? undefined : measurements[lastIdx];
+    if (!first || !last) {
+      return null;
+    }
+    return {
+      top: scrollContainerPaddingTop + first.start - scrollTop,
+      bottom: scrollContainerPaddingTop + last.end - ROW_PADDING_BOTTOM - scrollTop,
+    };
+  })();
   const stickyHeaderTop = Math.max(scrollContainerPaddingTop - scrollTop, 0);
   const stickyHeaderTranslateY =
     activeGroupBounds === null
@@ -722,26 +623,43 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       ) : null}
       <Container position="relative" width="100%" style={{height: totalSize}}>
         {virtualItems.map(vi => {
-          const group = groups[vi.index]!;
+          const row = rows[vi.index]!;
+          const isTop =
+            row.kind === 'header' ||
+            (row.kind === 'card' && row.isFirstInGroup && row.isUngrouped);
+          const isBottom = row.kind === 'card' && row.isLastInGroup;
+          const isSeparator = row.kind === 'card' && !row.isLastInGroup;
           return (
             <RowPositioner
               key={vi.key}
               data-index={vi.index}
+              data-last-in-group={isBottom ? '' : undefined}
               ref={virtualizer.measureElement}
               style={{transform: `translateY(${vi.start}px)`}}
             >
-              <GroupContainer
-                group={group}
-                imageBaseUrl={imageBaseUrl}
-                headBranch={headBranch}
-                selectedSnapshotKey={selectedSnapshotKey ?? null}
-                onSelectSnapshot={onSelectSnapshot}
-                onOpenSnapshot={onOpenSnapshot}
-                diffMode={diffMode}
-                overlayColor={overlayColor}
-                overlayOpacity={overlayOpacity}
-                diffImageBaseUrl={diffImageBaseUrl}
-              />
+              <RowFrame
+                overflow="hidden"
+                data-frame-top={isTop ? '' : undefined}
+                data-frame-bottom={isBottom ? '' : undefined}
+                data-separator={isSeparator ? '' : undefined}
+              >
+                {row.kind === 'header' ? (
+                  <SnapshotGroupHeader name={row.groupName} />
+                ) : (
+                  <CardRow
+                    row={row}
+                    imageBaseUrl={imageBaseUrl}
+                    headBranch={headBranch}
+                    selectedSnapshotKey={selectedSnapshotKey ?? null}
+                    onSelectSnapshot={onSelectSnapshot}
+                    onOpenSnapshot={onOpenSnapshot}
+                    diffMode={diffMode}
+                    overlayColor={overlayColor}
+                    overlayOpacity={overlayOpacity}
+                    diffImageBaseUrl={diffImageBaseUrl}
+                  />
+                )}
+              </RowFrame>
             </RowPositioner>
           );
         })}
@@ -750,8 +668,8 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
   );
 });
 
-const GroupContainer = memo(function GroupContainerImpl({
-  group,
+const CardRow = memo(function CardRowImpl({
+  row,
   imageBaseUrl,
   headBranch,
   selectedSnapshotKey,
@@ -763,8 +681,8 @@ const GroupContainer = memo(function GroupContainerImpl({
   diffImageBaseUrl,
 }: {
   diffMode: DiffMode;
-  group: GroupRow;
   imageBaseUrl: string;
+  row: Extract<ListRow, {kind: 'card'}>;
   selectedSnapshotKey: string | null;
   diffImageBaseUrl?: string;
   headBranch?: string | null;
@@ -774,62 +692,59 @@ const GroupContainer = memo(function GroupContainerImpl({
   overlayOpacity?: number;
 }) {
   const organization = useOrganization();
-  const cards = group.cards.map(card => {
-    const snapshotKey = snapshotKeyFor(card);
-    const isSelected = snapshotKey === selectedSnapshotKey;
-    const copyUrl = buildSnapshotLink(snapshotKey);
-    const diffStatus = card.type === 'pair-card' ? card.status : card.cardType;
-    const onCopyLink = () =>
+  const {card} = row;
+  const snapshotKey = snapshotKeyFor(card);
+  const isSelected = snapshotKey === selectedSnapshotKey;
+  const copyUrl = useMemo(() => buildSnapshotLink(snapshotKey), [snapshotKey]);
+  const diffStatus = card.type === 'pair-card' ? card.status : card.cardType;
+  const onCopyLink = useCallback(
+    () =>
       trackAnalytics('preprod.snapshots.details.image_link_copied', {
         organization,
         diff_status: diffStatus === 'solo' ? null : diffStatus,
-      });
-    const onCopyMetadata = () =>
+      }),
+    [organization, diffStatus]
+  );
+  const onCopyMetadata = useCallback(
+    () =>
       trackAnalytics('preprod.snapshots.details.image_metadata_copied', {
         organization,
         diff_status: diffStatus === 'solo' ? null : diffStatus,
-      });
-    return card.type === 'pair-card' ? (
-      <PairCard
-        key={card.id}
-        pair={card.pair}
-        status={card.status}
-        imageBaseUrl={imageBaseUrl}
-        headBranch={headBranch}
-        isSelected={isSelected}
-        copyUrl={copyUrl}
-        diffMode={diffMode}
-        overlayColor={overlayColor}
-        overlayOpacity={overlayOpacity}
-        diffImageBaseUrl={diffImageBaseUrl}
-        snapshotKey={snapshotKey}
-        onSelectSnapshot={onSelectSnapshot}
-        onOpenSnapshot={onOpenSnapshot}
-        onCopyLink={onCopyLink}
-        onCopyMetadata={onCopyMetadata}
-      />
-    ) : (
-      <ImageCard
-        key={card.id}
-        image={card.image}
-        cardType={card.cardType}
-        copyData={card.copyData}
-        imageBaseUrl={imageBaseUrl}
-        isSelected={isSelected}
-        copyUrl={copyUrl}
-        snapshotKey={snapshotKey}
-        onSelectSnapshot={onSelectSnapshot}
-        onOpenSnapshot={onOpenSnapshot}
-        onCopyLink={onCopyLink}
-        onCopyMetadata={onCopyMetadata}
-      />
-    );
-  });
-
-  return (
-    <SnapshotCardFrame groupName={group.isUngrouped ? null : group.name}>
-      {cards}
-    </SnapshotCardFrame>
+      }),
+    [organization, diffStatus]
+  );
+  return card.type === 'pair-card' ? (
+    <PairCard
+      pair={card.pair}
+      status={card.status}
+      imageBaseUrl={imageBaseUrl}
+      headBranch={headBranch}
+      isSelected={isSelected}
+      copyUrl={copyUrl}
+      diffMode={diffMode}
+      overlayColor={overlayColor}
+      overlayOpacity={overlayOpacity}
+      diffImageBaseUrl={diffImageBaseUrl}
+      snapshotKey={snapshotKey}
+      onSelectSnapshot={onSelectSnapshot}
+      onOpenSnapshot={onOpenSnapshot}
+      onCopyLink={onCopyLink}
+      onCopyMetadata={onCopyMetadata}
+    />
+  ) : (
+    <ImageCard
+      image={card.image}
+      cardType={card.cardType}
+      copyData={card.copyData}
+      imageBaseUrl={imageBaseUrl}
+      isSelected={isSelected}
+      copyUrl={copyUrl}
+      snapshotKey={snapshotKey}
+      onSelectSnapshot={onSelectSnapshot}
+      onOpenSnapshot={onOpenSnapshot}
+      onCopyLink={onCopyLink}
+      onCopyMetadata={onCopyMetadata}
+    />
   );
 });
 

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -236,6 +236,23 @@ function isGroupedRow(row: ListRow): boolean {
   return row.kind === 'header' || !row.isUngrouped;
 }
 
+// Where a row sits in its group's continuous bordered frame. A grouped group's
+// top border is carried by its header row, so a grouped first card is not a top.
+export function rowFrameEdges(row: ListRow): {
+  frameBottom: boolean;
+  frameTop: boolean;
+  separator: boolean;
+} {
+  if (row.kind === 'header') {
+    return {frameTop: true, frameBottom: false, separator: false};
+  }
+  return {
+    frameTop: row.isFirstInGroup && row.isUngrouped,
+    frameBottom: row.isLastInGroup,
+    separator: !row.isLastInGroup,
+  };
+}
+
 export interface SnapshotListViewHandle {
   scrollToGroup: (itemKey: string) => void;
 }
@@ -554,6 +571,8 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
   const activeRow = activeRowItem ? rows[activeRowItem.index] : undefined;
   const activeItemKey = activeRow && isGroupedRow(activeRow) ? activeRow.itemKey : null;
   const activeGroupName = activeItemKey === null ? null : (activeRow?.groupName ?? null);
+  // A large group's last row is often outside the overscan window, so its bound
+  // is an estimate until measured; the sticky bottom self-corrects once near it.
   const measurements = virtualizer.measurementsCache;
   const activeGroupBounds = (() => {
     if (activeItemKey === null) {
@@ -624,24 +643,20 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       <Container position="relative" width="100%" style={{height: totalSize}}>
         {virtualItems.map(vi => {
           const row = rows[vi.index]!;
-          const isTop =
-            row.kind === 'header' ||
-            (row.kind === 'card' && row.isFirstInGroup && row.isUngrouped);
-          const isBottom = row.kind === 'card' && row.isLastInGroup;
-          const isSeparator = row.kind === 'card' && !row.isLastInGroup;
+          const {frameTop, frameBottom, separator} = rowFrameEdges(row);
           return (
             <RowPositioner
               key={vi.key}
               data-index={vi.index}
-              data-last-in-group={isBottom ? '' : undefined}
+              data-last-in-group={frameBottom ? '' : undefined}
               ref={virtualizer.measureElement}
               style={{transform: `translateY(${vi.start}px)`}}
             >
               <RowFrame
                 overflow="hidden"
-                data-frame-top={isTop ? '' : undefined}
-                data-frame-bottom={isBottom ? '' : undefined}
-                data-separator={isSeparator ? '' : undefined}
+                data-frame-top={frameTop ? '' : undefined}
+                data-frame-bottom={frameBottom ? '' : undefined}
+                data-separator={separator ? '' : undefined}
               >
                 {row.kind === 'header' ? (
                   <SnapshotGroupHeader name={row.groupName} />
@@ -784,6 +799,12 @@ const RowPositioner = styled('div')`
   top: 0;
   left: 0;
   right: 0;
-  padding-bottom: ${p => p.theme.space.xl};
   contain: layout paint;
+
+  /* Only the last row of a group carries the inter-group gap, matching the
+   * ROW_PADDING_BOTTOM added to its estimated height in buildRows. Padding every
+   * row would break the group's continuous bordered frame. */
+  &[data-last-in-group] {
+    padding-bottom: ${p => p.theme.space.xl};
+  }
 `;

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -363,9 +363,9 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       const topRowItem = virtualRows.find(vi => vi.end > anchor) ?? virtualRows[0];
       visibleRowIdxRef.current = topRowItem?.index ?? 0;
       const topRow = topRowItem ? rowsRef.current[topRowItem.index] : undefined;
-      onVisibleGroupChangeRef.current?.(
-        topRow && isGroupedRow(topRow) ? topRow.itemKey : null
-      );
+      // The sidebar highlights whatever item is at the top — grouped or not
+      // (the sticky *header* is what hides for ungrouped items, computed below).
+      onVisibleGroupChangeRef.current?.(topRow?.itemKey ?? null);
 
       if (onScrollProgressRef.current) {
         const maxScroll = el.scrollHeight - el.clientHeight;

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -236,8 +236,6 @@ function isGroupedRow(row: ListRow): boolean {
   return row.kind === 'header' || !row.isUngrouped;
 }
 
-// Where a row sits in its group's continuous bordered frame. A grouped group's
-// top border is carried by its header row, so a grouped first card is not a top.
 export function rowFrameEdges(row: ListRow): {
   frameBottom: boolean;
   frameTop: boolean;
@@ -354,17 +352,11 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       setScrollTop(top);
       const virtualRows = virtualizer.getVirtualItems();
 
-      // Virtualizer offsets are content-relative; the container's top padding
-      // sits above them. Anchor row detection to the same line the sticky header
-      // uses so the sidebar group and progress counter stay in sync with it.
       const anchor = top - Number.parseFloat(theme.space.xl);
 
-      // Topmost visible row defines the active group and the scroll anchor.
       const topRowItem = virtualRows.find(vi => vi.end > anchor) ?? virtualRows[0];
       visibleRowIdxRef.current = topRowItem?.index ?? 0;
       const topRow = topRowItem ? rowsRef.current[topRowItem.index] : undefined;
-      // The sidebar highlights whatever item is at the top — grouped or not
-      // (the sticky *header* is what hides for ungrouped items, computed below).
       onVisibleGroupChangeRef.current?.(topRow?.itemKey ?? null);
 
       if (onScrollProgressRef.current) {
@@ -576,8 +568,6 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
   const activeRow = activeRowItem ? rows[activeRowItem.index] : undefined;
   const activeItemKey = activeRow && isGroupedRow(activeRow) ? activeRow.itemKey : null;
   const activeGroupName = activeItemKey === null ? null : (activeRow?.groupName ?? null);
-  // A large group's last row is often outside the overscan window, so its bound
-  // is an estimate until measured; the sticky bottom self-corrects once near it.
   const measurements = virtualizer.measurementsCache;
   const activeGroupBounds = (() => {
     if (activeItemKey === null) {
@@ -806,9 +796,6 @@ const RowPositioner = styled('div')`
   right: 0;
   contain: layout paint;
 
-  /* Only the last row of a group carries the inter-group gap, matching the
-   * ROW_PADDING_BOTTOM added to its estimated height in buildRows. Padding every
-   * row would break the group's continuous bordered frame. */
   &[data-last-in-group] {
     padding-bottom: ${p => p.theme.space.xl};
   }

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -118,6 +118,101 @@ export function isItemUngrouped(item: SidebarItem): boolean {
   return !item.images[0]?.group;
 }
 
+export type ListRow =
+  | {
+      estimatedHeight: number;
+      groupName: string;
+      id: string;
+      itemKey: string;
+      kind: 'header';
+    }
+  | {
+      card: GroupCard;
+      estimatedHeight: number;
+      groupName: string | null;
+      id: string;
+      isFirstInGroup: boolean;
+      isLastInGroup: boolean;
+      isUngrouped: boolean;
+      itemKey: string;
+      kind: 'card';
+    };
+
+function buildItemCards(item: SidebarItem, contentWidth: number): GroupCard[] {
+  const cards: GroupCard[] = [];
+  if (item.type === 'changed' || item.type === 'errored') {
+    const status = item.type === 'errored' ? DiffStatus.ERRORED : DiffStatus.CHANGED;
+    const bannerHeight = status === DiffStatus.ERRORED ? ERRORED_BANNER_HEIGHT : 0;
+    for (const pair of item.pairs) {
+      cards.push({
+        type: 'pair-card',
+        id: `c:${item.key}:${pair.head_image.image_file_name}`,
+        pair,
+        status,
+        estimatedHeight:
+          Math.max(
+            estimateCardHeight(pair.head_image, true, contentWidth),
+            estimateCardHeight(pair.base_image, true, contentWidth)
+          ) + bannerHeight,
+      });
+    }
+  } else if (item.type === 'renamed') {
+    for (const pair of item.pairs) {
+      cards.push({
+        type: 'image-card',
+        id: `c:${item.key}:${pair.head_image.image_file_name}`,
+        image: pair.head_image,
+        copyData: pair,
+        cardType: item.type,
+        estimatedHeight: estimateCardHeight(pair.head_image, false, contentWidth),
+      });
+    }
+  } else {
+    for (const image of item.images) {
+      cards.push({
+        type: 'image-card',
+        id: `c:${item.key}:${image.image_file_name}`,
+        image,
+        cardType: item.type,
+        estimatedHeight: estimateCardHeight(image, false, contentWidth),
+      });
+    }
+  }
+  return cards;
+}
+
+export function buildRows(items: SidebarItem[], contentWidth: number): ListRow[] {
+  const rows: ListRow[] = [];
+  for (const item of items) {
+    const cards = buildItemCards(item, contentWidth);
+    const ungrouped = isItemUngrouped(item);
+    if (!ungrouped) {
+      rows.push({
+        kind: 'header',
+        id: `h:${item.key}`,
+        itemKey: item.key,
+        groupName: item.name,
+        estimatedHeight: SNAPSHOT_GROUP_HEADER_HEIGHT,
+      });
+    }
+    cards.forEach((card, i) => {
+      const isLast = i === cards.length - 1;
+      rows.push({
+        kind: 'card',
+        id: card.id,
+        card,
+        itemKey: item.key,
+        groupName: ungrouped ? null : item.name,
+        isUngrouped: ungrouped,
+        isFirstInGroup: i === 0,
+        isLastInGroup: isLast,
+        estimatedHeight: card.estimatedHeight + (isLast ? ROW_PADDING_BOTTOM : 0),
+      });
+    });
+  }
+  return rows;
+}
+
 function buildGroups(items: SidebarItem[], contentWidth: number): GroupRow[] {
   const groups: GroupRow[] = [];
   for (const item of items) {

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -354,8 +354,13 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       setScrollTop(top);
       const virtualRows = virtualizer.getVirtualItems();
 
+      // Virtualizer offsets are content-relative; the container's top padding
+      // sits above them. Anchor row detection to the same line the sticky header
+      // uses so the sidebar group and progress counter stay in sync with it.
+      const anchor = top - Number.parseFloat(theme.space.xl);
+
       // Topmost visible row defines the active group and the scroll anchor.
-      const topRowItem = virtualRows.find(vi => vi.end > top) ?? virtualRows[0];
+      const topRowItem = virtualRows.find(vi => vi.end > anchor) ?? virtualRows[0];
       visibleRowIdxRef.current = topRowItem?.index ?? 0;
       const topRow = topRowItem ? rowsRef.current[topRowItem.index] : undefined;
       onVisibleGroupChangeRef.current?.(
@@ -366,7 +371,7 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
         const maxScroll = el.scrollHeight - el.clientHeight;
         const progress = maxScroll > 0 ? (top / maxScroll) * 100 : 0;
         const topCardItem = virtualRows.find(
-          vi => vi.end > top && rowsRef.current[vi.index]?.kind === 'card'
+          vi => vi.end > anchor && rowsRef.current[vi.index]?.kind === 'card'
         );
         const topCardRow = topCardItem ? rowsRef.current[topCardItem.index] : undefined;
         const key =
@@ -375,7 +380,7 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
         onScrollProgressRef.current(progress, ordinal);
       }
     });
-  }, [virtualizer]);
+  }, [virtualizer, theme.space.xl]);
 
   useEffect(() => {
     const el = scrollRef.current;

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -213,6 +213,32 @@ export function buildRows(items: SidebarItem[], contentWidth: number): ListRow[]
   return rows;
 }
 
+export interface RowIndex {
+  firstRowByItemKey: Map<string, number>;
+  order: string[];
+  positionByKey: Map<string, number>;
+  rowIndexByKey: Map<string, number>;
+}
+
+export function buildRowIndex(rows: ListRow[]): RowIndex {
+  const order: string[] = [];
+  const positionByKey = new Map<string, number>();
+  const rowIndexByKey = new Map<string, number>();
+  const firstRowByItemKey = new Map<string, number>();
+  rows.forEach((row, rowIdx) => {
+    if (!firstRowByItemKey.has(row.itemKey)) {
+      firstRowByItemKey.set(row.itemKey, rowIdx);
+    }
+    if (row.kind === 'card') {
+      const key = snapshotKeyFor(row.card);
+      positionByKey.set(key, order.length);
+      order.push(key);
+      rowIndexByKey.set(key, rowIdx);
+    }
+  });
+  return {order, positionByKey, rowIndexByKey, firstRowByItemKey};
+}
+
 function buildGroups(items: SidebarItem[], contentWidth: number): GroupRow[] {
   const groups: GroupRow[] = [];
   for (const item of items) {

--- a/static/app/views/preprod/snapshots/main/snapshotRowFrame.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotRowFrame.tsx
@@ -22,6 +22,7 @@ export const RowFrame = styled(Container)`
     border-bottom-right-radius: ${p => p.theme.radius.md};
   }
 
+  /* Keep in sync with SnapshotVariantContainer's separator in snapshotFrames.tsx. */
   &[data-separator] {
     border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   }

--- a/static/app/views/preprod/snapshots/main/snapshotRowFrame.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotRowFrame.tsx
@@ -1,0 +1,28 @@
+import styled from '@emotion/styled';
+
+import {Container} from '@sentry/scraps/layout';
+
+// A single virtualized row's frame. Grouped rows share a continuous bordered
+// container: side borders on every row, top/bottom border+radius on the group
+// edges, and a separator between adjacent cards.
+export const RowFrame = styled(Container)`
+  background: ${p => p.theme.tokens.background.primary};
+  border-left: 1px solid ${p => p.theme.tokens.border.primary};
+  border-right: 1px solid ${p => p.theme.tokens.border.primary};
+
+  &[data-frame-top] {
+    border-top: 1px solid ${p => p.theme.tokens.border.primary};
+    border-top-left-radius: ${p => p.theme.radius.md};
+    border-top-right-radius: ${p => p.theme.radius.md};
+  }
+
+  &[data-frame-bottom] {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
+    border-bottom-left-radius: ${p => p.theme.radius.md};
+    border-bottom-right-radius: ${p => p.theme.radius.md};
+  }
+
+  &[data-separator] {
+    border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
+  }
+`;

--- a/static/app/views/preprod/snapshots/main/snapshotRowFrame.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotRowFrame.tsx
@@ -2,9 +2,6 @@ import styled from '@emotion/styled';
 
 import {Container} from '@sentry/scraps/layout';
 
-// A single virtualized row's frame. Grouped rows share a continuous bordered
-// container: side borders on every row, top/bottom border+radius on the group
-// edges, and a separator between adjacent cards.
 export const RowFrame = styled(Container)`
   background: ${p => p.theme.tokens.background.primary};
   border-left: 1px solid ${p => p.theme.tokens.border.primary};
@@ -22,7 +19,6 @@ export const RowFrame = styled(Container)`
     border-bottom-right-radius: ${p => p.theme.radius.md};
   }
 
-  /* Keep in sync with SnapshotVariantContainer's separator in snapshotFrames.tsx. */
   &[data-separator] {
     border-bottom: 1px solid ${p => p.theme.tokens.border.secondary};
   }


### PR DESCRIPTION
The snapshot detail page (`/preprod/snapshots/{id}/`) scrolls very badly on snapshots with lots of changes — it was reported internally on a build with a large changeset, and it's laggy in all three diff modes.

The list already used `@tanstack/react-virtual`, but it virtualized at the **group** level: `count` was the number of groups, and each group row rendered *all* of its cards at once via `group.cards.map(...)`. When a snapshot's changes collapse into a single `img.group` (which is exactly what large builds do), one virtual row mounts hundreds of heavy `PairCard`s — each with two images, a D3 zoom layer, and per-card chrome — tens of thousands of pixels tall. Windowing was effectively defeated. Two DevTools traces (a large-changeset build vs. a 2-change control) confirmed it: identical code, but compositor `Commit` (~0.9ms → ~53ms) and per-frame layout/intersection work scaled 60–450× purely with the size of the mounted DOM tree.

This flattens the group→cards tree into a single ordered list of rows — one row per group header, one row per card — and points the virtualizer at that flat list (`count = rows.length`). Now the DOM only ever holds the rows in (or near) the viewport, no matter how the changes group. Alongside the core change: the group's continuous bordered frame is reconstructed per-row (`snapshotRowFrame.tsx`), the sticky header and scroll-progress reporting are derived from the virtualizer's own offsets instead of per-frame `querySelectorAll` + `getBoundingClientRect` sweeps, keyboard nav and scroll-to are remapped to row indices, and the per-card `GroupContainer.map` becomes a memoized `CardRow` with stabilized callbacks (restoring `memo` that inline props previously defeated).

The row model (`buildRows`, `buildRowIndex`, `rowFrameEdges`) is pure and unit-tested; the view tests cover header/no-header, frame edges, the inter-group padding contract, scroll-progress, and keyboard selection. Behavior parity is what the tests verify — the actual scroll-perf win is confirmed separately via a before/after Chrome trace, since jsdom can't measure layout or compositing.

Reviewed with a code-review / best-practices / security / thermo-nuclear pass before opening; findings addressed (notably: gate the inter-group padding to the last row so the frame stays continuous). One known pre-existing nit left in place: the "latest ref" pattern writes `ref.current` during render (only renamed here, not introduced) — moving it into an effect would change handler timing for no functional gain.
