### PR TITLE
feat(investigations): Add serializers for Seer orchestration payloads

### DIFF
--- a/src/sentry/investigations/contracts.py
+++ b/src/sentry/investigations/contracts.py
@@ -2,9 +2,16 @@ from __future__ import annotations
 
 from typing import Any
 
+from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from rest_framework import serializers
 
+from sentry.db.models.fields.bounded import I32_MAX, I64_MAX
+from sentry.investigations.models.block import InvestigationBlockKind
+from sentry.investigations.models.orchestration import (
+    InvestigationOrchestrationPhase,
+    InvestigationOrchestrationStatus,
+)
 from sentry.utils import json
 
 MAX_TABLE_ROWS = 100
@@ -12,6 +19,7 @@ MAX_CHART_SERIES = 5
 MAX_POINTS_PER_SERIES = 200
 MAX_ARTIFACT_BYTES = 1024 * 1024
 MAX_MARKDOWN_CHARS = 100_000
+MAX_PROJECTION_BYTES = 512 * 1024
 
 
 class StrictContractSerializer(serializers.Serializer[Any]):
@@ -21,6 +29,15 @@ class StrictContractSerializer(serializers.Serializer[Any]):
             if unknown:
                 raise serializers.ValidationError({field: "Unknown field." for field in unknown})
         return super().to_internal_value(data)
+
+
+class RelaxedContractSerializer(serializers.Serializer[Any]):
+    def to_internal_value(self, data: Any) -> dict[str, Any]:
+        validated = super().to_internal_value(data)
+        if not isinstance(data, dict):
+            return validated
+        passthrough = {key: value for key, value in data.items() if key not in self.fields}
+        return {**passthrough, **validated}
 
 
 class QueryTimeRangeSerializer(StrictContractSerializer):
@@ -259,3 +276,523 @@ def validate_text_result(value: Any) -> dict[str, Any]:
     serializer = InvestigationTextResultSerializer(data=value)
     serializer.is_valid(raise_exception=True)
     return dict(serializer.validated_data)
