### PR TITLE
preprod: attach build uploads to the release containing their head commit (#123124)

### DIFF
--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -250,6 +250,7 @@ def find_release_by_commit_sha(project: Project, head_sha: str) -> Release | Non
         )
         return None
 
+
 @internal_cell_silo_endpoint
 class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
     owner = ApiOwner.EMERGE_TOOLS

--- a/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
+++ b/src/sentry/preprod/api/endpoints/project_preprod_artifact_update.py
@@ -15,6 +15,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import internal_cell_silo_endpoint
 from sentry.models.project import Project
 from sentry.models.release import Release
+from sentry.models.releasecommit import ReleaseCommit
 from sentry.preprod.analytics import PreprodArtifactApiUpdateEvent
 from sentry.preprod.api.bases.preprod_artifact_endpoint import PreprodArtifactEndpoint
 from sentry.preprod.authentication import (
@@ -207,6 +208,47 @@ def find_or_create_release(
         )
         return None
 
+
+def find_release_by_commit_sha(project: Project, head_sha: str) -> Release | None:
+    """
+    Find the most recent release in a project that contains the given commit sha.
+
+    Used to attach preprod artifacts to the release that events actually land
+    on (the one created by the SDK/CLI from `options.release`), instead of
+    minting a bundle-id-named duplicate release that no events will ever
+    reference. See https://github.com/getsentry/sentry/issues/123124
+
+    Args:
+        project: The project the release must belong to
+        head_sha: The head commit sha of the uploaded artifact
+
+    Returns:
+        The most recently created matching Release, or None if no release in
+        this project contains the commit
+    """
+    try:
+        return (
+            Release.objects.filter(
+                organization_id=project.organization_id,
+                projects=project,
+                id__in=ReleaseCommit.objects.filter(
+                    organization_id=project.organization_id,
+                    commit__key=head_sha,
+                ).values_list("release_id", flat=True),
+            )
+            .order_by("-date_added")
+            .first()
+        )
+    except Exception as e:
+        logger.exception(
+            "Failed to find release by commit sha",
+            extra={
+                "project_id": project.id,
+                "head_sha": head_sha,
+                "error": str(e),
+            },
+        )
+        return None
 
 @internal_cell_silo_endpoint
 class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
@@ -403,12 +445,24 @@ class ProjectPreprodArtifactUpdateEndpoint(PreprodArtifactEndpoint):
             and build_version
             and head_artifact.state == PreprodArtifact.ArtifactState.PROCESSED
         ):
-            find_or_create_release(
-                project=project,
-                package=head_artifact.app_id,
-                version=build_version,
-                build_number=build_number,
-            )
+            # Prefer the release the artifact's head commit already belongs to
+            # (e.g. the one sentry-cli created from `options.release`). Falling
+            # back unconditionally to find_or_create_release mints a
+            # bundle-id-named duplicate release that receives no events.
+            # See https://github.com/getsentry/sentry/issues/123124
+            release = None
+            if head_artifact.commit_comparison is not None:
+                release = find_release_by_commit_sha(
+                    project=project,
+                    head_sha=head_artifact.commit_comparison.head_sha,
+                )
+            if release is None:
+                find_or_create_release(
+                    project=project,
+                    package=head_artifact.app_id,
+                    version=build_version,
+                    build_number=build_number,
+                )
 
         # Determine which features can run based on quota and filters
         requested_features: list[PreprodFeature] = []

--- a/src/sentry/releases/endpoints/organization_release_meta.py
+++ b/src/sentry/releases/endpoints/organization_release_meta.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import defaultdict
 from typing import TypedDict
 
+from django.db.models import Q
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -83,12 +84,28 @@ class OrganizationReleaseMetaEndpoint(OrganizationReleasesBaseEndpoint):
         release_project_ids = [pr["project__id"] for pr in project_releases]
 
         parsed_version = parse_release_version(release.version)
