### PR TITLE
feat(inbound-filters): Serialize catch-all and span filters to Relay

### DIFF
--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from rest_framework import serializers
 
 from sentry.models.custominboundfilter import (
-    DATA_TYPE_BY_CONDITION_TYPE,
     CustomInboundFilter,
     CustomInboundFilterConditionType,
     CustomInboundFilterDataType,
@@ -557,9 +556,9 @@ def _field_matcher(name: str) -> _ConditionMatcher:
     return match
 
 
-# A filter's data type selects the item its conditions match against, since only that
-# item carries such data. Release lives on a different field on each of them.
-_MATCHERS_BY_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMatchers] = {
+# Replays, sessions and profiles are not selectable data types: Relay reads their
+# release under `event.release`, so they cannot be told apart from errors.
+_MATCHERS_BY_SINGLE_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMatchers] = {
     CustomInboundFilterDataType.ERROR: {
         CustomInboundFilterConditionType.ERROR_TYPE: _custom_error_type_condition,
         CustomInboundFilterConditionType.ERROR_MESSAGE: _custom_error_message_condition,
@@ -577,23 +576,69 @@ _MATCHERS_BY_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMatchers]
             "trace_metric.attributes.sentry.release.value"
         ),
     },
+    CustomInboundFilterDataType.SPAN: {
+        CustomInboundFilterConditionType.RELEASE: _field_matcher(
+            "span.attributes.sentry.release.value"
+        ),
+    },
 }
 
 
-def _custom_filter_condition(conditions: list[dict[str, Any]]) -> RuleCondition | None:
+def _any_data_type_matcher(matchers: Sequence[_ConditionMatcher]) -> _ConditionMatcher:
+    # Relay reads a field the item does not carry as no match, so the OR reduces to the
+    # item's own field.
+    def match(values: list[str]) -> RuleCondition:
+        return {"op": "or", "inner": [matcher(values) for matcher in matchers]}
+
+    return match
+
+
+def _build_all_data_types_matchers() -> _ConditionMatchers:
+    per_data_type = list(_MATCHERS_BY_SINGLE_DATA_TYPE.values())
+    shared_condition_types = set.intersection(*(set(matchers) for matchers in per_data_type))
+
+    return {
+        condition_type: _any_data_type_matcher(
+            [matchers[condition_type] for matchers in per_data_type]
+        )
+        for condition_type in CustomInboundFilterConditionType
+        if condition_type in shared_condition_types
+    }
+
+
+_MATCHERS_BY_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMatchers] = {
+    CustomInboundFilterDataType.ALL: _build_all_data_types_matchers(),
+    **_MATCHERS_BY_SINGLE_DATA_TYPE,
+}
+
+
+def get_supported_condition_types(
+    data_type: CustomInboundFilterDataType,
+) -> list[CustomInboundFilterConditionType]:
+    return list(_MATCHERS_BY_DATA_TYPE[data_type])
+
+
+def _custom_filter_condition(
+    conditions: list[dict[str, Any]], data_type: str
+) -> RuleCondition | None:
     """
     Translates a custom inbound filter's conditions into a Relay rule condition.
 
-    Conditions are combined with AND. Returns None if any condition cannot be
-    translated (a type or value shape unknown to this revision, or a type whose
-    data the matched item does not carry): since every condition narrows the
-    match, dropping only the broken condition would filter more data than
-    configured.
+    Conditions are combined with AND. Returns None if the filter cannot be translated
+    (a data type, condition type, or value shape unknown to this revision, or a
+    condition type whose field the filter's data type does not carry): since every
+    condition narrows the match, dropping only the broken condition would filter more
+    data than configured.
     """
     if not conditions:
         return None
 
-    parsed: list[tuple[CustomInboundFilterConditionType, list[str]]] = []
+    try:
+        matchers = _MATCHERS_BY_DATA_TYPE[CustomInboundFilterDataType(data_type)]
+    except ValueError:
+        return None
+
+    rule_conditions: list[RuleCondition] = []
     for condition in conditions:
         try:
             condition_type = CustomInboundFilterConditionType(condition.get("type", ""))
@@ -604,22 +649,6 @@ def _custom_filter_condition(conditions: list[dict[str, Any]]) -> RuleCondition 
         if not (isinstance(values, list) and values and all(isinstance(v, str) for v in values)):
             return None
 
