### PR TITLE
fix(seer): Decouple Autofix Overview activity filter from global time

### DIFF
--- a/static/app/views/seerWorkflows/overview/index.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/index.spec.tsx
@@ -18,7 +18,10 @@ import {
 import {useDrawer} from '@sentry/scraps/drawer';
 
 import {DiffFileType, DiffLineType} from 'sentry/components/events/autofix/types';
-import {setPageFiltersStorage} from 'sentry/components/pageFilters/persistence';
+import {
+  getPageFilterStorage,
+  setPageFiltersStorage,
+} from 'sentry/components/pageFilters/persistence';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
@@ -556,31 +559,67 @@ describe('AutofixOverview', () => {
     expect(statusPollRequest).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps a pinned time window through param navigation instead of resetting it', async () => {
-    PageFiltersStore.onInitializeUrlState(
-      PageFiltersFixture({datetime: {period: '30d', start: null, end: null, utc: null}})
-    );
-    setPageFiltersStorage(organization.slug, new Set(['datetime']));
-    ProjectsStore.reset();
+  it('keeps the page-local activity window through param navigation instead of resetting it', async () => {
     const {statusPollRequest} = mockOverview({
       base: {autofix_root_cause: [{...rootCauseRun, status: 'processing'}]},
     });
 
-    const {router} = renderPage();
-    act(() => ProjectsStore.loadInitialData([ProjectFixture()]));
+    const {router} = renderPage({activityStatsPeriod: '30d'});
 
     await screen.findByRole('tab', {name: /All Runs/});
-    await waitFor(() => expect(router.location.query.statsPeriod).toBe('30d'));
+    expect(
+      screen.getByRole('button', {name: 'Autofix Activity 30D'})
+    ).toBeInTheDocument();
     const requestsBeforeClick = statusPollRequest.mock.calls.length;
 
     await userEvent.click(screen.getByRole('tab', {name: /In Progress/}));
 
     expect(router.location.query.view).toBe('in_progress');
-    expect(router.location.query.statsPeriod).toBe('30d');
+    expect(router.location.query.activityStatsPeriod).toBe('30d');
     expect(
       screen.getByRole('button', {name: 'Autofix Activity 30D'})
     ).toBeInTheDocument();
     expect(statusPollRequest).toHaveBeenCalledTimes(requestsBeforeClick);
+  });
+
+  it('defaults to the last 7 days and ignores a globally pinned time window', async () => {
+    PageFiltersStore.onInitializeUrlState(
+      PageFiltersFixture({datetime: {period: '30d', start: null, end: null, utc: null}})
+    );
+    setPageFiltersStorage(organization.slug, new Set(['datetime']));
+    const {statusPollRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole('button', {name: 'Autofix Activity 7D'})
+    ).toBeInTheDocument();
+    expect(statusPollRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/seer/autofix-overview/`,
+      expect.objectContaining({
+        query: expect.objectContaining({statsPeriod: '7d'}),
+      })
+    );
+  });
+
+  it('writes only the page-local param and leaves global page filters untouched', async () => {
+    mockOverview({base: {autofix_root_cause: [rootCauseRun]}});
+
+    const {router} = renderPage();
+
+    await userEvent.click(
+      await screen.findByRole('button', {name: 'Autofix Activity 7D'})
+    );
+    await userEvent.click(await screen.findByRole('option', {name: 'Last 24 hours'}));
+
+    await waitFor(() => expect(router.location.query.activityStatsPeriod).toBe('24h'));
+    expect(router.location.query.statsPeriod).not.toBe('24h');
+    expect(PageFiltersStore.getState().selection.datetime.period).not.toBe('24h');
+    expect(getPageFilterStorage(organization.slug).pinnedFilters.has('datetime')).toBe(
+      false
+    );
   });
 
   it('shows an empty state on the In Progress tab when nothing is processing', async () => {
@@ -673,13 +712,9 @@ describe('AutofixOverview', () => {
   });
 
   it('keeps a stale 90-day selection valid on the trigger', async () => {
-    PageFiltersStore.onInitializeUrlState(
-      PageFiltersFixture({datetime: {period: '90d', start: null, end: null, utc: null}})
-    );
-    setPageFiltersStorage(organization.slug, new Set(['datetime']));
     mockOverview({base: {}});
 
-    renderPage();
+    renderPage({activityStatsPeriod: '90d'});
 
     expect(
       await screen.findByRole('button', {name: 'Autofix Activity 90D'})
@@ -877,7 +912,7 @@ describe('AutofixOverview', () => {
     );
   });
 
-  it('scopes the request to the selected time window', async () => {
+  it('scopes the request to the page-local activity window', async () => {
     const {statusPollRequest} = mockOverview({
       base: {autofix_root_cause: [rootCauseRun]},
     });
@@ -885,7 +920,7 @@ describe('AutofixOverview', () => {
     render(<AutofixOverview />, {
       organization,
       initialRouterConfig: {
-        location: {pathname: basePath, query: {statsPeriod: '7d'}},
+        location: {pathname: basePath, query: {activityStatsPeriod: '24h'}},
       },
     });
 
@@ -895,7 +930,39 @@ describe('AutofixOverview', () => {
     expect(statusPollRequest).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/seer/autofix-overview/`,
       expect.objectContaining({
-        query: expect.objectContaining({statsPeriod: '7d'}),
+        query: expect.objectContaining({statsPeriod: '24h'}),
+      })
+    );
+  });
+
+  it('scopes the request to an absolute page-local activity window', async () => {
+    const {statusPollRequest} = mockOverview({
+      base: {autofix_root_cause: [rootCauseRun]},
+    });
+
+    render(<AutofixOverview />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: basePath,
+          query: {
+            activityStart: '2026-07-01T00:00:00',
+            activityEnd: '2026-07-08T00:00:00',
+          },
+        },
+      },
+    });
+
+    expect(
+      await screen.findByRole('link', {name: 'TypeError in checkout cart'})
+    ).toBeInTheDocument();
+    expect(statusPollRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/seer/autofix-overview/`,
+      expect.objectContaining({
+        query: expect.objectContaining({
+          start: expect.stringContaining('2026-07-01T00:00:00'),
+          end: expect.stringContaining('2026-07-08T00:00:00'),
+        }),
       })
     );
   });
@@ -1274,14 +1341,12 @@ describe('AutofixOverview', () => {
       body: {runsByMilestone: emptyMilestones},
     });
 
-    renderPage();
+    const {router} = renderPage();
     expect(
       await screen.findByRole('link', {name: 'TypeError in checkout cart'})
     ).toBeInTheDocument();
 
-    act(() =>
-      PageFiltersStore.updateDateTime({period: '24h', start: null, end: null, utc: null})
-    );
+    router.navigate(`${basePath}?activityStatsPeriod=24h`);
 
     expect((await screen.findAllByTestId('loading-placeholder')).length).toBeGreaterThan(
       0

--- a/static/app/views/seerWorkflows/overview/index.tsx
+++ b/static/app/views/seerWorkflows/overview/index.tsx
@@ -26,18 +26,20 @@ import * as Layout from 'sentry/components/layouts/thirds';
 import {LoadingError} from 'sentry/components/loadingError';
 import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 import {PageFiltersContainer} from 'sentry/components/pageFilters/container';
-import {DatePageFilter} from 'sentry/components/pageFilters/date/datePageFilter';
 import {PageFilterBar} from 'sentry/components/pageFilters/pageFilterBar';
+import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {ProjectPageFilter} from 'sentry/components/pageFilters/project/projectPageFilter';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
+import {TimeRangeSelector, type ChangeData} from 'sentry/components/timeRangeSelector';
 import {DEFAULT_RELATIVE_PERIODS} from 'sentry/constants';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import type {Actor} from 'sentry/types/core';
+import type {Actor, PageFilterDatetime} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {getUtcDateString} from 'sentry/utils/dates';
 import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
 import {
   indexMembersByProject,
@@ -104,6 +106,8 @@ const SORT_OPTIONS: Array<{label: string; value: OverviewSort}> = [
 ];
 
 const {'90d': _90d, ...ACTIVITY_RELATIVE_PERIODS} = DEFAULT_RELATIVE_PERIODS;
+
+const ACTIVITY_DEFAULT_PERIOD = '7d';
 
 const EMPTY_MEMBER_LIST: User[] = [];
 
@@ -199,6 +203,59 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
       value,
     });
 
+  const activityDatetime = useMemo<PageFilterDatetime>(() => {
+    const {statsPeriod, start, end, utc} = normalizeDateTimeParams(
+      {
+        statsPeriod: location.query.activityStatsPeriod,
+        start: location.query.activityStart,
+        end: location.query.activityEnd,
+        utc: location.query.activityUtc,
+      },
+      {defaultStatsPeriod: ACTIVITY_DEFAULT_PERIOD}
+    );
+    return {
+      period: statsPeriod ?? null,
+      start: start ?? null,
+      end: end ?? null,
+      utc: utc === undefined ? null : utc === 'true',
+    };
+  }, [
+    location.query.activityStatsPeriod,
+    location.query.activityStart,
+    location.query.activityEnd,
+    location.query.activityUtc,
+  ]);
+
+  const setActivityWindow = (next: {
+    activityEnd?: string;
+    activityStart?: string;
+    activityStatsPeriod?: string;
+    activityUtc?: string;
+  }) =>
+    navigate(
+      {pathname: location.pathname, query: {...location.query, ...next}},
+      {replace: true}
+    );
+
+  const handleActivityChange = ({start, end, relative, utc}: ChangeData) => {
+    trackFilterChanged('activity', relative ?? 'absolute');
+    if (start && end) {
+      setActivityWindow({
+        activityStatsPeriod: undefined,
+        activityStart: getUtcDateString(start),
+        activityEnd: getUtcDateString(end),
+        activityUtc: utc ? 'true' : undefined,
+      });
+      return;
+    }
+    setActivityWindow({
+      activityStatsPeriod: relative || undefined,
+      activityStart: undefined,
+      activityEnd: undefined,
+      activityUtc: undefined,
+    });
+  };
+
   const {
     data,
     projectConfig,
@@ -214,6 +271,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
   } = useAutofixOverview({
     organization,
     selection,
+    datetime: activityDatetime,
     sort,
     enabled: pageFiltersReady,
   });
@@ -230,7 +288,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
     numProjectsSelected: selection.projects.length,
     numUnconfiguredProjects: unconfiguredProjects.length,
     projectConfigPending,
-    statsPeriod: selection.datetime.period,
+    statsPeriod: activityDatetime.period,
   });
   const allUnconfigured =
     unconfiguredProjects.length > 0 &&
@@ -368,11 +426,15 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
         ) : (
           <ProjectFilterSkeleton />
         )}
-        <DatePageFilter
+        <TimeRangeSelector
+          relative={activityDatetime.period ?? ''}
+          start={activityDatetime.start}
+          end={activityDatetime.end}
+          utc={activityDatetime.utc}
           relativeOptions={activityRelativeOptions}
-          onChange={update =>
-            trackFilterChanged('activity', update.relative ?? 'absolute')
-          }
+          onChange={handleActivityChange}
+          menuTitle={t('Filter Time Range')}
+          menuWidth="22em"
           trigger={triggerProps => (
             <OverlayTrigger.Button {...triggerProps} prefix={t('Autofix Activity')} />
           )}
@@ -462,7 +524,7 @@ function AutofixOverviewContent({organization}: {organization: Organization}) {
                   collapsedGroups={collapsedGroups}
                   onToggle={toggleGroup}
                   orgSlug={organization.slug}
-                  statsPeriod={selection.datetime.period}
+                  statsPeriod={activityDatetime.period}
                   requestScmWindow={requestScmWindow}
                   scmWindowsByRunId={scmWindowsByRunId}
                   isScmSettled={isScmSettled}

--- a/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
+++ b/static/app/views/seerWorkflows/overview/useAutofixOverview.ts
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {useQuery, useQueryClient} from '@tanstack/react-query';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
-import type {PageFilters} from 'sentry/types/core';
+import type {PageFilterDatetime, PageFilters} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 
@@ -158,9 +158,11 @@ function overlayIssueStats(
 export function useAutofixOverview({
   organization,
   selection,
+  datetime,
   sort,
   enabled,
 }: {
+  datetime: PageFilterDatetime;
   enabled: boolean;
   organization: Organization;
   selection: PageFilters;
@@ -177,7 +179,7 @@ export function useAutofixOverview({
         path: {organizationIdOrSlug: organization.slug},
         query: {
           project: selection.projects,
-          ...normalizeDateTimeParams(selection.datetime),
+          ...normalizeDateTimeParams(datetime),
           // 'seer' is the backend's default order, so it needs no sort param.
           ...(sort === 'seer' ? {} : {sort}),
           ...query,
@@ -283,7 +285,7 @@ export function useAutofixOverview({
 
   // A scope change (sort/project/date) remounts the cards; clear the SCM caches
   // so the reshown cards re-window instead of being deduped against the old scope.
-  const scopeKey = JSON.stringify([selection.projects, selection.datetime, sort]);
+  const scopeKey = JSON.stringify([selection.projects, datetime, sort]);
   useEffect(() => {
     scopeGenerationRef.current += 1;
     requestedRunIdsRef.current.clear();


### PR DESCRIPTION
The Autofix Overview "Autofix Activity" time filter was bound to the app-wide page filters, so it inherited whatever time range had been selected on another page (e.g. a 12h telemetry window) and, when changed, persisted back to org-wide storage. That scoped Autofix runs to an unrelated selection and leaked that selection onto every other page-filter view.

The filter is now page-scoped and independent. The stock `DatePageFilter` is replaced with a controlled `TimeRangeSelector` bound to its own `activityStatsPeriod`/`activityStart`/`activityEnd`/`activityUtc` URL params, and that window is threaded through `useAutofixOverview` instead of `selection.datetime`. It opens to the last 7 days unless the URL carries a window — no cross-session memory and no bleed in either direction. Project and environment page filters are unchanged.

The activity params are deliberately *not* the page-filter system's reserved `page*` names: `PageFiltersContainer` reads `pageStatsPeriod` into the shared in-memory datetime, which would re-introduce the leak for relative windows, whereas the `activity*` names it ignores.
