### PR TITLE
fix(automations): hide bulk actions without write access

### DIFF
--- a/static/app/views/automations/components/automationListTable/index.tsx
+++ b/static/app/views/automations/components/automationListTable/index.tsx
@@ -151,14 +151,16 @@ export function AutomationListTable({
   return (
     <AutomationsSimpleTable
       header={
-        canEditAutomations && selected.size === 0 ? (
+        !canEditAutomations || selected.size === 0 ? (
           <SimpleTable.HeaderRow key="header">
             <HeaderCell sort={sort} sortKey="name">
               <Flex gap="md" align="center">
-                <SelectAllHeaderCheckbox
-                  checked={pageSelected || (anySelected ? 'indeterminate' : false)}
-                  onChange={checked => togglePageSelected(checked)}
-                />
+                {canEditAutomations && (
+                  <SelectAllHeaderCheckbox
+                    checked={pageSelected || (anySelected ? 'indeterminate' : false)}
+                    onChange={checked => togglePageSelected(checked)}
+                  />
+                )}
                 <span>{t('Name')}</span>
               </Flex>
             </HeaderCell>

--- a/static/app/views/automations/list.spec.tsx
+++ b/static/app/views/automations/list.spec.tsx
@@ -661,15 +661,18 @@ describe('AutomationsList', () => {
     });
   });
 
-  it('disables the create alert button without alerts:write permission', async () => {
+  it('disables alert controls without alerts:write permission', async () => {
     const noWriteOrg = OrganizationFixture({
       access: ['org:read', 'alerts:read'],
     });
 
     render(<AutomationsList />, {organization: noWriteOrg});
-    await screen.findByText('Automation 1');
+    await screen.findByTestId('automation-list-row');
 
     const createButton = screen.getByRole('button', {name: 'Create Alert'});
     expect(createButton).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.getByRole('columnheader', {name: 'Name'})).toBeInTheDocument();
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Delete'})).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Fixes ISWF-3416

Users without `alerts:write` were shown the automation bulk-action header, including Delete, even though row selection was unavailable:

<img width="470" height="410" alt="CleanShot 2026-09-02 at 16 25 02@2x" src="https://github.com/user-attachments/assets/3c096c4b-d2ef-4d73-a9b9-7a624c66788b" />
