### PR TITLE
fix(seer): Fix ambiguous monitor embed id instructions

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -548,7 +548,7 @@
   },
   {
     "name": "monitor",
-    "description": "The ONLY way to reference a Sentry monitor (error, metric, cron, uptime, or mobile build detector). Use the detector ID exactly as the monitors API returns it. Include the API-provided name when available. Inline: renders a compact link. Block: loads the live monitor and renders its type-specific configuration/rules. Never use a markdown link for monitor references.",
+    "description": "The ONLY way to reference a Sentry monitor (error, metric, cron, uptime, or mobile build detector). Use the numeric id from the detectors API (get_organization_detector / list_organization_detectors) — do NOT use the \"id\" field from the monitors API, which is a GUID and will not work here. Include the API-provided name when available. Inline: renders a compact link. Block: loads the live monitor and renders its type-specific configuration/rules. Never use a markdown link for monitor references.",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -399,7 +399,9 @@ export const SEER_EMBED_SCHEMAS = {
   monitor: {
     description:
       'The ONLY way to reference a Sentry monitor (error, metric, cron, uptime, ' +
-      'or mobile build detector). Use the detector ID exactly as the monitors API returns it. ' +
+      'or mobile build detector). Use the numeric id from the detectors API ' +
+      '(get_organization_detector / list_organization_detectors) — do NOT use the ' +
+      '"id" field from the monitors API, which is a GUID and will not work here. ' +
       'Include the API-provided name when available. ' +
       'Inline: renders a compact link. ' +
       'Block: loads the live monitor and renders its type-specific configuration/rules. ' +


### PR DESCRIPTION
### Why?

The Seer "monitor" embed's description told the agent to reference a monitor by "the detector ID exactly as the monitors API returns it." The monitors API's `id` field is actually a GUID, not the numeric id the embed's frontend route requires. Following the instruction literally, the agent would copy the GUID into the embed, and the UI would 404 trying to resolve it as an integer detector id.

### How?

Reword the widget description to point explicitly at the detectors API for the numeric id, and call out that the monitors API's id is a GUID that must not be used. Regenerate `embed_widgets.generated.json` to match.

<sub>Generated with Claude Code</sub>