+
+
+WORK_STATUSES = {
+    "not_started",
+    "queued",
+    "running",
+    "blocked",
+    "reauth_required",
+    "stalled",
+    "completed",
+    "failed",
+    "cancelled",
+}
+EFFECTIVE_HYPOTHESIS_STATUSES = {
+    "pending",
+    "investigating",
+    "supported",
+    "refuted",
+    "inconclusive",
+    "accepted",
+    "rejected",
+    "failed",
+    "cancelled",
+}
+REPORT_STATUSES = {
+    "not_started",
+    "waiting",
+    "composing",
+    "completed",
+    "partial_failed",
+    "failed",
+    "cancelled",
+}
+METADATA_STATUSES = {"not_started", "generating", "completed", "failed"}
+EVIDENCE_KINDS = {
+    "issue",
+    "event",
+    "trace",
+    "profile",
+    "replay",
+    "query",
+    "chart",
+    "release",
+    "monitor",
+    "external",
+    "other",
+}
+PROJECT_BACKED_EVIDENCE_KINDS = EVIDENCE_KINDS - {"external", "other"}
+
+MAX_HYPOTHESES = 50
+MAX_VERIFICATION_STEPS = 50
+MAX_EVIDENCE_ITEMS = 200
+MAX_TOOL_ACTIVITIES = 50
+MAX_EVIDENCE_DATA_BYTES = 128 * 1024
+MAX_PROJECT_IDS = 100
+MAX_PROJECTION_ERRORS = 50
+MAX_PROJECTION_INTENTS = 50
+
+
+class StrictCharField(serializers.CharField):
+    def to_internal_value(self, data: Any) -> str:
+        if not isinstance(data, str):
+            self.fail("invalid")
+        return super().to_internal_value(data)
+
+
+class StrictIntegerField(serializers.IntegerField):
+    def to_internal_value(self, data: Any) -> int:
+        if isinstance(data, bool) or not isinstance(data, int):
+            self.fail("invalid")
+        return super().to_internal_value(data)
+
+
+class StrictFloatField(serializers.FloatField):
+    def to_internal_value(self, data: Any) -> float:
+        if isinstance(data, bool):
+            self.fail("invalid")
+        return super().to_internal_value(data)
+
+
+class StrictBooleanField(serializers.BooleanField):
+    def to_internal_value(self, data: Any) -> bool:
+        if not isinstance(data, bool):
+            self.fail("invalid", input=data)
+        return data
+
+
+class OptionalStrictCharField(StrictCharField):
+    def __init__(self, max_length: int, **kwargs: Any) -> None:
+        kwargs.setdefault("required", False)
+        kwargs.setdefault("allow_null", True)
+        kwargs.setdefault("allow_blank", True)
+        super().__init__(max_length=max_length, **kwargs)
+
+
+class ProjectionErrorSerializer(RelaxedContractSerializer):
+    code = StrictCharField(max_length=128)
+    message = StrictCharField(max_length=10_000)
+    retryable = StrictBooleanField(required=False)
+    source = OptionalStrictCharField(128)  # type: ignore[assignment]
+    occurredAt = OptionalStrictCharField(64)
+
+
+class ToolActivitySerializer(RelaxedContractSerializer):
+    id = StrictCharField(max_length=128)
+    title = StrictCharField(max_length=200)
+    kind = serializers.ChoiceField(choices=["api", "library", "tool", "step"])
+    status = serializers.ChoiceField(choices=["queued", "running", "completed", "failed"])
+
+
+class ProjectScopedSerializer(RelaxedContractSerializer):
+    projectIds = serializers.ListField(
+        child=StrictIntegerField(min_value=1, max_value=I64_MAX),
+        required=False,
+        allow_null=True,
+        max_length=MAX_PROJECT_IDS,
+    )
+    useInvestigationProjectScope = StrictBooleanField(required=False)
+
+    def project_ids_are_required(self, attrs: dict[str, Any]) -> bool:
+        return True
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        project_ids = attrs.get("projectIds")
+        scoped = attrs.get("useInvestigationProjectScope", False)
+        required = self.project_ids_are_required(attrs) and not scoped
+        if project_ids is None:
+            if required:
+                raise serializers.ValidationError(
+                    {"projectIds": "Required unless investigation project scope is used."}
+                )
+            return attrs
+        if required and not project_ids:
+            raise serializers.ValidationError(
+                {"projectIds": "Must not be empty unless investigation project scope is used."}
+            )
+        if len(project_ids) != len(set(project_ids)):
+            raise serializers.ValidationError({"projectIds": "Must be unique."})
+        return attrs
+
+
+class EvidenceSerializer(ProjectScopedSerializer):
+    id = StrictCharField(max_length=128)
+    title = StrictCharField(max_length=500)
+    kind = serializers.ChoiceField(choices=sorted(EVIDENCE_KINDS))
+    reference = OptionalStrictCharField(2_000)
+    url = OptionalStrictCharField(4_000)
+    summary = OptionalStrictCharField(20_000)
+    data = serializers.DictField(required=False)  # type: ignore[assignment]
+
+    def project_ids_are_required(self, attrs: dict[str, Any]) -> bool:
+        return attrs.get("kind") in PROJECT_BACKED_EVIDENCE_KINDS
+
+    def validate_data(self, value: dict[str, Any]) -> dict[str, Any]:
+        if len(json.dumps(value).encode()) > MAX_EVIDENCE_DATA_BYTES:
+            raise serializers.ValidationError("Evidence data is too large.")
+        return value
+
+
+class AgentVerdictSerializer(RelaxedContractSerializer):
+    verdict = serializers.ChoiceField(choices=["supported", "refuted", "inconclusive"])
+    confidence = StrictFloatField(min_value=0, max_value=1)
+    rationale = StrictCharField(max_length=20_000)
+    supportingEvidenceIds = serializers.ListField(
+        child=StrictCharField(max_length=1_000), required=False, max_length=200
+    )
+    refutingEvidenceIds = serializers.ListField(
+        child=StrictCharField(max_length=1_000), required=False, max_length=200
+    )
+    remainingGaps = serializers.ListField(
+        child=StrictCharField(max_length=1_000), required=False, max_length=200
+    )
+    decidedAt = OptionalStrictCharField(64)
+
+
+class VerificationStepSerializer(RelaxedContractSerializer):
+    id = StrictCharField(max_length=128)
+    order = StrictIntegerField(min_value=0)
+    title = StrictCharField(max_length=500)
+    objective = StrictCharField(max_length=5_000)
+    method = StrictCharField(max_length=5_000)
+    status = serializers.ChoiceField(choices=sorted(WORK_STATUSES))
+    result = OptionalStrictCharField(20_000)
+    evidence = serializers.ListField(
+        child=EvidenceSerializer(), required=False, max_length=MAX_EVIDENCE_ITEMS
+    )
+    error = ProjectionErrorSerializer(required=False, allow_null=True)
+
+
+class HypothesisSerializer(RelaxedContractSerializer):
+    id = StrictCharField(max_length=128)
+    order = StrictIntegerField(min_value=0)
+    statement = StrictCharField(max_length=2_000)
+    rationale = StrictCharField(max_length=20_000, allow_blank=True)
+    status = serializers.ChoiceField(choices=sorted(WORK_STATUSES))
+    effectiveStatus = serializers.ChoiceField(choices=sorted(EFFECTIVE_HYPOTHESIS_STATUSES))
+    decisionSource = serializers.ChoiceField(choices=["none", "agent", "user"])
+    confidence = StrictFloatField(required=False, allow_null=True, min_value=0, max_value=1)
+    generation = StrictIntegerField(required=False, min_value=1)
+    attempt = StrictIntegerField(required=False, min_value=0)
+    automaticRetryCount = StrictIntegerField(required=False, min_value=0, max_value=1)
+    investigatorRunId = StrictIntegerField(
+        required=False, allow_null=True, min_value=1, max_value=I64_MAX
+    )
+    planningStatus = serializers.ChoiceField(
+        choices=["not_started", "running", "completed", "failed"],
+        required=False,
+    )
+    heartbeatAt = OptionalStrictCharField(64)
+    toolActivity = serializers.ListField(
+        child=ToolActivitySerializer(),
+        required=False,
+        max_length=MAX_TOOL_ACTIVITIES,
+    )
+    evidence = serializers.ListField(
+        child=EvidenceSerializer(), required=False, max_length=MAX_EVIDENCE_ITEMS
+    )
+    verificationSteps = serializers.ListField(
+        child=VerificationStepSerializer(),
+        required=False,
+        max_length=MAX_VERIFICATION_STEPS,
+    )
+    agentVerdict = AgentVerdictSerializer(required=False, allow_null=True)
+    error = ProjectionErrorSerializer(required=False, allow_null=True)
+
+
+class BroadScanSerializer(RelaxedContractSerializer):
+    status = serializers.ChoiceField(choices=sorted(WORK_STATUSES))
+    summary = OptionalStrictCharField(20_000)
+    heartbeatAt = OptionalStrictCharField(64)
+    error = ProjectionErrorSerializer(required=False, allow_null=True, default=None)
+    toolActivity = serializers.ListField(
+        child=ToolActivitySerializer(),
+        required=False,
+        default=list,
+        max_length=MAX_TOOL_ACTIVITIES,
+    )
+    generation = StrictIntegerField(required=False, min_value=1)
+    attempt = StrictIntegerField(required=False, min_value=0)
+    automaticRetryCount = StrictIntegerField(required=False, min_value=0, max_value=1)
+    runId = StrictIntegerField(required=False, allow_null=True, min_value=1, max_value=I64_MAX)
+
+
+class ClearIntentSerializer(RelaxedContractSerializer):
+    id = StrictCharField(max_length=128)
+    revision = StrictIntegerField(min_value=0)
+    reason = StrictCharField(max_length=1_000)
+    requestedAt = OptionalStrictCharField(64)
+    completed = StrictBooleanField(required=False)
+
+
+class ReportMetadataSerializer(RelaxedContractSerializer):
+    status = serializers.ChoiceField(choices=sorted(METADATA_STATUSES))
+    title = OptionalStrictCharField(255)
+    summary = OptionalStrictCharField(255)
+    summaryDescription = OptionalStrictCharField(10_000)
+    titleStatus = serializers.ChoiceField(choices=sorted(METADATA_STATUSES), required=False)
+    automaticRetryCount = StrictIntegerField(required=False, min_value=0, max_value=1)
+    error = ProjectionErrorSerializer(required=False, allow_null=True)
+
+
+class SuggestedHypothesisSerializer(RelaxedContractSerializer):
+    statement = StrictCharField(max_length=2_000)
+    rationale = StrictCharField(max_length=20_000, allow_blank=True)
+
+
+class ReportSerializer(RelaxedContractSerializer):
+    status = serializers.ChoiceField(choices=sorted(REPORT_STATUSES))
+    revision = StrictIntegerField(min_value=0, max_value=I32_MAX)
+    notebookRevision = StrictIntegerField(min_value=0, max_value=I32_MAX)
+    includedHypothesisIds = serializers.ListField(
+        child=StrictCharField(max_length=128), required=False, default=list, max_length=50
+    )
+    primaryHypothesisId = OptionalStrictCharField(128)
+    currentBlockKey = OptionalStrictCharField(128)
+    currentBlockStatus = serializers.ChoiceField(choices=sorted(WORK_STATUSES), required=False)
+    currentBlockToolActivity = serializers.ListField(
+        child=ToolActivitySerializer(),
+        required=False,
+        default=list,
+        max_length=MAX_TOOL_ACTIVITIES,
+    )
+    heartbeatAt = OptionalStrictCharField(64)
+    automaticRetryCount = StrictIntegerField(required=False, min_value=0, max_value=1)
+    clearIntent = ClearIntentSerializer(required=False, allow_null=True)
+    metadata = ReportMetadataSerializer()
+    suggestedHypotheses = serializers.ListField(
+        child=SuggestedHypothesisSerializer(), required=False, max_length=20
+    )
+    error = ProjectionErrorSerializer(required=False, allow_null=True, default=None)
+
+
+class PendingInputSerializer(RelaxedContractSerializer):
+    prompt = StrictCharField(max_length=4_000)
+    missingFields = serializers.ListField(
+        child=serializers.ChoiceField(choices=["prompt", "time_range"]),
+        required=False,
+        max_length=2,
+    )
+
+
+class InvestigatorSchedulingSerializer(RelaxedContractSerializer):
+    maxConcurrency = StrictIntegerField(required=False, min_value=0, max_value=50)
+    availableSlots = StrictIntegerField(required=False, min_value=0, max_value=50)
+    activeHypothesisIds = serializers.ListField(
+        child=StrictCharField(max_length=128), required=False, max_length=50
+    )
+    queuedHypothesisIds = serializers.ListField(
+        child=StrictCharField(max_length=128), required=False, max_length=50
+    )
+    nextHypothesisIds = serializers.ListField(
+        child=StrictCharField(max_length=128), required=False, max_length=50
+    )
+
+
+class CancellationIntentSerializer(RelaxedContractSerializer):
+    id = StrictCharField(max_length=128)
+    scope = serializers.ChoiceField(choices=["broad_scan", "hypothesis", "report", "workflow"])
+    targetId = OptionalStrictCharField(128)
+    childRunId = StrictIntegerField(required=False, allow_null=True, min_value=1, max_value=I64_MAX)
+    generation = StrictIntegerField(min_value=0)
+    reason = StrictCharField(max_length=1_000)
+    requestedAt = OptionalStrictCharField(64)
+    completed = StrictBooleanField(required=False)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        # Report cancellation fences on the report revision, which is zero for
+        # the first report, so only that scope may use generation zero.
+        if attrs["scope"] != "report" and attrs["generation"] < 1:
+            raise serializers.ValidationError({"generation": "Must be at least 1."})
+        return attrs
+
+
+class SteeringIntentSerializer(RelaxedContractSerializer):
+    id = StrictCharField(max_length=128)
+    requestId = StrictCharField(max_length=128)
+    instruction = StrictCharField(max_length=4_000)
+    target = serializers.ChoiceField(choices=["workflow", "hypothesis", "report", "block"])
+    targetId = OptionalStrictCharField(128)
+    createdAt = OptionalStrictCharField(64)
+    completed = StrictBooleanField(required=False)
+
+
+class OrchestrationProjectionSerializer(RelaxedContractSerializer):
+    """The projection blob Seer sends with every orchestration event."""
+
+    def to_internal_value(self, data: Any) -> dict[str, Any]:
+        if len(json.dumps(data).encode()) > MAX_PROJECTION_BYTES:
+            raise serializers.ValidationError("Projection is too large.")
+        return super().to_internal_value(data)
+
+    workflowVersion = StrictIntegerField(min_value=1, max_value=I32_MAX)
+    generation = StrictIntegerField(min_value=1, max_value=I32_MAX)
+    phase = serializers.ChoiceField(choices=InvestigationOrchestrationPhase.values)
+    status = serializers.ChoiceField(choices=InvestigationOrchestrationStatus.values)
+    sourceType = StrictCharField(max_length=64)
+    broadScan = BroadScanSerializer()
+    hypotheses = serializers.ListField(
+        child=HypothesisSerializer(), required=False, default=list, max_length=MAX_HYPOTHESES
+    )
+    report = ReportSerializer()
+    pendingInput = PendingInputSerializer(required=False, allow_null=True)
+    investigatorScheduling = InvestigatorSchedulingSerializer(required=False, allow_null=True)
+    cancellationIntents = serializers.ListField(
+        child=CancellationIntentSerializer(),
+        required=False,
+        max_length=MAX_PROJECTION_INTENTS,
+    )
+    steeringIntents = serializers.ListField(
+        child=SteeringIntentSerializer(),
+        required=False,
+        max_length=MAX_PROJECTION_INTENTS,
+    )
+    errors = serializers.ListField(  # type: ignore[assignment]
+        child=ProjectionErrorSerializer(),
+        required=False,
+        default=list,
+        max_length=MAX_PROJECTION_ERRORS,
+    )
+    heartbeatAt = StrictCharField(max_length=64)
+    updatedAt = OptionalStrictCharField(64)
+
+    def validate_heartbeatAt(self, value: str) -> str:
+        parsed = parse_datetime(value)
+        if parsed is None or not timezone.is_aware(parsed):
+            raise serializers.ValidationError("Must be a timezone-aware timestamp.")
+        return value
+
+
+MAX_REPORT_BLOCKS = 200
+MAX_TEXT_DELTA_CHARS = 64 * 1024
+MAX_SUMMARY_DESCRIPTION_CHARS = 10_000
+
+
+class _ReportRevisionMixin(RelaxedContractSerializer):
+    reportRevision = StrictIntegerField(min_value=0, max_value=I32_MAX)
+
+
+class _BlockKeyMixin(_ReportRevisionMixin):
+    stableAgentKey = StrictCharField(max_length=128)
+
+
+class WorkflowUpdatedPayloadSerializer(RelaxedContractSerializer):
+    projection = OrchestrationProjectionSerializer()
+
+
+class StateSnapshotPayloadSerializer(RelaxedContractSerializer):
+    projection = OrchestrationProjectionSerializer()
+    reportRevision = StrictIntegerField(required=False, min_value=0, max_value=I32_MAX)
+    blocks = serializers.ListField(
+        child=serializers.DictField(), required=False, max_length=MAX_REPORT_BLOCKS
+    )
+    metadata = serializers.DictField(required=False, allow_null=True)
+
+
+class ReportClearPayloadSerializer(_ReportRevisionMixin):
+    pass
+
+
+class ReportCompletedPayloadSerializer(_ReportRevisionMixin):
+    pass
+
+
+class ReportBlockRemovedPayloadSerializer(_BlockKeyMixin):
+    pass
+
+
+class ReportBlockStartedPayloadSerializer(_BlockKeyMixin, ProjectScopedSerializer):
+    kind = serializers.ChoiceField(choices=InvestigationBlockKind.values)
+    position = StrictIntegerField(min_value=0, max_value=I32_MAX)
+    producingRunId = StrictIntegerField(
+        required=False, allow_null=True, min_value=1, max_value=I64_MAX
+    )
+
+
+class ReportBlockMovedPayloadSerializer(_BlockKeyMixin):
+    position = StrictIntegerField(min_value=0, max_value=I32_MAX)
+
+
+class ReportTextDeltaPayloadSerializer(_BlockKeyMixin):
+    delta = StrictCharField(max_length=MAX_TEXT_DELTA_CHARS, allow_blank=True)
+    reset = StrictBooleanField(required=False)
+
+
+class TitleDeltaPayloadSerializer(_ReportRevisionMixin):
+    delta = StrictCharField(max_length=1_000, allow_blank=True)
+    reset = StrictBooleanField(required=False)
+
+
+class MetadataCompletedPayloadSerializer(_ReportRevisionMixin):
+    summary = StrictCharField(max_length=255)
+    summaryDescription = StrictCharField(max_length=MAX_SUMMARY_DESCRIPTION_CHARS)
+    title = StrictCharField(required=False, max_length=255)
+
+
+class WorkflowFailedPayloadSerializer(RelaxedContractSerializer):
+    error = ProjectionErrorSerializer()
+    projection = OrchestrationProjectionSerializer(required=False, allow_null=True)
+
+
+class ReportFailedPayloadSerializer(_ReportRevisionMixin):
+    error = ProjectionErrorSerializer()
+    projection = OrchestrationProjectionSerializer(required=False, allow_null=True)
+
+
+class ReportBlockUpsertedPayloadSerializer(_BlockKeyMixin, ProjectScopedSerializer):
+    kind = serializers.ChoiceField(choices=InvestigationBlockKind.values)
+    position = StrictIntegerField(required=False, min_value=0, max_value=I32_MAX)
+    producingRunId = StrictIntegerField(
+        required=False, allow_null=True, min_value=1, max_value=I64_MAX
+    )
+    title = StrictCharField(required=False, max_length=255, allow_blank=True)
+    config = serializers.DictField(required=False)
+    display = serializers.DictField(required=False)
+    content = StrictCharField(required=False, allow_blank=True, max_length=MAX_MARKDOWN_CHARS)
+    generatedContent = StrictCharField(
+        required=False, allow_blank=True, max_length=MAX_MARKDOWN_CHARS
+    )
+    generationPrompt = StrictCharField(
+        required=False, allow_blank=True, max_length=MAX_MARKDOWN_CHARS
+    )
+    result = serializers.JSONField(required=False)
+
+    def to_internal_value(self, data: Any) -> dict[str, Any]:
+        if isinstance(data, dict) and "collapsed" in data:
+            data = {**data}
+            collapsed = data.pop("collapsed")
+            if not isinstance(collapsed, bool):
+                raise serializers.ValidationError({"collapsed": "Must be a boolean."})
+            display = data.get("display")
+            data["display"] = {
+                **(display if isinstance(display, dict) else {}),
+                "queryCollapsed": collapsed,
+            }
+        return super().to_internal_value(data)
+
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        if attrs.get("kind") != InvestigationBlockKind.QUERY:
+            return attrs
+        if "result" not in attrs:
+            raise serializers.ValidationError({"result": "A query result is required."})
+        validate_query_result(attrs["result"])
+        return attrs
+
+
+EVENT_PAYLOAD_SERIALIZERS: dict[str, type[RelaxedContractSerializer]] = {
+    "workflow_updated": WorkflowUpdatedPayloadSerializer,
+    "state_snapshot": StateSnapshotPayloadSerializer,
+    "report_clear": ReportClearPayloadSerializer,
+    "report_block_started": ReportBlockStartedPayloadSerializer,
+    "report_text_delta": ReportTextDeltaPayloadSerializer,
+    "report_block_upserted": ReportBlockUpsertedPayloadSerializer,
+    "report_block_removed": ReportBlockRemovedPayloadSerializer,
+    "report_block_moved": ReportBlockMovedPayloadSerializer,
+    "report_completed": ReportCompletedPayloadSerializer,
+    "report_failed": ReportFailedPayloadSerializer,
+    "title_delta": TitleDeltaPayloadSerializer,
+    "metadata_completed": MetadataCompletedPayloadSerializer,
+    "workflow_failed": WorkflowFailedPayloadSerializer,
+}