-        if parsed_version and release_project_ids:
-            number_of_preprod_builds = PreprodArtifact.objects.filter(
-                app_id=parsed_version.app_id,
-                mobile_app_info__build_version=parsed_version.build_version,
-                project_id__in=release_project_ids,
-            ).count()
+        if release_project_ids:
+            # Preprod builds belong to the release that contains their head
+            # commit (e.g. the one created from `options.release`), even when
+            # the release version is not named after the artifact's bundle id.
+            # See https://github.com/getsentry/sentry/issues/123124
+            preprod_build_filter = Q(
+                commit_comparison__head_sha__in=ReleaseCommit.objects.filter(
+                    release=release
+                ).values("commit__key")
+            )
+            if parsed_version:
+                preprod_build_filter |= Q(
+                    app_id=parsed_version.app_id,
+                    mobile_app_info__build_version=parsed_version.build_version,
+                )
+            number_of_preprod_builds = (
+                PreprodArtifact.objects.filter(
+                    preprod_build_filter, project_id__in=release_project_ids
+                )
+                .distinct()
+                .count()
+            )
         else:
             number_of_preprod_builds = 0
 

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -804,3 +804,100 @@ class FindOrCreateReleaseTest(TestCase):
         assert result_with_build is not None
         assert result_with_build.id == existing_release.id
         assert result_with_build.version == f"{package}@{version}+456"
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    def test_existing_release_matched_by_head_sha_not_duplicated(self) -> None:
+        """Regression test for https://github.com/getsentry/sentry/issues/123124
+
+        sentry-cli creates the release from `options.release` (e.g. android@1.1+930)
+        and associates the build's head commit with it. When the artifact update
+        arrives, we must attach to that release instead of minting a
+        bundle-id-named duplicate (com.mobile@1.1+930) that no events land on.
+        """
+        from sentry.models.release import Release
+
+        head_sha = "a" * 40
+        repo = self.create_repo(project=self.project)
+        sdk_release = self.create_release(self.project, version="android@1.1+930")
+        commit = self.create_commit(repo=repo, project=self.project, key=head_sha)
+        self.create_release_commit(release=sdk_release, commit=commit)
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, head_sha=head_sha
+        )
+        self.preprod_artifact.commit_comparison = commit_comparison
+        self.preprod_artifact.save()
+
+        data = {
+            "app_id": "com.mobile",
+            "build_version": "1.1",
+            "build_number": 930,
+        }
+        response = self._make_request(data)
+        assert response.status_code == 200
+
+        self.preprod_artifact.refresh_from_db()
+        assert self.preprod_artifact.state == PreprodArtifact.ArtifactState.PROCESSED
+
+        # No bundle-id-named duplicate release is created
+        assert not Release.objects.filter(
+            organization_id=self.project.organization_id,
+            projects=self.project,
+            version="com.mobile@1.1+930",
+        ).exists()
+        # The SDK-created release is the only release in the project
+        releases = Release.objects.filter(
+            organization_id=self.project.organization_id, projects=self.project
+        )
+        assert releases.count() == 1
+        assert releases.first() is not None
+        assert releases.first().id == sdk_release.id
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    def test_release_created_when_head_sha_has_no_matching_release(self) -> None:
+        """Fallback: artifact with vcs info whose commit belongs to no release yet
+        still gets the bundle-id-named release (existing behavior)."""
+        from sentry.models.release import Release
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, head_sha="b" * 40
+        )
+        self.preprod_artifact.commit_comparison = commit_comparison
+        self.preprod_artifact.save()
+
+        data = {
+            "app_id": "com.example.app",
+            "build_version": "1.0.0",
+            "build_number": 123,
+        }
+        response = self._make_request(data)
+        assert response.status_code == 200
+
+        releases = Release.objects.filter(
+            organization_id=self.project.organization_id,
+            projects=self.project,
+            version="com.example.app@1.0.0+123",
+        )
+        assert releases.count() == 1
+
+    @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
+    def test_release_created_when_artifact_has_no_commit_comparison(self) -> None:
+        """Fallback: artifact uploaded without vcs info keeps existing behavior."""
+        from sentry.models.release import Release
+
+        assert self.preprod_artifact.commit_comparison is None
+
+        data = {
+            "app_id": "com.example.app",
+            "build_version": "1.0.0",
+            "build_number": 123,
+        }
+        response = self._make_request(data)
+        assert response.status_code == 200
+
+        releases = Release.objects.filter(
+            organization_id=self.project.organization_id,
+            projects=self.project,
+            version="com.example.app@1.0.0+123",
+        )
+        assert releases.count() == 1

