### PR TITLE
ref(conversations): Remove redundant empty bounds branch

### DIFF
--- a/static/app/views/explore/conversations/utils/timeBounds.ts
+++ b/static/app/views/explore/conversations/utils/timeBounds.ts
@@ -4,10 +4,6 @@ export function getTimeBoundsFromNodes(nodes: AITraceSpanNode[]): {
   endTimestamp: number | undefined;
   startTimestamp: number | undefined;
 } {
-  if (nodes.length === 0) {
-    return {startTimestamp: undefined, endTimestamp: undefined};
-  }
-
   let min = Infinity;
   let max = -Infinity;
 


### PR DESCRIPTION
The conversation time-bounds helper special-cased empty arrays even though its existing sentinel conversion already produces the same result.

Remove the redundant early return and let the shared bounds path handle empty arrays.