--- a/src/sentry/investigations/contracts.py
+++ b/src/sentry/investigations/contracts.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import orjson
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
 from rest_framework import serializers
@@ -12,7 +13,6 @@ from sentry.investigations.models.orchestration import (
     InvestigationOrchestrationPhase,
     InvestigationOrchestrationStatus,
 )
-from sentry.utils import json
 
 MAX_TABLE_ROWS = 100
 MAX_CHART_SERIES = 5
@@ -20,6 +20,16 @@ MAX_POINTS_PER_SERIES = 200
 MAX_ARTIFACT_BYTES = 1024 * 1024
 MAX_MARKDOWN_CHARS = 100_000
 MAX_PROJECTION_BYTES = 512 * 1024
+
+
+def json_byte_size(value: Any) -> int:
+    """Measure a payload in the UTF-8 JSON bytes Seer budgets against.
+
+    `default` keeps the tolerance the previous encoder had for types orjson
+    cannot serialize, such as the Decimals a query result can carry.
+    """
+
+    return len(orjson.dumps(value, default=str))
 
 
 class StrictContractSerializer(serializers.Serializer[Any]):
@@ -263,7 +273,7 @@ class InvestigationTextResultSerializer(StrictContractSerializer):
 
 
 def validate_query_result(value: Any) -> dict[str, Any]:
