### PR TITLE
feat(hybrid-cloud): report backfill watermark state on every cycle

### DIFF
--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -51,6 +51,20 @@ def get_backfill_key(table_name: str) -> str:
     return f"outbox_backfill.{table_name}"
 
 
+def read_processing_state(table_name: str) -> tuple[int, int] | None:
+    """
+    Read-only way to look at the stored watermark pair
+    """
+    client = _get_redis_client()
+    v = client.get(get_backfill_key(table_name))
+    if v is None:
+        return None
+    lower, version = json.loads(v)
+    if not (isinstance(lower, int) and isinstance(version, int)):
+        raise TypeError("Expected processing data to be a tuple of (int, int)")
+    return lower, version
+
+
 def get_processing_state(table_name: str) -> tuple[int, int]:
     result: tuple[int, int]
     client = _get_redis_client()
@@ -183,6 +197,108 @@ def process_outbox_backfill_batch(
 
 OUTBOX_BACKFILLS_PER_MINUTE = 10_000
 
+# new gauge which gets emitted every cycle, even if backfill budget is exhausted
+WATERMARK_STATE_METRIC = "backfill_outboxes.watermark_state"
+
+# stored version (per-table)
+WATERMARK_VERSION_METRIC = "backfill_outboxes.watermark_version"
+
+# version the backfill is working towards (per-table)
+WATERMARK_TARGET_VERSION_METRIC = "backfill_outboxes.watermark_target_version"
+
+# detects dropped watermarks
+WATERMARK_MISSING_METRIC = "backfill_outboxes.watermark_missing"
+
+# reporting errors, debugging only
+WATERMARK_REPORT_ERROR_METRIC = "backfill_outboxes.watermark_report_error"
+
+
+def _backfill_models(
+    silo_mode: SiloMode,
+) -> list[type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User]]:
+    """
+    The models the backfill loop would look at in this silo mode.
+    """
+    found: list[
+        type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User]
+    ] = []
+    for app_models in apps.all_models.values():
+        for model in app_models.values():
+            if not hasattr(model._meta, "silo_limit"):
+                continue
+
+            if silo_mode is not SiloMode.MONOLITH and silo_mode not in model._meta.silo_limit.modes:
+                continue
+
+            if not (
+                issubclass(model, CellOutboxProducingModel)
+                or issubclass(model, ControlOutboxProducingModel)
+                or issubclass(model, User)
+            ):
+                continue
+
+            found.append(model)
+    return found
+
+
+def _refresh_watermark_for_model(
+    model: type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User],
+    *,
+    force_synchronous: bool,
+) -> None:
+    table_name = model._meta.db_table
+    target_version = find_replication_version(model, force_synchronous=force_synchronous)
+    metrics.gauge(
+        WATERMARK_TARGET_VERSION_METRIC,
+        target_version,
+        tags=dict(table_name=table_name),
+        sample_rate=1.0,
+    )
+
+    state = read_processing_state(table_name)
+    if state is None:
+        metrics.incr(WATERMARK_MISSING_METRIC, skip_internal=True, sample_rate=1.0)
+        logger.warning(
+            "backfill_outboxes.watermark_absent",
+            extra={"table_name": table_name, "target_version": target_version},
+        )
+        return
+
+    lower, version = state
+    metrics.gauge(WATERMARK_STATE_METRIC, lower, tags=dict(table_name=table_name), sample_rate=1.0)
+    metrics.gauge(
+        WATERMARK_VERSION_METRIC, version, tags=dict(table_name=table_name), sample_rate=1.0
+    )
+    logger.info(
+        "backfill_outboxes.watermark_state",
+        extra={
+            "table_name": table_name,
+            "low_bound": lower,
+            "version": version,
+            "target_version": target_version,
+        },
+    )
+
+
+def refresh_backfill_watermarks(silo_mode: SiloMode, force_synchronous: bool = False) -> None:
+    """
+    Visit every backfill watermark key once, and report what it holds.
+    """
+    try:
+        for model in _backfill_models(silo_mode):
+            try:
+                _refresh_watermark_for_model(model, force_synchronous=force_synchronous)
+            except Exception:
+                # One bad table must not stop the rest of the walk.
+                metrics.incr(WATERMARK_REPORT_ERROR_METRIC, skip_internal=True, sample_rate=1.0)
+                logger.exception(
+                    "backfill_outboxes.watermark_report_failed",
+                    extra={"table_name": model._meta.db_table},
+                )
+    except Exception:
+        metrics.incr(WATERMARK_REPORT_ERROR_METRIC, skip_internal=True, sample_rate=1.0)
+        logger.exception("backfill_outboxes.watermark_report_failed")
+
 
 def backfill_outboxes_for(
     silo_mode: SiloMode,
@@ -198,6 +314,8 @@ def backfill_outboxes_for(
         "backfill_outboxes.start",
         extra={"remaining": remaining_to_backfill, "scheduled": scheduled_count},
     )
+
+    refresh_backfill_watermarks(silo_mode, force_synchronous=force_synchronous)
 
     if remaining_to_backfill > 0:
         for app, app_models in apps.all_models.items():

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -206,7 +206,6 @@ WATERMARK_VERSION_METRIC = "backfill_outboxes.watermark_version"
 # version the backfill is working towards (per-table)
 WATERMARK_TARGET_VERSION_METRIC = "backfill_outboxes.watermark_target_version"
 
-# detects dropped watermarks
 WATERMARK_MISSING_METRIC = "backfill_outboxes.watermark_missing"
 
 # reporting errors, debugging only
@@ -323,21 +322,23 @@ def backfill_outboxes_for(
         extra={"remaining": remaining_to_backfill, "scheduled": scheduled_count},
     )
 
-    if remaining_to_backfill > 0:
-        for model in _backfill_models(silo_mode):
-            # If we find some backfill work to perform, do it.
-            batch = process_outbox_backfill_batch(
-                model, batch_size=remaining_to_backfill, force_synchronous=force_synchronous
-            )
-            if batch is None:
-                continue
+    try:
+        if remaining_to_backfill > 0:
+            for model in _backfill_models(silo_mode):
+                # If we find some backfill work to perform, do it.
+                batch = process_outbox_backfill_batch(
+                    model, batch_size=remaining_to_backfill, force_synchronous=force_synchronous
+                )
+                if batch is None:
+                    continue
 
-            remaining_to_backfill -= batch.count
-            backfilled += batch.count
-            if remaining_to_backfill <= 0:
-                break
-
-    report_backfill_watermarks(silo_mode, force_synchronous=force_synchronous)
+                remaining_to_backfill -= batch.count
+                backfilled += batch.count
+                if remaining_to_backfill <= 0:
+                    break
+    finally:
+        # report the newest values from this cycle
+        report_backfill_watermarks(silo_mode, force_synchronous=force_synchronous)
 
     metrics.incr(
         "backfill_outboxes.backfilled",

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -323,8 +323,6 @@ def backfill_outboxes_for(
         extra={"remaining": remaining_to_backfill, "scheduled": scheduled_count},
     )
 
-    report_backfill_watermarks(silo_mode, force_synchronous=force_synchronous)
-
     if remaining_to_backfill > 0:
         for model in _backfill_models(silo_mode):
             # If we find some backfill work to perform, do it.
@@ -338,6 +336,8 @@ def backfill_outboxes_for(
             backfilled += batch.count
             if remaining_to_backfill <= 0:
                 break
+
+    report_backfill_watermarks(silo_mode, force_synchronous=force_synchronous)
 
     metrics.incr(
         "backfill_outboxes.backfilled",

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -197,7 +197,7 @@ def process_outbox_backfill_batch(
 
 OUTBOX_BACKFILLS_PER_MINUTE = 10_000
 
-# new gauge which gets emitted every cycle, even if backfill budget is exhausted
+# stored low bound, emitted every cycle even if the backfill budget is exhausted
 WATERMARK_STATE_METRIC = "backfill_outboxes.watermark_state"
 
 # stored version (per-table)
@@ -241,11 +241,11 @@ def _backfill_models(
     return found
 
 
-def _refresh_watermark_for_model(
+def _report_watermark_for_model(
     model: type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User],
     *,
     force_synchronous: bool,
-) -> None:
+) -> tuple[int, int] | None:
     table_name = model._meta.db_table
     target_version = find_replication_version(model, force_synchronous=force_synchronous)
     metrics.gauge(
@@ -257,44 +257,52 @@ def _refresh_watermark_for_model(
 
     state = read_processing_state(table_name)
     if state is None:
-        metrics.incr(WATERMARK_MISSING_METRIC, skip_internal=True, sample_rate=1.0)
+        metrics.incr(
+            WATERMARK_MISSING_METRIC,
+            tags=dict(table_name=table_name),
+            skip_internal=True,
+            sample_rate=1.0,
+        )
         logger.warning(
             "backfill_outboxes.watermark_absent",
             extra={"table_name": table_name, "target_version": target_version},
         )
-        return
+        return None
 
     lower, version = state
     metrics.gauge(WATERMARK_STATE_METRIC, lower, tags=dict(table_name=table_name), sample_rate=1.0)
     metrics.gauge(
         WATERMARK_VERSION_METRIC, version, tags=dict(table_name=table_name), sample_rate=1.0
     )
-    logger.info(
-        "backfill_outboxes.watermark_state",
-        extra={
-            "table_name": table_name,
-            "low_bound": lower,
-            "version": version,
-            "target_version": target_version,
-        },
-    )
+    return state
 
 
-def refresh_backfill_watermarks(silo_mode: SiloMode, force_synchronous: bool = False) -> None:
+def report_backfill_watermarks(silo_mode: SiloMode, force_synchronous: bool = False) -> None:
     """
-    Visit every backfill watermark key once, and report what it holds.
+    Read every backfill watermark once, and report what it holds.
     """
     try:
         for model in _backfill_models(silo_mode):
             try:
-                _refresh_watermark_for_model(model, force_synchronous=force_synchronous)
+                state = _report_watermark_for_model(model, force_synchronous=force_synchronous)
             except Exception:
                 # One bad table must not stop the rest of the walk.
-                metrics.incr(WATERMARK_REPORT_ERROR_METRIC, skip_internal=True, sample_rate=1.0)
+                metrics.incr(
+                    WATERMARK_REPORT_ERROR_METRIC,
+                    tags=dict(table_name=model._meta.db_table),
+                    skip_internal=True,
+                    sample_rate=1.0,
+                )
                 logger.exception(
                     "backfill_outboxes.watermark_report_failed",
                     extra={"table_name": model._meta.db_table},
                 )
+                continue
+
+            if state is None:
+                continue
+
+            # TODO: we'll dual-write to Postgres here
     except Exception:
         metrics.incr(WATERMARK_REPORT_ERROR_METRIC, skip_internal=True, sample_rate=1.0)
         logger.exception("backfill_outboxes.watermark_report_failed")
@@ -315,7 +323,7 @@ def backfill_outboxes_for(
         extra={"remaining": remaining_to_backfill, "scheduled": scheduled_count},
     )
 
-    refresh_backfill_watermarks(silo_mode, force_synchronous=force_synchronous)
+    report_backfill_watermarks(silo_mode, force_synchronous=force_synchronous)
 
     if remaining_to_backfill > 0:
         for model in _backfill_models(silo_mode):

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -206,8 +206,6 @@ WATERMARK_VERSION_METRIC = "backfill_outboxes.watermark_version"
 # version the backfill is working towards (per-table)
 WATERMARK_TARGET_VERSION_METRIC = "backfill_outboxes.watermark_target_version"
 
-WATERMARK_MISSING_METRIC = "backfill_outboxes.watermark_missing"
-
 # reporting errors, debugging only
 WATERMARK_REPORT_ERROR_METRIC = "backfill_outboxes.watermark_report_error"
 
@@ -256,12 +254,6 @@ def _report_watermark_for_model(
 
     state = read_processing_state(table_name)
     if state is None:
-        metrics.incr(
-            WATERMARK_MISSING_METRIC,
-            tags=dict(table_name=table_name),
-            skip_internal=True,
-            sample_rate=1.0,
-        )
         logger.warning(
             "backfill_outboxes.watermark_absent",
             extra={"table_name": table_name, "target_version": target_version},

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -217,7 +217,7 @@ def _backfill_models(
     silo_mode: SiloMode,
 ) -> list[type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User]]:
     """
-    The models the backfill loop would look at in this silo mode.
+    The models the backfill loop processes in this silo mode.
     """
     found: list[
         type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User]
@@ -318,29 +318,18 @@ def backfill_outboxes_for(
     refresh_backfill_watermarks(silo_mode, force_synchronous=force_synchronous)
 
     if remaining_to_backfill > 0:
-        for app, app_models in apps.all_models.items():
-            for model in app_models.values():
-                if not hasattr(model._meta, "silo_limit"):
-                    continue
+        for model in _backfill_models(silo_mode):
+            # If we find some backfill work to perform, do it.
+            batch = process_outbox_backfill_batch(
+                model, batch_size=remaining_to_backfill, force_synchronous=force_synchronous
+            )
+            if batch is None:
+                continue
 
-                # Only process models local this operational mode.
-                if (
-                    silo_mode is not SiloMode.MONOLITH
-                    and silo_mode not in model._meta.silo_limit.modes
-                ):
-                    continue
-
-                # If we find some backfill work to perform, do it.
-                batch = process_outbox_backfill_batch(
-                    model, batch_size=remaining_to_backfill, force_synchronous=force_synchronous
-                )
-                if batch is None:
-                    continue
-
-                remaining_to_backfill -= batch.count
-                backfilled += batch.count
-                if remaining_to_backfill <= 0:
-                    break
+            remaining_to_backfill -= batch.count
+            backfilled += batch.count
+            if remaining_to_backfill <= 0:
+                break
 
     metrics.incr(
         "backfill_outboxes.backfilled",

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -18,6 +18,7 @@ from sentry.hybridcloud.tasks.backfill_outboxes import (
     WATERMARK_VERSION_METRIC,
     _backfill_models,
     _get_redis_client,
+    _report_watermark_for_model,
     backfill_outboxes_for,
     get_backfill_key,
     get_processing_state,
@@ -423,3 +424,36 @@ def test_backfill_stops_at_the_budget() -> None:
 
     assert seen, "the walk never reached a model"
     assert [size for size in seen if size <= 0] == []
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_names_the_table_it_lost() -> None:
+    """The counters are what an alert reads, so they have to say which table."""
+    reset_processing_state()
+    kept = AuthProvider._meta.db_table
+    set_processing_state(kept, 7, 1)
+
+    with patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock:
+        backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    missing = {
+        call.kwargs["tags"]["table_name"]
+        for call in metrics_mock.incr.call_args_list
+        if call.args[0] == WATERMARK_MISSING_METRIC
+    }
+    assert kept not in missing
+    assert missing == {m._meta.db_table for m in _backfill_models(SiloMode.CONTROL)} - {kept}
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_hands_back_the_stored_pair() -> None:
+    """The dual write mirrors this pair, so the report has to return it."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(table_name, 8080, 2)
+
+    assert _report_watermark_for_model(AuthProvider, force_synchronous=False) == (8080, 2)
+    # An absent key reports itself and yields nothing to mirror.
+    assert _report_watermark_for_model(ApiToken, force_synchronous=False) is None

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -11,10 +11,19 @@ from sentry.hybridcloud.models.apitokenreplica import ApiTokenReplica
 from sentry.hybridcloud.models.outbox import CellOutbox, ControlOutbox, outbox_context
 from sentry.hybridcloud.outbox.base import run_outbox_replications_for_self_hosted
 from sentry.hybridcloud.tasks.backfill_outboxes import (
+    WATERMARK_MISSING_METRIC,
+    WATERMARK_REPORT_ERROR_METRIC,
+    WATERMARK_STATE_METRIC,
+    WATERMARK_TARGET_VERSION_METRIC,
+    WATERMARK_VERSION_METRIC,
+    _backfill_models,
+    _get_redis_client,
     backfill_outboxes_for,
     get_backfill_key,
     get_processing_state,
     process_outbox_backfill_batch,
+    read_processing_state,
+    set_processing_state,
 )
 from sentry.models.apitoken import ApiToken
 from sentry.models.authidentity import AuthIdentity
@@ -236,3 +245,145 @@ def test_run_outbox_replications_for_self_hosted() -> None:
 
     assert AuthProviderReplica.objects.count() == 1
     assert OrganizationMapping.objects.count() == 1
+
+
+def _gauge_values(metrics_mock: Any, name: str) -> dict[str, int]:
+    """Collect {table_name: value} from the gauge calls made on a mocked metrics module."""
+    found = {}
+    for call in metrics_mock.gauge.call_args_list:
+        if call.args[0] != name:
+            continue
+        found[call.kwargs["tags"]["table_name"]] = call.args[1]
+    return found
+
+
+def _counter_calls(metrics_mock: Any, name: str) -> int:
+    return sum(1 for call in metrics_mock.incr.call_args_list if call.args[0] == name)
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_runs_without_budget() -> None:
+    """The pass sits above the budget branch, so a starved tick still reports."""
+    reset_processing_state()
+    set_processing_state(AuthProvider._meta.db_table, 41, 1)
+
+    with patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock:
+        # No budget at all, so the backfill loop itself does nothing.
+        assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC)[AuthProvider._meta.db_table] == 41
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_covers_a_finished_table() -> None:
+    """A table past its target version returns None from the loop, but must still report."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    finished_version = AuthProvider.replication_version + 1
+    set_processing_state(table_name, 0, finished_version)
+
+    with patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock:
+        # Budget of 1, so the loop really runs. Every control table is past its
+        # target version here, so the loop finds no work and writes nothing.
+        assert not backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
+
+    # The loop did walk the tables: it created a key for every table that had none.
+    assert read_processing_state(ApiToken._meta.db_table) == (0, 1)
+    # It left the finished table alone.
+    assert read_processing_state(table_name) == (0, finished_version)
+    # The table is finished: its stored version is above every possible target.
+    assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC)[table_name] == 0
+    assert _gauge_values(metrics_mock, WATERMARK_VERSION_METRIC)[table_name] == finished_version
+    assert _gauge_values(metrics_mock, WATERMARK_TARGET_VERSION_METRIC)[table_name] == 0
+    assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 0
+    # Every other control table was cleared, so only they count as missing.
+    assert _counter_calls(metrics_mock, WATERMARK_MISSING_METRIC) == (
+        len(_backfill_models(SiloMode.CONTROL)) - 1
+    )
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_creates_no_key() -> None:
+    """Reporting must not write. get_processing_state would create (0, 1) on a miss."""
+    reset_processing_state()
+    models = _backfill_models(SiloMode.CONTROL)
+    assert models
+
+    with patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock:
+        backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    client = _get_redis_client()
+    for model in models:
+        assert client.get(get_backfill_key(model._meta.db_table)) is None
+
+    assert _counter_calls(metrics_mock, WATERMARK_MISSING_METRIC) == len(models)
+    assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 0
+    assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC) == {}
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_leaves_a_stored_value_alone() -> None:
+    """An existing key keeps its exact stored bytes after the pass."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(table_name, 12345, 3)
+    client = _get_redis_client()
+    before = client.get(get_backfill_key(table_name))
+
+    backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    assert client.get(get_backfill_key(table_name)) == before
+    assert read_processing_state(table_name) == (12345, 3)
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_continues_when_one_table_raises() -> None:
+    """One bad table must not stop the walk, and must not fail the scheduler tick."""
+    reset_processing_state()
+    broken_table = AuthProvider._meta.db_table
+    good_table = ApiToken._meta.db_table
+    set_processing_state(good_table, 7, 1)
+
+    real_read = read_processing_state
+
+    def fail_for_one(table_name: str) -> tuple[int, int] | None:
+        if table_name == broken_table:
+            raise ValueError("boom")
+        return real_read(table_name)
+
+    with (
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+        patch(
+            "sentry.hybridcloud.tasks.backfill_outboxes.read_processing_state",
+            side_effect=fail_for_one,
+        ),
+    ):
+        # No exception escapes to the caller.
+        backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 1
+    # The walk carried on past the broken table.
+    assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC)[good_table] == 7
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_does_not_fail_the_tick_on_a_registry_error() -> None:
+    """An error outside the per-table walk is caught too."""
+    reset_processing_state()
+
+    with (
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+        patch(
+            "sentry.hybridcloud.tasks.backfill_outboxes._backfill_models",
+            side_effect=ValueError("boom"),
+        ),
+    ):
+        backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 1

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -12,7 +12,6 @@ from sentry.hybridcloud.models.apitokenreplica import ApiTokenReplica
 from sentry.hybridcloud.models.outbox import CellOutbox, ControlOutbox, outbox_context
 from sentry.hybridcloud.outbox.base import run_outbox_replications_for_self_hosted
 from sentry.hybridcloud.tasks.backfill_outboxes import (
-    WATERMARK_MISSING_METRIC,
     WATERMARK_REPORT_ERROR_METRIC,
     WATERMARK_STATE_METRIC,
     WATERMARK_TARGET_VERSION_METRIC,
@@ -303,7 +302,6 @@ def test_watermark_report_covers_a_finished_table() -> None:
     assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 0
     # The report sits below the loop, so it sees the keys the loop just created. The loop
     # walked every table on this cycle, so every table reports a pair.
-    assert _counter_calls(metrics_mock, WATERMARK_MISSING_METRIC) == 0
     assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC).keys() == {
         model._meta.db_table for model in _backfill_models(SiloMode.CONTROL)
     }
@@ -359,7 +357,6 @@ def test_watermark_report_carries_the_value_the_cycle_left() -> None:
 
     reported = _gauge_values(metrics_mock, WATERMARK_STATE_METRIC)
     assert reported.keys() == {model._meta.db_table for model in models}
-    assert _counter_calls(metrics_mock, WATERMARK_MISSING_METRIC) == 0
     # Every table reports what Redis holds now, not what it held at the start of the cycle.
     for table_name, value in reported.items():
         assert read_processing_state(table_name) == (value, ANY)
@@ -371,11 +368,8 @@ def test_watermark_report_carries_the_value_the_cycle_left() -> None:
 
 @django_db_all
 @no_silo_test
-def test_watermark_report_marks_a_table_the_loop_never_reached() -> None:
-    """A spent budget ends the walk early, so a later table has no watermark to report.
-
-    The loop ran on this cycle. A missing key is not by itself a dropped key.
-    """
+def test_watermark_report_skips_a_table_the_loop_never_reached() -> None:
+    """A spent budget ends the walk early, so a later table has no watermark to report."""
     reset_processing_state()
     with outbox_context(flush=False):
         for _ in range(5):
@@ -390,15 +384,11 @@ def test_watermark_report_marks_a_table_the_loop_never_reached() -> None:
         backfill_outboxes_for(SiloMode.CONTROL, 0, 2)
 
     reported = set(_gauge_values(metrics_mock, WATERMARK_STATE_METRIC))
-    missing = {
-        call.kwargs["tags"]["table_name"]
-        for call in metrics_mock.incr.call_args_list
-        if call.args[0] == WATERMARK_MISSING_METRIC
-    }
     tables = {model._meta.db_table for model in _backfill_models(SiloMode.CONTROL)}
-    assert AuthProvider._meta.db_table in missing
-    assert reported | missing == tables
-    assert not reported & missing
+    # The budget ran out on auth_user, so the tables after it were never given a key.
+    assert User._meta.db_table in reported
+    assert AuthProvider._meta.db_table not in reported
+    assert reported < tables
 
 
 @django_db_all
@@ -416,7 +406,6 @@ def test_watermark_report_creates_no_key() -> None:
     for model in models:
         assert client.get(get_backfill_key(model._meta.db_table)) is None
 
-    assert _counter_calls(metrics_mock, WATERMARK_MISSING_METRIC) == len(models)
     assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 0
     assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC) == {}
 
@@ -519,26 +508,6 @@ def test_backfill_stops_at_the_budget() -> None:
 
     assert seen, "the walk never reached a model"
     assert [size for size in seen if size <= 0] == []
-
-
-@django_db_all
-@no_silo_test
-def test_watermark_report_names_the_table_it_lost() -> None:
-    """The counters are what an alert reads, so they have to say which table."""
-    reset_processing_state()
-    kept = AuthProvider._meta.db_table
-    set_processing_state(kept, 7, 1)
-
-    with patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock:
-        backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
-
-    missing = {
-        call.kwargs["tags"]["table_name"]
-        for call in metrics_mock.incr.call_args_list
-        if call.args[0] == WATERMARK_MISSING_METRIC
-    }
-    assert kept not in missing
-    assert missing == {m._meta.db_table for m in _backfill_models(SiloMode.CONTROL)} - {kept}
 
 
 @django_db_all

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -300,10 +300,12 @@ def test_watermark_report_covers_a_finished_table() -> None:
     assert _gauge_values(metrics_mock, WATERMARK_VERSION_METRIC)[table_name] == finished_version
     assert _gauge_values(metrics_mock, WATERMARK_TARGET_VERSION_METRIC)[table_name] == 0
     assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 0
-    # Every other control table was cleared, so only they count as missing.
-    assert _counter_calls(metrics_mock, WATERMARK_MISSING_METRIC) == (
-        len(_backfill_models(SiloMode.CONTROL)) - 1
-    )
+    # The report sits below the loop, so it sees the keys the loop just created and every
+    # control table reports a pair. Only a tick that skips the loop can report a missing key.
+    assert _counter_calls(metrics_mock, WATERMARK_MISSING_METRIC) == 0
+    assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC).keys() == {
+        model._meta.db_table for model in _backfill_models(SiloMode.CONTROL)
+    }
 
 
 @django_db_all

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -43,6 +43,7 @@ from sentry.testutils.silo import (
     create_test_cells,
     no_silo_test,
 )
+from sentry.users.models.user import User
 from sentry.utils import redis
 
 
@@ -387,3 +388,38 @@ def test_watermark_report_does_not_fail_the_tick_on_a_registry_error() -> None:
         backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
     assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 1
+
+
+@django_db_all
+@no_silo_test
+def test_backfill_stops_at_the_budget() -> None:
+    """A spent budget must end the walk, not carry a non-positive batch size to later models.
+
+    process_outbox_backfill_batch treats batch_size <= 0 as an empty page, reads
+    has_more as False, and marks the table complete having produced nothing.
+    """
+    reset_processing_state()
+    with outbox_context(flush=False):
+        for _ in range(5):
+            Factories.create_user()
+
+    seen: list[int] = []
+    real = process_outbox_backfill_batch
+
+    def spy(model: Any, batch_size: int, force_synchronous: bool = False) -> Any:
+        seen.append(batch_size)
+        return real(model, batch_size, force_synchronous=force_synchronous)
+
+    with (
+        override_options(
+            {"outbox_replication.auth_user.replication_version": User.replication_version}
+        ),
+        patch(
+            "sentry.hybridcloud.tasks.backfill_outboxes.process_outbox_backfill_batch",
+            side_effect=spy,
+        ),
+    ):
+        backfill_outboxes_for(SiloMode.CONTROL, 0, 2)
+
+    assert seen, "the walk never reached a model"
+    assert [size for size in seen if size <= 0] == []

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -1,7 +1,8 @@
 from collections.abc import Callable
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import ANY, patch
 
+import pytest
 from django.apps import apps
 from django.db import router, transaction
 from django.test.utils import override_settings
@@ -300,12 +301,104 @@ def test_watermark_report_covers_a_finished_table() -> None:
     assert _gauge_values(metrics_mock, WATERMARK_VERSION_METRIC)[table_name] == finished_version
     assert _gauge_values(metrics_mock, WATERMARK_TARGET_VERSION_METRIC)[table_name] == 0
     assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 0
-    # The report sits below the loop, so it sees the keys the loop just created and every
-    # control table reports a pair. Only a tick that skips the loop can report a missing key.
+    # The report sits below the loop, so it sees the keys the loop just created. The loop
+    # walked every table on this cycle, so every table reports a pair.
     assert _counter_calls(metrics_mock, WATERMARK_MISSING_METRIC) == 0
     assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC).keys() == {
         model._meta.db_table for model in _backfill_models(SiloMode.CONTROL)
     }
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_survives_a_failing_backfill_loop() -> None:
+    """The loop above the report is unguarded. Its failure must not take the report away."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(table_name, 41, 1)
+
+    def boom(model: Any, batch_size: int, force_synchronous: bool = False) -> Any:
+        raise RuntimeError("the backfill loop is broken")
+
+    with (
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+        patch(
+            "sentry.hybridcloud.tasks.backfill_outboxes.process_outbox_backfill_batch",
+            side_effect=boom,
+        ),
+        # The scheduler still sees the failure. Only the report is kept out of its way.
+        pytest.raises(RuntimeError),
+    ):
+        backfill_outboxes_for(SiloMode.CONTROL, 0, 10_000)
+
+    assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC)[table_name] == 41
+    assert _gauge_values(metrics_mock, WATERMARK_VERSION_METRIC)[table_name] == 1
+    assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 0
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_carries_the_value_the_cycle_left() -> None:
+    """The report runs after the loop, so a table the loop moved reports its new value."""
+    reset_processing_state()
+    models = _backfill_models(SiloMode.CONTROL)
+    for model in models:
+        set_processing_state(model._meta.db_table, 3, 1)
+    with outbox_context(flush=False):
+        for _ in range(5):
+            Factories.create_user()
+
+    with (
+        override_options(
+            {"outbox_replication.auth_user.replication_version": User.replication_version}
+        ),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+    ):
+        # A budget of 2 against 5 users: the loop advances auth_user, then breaks.
+        backfill_outboxes_for(SiloMode.CONTROL, 0, 2)
+
+    reported = _gauge_values(metrics_mock, WATERMARK_STATE_METRIC)
+    assert reported.keys() == {model._meta.db_table for model in models}
+    assert _counter_calls(metrics_mock, WATERMARK_MISSING_METRIC) == 0
+    # Every table reports what Redis holds now, not what it held at the start of the cycle.
+    for table_name, value in reported.items():
+        assert read_processing_state(table_name) == (value, ANY)
+    # The cycle moved this one off the value it started on.
+    assert reported[User._meta.db_table] != 3
+    # A table the loop never reached still reports its stored value.
+    assert reported[AuthProvider._meta.db_table] == 3
+
+
+@django_db_all
+@no_silo_test
+def test_watermark_report_marks_a_table_the_loop_never_reached() -> None:
+    """A spent budget ends the walk early, so a later table has no watermark to report.
+
+    The loop ran on this cycle. A missing key is not by itself a dropped key.
+    """
+    reset_processing_state()
+    with outbox_context(flush=False):
+        for _ in range(5):
+            Factories.create_user()
+
+    with (
+        override_options(
+            {"outbox_replication.auth_user.replication_version": User.replication_version}
+        ),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+    ):
+        backfill_outboxes_for(SiloMode.CONTROL, 0, 2)
+
+    reported = set(_gauge_values(metrics_mock, WATERMARK_STATE_METRIC))
+    missing = {
+        call.kwargs["tags"]["table_name"]
+        for call in metrics_mock.incr.call_args_list
+        if call.args[0] == WATERMARK_MISSING_METRIC
+    }
+    tables = {model._meta.db_table for model in _backfill_models(SiloMode.CONTROL)}
+    assert AuthProvider._meta.db_table in missing
+    assert reported | missing == tables
+    assert not reported & missing
 
 
 @django_db_all


### PR DESCRIPTION
This is basically fleshing out observability around backfill watermarks prior to any kind of migration. We're adding a reporting pass which is agnostic to backfill budget, aka we want a reporting pass on all backfill data even if that backfill isn't going to happen. It also opens the door to writing to Postgres every backfill cycle, which will be necessary for the migration.

Refs INFRENG-577