### PR TITLE
fix: incorrect Russian translation in django.po

### DIFF
--- a/src/sentry/locale/ru/LC_MESSAGES/django.po
+++ b/src/sentry/locale/ru/LC_MESSAGES/django.po
@@ -12586,7 +12586,7 @@ msgstr "Расписание"
 #: static/app/views/settings/projectMetrics/blockButton.tsx:45
 #: static/app/views/settings/projectMetrics/blockButton.tsx:47
 msgid "Disable"
-msgstr "Выключтиь"
+msgstr "Выключить"
 
 #: static/app/components/modals/bulkEditMonitorsModal.tsx:96
 #: static/app/views/monitors/details.tsx:115


### PR DESCRIPTION
Fixes #120651

Corrected the Russian translation of "Disable" from the misspelled "Выключтиь" to "Выключить" in `src/sentry/locale/ru/LC_MESSAGES/django.po`.

Could not run the suite locally: runner missing: pnpm. Fork CI needs a maintainer approval to run, so this branch has no test signal yet.

---
This change was prepared with AI assistance under human direction and review.