-        parsed.append((condition_type, values))
-
-    # A filter carrying only release conditions falls through to events, mirroring the
-    # legacy `releases` inbound filter.
-    data_type = next(
-        (
-            DATA_TYPE_BY_CONDITION_TYPE[condition_type]
-            for condition_type, _ in parsed
-            if condition_type in DATA_TYPE_BY_CONDITION_TYPE
-        ),
-        CustomInboundFilterDataType.ERROR,
-    )
-    matchers = _MATCHERS_BY_DATA_TYPE[data_type]
-
-    rule_conditions: list[RuleCondition] = []
-    for condition_type, values in parsed:
         matcher = matchers.get(condition_type)
         if matcher is None:
             return None
@@ -637,7 +666,7 @@ def get_custom_inbound_filter_generic_filters(project: Project) -> list[GenericF
         project_id=project.id, active=True
     ).order_by("id")
     for custom_filter in custom_filters:
-        condition = _custom_filter_condition(custom_filter.conditions)
+        condition = _custom_filter_condition(custom_filter.conditions, custom_filter.data_type)
         if condition is not None:
             generic_filters.append(
                 _generic_filter(f"{CUSTOM_INBOUND_FILTER_ID_PREFIX}{custom_filter.id}", condition)

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -630,7 +630,7 @@ def _custom_filter_condition(
     since every condition narrows the match, dropping only the broken condition would
     filter more data than configured.
     """
-    if not conditions:
+    if not conditions or data_type is None:
         return None
 
     try:

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -619,16 +619,16 @@ def get_supported_condition_types(
 
 
 def _custom_filter_condition(
-    conditions: list[dict[str, Any]], data_type: str
+    conditions: list[dict[str, Any]], data_type: str | None
 ) -> RuleCondition | None:
     """
     Translates a custom inbound filter's conditions into a Relay rule condition.
 
     Conditions are combined with AND. Returns None if the filter cannot be translated
-    (a data type, condition type, or value shape unknown to this revision, or a
-    condition type whose field the filter's data type does not carry): since every
-    condition narrows the match, dropping only the broken condition would filter more
-    data than configured.
+    (a missing data type, a data type, condition type, or value shape unknown to this
+    revision, or a condition type whose field the filter's data type does not carry):
+    since every condition narrows the match, dropping only the broken condition would
+    filter more data than configured.
     """
     if not conditions:
         return None

--- a/src/sentry/ingest/inbound_filters.py
+++ b/src/sentry/ingest/inbound_filters.py
@@ -556,8 +556,8 @@ def _field_matcher(name: str) -> _ConditionMatcher:
     return match
 
 
-# Replays, sessions and profiles are not selectable data types: Relay reads their
-# release under `event.release`, so they cannot be told apart from errors.
+# Replays, sessions, profiles and transactions are not selectable data types: Relay
+# reads their release under `event.release`, so they cannot be told apart from errors.
 _MATCHERS_BY_SINGLE_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMatchers] = {
     CustomInboundFilterDataType.ERROR: {
         CustomInboundFilterConditionType.ERROR_TYPE: _custom_error_type_condition,
@@ -576,6 +576,8 @@ _MATCHERS_BY_SINGLE_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMa
             "trace_metric.attributes.sentry.release.value"
         ),
     },
+    # Matches standalone spans only. A span sent inside a transaction is dropped with
+    # the transaction, which the error matcher reads.
     CustomInboundFilterDataType.SPAN: {
         CustomInboundFilterConditionType.RELEASE: _field_matcher(
             "span.attributes.sentry.release.value"
@@ -584,7 +586,7 @@ _MATCHERS_BY_SINGLE_DATA_TYPE: Mapping[CustomInboundFilterDataType, _ConditionMa
 }
 
 
-def _any_data_type_matcher(matchers: Sequence[_ConditionMatcher]) -> _ConditionMatcher:
+def _any_condition_matcher(matchers: Sequence[_ConditionMatcher]) -> _ConditionMatcher:
     # Relay reads a field the item does not carry as no match, so the OR reduces to the
     # item's own field.
     def match(values: list[str]) -> RuleCondition:
@@ -595,10 +597,10 @@ def _any_data_type_matcher(matchers: Sequence[_ConditionMatcher]) -> _ConditionM
 
 def _build_all_data_types_matchers() -> _ConditionMatchers:
     per_data_type = list(_MATCHERS_BY_SINGLE_DATA_TYPE.values())
-    shared_condition_types = set.intersection(*(set(matchers) for matchers in per_data_type))
+    shared_condition_types = set.intersection(*(set(matchers.keys()) for matchers in per_data_type))
 
     return {
-        condition_type: _any_data_type_matcher(
+        condition_type: _any_condition_matcher(
             [matchers[condition_type] for matchers in per_data_type]
         )
         for condition_type in CustomInboundFilterConditionType

--- a/src/sentry/models/custominboundfilter.py
+++ b/src/sentry/models/custominboundfilter.py
@@ -22,6 +22,7 @@ class CustomInboundFilterDataType(StrEnum):
     ERROR = "error"
     LOG = "log"
     METRIC = "metric"
+    SPAN = "span"
 
 
 # The data type each condition reads a field of. A filter targets a single data type,

--- a/tests/sentry/ingest/test_inbound_filters.py
+++ b/tests/sentry/ingest/test_inbound_filters.py
@@ -246,11 +246,29 @@ def error_type_rule_condition(values: list[str]) -> dict:
     }
 
 
+def release_rule_condition(values: list[str]) -> dict:
+    """The catch-all shape: the release field of every data type, combined with OR."""
+    return {
+        "op": "or",
+        "inner": [
+            {"op": "glob", "name": "event.release", "value": values},
+            {"op": "glob", "name": "log.attributes.sentry.release.value", "value": values},
+            {
+                "op": "glob",
+                "name": "trace_metric.attributes.sentry.release.value",
+                "value": values,
+            },
+            {"op": "glob", "name": "span.attributes.sentry.release.value", "value": values},
+        ],
+    }
+
+
 @django_db_all
 @pytest.mark.parametrize(
-    ("conditions", "expected_condition"),
+    ("data_type", "conditions", "expected_condition"),
     [
         pytest.param(
+            "error",
             [
                 {"type": "error_message", "value": ["*ConnectionError*"]},
                 {"type": "release", "value": ["1.*", "2.*"]},
@@ -265,11 +283,13 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="error_message_and_release",
         ),
         pytest.param(
+            "error",
             [{"type": "error_type", "value": ["TypeError", "*Timeout"]}],
             error_type_rule_condition(["TypeError", "*Timeout"]),
             id="error_type_only",
         ),
         pytest.param(
+            "error",
             [
                 {"type": "error_type", "value": ["TypeError"]},
                 {"type": "error_message", "value": ["*undefined*"]},
@@ -284,6 +304,7 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="error_type_and_error_message",
         ),
         pytest.param(
+            "error",
             [
                 {"type": "error_type", "value": ["TypeError"]},
                 {"type": "release", "value": ["1.*"]},
@@ -298,6 +319,7 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="error_type_and_release",
         ),
         pytest.param(
+            "log",
             [
                 {"type": "log_message", "value": ["*DEBUG*"]},
                 {"type": "release", "value": ["1.2.3"]},
@@ -316,6 +338,7 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="log_message_and_release",
         ),
         pytest.param(
+            "metric",
             [
                 {"type": "metric_name", "value": ["checkout.*"]},
                 {"type": "release", "value": ["1.2.3"]},
@@ -334,22 +357,51 @@ def error_type_rule_condition(values: list[str]) -> dict:
             id="metric_name_and_release",
         ),
         pytest.param(
+            "metric",
             [{"type": "metric_name", "value": ["checkout.*"]}],
             {"op": "glob", "name": "trace_metric.name", "value": ["checkout.*"]},
             id="single_condition_is_not_wrapped",
         ),
         pytest.param(
+            "span",
+            [{"type": "release", "value": ["1.2.3"]}],
+            {"op": "glob", "name": "span.attributes.sentry.release.value", "value": ["1.2.3"]},
+            id="release_on_spans",
+        ),
+        pytest.param(
+            "error",
             [{"type": "release", "value": ["1.*"]}],
             {"op": "glob", "name": "event.release", "value": ["1.*"]},
-            id="release_only_targets_events",
+            id="release_on_errors_reads_the_event_field_only",
+        ),
+        pytest.param(
+            "all",
+            [{"type": "release", "value": ["1.*"]}],
+            release_rule_condition(["1.*"]),
+            id="catch_all_release",
+        ),
+        pytest.param(
+            "all",
+            [
+                {"type": "release", "value": [">2*"]},
+                {"type": "release", "value": ["<4*"]},
+            ],
+            {
+                "op": "and",
+                "inner": [
+                    release_rule_condition([">2*"]),
+                    release_rule_condition(["<4*"]),
+                ],
+            },
+            id="catch_all_release_range",
         ),
     ],
 )
 def test_custom_inbound_filter_condition_translation(
-    default_project, factories, conditions, expected_condition
+    default_project, factories, data_type, conditions, expected_condition
 ) -> None:
     custom_filter = factories.create_project_custom_inbound_filter(
-        default_project, conditions=conditions
+        default_project, data_type=data_type, conditions=conditions
     )
 
     [generic_filter] = get_custom_inbound_filter_generic_filters(default_project)
@@ -462,6 +514,25 @@ def test_custom_inbound_filter_skips_untranslatable_filters(default_project, fac
     factories.create_project_custom_inbound_filter(
         default_project,
         conditions=[{"type": "release", "value": []}],
+    )
+    # A data type this revision does not know, e.g. one a newer deploy wrote.
+    factories.create_project_custom_inbound_filter(
+        default_project,
+        data_type="unknown_data_type",
+        conditions=[{"type": "release", "value": ["1.*"]}],
+    )
+    # A span filter accepts release alone, so any other condition disables the filter
+    # rather than widening it.
+    factories.create_project_custom_inbound_filter(
+        default_project,
+        data_type="span",
+        conditions=[{"type": "error_type", "value": ["TypeError"]}],
+    )
+    # A catch-all can only carry conditions every data type has a field for.
+    factories.create_project_custom_inbound_filter(
+        default_project,
+        data_type="all",
+        conditions=[{"type": "error_message", "value": ["*Error*"]}],
     )
     # A log carries no exception type, so a filter mixing data types matches nothing.
     factories.create_project_custom_inbound_filter(

--- a/tests/sentry/ingest/test_inbound_filters.py
+++ b/tests/sentry/ingest/test_inbound_filters.py
@@ -523,6 +523,11 @@ def test_custom_inbound_filter_skips_untranslatable_filters(default_project, fac
         data_type="unknown_data_type",
         conditions=[{"type": "release", "value": ["1.*"]}],
     )
+    # A row written before the column existed carries no data type at all.
+    factories.create_project_custom_inbound_filter(
+        default_project,
+        conditions=[{"type": "release", "value": ["1.*"]}],
+    ).update(data_type=None)
     # A span filter accepts release alone, so any other condition disables the filter
     # rather than widening it.
     factories.create_project_custom_inbound_filter(

--- a/tests/sentry/ingest/test_inbound_filters.py
+++ b/tests/sentry/ingest/test_inbound_filters.py
@@ -423,6 +423,7 @@ def test_custom_inbound_filter_row_becomes_relay_config(default_project, factori
 
     custom_filter = factories.create_project_custom_inbound_filter(
         default_project,
+        data_type="error",
         conditions=[
             {"type": "error_message", "value": ["*ConnectionError*", "Timeout*"]},
             {"type": "release", "value": ["1.*"]},
@@ -506,6 +507,7 @@ def test_custom_inbound_filter_skips_untranslatable_filters(default_project, fac
     # data than the user configured.
     factories.create_project_custom_inbound_filter(
         default_project,
+        data_type="error",
         conditions=[
             {"type": "error_message", "value": ["*Error*"]},
             {"type": "unknown_type", "value": ["nope"]},
@@ -537,6 +539,7 @@ def test_custom_inbound_filter_skips_untranslatable_filters(default_project, fac
     # A log carries no exception type, so a filter mixing data types matches nothing.
     factories.create_project_custom_inbound_filter(
         default_project,
+        data_type="error",
         conditions=[
             {"type": "error_type", "value": ["TypeError"]},
             {"type": "log_message", "value": ["*DEBUG*"]},


### PR DESCRIPTION
- Picks the fields a filter's conditions match from the stored `data_type`, instead of deriving the data type from the conditions themselves.
- Adds a catch-all rule type `all` - this is any ruleset that can apply to any datatype. Each of these expands into an OR over all of their field paths. A condition added to every data type becomes available to catch-all filters with no further work. At the moment this only applies to `release`
- Replays, sessions and profiles stay unselectable: They are discarded along with errors, because they also have `event.release`. We can ref this later if we choose to. 
- Filters with no data type are dropped - but at the moment this table is empty, so it should not have an effect. 

Contributes to TET-2841