-    if len(json.dumps(value).encode()) > MAX_ARTIFACT_BYTES:
+    if json_byte_size(value) > MAX_ARTIFACT_BYTES:
         raise serializers.ValidationError("Query result exceeds the maximum artifact size.")
     serializer = InvestigationQueryResultSerializer(data=value)
     serializer.is_valid(raise_exception=True)
@@ -271,7 +281,7 @@ def validate_query_result(value: Any) -> dict[str, Any]:
 
 
 def validate_text_result(value: Any) -> dict[str, Any]:
-    if len(json.dumps(value).encode()) > MAX_ARTIFACT_BYTES:
+    if json_byte_size(value) > MAX_ARTIFACT_BYTES:
         raise serializers.ValidationError("Text result exceeds the maximum artifact size.")
     serializer = InvestigationTextResultSerializer(data=value)
     serializer.is_valid(raise_exception=True)
@@ -336,6 +346,12 @@ MAX_PROJECTION_INTENTS = 50
 
 
 class StrictCharField(serializers.CharField):
+    """A string that rejects the numbers DRF would stringify, and keeps its whitespace."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        kwargs.setdefault("trim_whitespace", False)
+        super().__init__(**kwargs)
+
     def to_internal_value(self, data: Any) -> str:
         if not isinstance(data, str):
             self.fail("invalid")
@@ -343,6 +359,8 @@ class StrictCharField(serializers.CharField):
 
 
 class StrictIntegerField(serializers.IntegerField):
+    """An integer that rejects the numeric strings DRF would otherwise parse."""
+
     def to_internal_value(self, data: Any) -> int:
         if isinstance(data, bool) or not isinstance(data, int):
             self.fail("invalid")
@@ -350,8 +368,10 @@ class StrictIntegerField(serializers.IntegerField):
 
 
 class StrictFloatField(serializers.FloatField):
+    """A number that rejects the booleans and numeric strings DRF would coerce."""
+
     def to_internal_value(self, data: Any) -> float:
-        if isinstance(data, bool):
+        if isinstance(data, bool) or not isinstance(data, (int, float)):
             self.fail("invalid")
         return super().to_internal_value(data)
 
@@ -430,7 +450,7 @@ class EvidenceSerializer(ProjectScopedSerializer):
         return attrs.get("kind") in PROJECT_BACKED_EVIDENCE_KINDS
 
     def validate_data(self, value: dict[str, Any]) -> dict[str, Any]:
-        if len(json.dumps(value).encode()) > MAX_EVIDENCE_DATA_BYTES:
+        if json_byte_size(value) > MAX_EVIDENCE_DATA_BYTES:
             raise serializers.ValidationError("Evidence data is too large.")
         return value
 
@@ -463,6 +483,12 @@ class VerificationStepSerializer(RelaxedContractSerializer):
         child=EvidenceSerializer(), required=False, max_length=MAX_EVIDENCE_ITEMS
     )
     error = ProjectionErrorSerializer(required=False, allow_null=True)
+
+
+class UserDispositionSerializer(RelaxedContractSerializer):
+    disposition = serializers.ChoiceField(choices=["accepted", "rejected"])
+    userId = StrictIntegerField(required=False, allow_null=True, min_value=1, max_value=I64_MAX)
+    decidedAt = OptionalStrictCharField(64)
 
 
 class HypothesisSerializer(RelaxedContractSerializer):
@@ -499,6 +525,7 @@ class HypothesisSerializer(RelaxedContractSerializer):
         max_length=MAX_VERIFICATION_STEPS,
     )
     agentVerdict = AgentVerdictSerializer(required=False, allow_null=True)
+    userDisposition = UserDispositionSerializer(required=False, allow_null=True)
     error = ProjectionErrorSerializer(required=False, allow_null=True)
 
 
@@ -623,7 +650,7 @@ class OrchestrationProjectionSerializer(RelaxedContractSerializer):
     """The projection blob Seer sends with every orchestration event."""
 
     def to_internal_value(self, data: Any) -> dict[str, Any]:
-        if len(json.dumps(data).encode()) > MAX_PROJECTION_BYTES:
+        if json_byte_size(data) > MAX_PROJECTION_BYTES:
             raise serializers.ValidationError("Projection is too large.")
         return super().to_internal_value(data)
 
@@ -773,11 +800,12 @@ class ReportBlockUpsertedPayloadSerializer(_BlockKeyMixin, ProjectScopedSerializ
         return super().to_internal_value(data)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        attrs = super().validate(attrs)
         if attrs.get("kind") != InvestigationBlockKind.QUERY:
             return attrs
         if "result" not in attrs:
             raise serializers.ValidationError({"result": "A query result is required."})
-        validate_query_result(attrs["result"])
+        attrs["result"] = validate_query_result(attrs["result"])
         return attrs
 
 

--- a/src/sentry/investigations/contracts.py
+++ b/src/sentry/investigations/contracts.py
@@ -29,7 +29,10 @@ def json_byte_size(value: Any) -> int:
     cannot serialize, such as the Decimals a query result can carry.
     """
 
