### PR TITLE
feat(preprod): Pass organization_slug to launchpad process_artifact task

### DIFF
--- a/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
+++ b/src/sentry/preprod/api/endpoints/preprod_artifact_rerun_analysis.py
@@ -69,7 +69,12 @@ class PreprodArtifactRerunAnalysisEndpoint(PreprodArtifactEndpoint):
             cleanup_old_metrics(head_artifact)
         reset_artifact_data(head_artifact)
 
-        if not dispatch_taskbroker(head_artifact.project.id, organization.id, head_artifact_id):
+        if not dispatch_taskbroker(
+            head_artifact.project.id,
+            organization.id,
+            head_artifact_id,
+            organization_slug=organization.slug,
+        ):
             return Response(
                 {
                     "detail": f"Failed to queue analysis for artifact {head_artifact_id}",
@@ -147,7 +152,10 @@ class PreprodArtifactAdminRerunAnalysisEndpoint(Endpoint):
 
         organization = preprod_artifact.project.organization
         if not dispatch_taskbroker(
-            preprod_artifact.project.id, organization.id, preprod_artifact_id
+            preprod_artifact.project.id,
+            organization.id,
+            preprod_artifact_id,
+            organization_slug=organization.slug,
         ):
             return Response(
                 {
@@ -240,7 +248,12 @@ class PreprodArtifactAdminBatchRerunAnalysisEndpoint(Endpoint):
             cleanup_stats = cleanup_old_metrics(artifact)
             reset_artifact_data(artifact)
 
-            dispatched = dispatch_taskbroker(artifact.project.id, organization.id, artifact_id)
+            dispatched = dispatch_taskbroker(
+                artifact.project.id,
+                organization.id,
+                artifact_id,
+                organization_slug=organization.slug,
+            )
             if not dispatched:
                 artifact.refresh_from_db()
 

--- a/src/sentry/preprod/tasks.py
+++ b/src/sentry/preprod/tasks.py
@@ -67,7 +67,11 @@ logger = logging.getLogger(__name__)
     processing_deadline_duration=60 * 15,
 )
 def process_artifact(
-    artifact_id: str, project_id: str, organization_id: str, **kwargs: Any
+    artifact_id: str,
+    project_id: str,
+    organization_id: str,
+    organization_slug: str | None = None,
+    **kwargs: Any,
 ) -> None:
     pass
 
@@ -167,7 +171,9 @@ def assemble_preprod_artifact(
         except Exception:
             pass
 
-    taskbroker_dispatched = dispatch_taskbroker(project_id, org_id, artifact_id)
+    taskbroker_dispatched = dispatch_taskbroker(
+        project_id, org_id, artifact_id, organization_slug=organization.slug
+    )
     if not taskbroker_dispatched:
         return
 
@@ -1017,7 +1023,9 @@ def detect_expired_preprod_artifacts(**kwargs: Any) -> None:
     )
 
 
-def dispatch_taskbroker(project_id: int, org_id: int, artifact_id: int) -> bool:
+def dispatch_taskbroker(
+    project_id: int, org_id: int, artifact_id: int, organization_slug: str | None = None
+) -> bool:
     try:
         logger.info(
             "preprod.dispatch_taskbroker",
@@ -1032,6 +1040,7 @@ def dispatch_taskbroker(project_id: int, org_id: int, artifact_id: int) -> bool:
             artifact_id=str(artifact_id),
             project_id=str(project_id),
             organization_id=str(org_id),
+            organization_slug=organization_slug,
         )
         return True
     except Exception:

--- a/tests/sentry/preprod/test_tasks.py
+++ b/tests/sentry/preprod/test_tasks.py
@@ -416,7 +416,12 @@ class AssemblePreprodArtifactTest(BaseAssembleTest):
             artifact_id=artifact.id,
         )
 
-        mock_dispatch.assert_called_once_with(self.project.id, self.organization.id, artifact.id)
+        mock_dispatch.assert_called_once_with(
+            self.project.id,
+            self.organization.id,
+            artifact.id,
+            organization_slug=self.organization.slug,
+        )
 
 
 class CreatePreprodArtifactTest(TestCase):


### PR DESCRIPTION
The per-org processing-time views on the Datadog Preprod dashboard group launchpad's `artifact.processing.duration` metric by numeric `organization_id`, which is hard to read when trying to spot which customer is uploading large / slow-to-process builds. The launchpad worker only receives the numeric id today, so the readable slug never reaches the metric.

This threads the organization slug through `dispatch_taskbroker` and the `process_artifact` RPC stub, passing `organization.slug` from all three call sites (the assemble task and the two rerun-analysis endpoints, plus the batch admin endpoint). The launchpad worker appends it as an `organization_slug` tag when present.

The worker already accepts `organization_slug` as an optional argument (getsentry/launchpad#666, deployed first), so this is safe to ship afterward — before that, the arg simply isn't read.

Updated the dispatch assertion in test_tasks.py; the affected task and rerun-analysis endpoint tests pass locally.