### PR TITLE
fix(action-log): Serialize comments by their `Activity` id

### DIFF
--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -1,3 +1,4 @@
+import logging
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -34,6 +35,8 @@ from sentry.utils.action_log.activity_translator import (
 if TYPE_CHECKING:
     from sentry.models.group import Group
 
+logger = logging.getLogger(__name__)
+
 
 class GroupActionLogEntrySerializerResponse(TypedDict):
     id: str
@@ -64,6 +67,26 @@ def serialize_first_seen_entry(group: "Group") -> GroupActionLogEntrySerializerR
         "data": {"priority": initial_priority},
         "dateCreated": group.first_seen,
     }
+
+
+def _serialized_id(obj: GroupActionLogEntry) -> str:
+    """
+    The id clients address this entry by.
+
+    The notes endpoints resolve ``note_id`` against ``Activity.id``, so a COMMENT
+    serializes its ``comment_id`` (the Activity it mirrors) rather than its own.
+    COMMENT_EDIT and COMMENT_DELETE carry a ``comment_id`` too, but theirs points
+    at the GALE id of the COMMENT they supersede, so they keep their own.
+    """
+    if obj.type == GroupActionType.COMMENT.value:
+        comment_id = (obj.data or {}).get("comment_id")
+        if comment_id is not None:
+            return str(comment_id)
+        logger.warning(
+            "group_action_log.comment_missing_comment_id",
+            extra={"group_id": obj.group_id, "entry_id": obj.id},
+        )
+    return str(obj.id)
 
 
 @register(GroupActionLogEntry)