--- a/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
+++ b/tests/sentry/preprod/api/endpoints/test_project_preprod_artifact_update.py
@@ -4,7 +4,10 @@ from unittest.mock import patch
 import orjson
 from django.test import override_settings
 
-from sentry.preprod.api.endpoints.project_preprod_artifact_update import find_or_create_release
+from sentry.preprod.api.endpoints.project_preprod_artifact_update import (
+    find_or_create_release,
+    find_release_by_commit_sha,
+)
 from sentry.preprod.models import (
     PreprodArtifact,
     PreprodArtifactMobileAppInfo,
@@ -773,38 +776,6 @@ class ProjectPreprodArtifactUpdateEndpointTest(TestCase):
             == "Distribution disabled for this project"
         )
 
-
-class FindOrCreateReleaseTest(TestCase):
-    def test_exact_version_matching_prevents_incorrect_matches(self) -> None:
-        package = "com.hackernews"
-        version = "1.2.3"
-
-        self.create_release(project=self.project, version=f"{package}@{version}333333")
-        self.create_release(project=self.project, version=f"{package}@{version}.0")
-        self.create_release(project=self.project, version=f"{package}@{version}-beta")
-
-        result = find_or_create_release(self.project, package, version)
-
-        assert result is not None
-        assert result.version == f"{package}@{version}"
-
-    def test_finds_existing_release_regardless_of_build_number(self) -> None:
-        package = "com.example.app"
-        version = "2.1.0"
-
-        existing_release = self.create_release(
-            project=self.project, version=f"{package}@{version}+456"
-        )
-
-        result = find_or_create_release(self.project, package, version)
-        assert result is not None
-        assert result.id == existing_release.id
-
-        result_with_build = find_or_create_release(self.project, package, version, 789)
-        assert result_with_build is not None
-        assert result_with_build.id == existing_release.id
-        assert result_with_build.version == f"{package}@{version}+456"
-
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_existing_release_matched_by_head_sha_not_duplicated(self) -> None:
         """Regression test for https://github.com/getsentry/sentry/issues/123124
@@ -850,8 +821,9 @@ class FindOrCreateReleaseTest(TestCase):
             organization_id=self.project.organization_id, projects=self.project
         )
         assert releases.count() == 1
-        assert releases.first() is not None
-        assert releases.first().id == sdk_release.id
+        first = releases.first()
+        assert first is not None
+        assert first.id == sdk_release.id
 
     @override_settings(LAUNCHPAD_RPC_SHARED_SECRET=["test-secret-key"])
     def test_release_created_when_head_sha_has_no_matching_release(self) -> None:
@@ -901,3 +873,49 @@ class FindOrCreateReleaseTest(TestCase):
             version="com.example.app@1.0.0+123",
         )
         assert releases.count() == 1
+
+
+class FindOrCreateReleaseTest(TestCase):
+    def test_exact_version_matching_prevents_incorrect_matches(self) -> None:
+        package = "com.hackernews"
+        version = "1.2.3"
+
+        self.create_release(project=self.project, version=f"{package}@{version}333333")
+        self.create_release(project=self.project, version=f"{package}@{version}.0")
+        self.create_release(project=self.project, version=f"{package}@{version}-beta")
+
+        result = find_or_create_release(self.project, package, version)
+
+        assert result is not None
+        assert result.version == f"{package}@{version}"
+
+    def test_finds_existing_release_regardless_of_build_number(self) -> None:
+        package = "com.example.app"
+        version = "2.1.0"
+
+        existing_release = self.create_release(
+            project=self.project, version=f"{package}@{version}+456"
+        )
+
+        result = find_or_create_release(self.project, package, version)
+        assert result is not None
+        assert result.id == existing_release.id
+
+        result_with_build = find_or_create_release(self.project, package, version, 789)
+        assert result_with_build is not None
+        assert result_with_build.id == existing_release.id
+        assert result_with_build.version == f"{package}@{version}+456"
+
+    def test_find_release_by_commit_sha(self) -> None:
+        head_sha = "f" * 40
+        repo = self.create_repo(project=self.project)
+        release = self.create_release(project=self.project, version="android@1.1+930")
+        commit = self.create_commit(repo=repo, project=self.project, key=head_sha)
+        self.create_release_commit(release=release, commit=commit)
+
+        result = find_release_by_commit_sha(self.project, head_sha)
+        assert result is not None
+        assert result.id == release.id
+
+        # a commit not attached to any release in this project must not match
+        assert find_release_by_commit_sha(self.project, "0" * 40) is None

--- a/tests/sentry/releases/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_meta.py
@@ -228,7 +228,9 @@ class ReleaseMetaTest(APITestCase):
         head_sha = "c" * 40
         repo = Repository.objects.create(organization_id=org.id, name=project.name)
         commit = Commit.objects.create(organization_id=org.id, repository_id=repo.id, key=head_sha)
-        ReleaseCommit.objects.create(organization_id=org.id, release=release, commit=commit, order=1)
+        ReleaseCommit.objects.create(
+            organization_id=org.id, release=release, commit=commit, order=1
+        )
 
         self.create_member(teams=[team1], user=user, organization=org)
         self.login_as(user=user)
@@ -289,8 +291,8 @@ class ReleaseMetaTest(APITestCase):
         data = orjson.loads(response.content)
         assert data["preprodBuildCount"] == 1
 
-        # Now a build with a different app_id whose commit is not in the
-        # release: must NOT be counted
+        # A build with a different app_id whose commit is not in the release
+        # must NOT be counted
         other_comparison = self.create_commit_comparison(organization=org, head_sha="e" * 40)
         self.create_preprod_artifact(
             project=project,

--- a/tests/sentry/releases/endpoints/test_organization_release_meta.py
+++ b/tests/sentry/releases/endpoints/test_organization_release_meta.py
@@ -208,3 +208,99 @@ class ReleaseMetaTest(APITestCase):
         data = orjson.loads(response.content)
         assert data["releaseFileCount"] == 40
         assert data["isArtifactBundle"]
+
+    def test_preprod_build_count_matched_by_commit_sha(self) -> None:
+        """Regression test for https://github.com/getsentry/sentry/issues/123124
+
+        A preprod build attaches to the release containing its head commit even
+        when the release version is not named after the artifact's bundle id.
+        """
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        team1 = self.create_team(organization=org)
+        project = self.create_project(teams=[team1], organization=org)
+
+        # Release created by sentry-cli from options.release; its version does
+        # not follow the bundle-id convention
+        release = Release.objects.create(organization_id=org.id, version="android@1.1+930")
+        release.add_project(project)
+
+        head_sha = "c" * 40
+        repo = Repository.objects.create(organization_id=org.id, name=project.name)
+        commit = Commit.objects.create(organization_id=org.id, repository_id=repo.id, key=head_sha)
+        ReleaseCommit.objects.create(organization_id=org.id, release=release, commit=commit, order=1)
+
+        self.create_member(teams=[team1], user=user, organization=org)
+        self.login_as(user=user)
+
+        commit_comparison = self.create_commit_comparison(organization=org, head_sha=head_sha)
+        self.create_preprod_artifact(
+            project=project,
+            app_id="com.mobile",
+            build_version="1.1",
+            build_number=930,
+            commit_comparison=commit_comparison,
+        )
+
+        url = reverse(
+            "sentry-api-0-organization-release-meta",
+            kwargs={"organization_id_or_slug": org.slug, "version": release.version},
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        data = orjson.loads(response.content)
+        assert data["preprodBuildCount"] == 1
+
+    def test_preprod_build_count_unmatched_commit_not_counted(self) -> None:
+        """A build whose commit is not in the release must not be counted via
+        the commit path; the name-derived path still applies."""
+        user = self.create_user(is_staff=False, is_superuser=False)
+        org = self.organization
+        team1 = self.create_team(organization=org)
+        project = self.create_project(teams=[team1], organization=org)
+
+        release = Release.objects.create(organization_id=org.id, version="com.mobile@1.1+930")
+        release.add_project(project)
+
+        # Head sha that is not attached to any release's commits
+        other_sha = "d" * 40
+
+        self.create_member(teams=[team1], user=user, organization=org)
+        self.login_as(user=user)
+
+        # Name-matching build with an unrelated commit: counted via name path
+        commit_comparison = self.create_commit_comparison(organization=org, head_sha=other_sha)
+        self.create_preprod_artifact(
+            project=project,
+            app_id="com.mobile",
+            build_version="1.1",
+            build_number=930,
+            commit_comparison=commit_comparison,
+        )
+
+        url = reverse(
+            "sentry-api-0-organization-release-meta",
+            kwargs={"organization_id_or_slug": org.slug, "version": release.version},
+        )
+        response = self.client.get(url)
+
+        assert response.status_code == 200, response.content
+        data = orjson.loads(response.content)
+        assert data["preprodBuildCount"] == 1
+
+        # Now a build with a different app_id whose commit is not in the
+        # release: must NOT be counted
+        other_comparison = self.create_commit_comparison(organization=org, head_sha="e" * 40)
+        self.create_preprod_artifact(
+            project=project,
+            app_id="com.other",
+            build_version="9.9",
+            build_number=1,
+            commit_comparison=other_comparison,
+        )
+
+        response = self.client.get(url)
+        assert response.status_code == 200, response.content
+        data = orjson.loads(response.content)
+        assert data["preprodBuildCount"] == 1


### PR DESCRIPTION
## Summary

Fixes #123124 - `sentry-cli build upload` mints a dead duplicate Release (0 events, broken release analytics) whenever the SDK's `options.release` differs from the artifact's bundle id.

**Root cause:** on transition to `PROCESSED`, the preprod artifact update endpoint resolves the release via `find_or_create_release`, whose attach-side lookup (`^{package@version}(\+\d+)?$`) can only ever match bundle-id-named releases. An `options.release` like `android@1.1+930` never matches, so a second release `com.mobile@1.1+930` is minted - no events ever land on it, and the real release never shows the build. The VCS head sha (stored on the artifact at assemble time) is the join key both sides already share, but it was never used.

**Fix (server-side join on `vcs_info.head_sha`, per the issue's brainstorm):**

- `project_preprod_artifact_update.py`: new `find_release_by_commit_sha` resolves the release whose commits contain the artifact's head sha; the bundle-id find-or-create is now only a fallback when no release contains the commit (or no vcs info was uploaded).
- `organization_release_meta.py`: `preprodBuildCount` additionally counts builds via their commit association, so build size info lands on the release events actually reference.

No CLI changes required.

**Tests:** regression test reproducing the reporter's exact setup (SDK release `android@1.1+930` + head commit attached; artifact bundle id `com.mobile`) asserting no duplicate is minted; fallback tests for no-matching-release and no-vcs-info; release-meta tests for the commit-derived build count and no false positives. The preprod upload path requires a Launchpad token + Emerge preprocessing, so the reporter's CD script can't be run end-to-end here - behavioral guarantee is via unit tests + CI.

> Built by breken, your AI support engineer - breken.ai - this one's on us.