-    return len(orjson.dumps(value, default=str))
+    try:
+        return len(orjson.dumps(value, default=str))
+    except TypeError as error:
+        raise serializers.ValidationError("Payload is not serializable.") from error
 
 
 class StrictContractSerializer(serializers.Serializer[Any]):
@@ -793,10 +796,9 @@ class ReportBlockUpsertedPayloadSerializer(_BlockKeyMixin, ProjectScopedSerializ
             if not isinstance(collapsed, bool):
                 raise serializers.ValidationError({"collapsed": "Must be a boolean."})
             display = data.get("display")
-            data["display"] = {
-                **(display if isinstance(display, dict) else {}),
-                "queryCollapsed": collapsed,
-            }
+            if display is not None and not isinstance(display, dict):
+                raise serializers.ValidationError({"display": "Must be an object."})
+            data["display"] = {**(display or {}), "queryCollapsed": collapsed}
         return super().to_internal_value(data)
 
     def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:

--- a/tests/sentry/investigations/test_contracts.py
+++ b/tests/sentry/investigations/test_contracts.py
@@ -1,13 +1,20 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
 import pytest
 from rest_framework.exceptions import ValidationError
 
+from sentry.db.models.fields.bounded import I32_MAX, I64_MAX
 from sentry.investigations.contracts import (
     MAX_ARTIFACT_BYTES,
+    OrchestrationProjectionSerializer,
+    RelaxedContractSerializer,
+    ReportBlockStartedPayloadSerializer,
+    ReportBlockUpsertedPayloadSerializer,
+    ReportClearPayloadSerializer,
     validate_query_result,
     validate_text_result,
 )
@@ -148,3 +155,266 @@ def test_text_result_rejects_oversized_payloads() -> None:
     with pytest.raises(ValidationError) as excinfo:
         validate_text_result({"schemaVersion": 1, "markdown": "x" * (MAX_ARTIFACT_BYTES + 1)})
     assert "maximum artifact size" in str(excinfo.value)
+
+
+def projection(**overrides: Any) -> dict[str, Any]:
+    """The smallest projection Seer can send that Sentry accepts."""
+
+    return {
+        "runId": 4815,
+        "investigationId": "162342",
+        "sourceType": "manual",
+        "workflowVersion": 1,
+        "generation": 1,
+        "phase": "broad_scan",
+        "status": "processing",
+        "broadScan": {"status": "running"},
+        "hypotheses": [],
+        "report": {
+            "revision": 0,
+            "status": "not_started",
+            "clearIntent": None,
+            "notebookRevision": 0,
+            "metadata": {"status": "not_started"},
+        },
+        "pendingInput": None,
+        "errors": [],
+        "heartbeatAt": "2025-01-01T00:00:00+00:00",
+        **overrides,
+    }
+
+
+def block_payload(**overrides: Any) -> dict[str, Any]:
+    return {
+        "reportRevision": 0,
+        "stableAgentKey": "block",
+        "position": 0,
+        "kind": "text",
+        "title": "Block",
+        "content": "body",
+        "projectIds": [162342],
+        **overrides,
+    }
+
+
+def validated(serializer: type[RelaxedContractSerializer], payload: dict[str, Any]) -> Any:
+    validator = serializer(data=payload)
+    validator.is_valid(raise_exception=True)
+    return validator.validated_data
+
+
+def rejects(serializer: type[RelaxedContractSerializer], payload: dict[str, Any]) -> None:
+    assert not serializer(data=payload).is_valid()
+
+
+def test_relaxed_serializer_passes_unknown_fields_through() -> None:
+    result = validated(
+        OrchestrationProjectionSerializer,
+        projection(seerAddedThisLater={"nested": [1, 2, 3]}),
+    )
+
+    assert result["seerAddedThisLater"] == {"nested": [1, 2, 3]}
+
+
+def test_relaxed_serializer_passes_unknown_nested_fields_through() -> None:
+    result = validated(
+        OrchestrationProjectionSerializer,
+        projection(broadScan={"status": "running", "seerAddedThisLater": "kept"}),
+    )
+
+    assert result["broadScan"]["seerAddedThisLater"] == "kept"
+
+
+def test_projection_is_bounded_by_its_serialized_size() -> None:
+    # An undeclared field is passed through untouched, so nothing but the size
+    # guard bounds it.
+    rejects(OrchestrationProjectionSerializer, projection(seerAddedThisLater="x" * (600 * 1024)))
+
+
+def test_projection_phase_and_status_must_be_known_values() -> None:
+    rejects(OrchestrationProjectionSerializer, projection(phase="not_a_phase"))
+    rejects(OrchestrationProjectionSerializer, projection(status="not_a_status"))
+
+
+def test_projection_integers_stay_within_their_database_columns() -> None:
+    rejects(OrchestrationProjectionSerializer, projection(workflowVersion=I32_MAX + 1))
+    rejects(OrchestrationProjectionSerializer, projection(generation=I32_MAX + 1))
+    rejects(ReportClearPayloadSerializer, {"reportRevision": I32_MAX + 1})
+    rejects(ReportBlockStartedPayloadSerializer, block_payload(projectIds=[I64_MAX + 1]))
+    rejects(ReportBlockStartedPayloadSerializer, block_payload(producingRunId=I64_MAX + 1))
+
+
+def test_projection_rejects_malformed_nested_shapes() -> None:
+    mutations: list[Callable[[dict[str, Any]], object]] = [
+        lambda value: value.update(
+            {
+                "hypotheses": [
+                    {
+                        "id": "bad",
+                        "order": 0,
+                        "statement": "Bad projection",
+                        "rationale": "Invalid status",
+                        "status": "surprise",
+                        "effectiveStatus": "pending",
+                        "decisionSource": "none",
+                    }
+                ]
+            }
+        ),
+        lambda value: value["broadScan"].update(
+            {"error": {"code": "bad_error", "message": "Malformed", "retryable": "yes"}}
+        ),
+        lambda value: value["broadScan"].update({"summary": "x" * (512 * 1024)}),
+        lambda value: value["report"].pop("metadata"),
+        lambda value: value["report"].pop("notebookRevision"),
+        lambda value: value.pop("heartbeatAt"),
+        lambda value: value.update({"heartbeatAt": "not-a-timestamp"}),
+        lambda value: value.update({"heartbeatAt": "2025-01-01T00:00:00"}),
+    ]
+    for mutate in mutations:
+        payload = projection()
+        mutate(payload)
+
+        rejects(OrchestrationProjectionSerializer, payload)
+
+
+def test_declared_fields_reject_the_types_drf_would_coerce() -> None:
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(title=12))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(generatedContent=12))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(position="0"))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(producingRunId="12"))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(producingRunId=True))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(useInvestigationProjectScope="yes"))
+
+
+def test_block_upsert_rejects_malformed_fields() -> None:
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(title="x" * 256))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(config="not-an-object"))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(display=["not-an-object"]))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(content=None))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(generationPrompt={"no": "t"}))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(producingRunId=0))
+
+
+def test_block_upsert_folds_the_legacy_collapsed_flag_into_display() -> None:
+    result = validated(ReportBlockUpsertedPayloadSerializer, block_payload(collapsed=True))
+
+    assert result["display"] == {"queryCollapsed": True}
+    assert "collapsed" not in result
+
+
+def test_block_upsert_rejects_a_non_boolean_collapsed_flag() -> None:
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(collapsed="yes"))
+
+
+def test_report_blocks_require_project_provenance() -> None:
+    rejects(ReportBlockStartedPayloadSerializer, block_payload(projectIds=[]))
+    rejects(ReportBlockStartedPayloadSerializer, block_payload(projectIds=None))
+    rejects(ReportBlockStartedPayloadSerializer, block_payload(projectIds=[1, 1]))
+
+
+def test_report_blocks_may_defer_to_the_investigation_project_scope() -> None:
+    result = validated(
+        ReportBlockStartedPayloadSerializer,
+        block_payload(projectIds=None, useInvestigationProjectScope=True),
+    )
+
+    assert result["useInvestigationProjectScope"] is True
+
+
+def hypothesis_with_evidence(evidence: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "id": "hypothesis-1",
+        "order": 0,
+        "statement": "A release caused the regression",
+        "rationale": "The timing lines up.",
+        "status": "completed",
+        "effectiveStatus": "supported",
+        "decisionSource": "agent",
+        "verificationSteps": [],
+        "evidence": [evidence],
+        "toolActivity": [],
+    }
+
+
+def test_project_backed_evidence_requires_project_provenance() -> None:
+    rejects(
+        OrchestrationProjectionSerializer,
+        projection(
+            hypotheses=[
+                hypothesis_with_evidence(
+                    {"id": "evidence-1", "title": "Event without provenance", "kind": "event"}
+                )
+            ]
+        ),
+    )
+
+
+def test_evidence_without_a_project_needs_no_provenance() -> None:
+    result = validated(
+        OrchestrationProjectionSerializer,
+        projection(
+            hypotheses=[
+                hypothesis_with_evidence(
+                    {"id": "evidence-1", "title": "An external document", "kind": "external"}
+                )
+            ]
+        ),
+    )
+
+    assert result["hypotheses"][0]["evidence"][0]["kind"] == "external"
+
+
+def test_projection_accepts_visible_broad_scan_steps() -> None:
+    result = validated(
+        OrchestrationProjectionSerializer,
+        projection(
+            broadScan={
+                "status": "running",
+                "toolActivity": [
+                    {
+                        "id": "step-1",
+                        "title": "Inspect the error spike",
+                        "kind": "step",
+                        "status": "queued",
+                    }
+                ],
+            }
+        ),
+    )
+
+    assert result["broadScan"]["toolActivity"][0]["id"] == "step-1"
+
+
+def test_report_cancellation_may_fence_on_the_first_revision() -> None:
+    result = validated(
+        OrchestrationProjectionSerializer,
+        projection(
+            cancellationIntents=[
+                {
+                    "id": "cancel-1",
+                    "scope": "report",
+                    "generation": 0,
+                    "reason": "The user cleared the report.",
+                }
+            ]
+        ),
+    )
+
+    assert result["cancellationIntents"][0]["generation"] == 0
+
+
+def test_other_cancellation_scopes_may_not_fence_on_generation_zero() -> None:
+    rejects(
+        OrchestrationProjectionSerializer,
+        projection(
+            cancellationIntents=[
+                {
+                    "id": "cancel-1",
+                    "scope": "workflow",
+                    "generation": 0,
+                    "reason": "The user stopped the investigation.",
+                }
+            ]
+        ),
+    )