@@ -215,7 +238,7 @@ class GroupActionLogEntrySerializer(Serializer):
             data.pop("current_release_version", None)
 
         return {
-            "id": str(obj.id),
+            "id": _serialized_id(obj),
             "type": type_display,
             "user": attrs["user"],
             "sentry_app": attrs["sentry_app"],

--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -1,4 +1,3 @@
-import logging
 from collections.abc import Mapping, Sequence
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -12,6 +11,7 @@ from sentry.issues.action_log.types import (
     ACTION_TYPES_WITH_COMMIT_DATA,
     COMMIT_ACTION_TYPES,
     PULL_REQUEST_ACTION_TYPES,
+    CommentAction,
     GroupActionType,
     GroupActorType,
 )
@@ -34,8 +34,6 @@ from sentry.utils.action_log.activity_translator import (
 
 if TYPE_CHECKING:
     from sentry.models.group import Group
-
-logger = logging.getLogger(__name__)
 
 
 class GroupActionLogEntrySerializerResponse(TypedDict):
@@ -79,13 +77,9 @@ def _serialized_id(obj: GroupActionLogEntry) -> str:
     at the GALE id of the COMMENT they supersede, so they keep their own.
     """
     if obj.type == GroupActionType.COMMENT.value:
-        comment_id = (obj.data or {}).get("comment_id")
-        if comment_id is not None:
-            return str(comment_id)
-        logger.warning(
-            "group_action_log.comment_missing_comment_id",
-            extra={"group_id": obj.group_id, "entry_id": obj.id},
-        )
+        match obj.action:
+            case CommentAction(comment_id=comment_id):
+                return str(comment_id)
     return str(obj.id)
 
 

--- a/src/sentry/issues/endpoints/group_notes.py
+++ b/src/sentry/issues/endpoints/group_notes.py
@@ -20,7 +20,6 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.action_log import action_context_scope, resolve_action_source
 from sentry.issues.action_log.types import (
-    CommentAction,
     CommentDeleteAction,
     CommentEditAction,
     GroupActionActor,
@@ -96,14 +95,7 @@ class GroupNotesEndpoint(GroupEndpoint):
                             **(entry.data or {}),
                             "text": latest_edit_text_by_comment[entry.id],
                         }
-                serialized = serialize(comment_entries, request.user)
-                # Return the Activity id (in comment_id) as `id`, matching the
-                # flag-off contract so clients can still edit/delete via note_id.
-                for entry, item in zip(comment_entries, serialized):
-                    action = entry.action
-                    if isinstance(action, CommentAction):
-                        item["id"] = str(action.comment_id)
-                return serialized
+                return serialize(comment_entries, request.user)
 
             return self.paginate(
                 request=request,
@@ -201,11 +193,7 @@ class GroupNotesEndpoint(GroupEndpoint):
                 idempotency_key=activity_action_idempotency_key(activity),
             ).first()
             if entry:
-                serialized = serialize(entry, request.user)
-                # Return the Activity id as `id`, matching the flag-off contract
-                # so clients can edit/delete via note_id.
-                serialized["id"] = str(activity.id)
-                return Response(serialized, status=201)
+                return Response(serialize(entry, request.user), status=201)
             logger.info("group_notes.groupactionlogentry.not_found", extra={"group_id": group.id})
 
         return Response(serialize(activity, request.user), status=201)

--- a/src/sentry/issues/endpoints/group_notes_details.py
+++ b/src/sentry/issues/endpoints/group_notes_details.py
@@ -214,17 +214,16 @@ class GroupNotesDetailsEndpoint(GroupEndpoint):
                 if original_comment_log_action is not None:
                     # editing a note doesn't update its COMMENT entry (instead it
                     # appends a separate COMMENT_EDIT entry), so patch in the fresh
-                    # text we just published to GALE; the Activity is used only for
-                    # the id below.
+                    # text we just published to GALE. The serializer resolves `id`
+                    # back to the Activity id from the entry's comment_id, matching
+                    # the flag-off contract so clients can edit/delete via note_id.
                     original_comment_log_action.data = {
                         **original_comment_log_action.data,
                         "text": payload.get("text"),
                     }
-                    serialized = serialize(original_comment_log_action, request.user)
-                    # Return the Activity id as `id`, matching the flag-off
-                    # contract so clients can edit/delete via note_id.
-                    serialized["id"] = str(note.id)
-                    return Response(serialized, status=200)
+                    return Response(
+                        serialize(original_comment_log_action, request.user), status=200
+                    )
 
             return Response(serialize(note, request.user), status=200)
 

--- a/tests/sentry/api/serializers/test_groupactionlogentry.py
+++ b/tests/sentry/api/serializers/test_groupactionlogentry.py
@@ -317,3 +317,56 @@ class GroupActionLogEntrySerializerTestCase(TestCase):
 
         result = serialize(entry, user)
         assert result["data"] == {"issues": [{"id": "2"}, {"id": "3"}]}
+
+    def test_comment_entry_serializes_the_activity_id(self) -> None:
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"comment_id": 123, "text": "hello world"},
+        )
+
+        result = serialize(entry, user)
+        assert result["id"] == "123"
+        assert result["type"] == "note"
+
+    def test_comment_entry_without_comment_id_falls_back_to_own_id(self) -> None:
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        entry = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"text": "hello world"},
+        )
+
+        result = serialize(entry, user)
+        assert result["id"] == str(entry.id)
+
+    def test_comment_edit_entry_keeps_its_own_id(self) -> None:
+        user = self.create_user()
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        comment = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"comment_id": 123, "text": "original"},
+        )
+        edit = self.create_group_action_log_entry(
+            group=group,
+            type=GroupActionType.COMMENT_EDIT,
+            actor_type=GroupActorType.USER,
+            actor_id=user.id,
+            data={"comment_id": comment.id, "text": "edited"},
+        )
+
+        result = serialize(edit, user)
+        assert result["id"] == str(edit.id)

--- a/tests/sentry/api/serializers/test_groupactionlogentry.py
+++ b/tests/sentry/api/serializers/test_groupactionlogentry.py
@@ -334,21 +334,6 @@ class GroupActionLogEntrySerializerTestCase(TestCase):
         assert result["id"] == "123"
         assert result["type"] == "note"
 
-    def test_comment_entry_without_comment_id_falls_back_to_own_id(self) -> None:
-        user = self.create_user()
-        group = self.create_group(status=GroupStatus.UNRESOLVED)
-
-        entry = self.create_group_action_log_entry(
-            group=group,
-            type=GroupActionType.COMMENT,
-            actor_type=GroupActorType.USER,
-            actor_id=user.id,
-            data={"text": "hello world"},
-        )
-
-        result = serialize(entry, user)
-        assert result["id"] == str(entry.id)
-
     def test_comment_edit_entry_keeps_its_own_id(self) -> None:
         user = self.create_user()
         group = self.create_group(status=GroupStatus.UNRESOLVED)

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -13,10 +13,16 @@ from sentry.deletions.tasks.hybrid_cloud import schedule_hybrid_cloud_foreign_ke
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.services.integration import integration_service
 from sentry.issues.action_log import action_context_scope
-from sentry.issues.action_log.types import ActionSource, GroupActionActor, ReconcileStatusAction
+from sentry.issues.action_log.types import (
+    ActionSource,
+    GroupActionActor,
+    GroupActionType,
+    ReconcileStatusAction,
+)
 from sentry.issues.constants import cache_key_for_issue_view
 from sentry.issues.derived.gate import GROUP_ACTION_LOG_BACKFILL_COMPLETED_OPTION
 from sentry.issues.grouptype import PerformanceSlowDBQueryGroupType
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.activity import Activity
 from sentry.models.apikey import ApiKey
 from sentry.models.auditlogentry import AuditLogEntry
@@ -161,6 +167,42 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
             "rule": None,
         }
         assert entry["dateCreated"] is not None
+
+    @with_feature(["projects:issue-action-log-write-to-db", "projects:issue-action-log-activity"])
+    def test_group_action_log_comment_is_addressable(self) -> None:
+        self.login_as(user=self.user)
+        group = self.create_group()
+
+        comments_url = f"/api/0/issues/{group.id}/comments/"
+        response = self.client.post(comments_url, format="json", data={"text": "original"})
+        assert response.status_code == 201, response.content
+        activity_id = response.data["data"]["comment_id"]
+
+        details_url = f"/api/0/organizations/{group.organization.slug}/issues/{group.id}/"
+        response = self.client.get(details_url, format="json")
+        assert response.status_code == 200, response.content
+
+        notes = [item for item in response.data["activity"] if item["type"] == "note"]
+        assert len(notes) == 1
+        note_id = notes[0]["id"]
+        assert note_id == str(activity_id)
+
+        entry = GroupActionLogEntry.objects.get(
+            group_id=group.id, type=GroupActionType.COMMENT.value
+        )
+        assert entry.data["comment_id"] == activity_id
+
+        # the id served by the feed round-trips through edit ...
+        response = self.client.put(
+            f"{comments_url}{note_id}/", format="json", data={"text": "edited"}
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["id"] == note_id
+        assert response.data["data"]["text"] == "edited"
+
+        # ... and delete
+        response = self.client.delete(f"{comments_url}{note_id}/", format="json")
+        assert response.status_code == 204, response.status_code
 
     def test_pending_delete_pending_merge_excluded(self) -> None:
         group1 = self.create_group(status=GroupStatus.PENDING_DELETION)


### PR DESCRIPTION
Fixes https://linear.app/getsentry/issue/ISWF-3413/gale-backed-activity-responses-return-gale-ids-breaking-comment.

With `projects:issue-action-log-activity` on, editing or deleting a comment from the issue activity feed 404s.

The feed paths (`group_details.py`, `group_activities.py`, `group_index/update.py`) serialize the GALE's own ID, but the notes endpoints resolve `note_id` against `Activity.id` and the frontend edits/deletes straight off the feed. `GroupNotesEndpoint` already rewrote the ID back to the `Activity` ID, but the feed paths did not.

This PR moves the mapping into `GroupActionLogEntrySerializer` so that every consumer gets the same ID patch. `COMMENT_EDIT` / `COMMENT_DELETE` are excluded - they carry a `comment_id` too, but theirs points at the GALE ID of the `COMMENT` they supersede.