### PR TITLE
fix(issue detection): Handle data location differences in segment-derived evidence spans

### DIFF
--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import {InfoTip} from '@sentry/scraps/info';
 
 import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
+import {getSpanHash} from 'sentry/components/events/interfaces/performance/utils';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
 import {IconCheckmark, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -118,7 +119,7 @@ export function GroupingVariant({
         const spansToHashes = Object.fromEntries(
           event.entries
             .find((c): c is EntrySpans => c.type === 'spans')
-            ?.data?.map((span: RawSpanType) => [span.span_id, span.hash]) ?? []
+            ?.data?.map((span: RawSpanType) => [span.span_id, getSpanHash(span)]) ?? []
         );
 
         data.push(

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.spec.tsx
@@ -165,6 +165,123 @@ describe('SpanEvidenceKeyValueList', () => {
     });
   });
 
+  describe('N+1 Database Queries repeating-span deduping', () => {
+    function buildEvent(
+      offendingSpans: Array<{
+        description: string;
+        data?: Record<string, any>;
+        hash?: string;
+      }>
+    ) {
+      const builder = new TransactionEventBuilder('11211231', '/dog-park');
+      builder.getEventFixture().projectID = '415908';
+
+      const parentSpan = new MockSpan({
+        startTimestamp: 0,
+        endTimestamp: 0.2,
+        op: 'http.server',
+        problemSpan: ProblemSpan.PARENT,
+      });
+
+      offendingSpans.forEach(({description, data, hash}, i) => {
+        parentSpan.addChild({
+          startTimestamp: i,
+          endTimestamp: i + 1,
+          op: 'db',
+          description,
+          data,
+          hash,
+          problemSpan: ProblemSpan.OFFENDER,
+        });
+      });
+
+      builder.addSpan(parentSpan);
+      return builder.getEventFixture();
+    }
+
+    it('dedupes on the hash value, not the description, transaction-style spans', () => {
+      // The two `dogs` queries share a hash value but differ in description, so they have to
+      // collapse into a single row. If we compared descriptions instead, they'd get a row each.
+      const event = buildEvent([
+        {
+          description: 'SELECT * FROM dogs WHERE id = 1121',
+          hash: 'dog_pack',
+        },
+        {
+          description: 'SELECT * FROM dogs WHERE id = 1231',
+          hash: 'dog_pack',
+        },
+        {
+          description: 'SELECT * FROM tricks WHERE id = 908',
+          hash: 'talent_show',
+        },
+      ]);
+
+      render(<SpanEvidenceKeyValueList event={event} projectSlug={projectSlug} />);
+
+      // In the span evidence table, the first row gets a different test id than the rest. They all
+      // start with `span-evidence-key-value-list.`, but the first row also has
+      // `repeating-spans-<repeating_span_count>` on the end.
+      const fullTable = screen.getByRole('table');
+      const firstTableRow = screen.getByTestId(
+        'span-evidence-key-value-list.repeating-spans-3'
+      );
+      const remainingTableRows = screen.getAllByTestId('span-evidence-key-value-list.');
+
+      // The second `dogs` query shares a hash value with the first, so it doesn't get a separate
+      // table row.
+      expect(firstTableRow).toHaveTextContent('SELECT * FROM dogs WHERE id = 1121');
+      expect(fullTable).not.toHaveTextContent('SELECT * FROM dogs WHERE id = 1231');
+
+      // Since there are only two distinct hash values, there are only two total rows, or one more
+      // after the first.
+      expect(remainingTableRows).toHaveLength(1);
+      const secondTableRow = screen.getByTestId('span-evidence-key-value-list.');
+      expect(secondTableRow).toHaveTextContent('SELECT * FROM tricks WHERE id = 908');
+    });
+
+    it('dedupes on the hash value, not the description, segment-style spans', () => {
+      // The two `dogs` queries share a hash value but differ in description, so they have to
+      // collapse into a single row. If we compared descriptions instead, they'd get a row each.
+      const event = buildEvent([
+        {
+          description: 'SELECT * FROM dogs WHERE id = 1121',
+          data: {hash: 'dog_pack'},
+        },
+        {
+          description: 'SELECT * FROM dogs WHERE id = 1231',
+          data: {hash: 'dog_pack'},
+        },
+        {
+          description: 'SELECT * FROM tricks WHERE id = 908',
+          data: {hash: 'talent_show'},
+        },
+      ]);
+
+      render(<SpanEvidenceKeyValueList event={event} projectSlug={projectSlug} />);
+
+      // In the span evidence table, the first row gets a different test id than the rest. They all
+      // start with `span-evidence-key-value-list.`, but the first row also has
+      // `repeating-spans-<repeating_span_count>` on the end.
+      const fullTable = screen.getByRole('table');
+      const firstTableRow = screen.getByTestId(
+        'span-evidence-key-value-list.repeating-spans-3'
+      );
+      const remainingTableRows = screen.getAllByTestId('span-evidence-key-value-list.');
+
+      // The second `dogs` query shares a hash value with the first, so it doesn't get a separate
+      // table row.
+      expect(firstTableRow).toHaveTextContent('SELECT * FROM dogs WHERE id = 1121');
+      expect(fullTable).not.toHaveTextContent('SELECT * FROM dogs WHERE id = 1231');
+
+      // Since there are only two distinct hash values, there are only two total rows, or one more
+      // after the first.
+      expect(remainingTableRows).toHaveLength(1);
+      const secondTableRow = screen.getByTestId('span-evidence-key-value-list.');
+      expect(secondTableRow).toHaveTextContent('SELECT * FROM tricks WHERE id = 908');
+    });
+  });
+
   describe('MN+1 Database Queries', () => {
     const builder = new TransactionEventBuilder('a1', '/');
     builder.getEventFixture().projectID = '123';

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -20,7 +20,12 @@ import {
   getSpanDuration,
   getSpanFieldBytes,
 } from 'sentry/components/events/interfaces/performance/spanMetrics';
-import {getSpanInfoFromTransactionEvent} from 'sentry/components/events/interfaces/performance/utils';
+import {
+  getSpanCategory,
+  getSpanHash,
+  getSpanInfoFromTransactionEvent,
+  getSpanSentryGroupValue,
+} from 'sentry/components/events/interfaces/performance/utils';
 import type {
   ProcessedSpanType,
   RawSpanType,
@@ -506,7 +511,6 @@ function SlowDBQueryEvidence({
   location,
 }: SpanEvidenceKeyValueListProps) {
   const span = offendingSpans[0]!;
-  const sentryTags = 'sentry_tags' in span ? span.sentry_tags : undefined;
   const hasExplore = organization.features.includes('visibility-explore-view');
 
   const codeFilepath = getAttributeValue(span.data ?? {}, 'code.file.path', 'string');
@@ -538,8 +542,8 @@ function SlowDBQueryEvidence({
       <Flex gap="md" padding="md lg" borderTop="muted">
         <SpanSummaryLink
           op={span.op}
-          category={sentryTags?.category}
-          group={sentryTags?.group}
+          category={getSpanCategory(span)}
+          group={getSpanSentryGroupValue(span)}
           organization={organization}
         />
         {hasExplore && span.description && (
@@ -756,7 +760,7 @@ function dedupeSpansByHash(spans: Span[]): Span[] {
 
   // Only keep spans whose hashes we haven't yet seen, tracking the ones we have seen as we go
   const shouldKeepSpan = (span: Span) => {
-    const hash = span.hash;
+    const hash = getSpanHash(span);
 
     if (hashesSeen.has(hash)) {
       return false;

--- a/static/app/components/events/interfaces/performance/utils.spec.tsx
+++ b/static/app/components/events/interfaces/performance/utils.spec.tsx
@@ -1,0 +1,61 @@
+import {getSpanCategory, getSpanHash, getSpanSentryGroupValue} from './utils';
+
+describe('getSpanSentryGroupValue', () => {
+  it('handles both transaction-derived and segment-derived spans', () => {
+    // Segment-derived spans
+    expect(
+      getSpanSentryGroupValue({
+        span_id: '1121201212312012',
+        data: {'sentry.group': 'dog_pack'},
+      })
+    ).toBe('dog_pack');
+
+    // Transaction-derived spans
+    expect(
+      getSpanSentryGroupValue({
+        span_id: '1121201212312012',
+        sentry_tags: {group: 'dog_pack'},
+      })
+    ).toBe('dog_pack');
+  });
+});
+
+describe('getSpanHash', () => {
+  it('handles both transaction-derived and segment-derived spans', () => {
+    // Segment-derived spans
+    expect(
+      getSpanHash({
+        span_id: '1121201212312012',
+        data: {hash: 'dogs_are_great'},
+      })
+    ).toBe('dogs_are_great');
+
+    // Transaction-derived spans
+    expect(
+      getSpanHash({
+        span_id: '1121201212312012',
+        hash: 'dogs_are_great',
+      })
+    ).toBe('dogs_are_great');
+  });
+});
+
+describe('getSpanCategory', () => {
+  it('handles both transaction-derived and segment-derived spans', () => {
+    // Segment-derived spans
+    expect(
+      getSpanCategory({
+        span_id: '1121201212312012',
+        data: {'sentry.category': 'good_dogs'},
+      })
+    ).toBe('good_dogs');
+
+    // Transaction-derived spans
+    expect(
+      getSpanCategory({
+        span_id: '1121201212312012',
+        sentry_tags: {category: 'good_dogs'},
+      })
+    ).toBe('good_dogs');
+  });
+});

--- a/static/app/components/events/interfaces/performance/utils.tsx
+++ b/static/app/components/events/interfaces/performance/utils.tsx
@@ -28,6 +28,72 @@ export function eventHasSyntheticTrace(event: Event): boolean {
   );
 }
 
+/**
+ * Get Relay's span group value, which EAP indexes as `span.group`, for use in queries passed to
+ * features like Explore and Insights.
+ *
+ * Note that though the return values do *sometimes* match, this is not interchangeable with
+ * `getSpanHash`, which gets the results of our server-side span grouping algorithm, as EAP doesn't
+ * record the span `hash` value.
+ */
+export function getSpanSentryGroupValue(span: {
+  [key: string]: any;
+  data?: Record<string, any> | null;
+  sentry_tags?: Record<string, string>;
+}): string | undefined {
+  return (
+    // The location for segment-derived occurrences
+    span.data?.['sentry.group'] ??
+    // The location for transaction-derived occurrences
+    // TODO: once we fully switch to segment-based occurrence creation, and all transaction events
+    // have aged out, we can remove this half of expression
+    span.sentry_tags?.group
+  );
+}
+
+/**
+ * Get the span's grouping hash, used for visually grouping spans representing the same operation in
+ * the span evidence section of the issue details page and for explaining occurrence grouping in the
+ * grouping info section.
+ *
+ * Note that though the return values do *sometimes* match, this is not interchangeable with
+ * `getSpanSentryGroupValue`, which returns the `sentry.group` value added to some spans by Relay
+ * for use in queries to EAP.
+ */
+export function getSpanHash(span: {
+  [key: string]: any;
+  data?: Record<string, any> | null;
+  hash?: string;
+}): string | undefined {
+  return (
+    // The location for segment-derived occurrences
+    span.data?.hash ??
+    // The location for transaction-derived occurrences
+    // TODO: once we fully switch to segment-based occurrence creation, and all transaction events
+    // have aged out, we can remove this half of expression
+    span.hash
+  );
+}
+
+/**
+ * Get the span category, used to build the span summary link. Like the span hash, where it lives
+ * depends on which pipeline (transaction or segment processing) created the evidence span.
+ */
+export function getSpanCategory(span: {
+  [key: string]: any;
+  data?: Record<string, any> | null;
+  sentry_tags?: Record<string, string>;
+}): string | undefined {
+  return (
+    // The location for segment-derived occurrences
+    span.data?.['sentry.category'] ??
+    // The location for transaction-derived occurrences
+    // TODO: once we fully switch to segment-based occurrence creation, and all transaction events
+    // have aged out, we can remove this half of expression
+    span.sentry_tags?.category
+  );
+}
+
 export function getSpanInfoFromTransactionEvent(
   event: Pick<
     EventTransaction,

--- a/tests/js/sentry-test/performance/utils.ts
+++ b/tests/js/sentry-test/performance/utils.ts
@@ -227,8 +227,16 @@ export class MockSpan {
    * @param opts.numSpans If provided, will create the same span numSpan times
    */
   addChild(opts: AddSpanOpts, numSpans = 1) {
-    const {startTimestamp, endTimestamp, op, description, hash, status, problemSpan} =
-      opts;
+    const {
+      startTimestamp,
+      endTimestamp,
+      op,
+      description,
+      hash,
+      status,
+      problemSpan,
+      data,
+    } = opts;
 
     for (let i = 0; i < numSpans; i++) {
       const span = new MockSpan({
@@ -239,6 +247,7 @@ export class MockSpan {
         hash,
         status,
         problemSpan,
+        data,
       });
       this.children.push(span);
     }


### PR DESCRIPTION
Because of differences in span schema and processing order between the transaction and segment processing pipelines, evidence spans derived from segments store parts of their data in different locations and under different names than their transaction-derived counterparts. Now that we're creating occurrences from problems detected on segments, we need to update the front end to look in the new spots as well as the old spots.

This makes that change by introducing a span-origin-agnostic helper to retrieve each value. 