### PR TITLE
fix(action_log): Sanitize non-jsonb-able data when converting from Activity

### DIFF
--- a/src/sentry/utils/action_log/activity_translator.py
+++ b/src/sentry/utils/action_log/activity_translator.py
@@ -1,6 +1,7 @@
 import logging
-from typing import TYPE_CHECKING, Mapping
+from typing import TYPE_CHECKING, Any, Mapping
 
+import orjson
 from pydantic.error_wrappers import ValidationError
 
 from sentry.issues.action_log.types import (
@@ -49,6 +50,7 @@ from sentry.issues.action_log.types import (
 )
 from sentry.types.activity import ActivityType
 from sentry.utils.env import in_test_environment
+from sentry.utils.strings import strip_lone_surrogates
 
 if TYPE_CHECKING:
     from sentry.models.activity import Activity
@@ -155,6 +157,57 @@ GROUP_ACTION_TYPE_TO_ACTIVITY_KEYS = {
 logger = logging.getLogger(__name__)
 
 
+def _needs_jsonb_sanitize(value: Any) -> bool:
+    """
+    Return True if ``value`` contains any character that Postgres ``jsonb`` (or
+    psycopg2's UTF-8 param encoding) refuses.
+
+    Uses orjson to walk the tree in native code: serializing a JSON-shaped
+    Python object is dramatically faster than a pure-Python recursive scan,
+    and orjson conveniently distinguishes the two failure modes for us —
+    it raises ``TypeError`` on lone UTF-16 surrogates, and escapes ``\\x00``
+    as the six-byte sequence ``\\u0000`` which we detect with a bytes search.
+    """
+    try:
+        blob = orjson.dumps(value)
+    except TypeError:
+        # orjson refuses lone surrogates ("str is not valid UTF-8"). That's
+        # exactly the shape jsonb refuses, so treat as dirty.
+        return True
+    return b"\\u0000" in blob
+
+
+def _sanitize_for_jsonb(value: Any) -> Any:
+    """
+    Recursively scrub string values so they can safely be written to a Postgres
+    ``jsonb`` column.
+
+    Activity ``data`` is stored in a text-based JSON column (and originates from
+    permissive sources like webhook payloads and user input), so it can contain
+    two shapes that ``jsonb`` refuses:
+
+    * ``NUL`` (``\\x00``) bytes — ``jsonb`` rejects the ``\\u0000`` escape.
+    * Lone UTF-16 surrogates (``\\uD800``–``\\uDFFF``) — Python ``str`` tolerates
+      them, but they are not valid UTF-8 and both psycopg2's parameter encoding
+      and ``jsonb`` refuse them.
+
+    Callers should gate this on :func:`_needs_jsonb_sanitize` so the common
+    "clean data" path avoids rebuilding the object tree.
+    """
+    if isinstance(value, str):
+        cleaned = strip_lone_surrogates(value)
+        if "\x00" in cleaned:
+            cleaned = cleaned.replace("\x00", "")
+        return cleaned
+    if isinstance(value, dict):
+        return {_sanitize_for_jsonb(k): _sanitize_for_jsonb(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_for_jsonb(v) for v in value]
+    if isinstance(value, tuple):
+        return tuple(_sanitize_for_jsonb(v) for v in value)
+    return value
+
+
 def activity_to_action(activity: "Activity") -> GroupAction | None:
     """
     Translates an Activity to a GroupAction. None is returned in the error case.
@@ -177,6 +230,14 @@ def activity_to_action(activity: "Activity") -> GroupAction | None:
 
     # Instantiate & return
     kwargs = activity.data or {}  # Sometimes None
+
+    # Activity data is stored in a text JSON column that tolerates NUL bytes
+    # and lone surrogates, but the resulting action payload is written to a
+    # jsonb column (outbox payload and GroupActionLogEntry.data) which rejects
+    # both. Scan the tree first — only rewrite when we actually find something
+    # to strip, so the common clean-data path avoids the extra allocations.
+    if _needs_jsonb_sanitize(kwargs):
+        kwargs = _sanitize_for_jsonb(kwargs)
 
     if activity.type in ACTIVITY_TYPE_TO_ARG_TRANSLATIONS.keys():
         kwargs = {

--- a/tests/sentry/utils/action_log/test_activity_translator.py
+++ b/tests/sentry/utils/action_log/test_activity_translator.py
@@ -151,7 +151,7 @@ class ActivityToActionTest(TestCase):
         assert action is not None
         # The sanitized payload must be encodable as UTF-8; lone surrogates raise
         # UnicodeEncodeError, which is what breaks psycopg2 param encoding.
-        json.dumps(action.dict(), ensure_ascii=False).encode("utf-8")
+        action.dict()["title"].encode("utf-8")
         assert "\ud800" not in action.dict()["title"]
 
     def test_strips_bad_chars_in_dict_keys(self) -> None:

--- a/tests/sentry/utils/action_log/test_activity_translator.py
+++ b/tests/sentry/utils/action_log/test_activity_translator.py
@@ -3,6 +3,7 @@ from sentry.models.activity import Activity
 from sentry.testutils.cases import TestCase
 from sentry.testutils.factories import Factories
 from sentry.types.activity import ActivityType
+from sentry.utils import json
 from sentry.utils.action_log.activity_translator import (
     ACTIVITY_TYPE_TO_GROUP_ACTION_TYPE,
     ACTIVITY_TYPES_WITH_NO_ACTION,
@@ -79,3 +80,98 @@ class ActivityToActionTest(TestCase):
         )
 
         assert activity_to_action(act) == SetRegressedAction(version="abc")
+
+    def test_strips_null_bytes_from_string_fields(self) -> None:
+        # Activity data is stored in a text JSON column that tolerates NUL bytes,
+        # but the resulting GroupAction payload is serialized into a Postgres
+        # jsonb column, which rejects \u0000 escapes. activity_to_action must
+        # scrub null bytes so downstream jsonb writes (outbox payloads,
+        # bulk_insert_action_log_entries) don't fail.
+        act = Factories.create_group_activity(
+            group=self.group,
+            type=ActivityType.CREATE_ISSUE.value,
+            data={
+                "title": "prefix\x00suffix",
+                "provider": "ExampleProvider",
+                "location": "https://example.invalid/issues/1",
+                "label": "example/repo#1",
+                "new": True,
+            },
+        )
+
+        action = activity_to_action(act)
+
+        assert action is not None
+        payload = action.dict()
+        assert payload["title"] == "prefixsuffix"
+        # The serialized payload must not contain a \u0000 escape sequence,
+        # which is the shape jsonb rejects.
+        assert "\\u0000" not in json.dumps(payload)
+
+    def test_strips_null_bytes_nested(self) -> None:
+        # Even fields we don't currently model on GroupAction subclasses can
+        # carry null bytes (Pydantic silently drops unknown kwargs). Sanitize
+        # the whole data blob defensively so no null byte ever reaches the
+        # jsonb payload, regardless of which fields Pydantic keeps.
+        act = Factories.create_group_activity(
+            group=self.group,
+            type=ActivityType.MERGE.value,
+            data={
+                "issues": [
+                    {"id": 1, "label": "clean"},
+                    {"id": 2, "label": "with\x00null"},
+                ],
+            },
+        )
+
+        action = activity_to_action(act)
+
+        assert action is not None
+        assert "\\u0000" not in json.dumps(action.dict())
+
+    def test_strips_lone_surrogates(self) -> None:
+        # Python str tolerates lone UTF-16 surrogates, and Pydantic v1 accepts
+        # them, but they can't be encoded as UTF-8 for psycopg2 wire parameters
+        # and Postgres jsonb also rejects them. Sanitize like NUL bytes so the
+        # payload survives the trip to jsonb.
+        act = Factories.create_group_activity(
+            group=self.group,
+            type=ActivityType.CREATE_ISSUE.value,
+            data={
+                "title": "before\ud800after",
+                "provider": "ExampleProvider",
+                "location": "https://example.invalid/issues/2",
+                "label": "example/repo#2",
+                "new": True,
+            },
+        )
+
+        action = activity_to_action(act)
+
+        assert action is not None
+        # The sanitized payload must be encodable as UTF-8; lone surrogates raise
+        # UnicodeEncodeError, which is what breaks psycopg2 param encoding.
+        json.dumps(action.dict(), ensure_ascii=False).encode("utf-8")
+        assert "\ud800" not in action.dict()["title"]
+
+    def test_strips_bad_chars_in_dict_keys(self) -> None:
+        # Dict keys go into jsonb too. Activity keys are normally set by
+        # internal Sentry code, but the sanitizer should still handle a bad key
+        # so the pre-flight scan and the rewrite agree.
+        act = Factories.create_group_activity(
+            group=self.group,
+            type=ActivityType.MERGE.value,
+            data={
+                # An unmodeled sibling key with a NUL byte — MERGE only reads
+                # "issues", so Pydantic will drop this, but the pre-flight scan
+                # must still see it and the sanitized data must not carry it
+                # forward if we ever surface unknown keys.
+                "extra\x00key": "value",
+                "issues": [{"id": 1}],
+            },
+        )
+
+        action = activity_to_action(act)
+
+        assert action is not None
+        assert "\\u0000" not in json.dumps(action.dict())


### PR DESCRIPTION
JSONB is less permissive than the legacy JSON setup Activity uses, so we need to scrub to ensure everything can safely move on.
Actually needing scrubbing is very rare, so we lean on the speed of orjson to check very quickly (16x-30x faster) before we spend the time walking the JSON and rewriting everything.


Fixes ISWF-3417.