--- a/tests/sentry/investigations/test_contracts.py
+++ b/tests/sentry/investigations/test_contracts.py
@@ -1,20 +1,25 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from decimal import Decimal
 from pathlib import Path
 from typing import Any
 
+import orjson
 import pytest
 from rest_framework.exceptions import ValidationError
 
 from sentry.db.models.fields.bounded import I32_MAX, I64_MAX
 from sentry.investigations.contracts import (
     MAX_ARTIFACT_BYTES,
+    MAX_PROJECTION_BYTES,
     OrchestrationProjectionSerializer,
     RelaxedContractSerializer,
     ReportBlockStartedPayloadSerializer,
     ReportBlockUpsertedPayloadSerializer,
     ReportClearPayloadSerializer,
+    ReportTextDeltaPayloadSerializer,
+    json_byte_size,
     validate_query_result,
     validate_text_result,
 )
@@ -195,6 +200,10 @@ def block_payload(**overrides: Any) -> dict[str, Any]:
         "projectIds": [162342],
         **overrides,
     }
+
+
+def delta_payload(**overrides: Any) -> dict[str, Any]:
+    return {"reportRevision": 0, "stableAgentKey": "block", **overrides}
 
 
 def validated(serializer: type[RelaxedContractSerializer], payload: dict[str, Any]) -> Any:
@@ -418,3 +427,100 @@ def test_other_cancellation_scopes_may_not_fence_on_generation_zero() -> None:
             ]
         ),
     )
+
+
+def test_strings_keep_the_whitespace_seer_sent() -> None:
+    first = validated(ReportTextDeltaPayloadSerializer, {**delta_payload(), "delta": "Hello "})
+    second = validated(ReportTextDeltaPayloadSerializer, {**delta_payload(), "delta": " world\n"})
+
+    assert first["delta"] + second["delta"] == "Hello  world\n"
+
+
+def test_sizes_are_measured_in_the_bytes_seer_counted() -> None:
+    # Seer budgets with orjson, which does not escape non-ASCII.
+    payload = projection(seerAddedThisLater="错误率升高 🚨" * 20_000)
+
+    assert len(json.dumps(payload).encode()) > MAX_PROJECTION_BYTES
+    assert len(orjson.dumps(payload)) < MAX_PROJECTION_BYTES
+    validated(OrchestrationProjectionSerializer, payload)
+
+
+def test_block_upsert_requires_project_provenance() -> None:
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(projectIds=None))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(projectIds=[]))
+    rejects(ReportBlockUpsertedPayloadSerializer, block_payload(projectIds=[1, 1]))
+
+
+def test_floats_reject_the_strings_drf_would_parse() -> None:
+    hypothesis = {
+        "id": "hypothesis-1",
+        "order": 0,
+        "statement": "A release caused the regression",
+        "rationale": "The timing lines up.",
+        "status": "completed",
+        "effectiveStatus": "supported",
+        "decisionSource": "agent",
+        "confidence": "0.5",
+    }
+
+    rejects(OrchestrationProjectionSerializer, projection(hypotheses=[hypothesis]))
+
+
+def test_block_upsert_returns_the_normalized_query_result() -> None:
+    result = {**golden_payload(), "chart": None, "preferredView": "chart"}
+    validated_block = validated(
+        ReportBlockUpsertedPayloadSerializer,
+        block_payload(kind="query", result=result),
+    )
+
+    assert validated_block["result"]["preferredView"] == "table"
+
+
+def hypothesis_with(**overrides: Any) -> dict[str, Any]:
+    return {
+        "id": "hypothesis-1",
+        "order": 0,
+        "statement": "A release caused the regression",
+        "rationale": "The timing lines up.",
+        "status": "completed",
+        "effectiveStatus": "supported",
+        "decisionSource": "user",
+        **overrides,
+    }
+
+
+def test_user_disposition_is_validated() -> None:
+    for bad in (
+        "accepted",
+        {"disposition": "maybe"},
+        {},
+        {"disposition": "accepted", "userId": 0},
+        {"disposition": "accepted", "userId": "12"},
+        {"disposition": "accepted", "decidedAt": 12},
+    ):
+        rejects(
+            OrchestrationProjectionSerializer,
+            projection(hypotheses=[hypothesis_with(userDisposition=bad)]),
+        )
+
+    result = validated(
+        OrchestrationProjectionSerializer,
+        projection(
+            hypotheses=[
+                hypothesis_with(
+                    userDisposition={
+                        "disposition": "rejected",
+                        "userId": 42,
+                        "decidedAt": "2025-01-01T00:00:00+00:00",
+                    }
+                )
+            ]
+        ),
+    )
+
+    assert result["hypotheses"][0]["userDisposition"]["disposition"] == "rejected"
+
+
+def test_size_measurement_tolerates_values_orjson_cannot_serialize() -> None:
+    # Query results reach this from Snuba, which returns Decimals.
+    assert json_byte_size({"total": Decimal("1.5")}) > 0

--- a/tests/sentry/investigations/test_contracts.py
+++ b/tests/sentry/investigations/test_contracts.py
@@ -524,3 +524,16 @@ def test_user_disposition_is_validated() -> None:
 def test_size_measurement_tolerates_values_orjson_cannot_serialize() -> None:
     # Query results reach this from Snuba, which returns Decimals.
     assert json_byte_size({"total": Decimal("1.5")}) > 0
+
+
+def test_size_measurement_rejects_input_it_cannot_serialize() -> None:
+    # A parsed JSON payload can carry an integer wider than orjson handles.
+    with pytest.raises(ValidationError):
+        json_byte_size({"x": 2**65})
+
+
+def test_block_upsert_rejects_a_bad_display_beside_the_collapsed_flag() -> None:
+    rejects(
+        ReportBlockUpsertedPayloadSerializer,
+        block_payload(collapsed=True, display="not-an-object"),
+    )


### PR DESCRIPTION
Describe Seer's orchestration projection and its per-event payloads as DRF serializers in `contracts.py`.

Nothing calls these yet. The reducer in #123281 will be rebased onto this branch and use them.
