### PR TITLE
ref(agents): update Explore Agents onboarding arcade

### DIFF
--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -214,7 +214,7 @@ function OnboardingPanel({
                 <Preview>
                   <BodyTitle>{t('Preview Agent Insights')}</BodyTitle>
                   <Arcade
-                    src="https://demo.arcade.software/0NzB6M1Wn8sDsFDAj4sE?embed"
+                    src="https://demo.arcade.software/aEDAYP7ebTJvWKABSBdc?embed"
                     loading="lazy"
                     allowFullScreen
                   />


### PR DESCRIPTION
Points the "Preview Agent Insights" Arcade embed on the Explore > Agents onboarding panel at the refreshed recording.

- Old: `https://demo.arcade.software/0NzB6M1Wn8sDsFDAj4sE?embed`
- New: `https://demo.arcade.software/aEDAYP7ebTJvWKABSBdc?embed`

The new embed URL was verified to load (HTTP 200, page title "Sentry - Explore Agents", 6-step flow starting on "Quickly find conversations").

Frontend-only change — a single string in `static/app/views/insights/pages/agents/onboarding.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)