### PR TITLE
fix(seer-infra-telemetry): Hide the previous GCP integration verification check result while a new one runs

### DIFF
--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
@@ -187,14 +187,52 @@ describe('GcpConnectionStatus', () => {
       configData: {
         ...baseConfig,
         connection_status: 'unverified',
-        project_statuses: [],
+        project_statuses: [
+          {
+            gcp_project_id: 'project-prod',
+            connection_status: 'permission_denied',
+            error_detail: 'IAM roles not granted',
+          },
+        ],
         last_verified_at: null,
       },
     });
 
     expect(screen.getByText('Checking connection...')).toBeInTheDocument();
     expect(screen.queryByText('Not verified')).not.toBeInTheDocument();
+    expect(screen.queryByText('IAM roles not granted')).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Re-test'})).toBeDisabled();
+  });
+
+  it('hides the previous result while a re-test is running', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: {connectionStatus: 'connected', projects: []},
+      asyncDelay: 50,
+    });
+    renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'permission_denied',
+        project_statuses: [
+          {
+            gcp_project_id: 'project-prod',
+            connection_status: 'permission_denied',
+            error_detail: 'IAM roles not granted',
+          },
+        ],
+        last_verified_at: '2026-08-30T00:00:00+00:00',
+      },
+    });
+
+    expect(screen.getByText('IAM roles not granted')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
+
+    expect(await screen.findByText('Checking connection...')).toBeInTheDocument();
+    expect(screen.queryByText('IAM roles not granted')).not.toBeInTheDocument();
+    expect(screen.queryByText(/Last checked/)).not.toBeInTheDocument();
   });
 
   it('cannot be re-tested when the config is incomplete', () => {

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
@@ -60,6 +60,7 @@ export function GcpConnectionStatus({
   });
 
   const isPending = isRetesting || isVerifying;
+  const shownErrorDetails = isPending ? [] : errorDetails;
 
   return (
     <FieldGroup title={t('Connection Status')}>
@@ -78,7 +79,7 @@ export function GcpConnectionStatus({
           </Text>
         </Flex>
 
-        {errorDetails.map(detail => (
+        {shownErrorDetails.map(detail => (
           <Text key={detail} variant="muted" size="sm">
             {detail}
           </Text>
@@ -86,9 +87,11 @@ export function GcpConnectionStatus({
 
         <Flex gap="md" align="center" justify="between">
           <Text variant="muted" size="sm">
-            {typeof lastVerifiedAt === 'string'
-              ? tct('Last checked [when]', {when: <TimeSince date={lastVerifiedAt} />})
-              : t('Never checked')}
+            {isPending
+              ? null
+              : typeof lastVerifiedAt === 'string'
+                ? tct('Last checked [when]', {when: <TimeSince date={lastVerifiedAt} />})
+                : t('Never checked')}
           </Text>
           <Button
             size="sm"


### PR DESCRIPTION
https://linear.app/getsentry/issue/CW-1986/polish-the-gcp-integration-onboarding-flow-before-releasing-to-users

This PR makes sure stale connection error detail does not persist on the UI while a verification test is running, and the brief "Never checked" connection status does not show up in the interim.

[Slack thread for context](https://sentry.slack.com/archives/C0B8X2W4TB2/p1788378442573109)