### PR TITLE
test(seer): Stabilize overview action loading test

### DIFF
--- a/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
+++ b/static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx
@@ -351,12 +351,13 @@ describe('OverviewCardAction', () => {
   });
 
   it('shows a loading state before revealing all options at once', async () => {
+    const codingAgents = Promise.withResolvers<void>();
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/integrations/coding-agents/',
       body: {
         integrations: [{id: '123', name: 'Claude Agent', provider: 'claude_code'}],
       },
-      asyncDelay: 50,
+      asyncDelay: codingAgents.promise,
     });
 
     render(
@@ -373,6 +374,8 @@ describe('OverviewCardAction', () => {
     expect(
       screen.queryByRole('menuitemradio', {name: 'Open Seer'})
     ).not.toBeInTheDocument();
+
+    codingAgents.resolve();
 
     expect(
       await screen.findByRole('menuitemradio', {name: 'Open Seer'})


### PR DESCRIPTION
Replace the fixed API delay in the overview card action test with a controlled pending response. This keeps the loading state observable until the assertion completes and removes dependence on CI timing.

Tests:
- `.devenv/bin/pnpm test-ci static/app/views/seerWorkflows/overview/overviewCardAction.spec.tsx`
- `.venv/bin/prek run -q`