### PR TITLE
chore(pr iter) quick fix failed tool call metrics

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -313,11 +313,11 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 "autofix.pr_iteration.failed_tool_call",
                 amount=amount,
                 tags={"tool": function},
+                sample_rate=1.0,
             )
 
         cls._iteration_log_context(organization, group, state).info(
             "autofix.pr_iteration.failed_tool_calls",
-            failed_tool_functions=[call.function for call in failed],
             failed_tool_counts=dict(counts),
         )
 

--- a/tests/sentry/seer/autofix/test_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_on_completion_hook.py
@@ -174,6 +174,7 @@ class TestRecordFailedToolCalls(TestCase):
             "autofix.pr_iteration.failed_tool_call",
             amount=1,
             tags={"tool": "summarize_failed_ci_logs"},
+            sample_rate=1.0,
         )
 
     def test_counts_duplicate_tool_failures(self, mock_metrics) -> None:
@@ -190,6 +191,7 @@ class TestRecordFailedToolCalls(TestCase):
             "autofix.pr_iteration.failed_tool_call",
             amount=2,
             tags={"tool": "get_pr_diff"},
+            sample_rate=1.0,
         )
 
     def test_skips_after_changes_are_pushed(self, mock_metrics) -> None:
@@ -223,4 +225,5 @@ class TestRecordFailedToolCalls(TestCase):
             "autofix.pr_iteration.failed_tool_call",
             amount=1,
             tags={"tool": "get_pr_diff"},
+            sample_rate=1.0,
         )


### PR DESCRIPTION
sample rate -> 1.0 since this doesn't happen often

removing failed_tool_functions from the log since it repeats
what failed_tool_counts is saying
