### PR TITLE
fix(workflow-engine): Remove ordering from all project detector queries

### DIFF
--- a/src/sentry/workflow_engine/defaults/detectors.py
+++ b/src/sentry/workflow_engine/defaults/detectors.py
@@ -284,15 +284,13 @@ def ensure_default_all_projects_detector(organization_id: int) -> Detector:
     """
     Ensure that an org-scoped all-project detector exists for the organization.
     This detector has project=NULL and config={"organization_id": org_id}.
+
+    Raises on Detector.MultipleObjectsReturned, UnableToAcquireLockApiError
     """
-    existing = (
-        Detector.objects.filter(
-            type=IssueStreamGroupType.slug,
-            project__isnull=True,
-            config__organization_id=organization_id,
-        )
-        .order_by("id")
-        .first()
+    existing = Detector.objects.get_or_none(
+        type=IssueStreamGroupType.slug,
+        project__isnull=True,
+        config__organization_id=organization_id,
     )
     if existing:
         return existing
@@ -307,14 +305,10 @@ def ensure_default_all_projects_detector(organization_id: int) -> Detector:
             lock.blocking_acquire(initial_delay=0.1, timeout=3),
             transaction.atomic(router.db_for_write(Detector)),
         ):
-            existing = (
-                Detector.objects.filter(
-                    type=IssueStreamGroupType.slug,
-                    project__isnull=True,
-                    config__organization_id=organization_id,
-                )
-                .order_by("id")
-                .first()
+            existing = Detector.objects.get_or_none(
+                type=IssueStreamGroupType.slug,
+                project__isnull=True,
+                config__organization_id=organization_id,
             )
             if existing:
                 return existing
@@ -331,6 +325,9 @@ def ensure_default_all_projects_detector(organization_id: int) -> Detector:
 
 
 def ensure_default_organization_detectors(organization: Organization) -> dict[str, Detector]:
+    """
+    Raises on Detector.MultipleObjectsReturned, UnableToAcquireLockApiError
+    """
     detectors: dict[str, Detector] = {}
     if options.get("workflow_engine.auto_creation.all_projects_detector"):
         detectors[IssueStreamGroupType.slug] = ensure_default_all_projects_detector(

--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -181,12 +181,14 @@ def ensure_pull_request_workflow(organization: Organization, detector: Detector)
     but this will guard if that does happen in quick succession (maybe from an RPC blip somehow).
 
     Note: If the detector is not connected, a new pull request workflow will be created.
+
+    Raises on Workflow.MultipleObjectsReturned, UnableToAcquireLockApiError
     """
-    existing = Workflow.objects.filter(
+    existing = Workflow.objects.get_or_none(
         organization=organization,
         name=PULL_REQUEST_WORKFLOW_LABEL,
         detectorworkflow__detector=detector,
-    ).first()
+    )
     if existing:
         return existing
 
@@ -200,11 +202,11 @@ def ensure_pull_request_workflow(organization: Organization, detector: Detector)
             lock.blocking_acquire(initial_delay=0.1, timeout=3),
             transaction.atomic(router.db_for_write(Workflow)),
         ):
-            existing = Workflow.objects.filter(
+            existing = Workflow.objects.get_or_none(
                 organization=organization,
                 name=PULL_REQUEST_WORKFLOW_LABEL,
                 detectorworkflow__detector=detector,
-            ).first()
+            )
             if existing:
                 return existing
             return create_and_connect_pull_request_workflow(organization, detector)
@@ -213,6 +215,9 @@ def ensure_pull_request_workflow(organization: Organization, detector: Detector)
 
 
 def ensure_default_organization_workflows(organization: Organization) -> list[Workflow]:
+    """
+    Raises on Workflow.MultipleObjectsReturned, Detector.MultipleObjectsReturned, UnableToAcquireLockApiError
+    """
     workflows: list[Workflow] = []
     if not options.get("workflow_engine.auto_creation.pull_request_workflow"):
         return workflows

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -50,12 +50,14 @@ def get_all_projects_detector(organization_id: int) -> Detector | None:
             metrics_tags["cache_hit"] = "true"
             metrics_tags["detector_found"] = "true" if cached is not None else "false"
             return cached
-
-        result = Detector.objects.filter(
-            project__isnull=True,
-            type=IssueStreamGroupType.slug,
-            config__organization_id=organization_id,
-        ).first()
+        try:
+            result = Detector.objects.get(
+                project__isnull=True,
+                type=IssueStreamGroupType.slug,
+                config__organization_id=organization_id,
+            )
+        except (Detector.DoesNotExist, Detector.MultipleObjectsReturned):
+            result = None
         metrics_tags["cache_hit"] = "false"
         metrics_tags["detector_found"] = "true" if result is not None else "false"
         cache.set(cache_key, result, Detector.CACHE_TTL)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -51,12 +51,15 @@ def get_all_projects_detector(organization_id: int) -> Detector | None:
             metrics_tags["detector_found"] = "true" if cached is not None else "false"
             return cached
         try:
-            result = Detector.objects.get(
+            result = Detector.objects.get_or_none(
                 project__isnull=True,
                 type=IssueStreamGroupType.slug,
                 config__organization_id=organization_id,
             )
-        except (Detector.DoesNotExist, Detector.MultipleObjectsReturned):
+        except Detector.MultipleObjectsReturned:
+            logger.exception(
+                "get_all_projects_detector.many_exist", extra={"organization_id": organization_id}
+            )
             result = None
         metrics_tags["cache_hit"] = "false"
         metrics_tags["detector_found"] = "true" if result is not None else "false"

--- a/src/sentry/workflow_engine/receivers/organization_detectors.py
+++ b/src/sentry/workflow_engine/receivers/organization_detectors.py
@@ -14,7 +14,7 @@ from sentry.workflow_engine.models import Detector
 def create_organization_detectors(organization: Organization, **kwargs: Any) -> dict[str, Detector]:
     try:
         return ensure_default_organization_detectors(organization)
-    except UnableToAcquireLockApiError as e:
+    except (UnableToAcquireLockApiError, Detector.MultipleObjectsReturned) as e:
         sentry_sdk.capture_exception(e)
     return {}
 

--- a/src/sentry/workflow_engine/receivers/organization_workflows.py
+++ b/src/sentry/workflow_engine/receivers/organization_workflows.py
@@ -8,12 +8,17 @@ from sentry.workflow_engine.defaults.detectors import (
     UnableToAcquireLockApiError,
 )
 from sentry.workflow_engine.defaults.workflows import ensure_default_organization_workflows
+from sentry.workflow_engine.models import Detector, Workflow
 
 
 def create_organization_workflows(organization: Organization, **kwargs: Any) -> None:
     try:
         ensure_default_organization_workflows(organization)
-    except UnableToAcquireLockApiError as e:
+    except (
+        UnableToAcquireLockApiError,
+        Detector.MultipleObjectsReturned,
+        Workflow.MultipleObjectsReturned,
+    ) as e:
         sentry_sdk.capture_exception(e)
 
 

--- a/tests/sentry/workflow_engine/defaults/test_detectors.py
+++ b/tests/sentry/workflow_engine/defaults/test_detectors.py
@@ -118,6 +118,14 @@ class TestEnsureDefaultAllProjectsDetector(TestCase):
             with pytest.raises(UnableToAcquireLockApiError):
                 ensure_default_all_projects_detector(self.organization.id)
 
+    def test_duplicate_detectors_raises(self) -> None:
+        org = self.create_organization()
+        self.create_all_projects_detector(org)
+        self.create_all_projects_detector(org)
+
+        with pytest.raises(Detector.MultipleObjectsReturned):
+            ensure_default_all_projects_detector(org.id)
+
     def test_returns_none_when_option_disabled(self) -> None:
         result = ensure_default_organization_detectors(self.organization)
         assert result == {}

--- a/tests/sentry/workflow_engine/defaults/test_workflows.py
+++ b/tests/sentry/workflow_engine/defaults/test_workflows.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sentry.notifications.types import FallthroughChoiceType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
@@ -314,6 +316,13 @@ class TestEnsurePullRequestWorkflow(TestCase):
         second = ensure_pull_request_workflow(self.organization, random_detector)
 
         assert first.id != second.id
+
+    def test_duplicate_workflows_raises(self) -> None:
+        ensure_pull_request_workflow(self.organization, self.all_projects_detector)
+        create_and_connect_pull_request_workflow(self.organization, self.all_projects_detector)
+
+        with pytest.raises(Workflow.MultipleObjectsReturned):
+            ensure_pull_request_workflow(self.organization, self.all_projects_detector)
 
 
 class TestEnsureDefaultOrganizationWorkflows(TestCase):

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1282,6 +1282,18 @@ class TestEventDetectorsAllProject(TestCase):
         assert ed.has_detectors is True
         assert ed.detectors == {self.all_projects_detector}
 
+    def test_missing_all_projects_detector(self) -> None:
+        self.all_projects_detector.delete()
+        cache.clear()
+        assert get_all_projects_detector(self.organization.id) is None
+
+    def test_many_all_projects_detectors(self) -> None:
+        self.create_all_projects_detector(self.organization)
+        self.create_all_projects_detector(self.organization)
+        self.create_all_projects_detector(self.organization)
+        cache.clear()
+        assert get_all_projects_detector(self.organization.id) is None
+
     def test_cached_miss_is_invalidated_when_detector_is_created(self) -> None:
         self.all_projects_detector.delete()
         cache.clear()

--- a/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
@@ -69,7 +69,7 @@ class TestCreateOrganizationDetectors(TestCase):
     ],
 )
 @override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
-@mock.patch("sentry.workflow_engine.receivers.organization_workflows.sentry_sdk")
+@mock.patch("sentry.workflow_engine.receivers.organization_detectors.sentry_sdk")
 def test_captures_exception_on_creation_failure(
     mock_sdk: mock.MagicMock, expected_error: Exception
 ) -> None:
@@ -77,7 +77,7 @@ def test_captures_exception_on_creation_failure(
     organization = Factories.create_organization(owner=user)
 
     with mock.patch(
-        "sentry.workflow_engine.receivers.organization_workflows.ensure_default_organization_workflows",
+        "sentry.workflow_engine.receivers.organization_detectors.ensure_default_organization_detectors",
         side_effect=expected_error,
     ):
         organization_created.send_robust(organization=organization, user=user, sender="test-case")

--- a/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
@@ -1,8 +1,12 @@
 from unittest import mock
 
+import pytest
+
 from sentry.signals import organization_created
 from sentry.testutils.cases import TestCase
+from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.workflow_engine.defaults.detectors import (
     UnableToAcquireLockApiError,
     ensure_default_organization_detectors,
@@ -55,28 +59,26 @@ class TestCreateOrganizationDetectors(TestCase):
             == 1
         )
 
-    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
-    @mock.patch("sentry.workflow_engine.receivers.organization_detectors.sentry_sdk")
-    def test_captures_exception_on_creation_failure(self, mock_sdk: mock.MagicMock) -> None:
-        organization = self.create_organization()
 
-        with mock.patch(
-            "sentry.workflow_engine.receivers.organization_detectors.ensure_default_organization_detectors",
-            side_effect=UnableToAcquireLockApiError,
-        ):
-            organization_created.send_robust(
-                organization=organization, user=self.user, sender=type(self)
-            )
+@django_db_all
+@pytest.mark.parametrize(
+    "expected_error",
+    [
+        UnableToAcquireLockApiError,
+        Detector.MultipleObjectsReturned,
+    ],
+)
+@override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
+@mock.patch("sentry.workflow_engine.receivers.organization_workflows.sentry_sdk")
+def test_captures_exception_on_creation_failure(
+    mock_sdk: mock.MagicMock, expected_error: Exception
+) -> None:
+    user = Factories.create_user()
+    organization = Factories.create_organization(owner=user)
 
-        mock_sdk.capture_exception.assert_called_once()
-        mock_sdk.reset_mock()
-
-        with mock.patch(
-            "sentry.workflow_engine.receivers.organization_detectors.ensure_default_organization_detectors",
-            side_effect=Detector.MultipleObjectsReturned,
-        ):
-            organization_created.send_robust(
-                organization=organization, user=self.user, sender=type(self)
-            )
-
-        mock_sdk.capture_exception.assert_called_once()
+    with mock.patch(
+        "sentry.workflow_engine.receivers.organization_workflows.ensure_default_organization_workflows",
+        side_effect=expected_error,
+    ):
+        organization_created.send_robust(organization=organization, user=user, sender="test-case")
+    mock_sdk.capture_exception.assert_called_once()

--- a/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_detectors.py
@@ -69,3 +69,14 @@ class TestCreateOrganizationDetectors(TestCase):
             )
 
         mock_sdk.capture_exception.assert_called_once()
+        mock_sdk.reset_mock()
+
+        with mock.patch(
+            "sentry.workflow_engine.receivers.organization_detectors.ensure_default_organization_detectors",
+            side_effect=Detector.MultipleObjectsReturned,
+        ):
+            organization_created.send_robust(
+                organization=organization, user=self.user, sender=type(self)
+            )
+
+        mock_sdk.capture_exception.assert_called_once()

--- a/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
@@ -1,8 +1,12 @@
 from unittest import mock
 
+import pytest
+
 from sentry.signals import organization_created
 from sentry.testutils.cases import TestCase
+from sentry.testutils.factories import Factories
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.workflow_engine.defaults.detectors import UnableToAcquireLockApiError
 from sentry.workflow_engine.defaults.workflows import (
     PULL_REQUEST_WORKFLOW_LABEL,
@@ -56,36 +60,27 @@ class TestCreateOrganizationWorkflows(TestCase):
             == 1
         )
 
-    @override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
-    @mock.patch("sentry.workflow_engine.receivers.organization_workflows.sentry_sdk")
-    def test_captures_exception_on_creation_failure(self, mock_sdk: mock.MagicMock) -> None:
-        organization = self.create_organization()
 
-        with mock.patch(
-            "sentry.workflow_engine.receivers.organization_workflows.ensure_default_organization_workflows",
-            side_effect=UnableToAcquireLockApiError,
-        ):
-            organization_created.send_robust(
-                organization=organization, user=self.user, sender=type(self)
-            )
-        mock_sdk.capture_exception.assert_called_once()
-        mock_sdk.reset_mock()
+@django_db_all
+@pytest.mark.parametrize(
+    "expected_error",
+    [
+        UnableToAcquireLockApiError,
+        Detector.MultipleObjectsReturned,
+        Workflow.MultipleObjectsReturned,
+    ],
+)
+@override_options({"workflow_engine.auto_creation.pull_request_workflow": True})
+@mock.patch("sentry.workflow_engine.receivers.organization_workflows.sentry_sdk")
+def test_captures_exception_on_creation_failure(
+    mock_sdk: mock.MagicMock, expected_error: Exception
+) -> None:
+    user = Factories.create_user()
+    organization = Factories.create_organization(owner=user)
 
-        with mock.patch(
-            "sentry.workflow_engine.receivers.organization_workflows.ensure_default_organization_workflows",
-            side_effect=Detector.MultipleObjectsReturned,
-        ):
-            organization_created.send_robust(
-                organization=organization, user=self.user, sender=type(self)
-            )
-        mock_sdk.capture_exception.assert_called_once()
-        mock_sdk.reset_mock()
-
-        with mock.patch(
-            "sentry.workflow_engine.receivers.organization_workflows.ensure_default_organization_workflows",
-            side_effect=Workflow.MultipleObjectsReturned,
-        ):
-            organization_created.send_robust(
-                organization=organization, user=self.user, sender=type(self)
-            )
-        mock_sdk.capture_exception.assert_called_once()
+    with mock.patch(
+        "sentry.workflow_engine.receivers.organization_workflows.ensure_default_organization_workflows",
+        side_effect=expected_error,
+    ):
+        organization_created.send_robust(organization=organization, user=user, sender="test-case")
+    mock_sdk.capture_exception.assert_called_once()

--- a/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
+++ b/tests/sentry/workflow_engine/receivers/test_organization_workflows.py
@@ -8,7 +8,7 @@ from sentry.workflow_engine.defaults.workflows import (
     PULL_REQUEST_WORKFLOW_LABEL,
     ensure_default_organization_workflows,
 )
-from sentry.workflow_engine.models import DetectorWorkflow, Workflow
+from sentry.workflow_engine.models import Detector, DetectorWorkflow, Workflow
 
 
 class TestCreateOrganizationWorkflows(TestCase):
@@ -68,5 +68,24 @@ class TestCreateOrganizationWorkflows(TestCase):
             organization_created.send_robust(
                 organization=organization, user=self.user, sender=type(self)
             )
+        mock_sdk.capture_exception.assert_called_once()
+        mock_sdk.reset_mock()
 
+        with mock.patch(
+            "sentry.workflow_engine.receivers.organization_workflows.ensure_default_organization_workflows",
+            side_effect=Detector.MultipleObjectsReturned,
+        ):
+            organization_created.send_robust(
+                organization=organization, user=self.user, sender=type(self)
+            )
+        mock_sdk.capture_exception.assert_called_once()
+        mock_sdk.reset_mock()
+
+        with mock.patch(
+            "sentry.workflow_engine.receivers.organization_workflows.ensure_default_organization_workflows",
+            side_effect=Workflow.MultipleObjectsReturned,
+        ):
+            organization_created.send_robust(
+                organization=organization, user=self.user, sender=type(self)
+            )
         mock_sdk.capture_exception.assert_called_once()


### PR DESCRIPTION
Avoids adding an `ORDER BY id LIMIT 1` onto some expensive queries for code simplicity. Also catches the new `MultipleObjectsReturned` exceptions that can trigger.

For the organization tests, I had to break the exception test out of the `TestCase` to use `pytest.mark.parameterize`, not sure if there's another way around this but I like that this way produces multiple tests and dedupes the boilerplate stuff