### PR TITLE
feat(apidocs): Document the custom integration features field

### DIFF
--- a/src/sentry/sentry_apps/api/parsers/sentry_app.py
+++ b/src/sentry/sentry_apps/api/parsers/sentry_app.py
@@ -108,7 +108,6 @@ class URLField(serializers.URLField):
     omit_from_public_schema={
         "popularity": "Internal ranking value used to order integrations in the directory.",
         "isDisabled": "Set by Sentry when an integration is disabled; not client-settable.",
-        "features": "Set through the integration's own configuration flow rather than this endpoint.",
         "status": "Only applied for elevated Sentry staff; ignored for everyone else.",
     }
 )


### PR DESCRIPTION
`features` was excluded from the schema alongside `popularity`, `status` and `isDisabled`, but it does not belong with them. It is read from validated input for any user in [`SentryAppUpdater`](https://github.com/getsentry/sentry/blob/master/src/sentry/sentry_apps/logic.py), guarded only against updating a published integration — the other three are either set by Sentry or gated behind an elevated-user check.

It already carried an accurate `help_text`, so this only lifts the exclusion. `SentryAppParser` goes from 13 to 14 documented properties.

Stacked on https://github.com/getsentry/sentry/pull/123488.