### PR TITLE
fix(alerts): clarify Microsoft Teams channel input

### DIFF
--- a/static/app/views/automations/components/actions/msTeams.tsx
+++ b/static/app/views/automations/components/actions/msTeams.tsx
@@ -29,7 +29,7 @@ export function MSTeamsNode() {
   return tct('Send a [logo] Microsoft Teams notification to [team] team, to [channel]', {
     logo: ActionMetadata[ActionType.MSTEAMS]?.icon,
     team: <IntegrationField />,
-    channel: <TargetDisplayField />,
+    channel: <TargetDisplayField placeholder={t('channel name')} />,
   });
 }
 

--- a/static/app/views/automations/new.spec.tsx
+++ b/static/app/views/automations/new.spec.tsx
@@ -368,10 +368,9 @@ describe('AutomationNewSettings', () => {
     });
 
     await addAction('MS Teams');
-    const targets = screen.getAllByRole('textbox', {name: 'Target'});
-    const msTeamsTarget = targets.at(-1);
-    expect(msTeamsTarget).toBeDefined();
-    await userEvent.type(msTeamsTarget!, 'alerts-team', {delay: null});
+    await userEvent.type(screen.getByPlaceholderText('channel name'), 'alerts-team', {
+      delay: null,
+    });
 
     await addAction('Pagerduty');
     await addAction('Opsgenie');


### PR DESCRIPTION
Fixes ISWF-3418

The Microsoft Teams automation action currently suggests users can enter a channel ID, but backend validation resolves targetDisplay as a channel name. This changes the placeholder to channel name so the UI matches the supported behavior.