### PR TITLE
perf(snapshots): Defer d3-zoom attach on split cards until interaction

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/useD3Zoom.ts
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/useD3Zoom.ts
@@ -3,6 +3,9 @@ import {select} from 'd3-selection';
 import {zoom, zoomIdentity, type ZoomBehavior, type ZoomTransform} from 'd3-zoom';
 
 interface UseD3ZoomOptions {
+  // When false, the zoom behavior is not attached to the DOM. Lets callers
+  // defer the d3 selection + listener setup until the user first interacts.
+  enabled?: boolean;
   maxScale?: number;
   minScale?: number;
   onTransformChange?: (transform: ZoomTransform) => void;
@@ -25,6 +28,7 @@ export function useD3Zoom({
   maxScale = 10,
   onTransformChange,
   wheelRequiresModifier = false,
+  enabled = true,
 }: UseD3ZoomOptions = {}): UseD3ZoomReturn {
   const containerRef = useRef<HTMLDivElement>(null);
   const [transform, setTransform] = useState(zoomIdentity);
@@ -34,7 +38,7 @@ export function useD3Zoom({
 
   useEffect(() => {
     const container = containerRef.current;
-    if (!container) {
+    if (!container || !enabled) {
       return;
     }
 
@@ -63,7 +67,7 @@ export function useD3Zoom({
       select(container).on('.zoom', null);
       zoomBehaviorRef.current = null;
     };
-  }, [minScale, maxScale, wheelRequiresModifier]);
+  }, [minScale, maxScale, wheelRequiresModifier, enabled]);
 
   const zoomIn = useCallback(() => {
     const container = containerRef.current;

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.spec.tsx
@@ -1,0 +1,81 @@
+import {fireEvent, render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {mockElementSize} from 'sentry/utils/fixtures/virtualization';
+import type {SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
+
+import {SplitPairBody} from './snapshotDiffBodies';
+
+const mockZoom = {
+  containerRef: {current: null},
+  resetZoom: jest.fn(),
+  transform: {x: 0, y: 0, k: 1},
+  zoomBehaviorRef: {current: null},
+  zoomIn: jest.fn(),
+  zoomOut: jest.fn(),
+};
+
+const mockUseSyncedD3Zoom = jest.fn((_options?: unknown) => [mockZoom, mockZoom]);
+
+jest.mock('./imageDisplay/useD3Zoom', () => ({
+  useD3Zoom: () => mockZoom,
+  useSyncedD3Zoom: (options: unknown) => mockUseSyncedD3Zoom(options),
+}));
+
+function image(overrides: Partial<SnapshotImage> = {}): SnapshotImage {
+  return {
+    display_name: 'S',
+    height: 180,
+    image_file_name: 'a.png',
+    key: 'k',
+    tags: null,
+    width: 320,
+    ...overrides,
+  };
+}
+
+function renderBody() {
+  return render(
+    <SplitPairBody
+      baseUrl="/base.png"
+      headUrl="/head.png"
+      baseImage={image({image_file_name: 'a.base.png', key: 'base'})}
+      headImage={image({image_file_name: 'a.png', key: 'head'})}
+      headLabel="Head"
+      altPrefix="Login"
+    />
+  );
+}
+
+describe('SplitPairBody zoom deferral', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockElementSize({width: 900, height: 600});
+  });
+
+  it('attaches d3-zoom only after the card is interacted with', () => {
+    const {container} = renderBody();
+
+    // Zoom starts disabled so its d3 selection + listeners stay off the mount path.
+    expect(mockUseSyncedD3Zoom).toHaveBeenLastCalledWith(
+      expect.objectContaining({enabled: false})
+    );
+
+    // The root carries onPointerEnter; pointerenter does not bubble, so fire it
+    // directly on the element that owns the handler.
+    fireEvent.pointerEnter(container.firstChild as Element);
+
+    expect(mockUseSyncedD3Zoom).toHaveBeenLastCalledWith(
+      expect.objectContaining({enabled: true})
+    );
+  });
+
+  it('also enables zoom when focus enters the card (keyboard users)', () => {
+    renderBody();
+
+    fireEvent.focus(screen.getByRole('button', {name: 'Zoom in'}));
+
+    expect(mockUseSyncedD3Zoom).toHaveBeenLastCalledWith(
+      expect.objectContaining({enabled: true})
+    );
+  });
+});

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -56,14 +56,22 @@ export const SplitPairBody = memo(function SplitPairBodyImpl({
   overlayColor?: string;
   overlayOpacity?: number;
 }) {
-  const [zoom1, zoom2] = useSyncedD3Zoom({wheelRequiresModifier: true});
+  // Attaching d3-zoom mounts a d3 selection + wheel/pointer listeners per pane.
+  // Defer that until the card is first interacted with so it stays off the
+  // scroll path as cards stream into the virtualized viewport.
+  const [zoomEnabled, setZoomEnabled] = useState(false);
+  const enableZoom = () => setZoomEnabled(true);
+  const [zoom1, zoom2] = useSyncedD3Zoom({
+    wheelRequiresModifier: true,
+    enabled: zoomEnabled,
+  });
   const hasVisibleOverlay = !!overlayColor && overlayColor !== 'transparent';
   const diffMaskUrl =
     hasVisibleOverlay && diffImageKey && diffImageBaseUrl
       ? `${diffImageBaseUrl}${diffImageKey}/`
       : null;
   return (
-    <Container position="relative">
+    <Container position="relative" onPointerEnter={enableZoom} onFocus={enableZoom}>
       <Grid columns="1fr 1fr" gap="0">
         <Stack minWidth="0">
           <Container padding="sm xl">


### PR DESCRIPTION
Stacked on #123500 (per-card virtualization). Review that one first — the diff here is just the top commit.

A small follow-up from the same performance work. Every split diff card mounted **two** `d3-zoom` behaviors on mount — a d3 selection plus wheel/pointer listeners on each pane. With the new per-card virtualization, cards stream in and out of the viewport as you scroll, so that attach/teardown ran on the scroll path even though zoom only matters once you actually interact with a card.

This adds an `enabled` option to `useD3Zoom` (defaulting to `true`, so the single-image and detail views are untouched) and has `SplitPairBody` start with it disabled, attaching both panes together on the first `pointerenter` or `focus` on the card. The zoom transform is identity until then, so nothing is visible pre-interaction; attaching on `pointerenter` (rather than pointerdown) means the gesture that triggers activation isn't lost, and wiring `focus` too means the +/−/reset buttons are live before a keyboard user can press them. Both panes are enabled by the same flag because the two-pane sync skips a pane whose behavior isn't attached yet.

Frontend-only, no API change. A focused test covers the deferral wiring (starts disabled → enables on pointer-enter and on focus); the existing split-card tests continue to pass with the hook mocked.

Impact is modest on its own now that per-card virtualization already caps how many cards mount — this trims the remaining per-card work off the fast-scroll path. Worth confirming against a trace, same as the parent PR.
