### PR TITLE
feat(inbound-filters): Read and write the filter data type in the API

### DIFF
--- a/src/sentry/api/endpoints/project_custom_inbound_filters.py
+++ b/src/sentry/api/endpoints/project_custom_inbound_filters.py
@@ -17,8 +17,8 @@ from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.paginator import OffsetPaginator
 from sentry.apidocs.constants import RESPONSE_BAD_REQUEST, RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND
 from sentry.apidocs.parameters import GlobalParams
+from sentry.ingest.inbound_filters import get_supported_condition_types
 from sentry.models.custominboundfilter import (
-    DATA_TYPE_BY_CONDITION_TYPE,
     CustomInboundFilter,
     CustomInboundFilterConditionType,
     CustomInboundFilterDataType,
@@ -31,7 +31,6 @@ MAX_FILTERS_PER_PROJECT = 50
 
 
 # Ingestion feature an organization needs before a filter can target a data type.
-# Errors need none.
 _REQUIRED_FEATURE_BY_DATA_TYPE: Mapping[CustomInboundFilterDataType, str] = {
     CustomInboundFilterDataType.LOG: "organizations:ourlogs-ingestion",
     CustomInboundFilterDataType.METRIC: "organizations:tracemetrics-ingestion",
@@ -59,6 +58,15 @@ class CustomInboundFilterSerializer(serializers.ModelSerializer[CustomInboundFil
         max_length=256, allow_blank=True, allow_null=True, required=False, trim_whitespace=True
     )
     active = serializers.BooleanField(required=False)
+    dataType = serializers.ChoiceField(
+        source="data_type",
+        choices=[data_type.value for data_type in CustomInboundFilterDataType],
+        help_text=(
+            "The data the filter matches against. `all` is the catch-all: it filters every "
+            "data type Sentry ingests, including ones added later, and accepts only the "
+            "conditions that every data type carries a field for."
+        ),
+    )
     conditions = CustomInboundFilterConditionSerializer(
         many=True,
         allow_empty=False,
@@ -75,37 +83,54 @@ class CustomInboundFilterSerializer(serializers.ModelSerializer[CustomInboundFil
 
     class Meta:
         model = CustomInboundFilter
-        fields = ["id", "name", "active", "conditions", "dateCreated", "dateUpdated"]
+        fields = ["id", "name", "active", "dataType", "conditions", "dateCreated", "dateUpdated"]
 
     def create(self, validated_data: dict[str, Any]) -> CustomInboundFilter:
         return CustomInboundFilter.objects.create(**validated_data)
 
-    def validate_conditions(self, conditions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    def validate_dataType(self, data_type: str) -> str:
         organization = self.context["project"].organization
         request = self.context["request"]
-        condition_types = {condition["type"] for condition in conditions}
 
-        data_types = {
-            DATA_TYPE_BY_CONDITION_TYPE[condition_type]
-            for condition_type in condition_types
-            if condition_type in DATA_TYPE_BY_CONDITION_TYPE
-        }
-        if len(data_types) > 1:
+        required_feature = _REQUIRED_FEATURE_BY_DATA_TYPE.get(
+            CustomInboundFilterDataType(data_type)
+        )
+        if required_feature and not features.has(
+            required_feature, organization, actor=request.user
+        ):
             raise serializers.ValidationError(
-                "A filter matches one data type, so error, log, and metric conditions "
-                "cannot be combined."
+                f"{data_type.capitalize()} filters are not enabled for this organization."
             )
 
-        for data_type in data_types:
-            required_feature = _REQUIRED_FEATURE_BY_DATA_TYPE.get(data_type)
-            if required_feature and not features.has(
-                required_feature, organization, actor=request.user
-            ):
-                raise serializers.ValidationError(
-                    f"{data_type.capitalize()} filters are not enabled for this organization."
-                )
+        return data_type
 
-        return conditions
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        # A partial update may change the data type or the conditions alone, so the
+        # other side comes from the stored filter.
+        stored = self.instance
+        conditions = attrs.get("conditions")
+        if conditions is None:
+            conditions = stored.conditions if stored else None
+
+        raw_data_type = attrs.get("data_type") or (stored.data_type if stored else None)
+        if conditions is None or raw_data_type is None:
+            return attrs
+
+        data_type = CustomInboundFilterDataType(raw_data_type)
+        supported = get_supported_condition_types(data_type)
+        unsupported = sorted({condition["type"] for condition in conditions} - set(supported))
+        if unsupported:
+            raise serializers.ValidationError(
+                {
+                    "conditions": (
+                        f"A filter on {data_type.value} data cannot use the "
+                        f"{', '.join(unsupported)} condition. It accepts "
+                        f"{', '.join(supported)}."
+                    )
+                }
+            )
+
+        return attrs
 
 
 class ProjectCustomInboundFilterEndpoint(ProjectEndpoint):
@@ -132,6 +157,7 @@ class ProjectCustomInboundFilterEndpoint(ProjectEndpoint):
             "filter_id": str(custom_filter.id),
             "filter_name": custom_filter.name,
             "active": custom_filter.active,
+            "data_type": custom_filter.data_type,
             "conditions": custom_filter.conditions,
             "operation": operation,
         }
@@ -304,7 +330,7 @@ class CustomInboundFilterDetailsEndpoint(ProjectCustomInboundFilterEndpoint):
             return Response(serializer.errors, status=400)
 
         changes: dict[str, Any] = {}
-        for field in ("name", "active", "conditions"):
+        for field in ("name", "active", "data_type", "conditions"):
             if field not in serializer.validated_data:
                 continue
 
@@ -323,7 +349,7 @@ class CustomInboundFilterDetailsEndpoint(ProjectCustomInboundFilterEndpoint):
                 event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
                 data=self.get_audit_log_data(project, custom_filter, "edit", changes),
             )
-            if changes.keys() & {"active", "conditions"}:
+            if changes.keys() & {"active", "data_type", "conditions"}:
                 schedule_invalidate_project_config(
                     project_id=project.id, trigger="custom_inbound_filters"
                 )

--- a/src/sentry/api/endpoints/project_custom_inbound_filters.py
+++ b/src/sentry/api/endpoints/project_custom_inbound_filters.py
@@ -113,7 +113,11 @@ class CustomInboundFilterSerializer(serializers.ModelSerializer[CustomInboundFil
             conditions = stored.conditions if stored else None
 
         raw_data_type = attrs.get("data_type") or (stored.data_type if stored else None)
-        if conditions is None or raw_data_type is None:
+        if raw_data_type is None:
+            raise serializers.ValidationError(
+                {"dataType": "This filter has no data type. Send dataType to update it."}
+            )
+        if conditions is None:
             return attrs
 
         data_type = CustomInboundFilterDataType(raw_data_type)

--- a/src/sentry/models/custominboundfilter.py
+++ b/src/sentry/models/custominboundfilter.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
 from enum import StrEnum
 
 from django.db import models
@@ -23,19 +22,6 @@ class CustomInboundFilterDataType(StrEnum):
     LOG = "log"
     METRIC = "metric"
     SPAN = "span"
-
-
-# The data type each condition reads a field of. A filter targets a single data type,
-# so its conditions must all map to the same one. `release` is absent because every
-# data type carries a release, so it does not tie a filter to one data type.
-DATA_TYPE_BY_CONDITION_TYPE: Mapping[
-    CustomInboundFilterConditionType, CustomInboundFilterDataType
-] = {
-    CustomInboundFilterConditionType.ERROR_TYPE: CustomInboundFilterDataType.ERROR,
-    CustomInboundFilterConditionType.ERROR_MESSAGE: CustomInboundFilterDataType.ERROR,
-    CustomInboundFilterConditionType.LOG_MESSAGE: CustomInboundFilterDataType.LOG,
-    CustomInboundFilterConditionType.METRIC_NAME: CustomInboundFilterDataType.METRIC,
-}
 
 
 @cell_silo_model

--- a/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
+++ b/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
@@ -28,6 +28,7 @@ class CustomInboundFiltersTest(APITestCase):
         first_filter = self.create_project_custom_inbound_filter(
             project=self.project,
             name="Release filter",
+            data_type="all",
             conditions=[{"type": "release", "value": ["1.*"]}],
         )
         second_filter = self.create_project_custom_inbound_filter(
@@ -50,12 +51,14 @@ class CustomInboundFiltersTest(APITestCase):
             "id": str(first_filter.id),
             "name": "Release filter",
             "active": True,
+            "dataType": "all",
             "conditions": [{"type": "release", "value": ["1.*"]}],
         }
         assert second_data == {
             "id": str(second_filter.id),
             "name": "Error filter",
             "active": False,
+            "dataType": "error",
             "conditions": [{"type": "error_message", "value": ["TypeError*"]}],
         }
 
@@ -72,6 +75,7 @@ class CustomInboundFiltersTest(APITestCase):
                 method="post",
                 name="Important errors",
                 active=False,
+                dataType="error",
                 conditions=conditions,
                 status_code=201,
             )
@@ -80,6 +84,7 @@ class CustomInboundFiltersTest(APITestCase):
         assert custom_filter.project_id == self.project.id
         assert custom_filter.name == "Important errors"
         assert custom_filter.active is False
+        assert custom_filter.data_type == "error"
         assert custom_filter.conditions == conditions
 
         with assume_test_silo_mode(SiloMode.CONTROL):
@@ -90,6 +95,7 @@ class CustomInboundFiltersTest(APITestCase):
         assert audit_entry.target_object == custom_filter.id
         assert audit_entry.data["operation"] == "add"
         assert audit_entry.data["filter_name"] == "Important errors"
+        assert audit_entry.data["data_type"] == "error"
         assert audit_entry.data["conditions"] == conditions
 
     def test_post_without_name(self) -> None:
@@ -100,6 +106,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.organization.slug,
                 self.project.slug,
                 method="post",
+                dataType="error",
                 conditions=conditions,
                 status_code=201,
             )
@@ -120,47 +127,127 @@ class CustomInboundFiltersTest(APITestCase):
 
         assert response.data["detail"] == "You do not have that feature enabled"
 
-    def test_rejects_conditions_from_two_data_types(self) -> None:
-        conditions = [
-            {"type": "error_message", "value": ["TypeError*"]},
-            {"type": "log_message", "value": ["Rate limit*"]},
+    def test_rejects_condition_the_data_type_does_not_carry(self) -> None:
+        cases = [
+            (
+                "error",
+                [
+                    {"type": "error_message", "value": ["TypeError*"]},
+                    {"type": "log_message", "value": ["Rate limit*"]},
+                ],
+                "A filter on error data cannot use the log_message condition. "
+                "It accepts error_type, error_message, release.",
+            ),
+            (
+                "log",
+                [
+                    {"type": "error_type", "value": ["TypeError"]},
+                    {"type": "log_message", "value": ["Rate limit*"]},
+                ],
+                "A filter on log data cannot use the error_type condition. "
+                "It accepts log_message, release.",
+            ),
+            (
+                "span",
+                [
+                    {"type": "release", "value": ["1.*"]},
+                    {"type": "metric_name", "value": ["counter.*"]},
+                ],
+                "A filter on span data cannot use the metric_name condition. It accepts release.",
+            ),
+            (
+                "all",
+                [
+                    {"type": "release", "value": ["1.*"]},
+                    {"type": "error_message", "value": ["TypeError*"]},
+                ],
+                "A filter on all data cannot use the error_message condition. It accepts release.",
+            ),
         ]
 
-        with self.feature([*self.features, "organizations:ourlogs-ingestion"]):
+        for data_type, conditions, expected in cases:
+            with self.feature([*self.features, "organizations:ourlogs-ingestion"]):
+                response = self.get_error_response(
+                    self.organization.slug,
+                    self.project.slug,
+                    method="post",
+                    name="Mixed data types",
+                    dataType=data_type,
+                    conditions=conditions,
+                )
+
+            assert str(response.data["conditions"][0]) == expected
+
+    def test_post_catch_all(self) -> None:
+        conditions = [{"type": "release", "value": ["1.*"]}]
+
+        with self.feature(self.features), outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                method="post",
+                name="Bad release, every data type",
+                dataType="all",
+                conditions=conditions,
+                status_code=201,
+            )
+
+        custom_filter = CustomInboundFilter.objects.get(id=response.data["id"])
+        assert response.data["dataType"] == "all"
+        assert custom_filter.data_type == "all"
+
+    def test_post_span(self) -> None:
+        """Relay ingests spans for every organization, so a span filter needs no feature."""
+        with self.feature(self.features), outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                method="post",
+                name="Spans from a bad release",
+                dataType="span",
+                conditions=[{"type": "release", "value": ["1.*"]}],
+                status_code=201,
+            )
+
+        custom_filter = CustomInboundFilter.objects.get(id=response.data["id"])
+        assert response.data["dataType"] == "span"
+        assert custom_filter.data_type == "span"
+
+    def test_catch_all_needs_no_ingestion_feature(self) -> None:
+        """The catch-all filters whichever data types the organization ingests."""
+        with self.feature(self.features):
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                method="post",
+                name="Bad release",
+                dataType="all",
+                conditions=[{"type": "release", "value": ["1.*"]}],
+                status_code=201,
+            )
+
+    def test_rejects_unknown_data_type(self) -> None:
+        with self.feature(self.features):
             response = self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
                 method="post",
-                name="Mixed data types",
-                conditions=conditions,
+                dataType="replay",
+                conditions=[{"type": "release", "value": ["1.*"]}],
             )
 
-        assert (
-            str(response.data["conditions"][0])
-            == "A filter matches one data type, so error, log, and metric conditions "
-            "cannot be combined."
-        )
+        assert '"replay" is not a valid choice.' in str(response.data["dataType"][0])
 
-    def test_rejects_error_type_with_another_data_type(self) -> None:
-        conditions = [
-            {"type": "error_type", "value": ["TypeError"]},
-            {"type": "log_message", "value": ["Rate limit*"]},
-        ]
-
-        with self.feature([*self.features, "organizations:ourlogs-ingestion"]):
+    def test_rejects_missing_data_type(self) -> None:
+        with self.feature(self.features):
             response = self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
                 method="post",
-                name="Error type and log",
-                conditions=conditions,
+                conditions=[{"type": "release", "value": ["1.*"]}],
             )
 
-        assert (
-            str(response.data["conditions"][0])
-            == "A filter matches one data type, so error, log, and metric conditions "
-            "cannot be combined."
-        )
+        assert str(response.data["dataType"][0]) == "This field is required."
 
     def test_allows_error_type_with_error_message(self) -> None:
         conditions = [
@@ -174,6 +261,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.project.slug,
                 method="post",
                 name="Type and message",
+                dataType="error",
                 conditions=conditions,
                 status_code=201,
             )
@@ -193,6 +281,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.project.slug,
                 method="post",
                 name="Release range",
+                dataType="error",
                 conditions=conditions,
                 status_code=201,
             )
@@ -207,6 +296,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.project.slug,
                 method="post",
                 name="",
+                dataType="error",
                 conditions=[],
             )
 
@@ -220,6 +310,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.project.slug,
                 method="post",
                 name="Empty value",
+                dataType="error",
                 conditions=[{"type": "release", "value": []}],
             )
 
@@ -235,6 +326,7 @@ class CustomInboundFiltersTest(APITestCase):
                 self.organization.slug,
                 self.project.slug,
                 method="post",
+                dataType="error",
                 conditions=conditions,
             )
 
@@ -253,26 +345,28 @@ class CustomInboundFiltersTest(APITestCase):
                 self.organization.slug,
                 self.project.slug,
                 method="post",
+                dataType="error",
                 conditions=[{"type": "release", "value": ["1.*"]}],
             )
 
         assert "at most 2" in response.data["detail"]
         assert CustomInboundFilter.objects.filter(project_id=self.project.id).count() == 2
 
-    def test_rejects_conditions_without_required_ingestion_feature(self) -> None:
+    def test_rejects_data_type_without_required_ingestion_feature(self) -> None:
         cases = [
-            ("log_message", ["Rate limit*"], "Log filters are not enabled"),
-            ("metric_name", ["counter.*"], "Metric filters are not enabled"),
+            ("log", "log_message", ["Rate limit*"], "Log filters are not enabled"),
+            ("metric", "metric_name", ["counter.*"], "Metric filters are not enabled"),
         ]
-        for condition_type, value, expected in cases:
+        for data_type, condition_type, value, expected in cases:
             with self.feature(self.features):
                 response = self.get_error_response(
                     self.organization.slug,
                     self.project.slug,
                     method="post",
+                    dataType=data_type,
                     conditions=[{"type": condition_type, "value": value}],
                 )
-            assert expected in str(response.data["conditions"][0])
+            assert expected in str(response.data["dataType"][0])
 
 
 class CustomInboundFilterDetailsTest(APITestCase):
@@ -304,6 +398,7 @@ class CustomInboundFilterDetailsTest(APITestCase):
         assert response.data["id"] == str(self.custom_filter.id)
         assert response.data["name"] == "Original filter"
         assert response.data["active"] is True
+        assert response.data["dataType"] == "error"
         assert response.data["conditions"] == [{"type": "release", "value": ["1.*"]}]
 
     def test_put(self) -> None:
@@ -399,25 +494,80 @@ class CustomInboundFilterDetailsTest(APITestCase):
                 event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
             ).exists()
 
-    def test_put_rejects_conditions_from_two_data_types(self) -> None:
-        conditions = [
-            {"type": "error_message", "value": ["TypeError*"]},
-            {"type": "log_message", "value": ["Rate limit*"]},
-        ]
-
+    def test_put_validates_new_conditions_against_stored_data_type(self) -> None:
+        """A partial update sending conditions alone keeps the stored data type."""
         with self.feature([*self.features, "organizations:ourlogs-ingestion"]):
             response = self.get_error_response(
                 self.organization.slug,
                 self.project.slug,
                 self.custom_filter.id,
-                conditions=conditions,
+                conditions=[{"type": "log_message", "value": ["Rate limit*"]}],
             )
 
         assert (
             str(response.data["conditions"][0])
-            == "A filter matches one data type, so error, log, and metric conditions "
-            "cannot be combined."
+            == "A filter on error data cannot use the log_message condition. "
+            "It accepts error_type, error_message, release."
         )
+
+    def test_put_to_catch_all(self) -> None:
+        with self.feature(self.features), outbox_runner():
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                dataType="all",
+            )
+
+        self.custom_filter.refresh_from_db()
+        assert response.data["dataType"] == "all"
+        assert self.custom_filter.data_type == "all"
+
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            audit_entry = AuditLogEntry.objects.get(
+                organization_id=self.organization.id,
+                event=audit_log.get_event_id("CUSTOM_INBOUND_FILTER"),
+            )
+        assert audit_entry.data["changes"] == {"data_type": {"old": "error", "new": "all"}}
+
+    def test_put_widening_data_type_and_conditions_together(self) -> None:
+        """A data type and the conditions it allows are validated as one update."""
+        with self.feature(self.features), outbox_runner():
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                dataType="all",
+                conditions=[{"type": "release", "value": ["2.*"]}],
+            )
+
+        self.custom_filter.refresh_from_db()
+        assert self.custom_filter.data_type == "all"
+        assert self.custom_filter.conditions == [{"type": "release", "value": ["2.*"]}]
+
+    def test_put_rejects_data_type_the_stored_conditions_do_not_fit(self) -> None:
+        """Widening alone would strand conditions the new data type cannot read."""
+        error_filter = self.create_project_custom_inbound_filter(
+            project=self.project,
+            name="Error filter",
+            conditions=[{"type": "error_message", "value": ["TypeError*"]}],
+        )
+
+        with self.feature(self.features):
+            response = self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                error_filter.id,
+                dataType="all",
+            )
+
+        assert (
+            str(response.data["conditions"][0])
+            == "A filter on all data cannot use the error_message condition. "
+            "It accepts release."
+        )
+        error_filter.refresh_from_db()
+        assert error_filter.data_type == "error"
 
     def test_delete(self) -> None:
         with self.feature(self.features), outbox_runner():
@@ -506,7 +656,12 @@ class CustomInboundFilterProjectConfigInvalidationTest(APITestCase):
             args=[self.organization.slug, self.project.slug, self.custom_filter.id],
         )
         cases = [
-            ("post", list_url, {"conditions": [{"type": "release", "value": ["1.*"]}]}, 201),
+            (
+                "post",
+                list_url,
+                {"dataType": "all", "conditions": [{"type": "release", "value": ["1.*"]}]},
+                201,
+            ),
             ("put", details_url, {"active": False}, 200),
             ("delete", details_url, {}, 204),
         ]

--- a/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
+++ b/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
@@ -35,6 +35,7 @@ class CustomInboundFiltersTest(APITestCase):
             project=self.project,
             name="Error filter",
             active=False,
+            data_type="error",
             conditions=[{"type": "error_message", "value": ["TypeError*"]}],
         )
 
@@ -382,6 +383,7 @@ class CustomInboundFilterDetailsTest(APITestCase):
         self.custom_filter = self.create_project_custom_inbound_filter(
             project=self.project,
             name="Original filter",
+            data_type="error",
             conditions=[{"type": "release", "value": ["1.*"]}],
         )
         self.login_as(user=self.user)
@@ -550,6 +552,7 @@ class CustomInboundFilterDetailsTest(APITestCase):
         error_filter = self.create_project_custom_inbound_filter(
             project=self.project,
             name="Error filter",
+            data_type="error",
             conditions=[{"type": "error_message", "value": ["TypeError*"]}],
         )
 

--- a/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
+++ b/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
@@ -572,6 +572,36 @@ class CustomInboundFilterDetailsTest(APITestCase):
         error_filter.refresh_from_db()
         assert error_filter.data_type == "error"
 
+    def test_put_refuses_filter_without_data_type_until_one_is_sent(self) -> None:
+        """A row written before the column existed carries no data type."""
+        self.custom_filter.update(data_type=None)
+
+        with self.feature(self.features):
+            response = self.get_error_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                name="Renamed filter",
+            )
+
+        assert (
+            str(response.data["dataType"][0])
+            == "This filter has no data type. Send dataType to update it."
+        )
+
+        with self.feature(self.features), outbox_runner():
+            self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                name="Renamed filter",
+                dataType="error",
+            )
+
+        self.custom_filter.refresh_from_db()
+        assert self.custom_filter.name == "Renamed filter"
+        assert self.custom_filter.data_type == "error"
+
     def test_delete(self) -> None:
         with self.feature(self.features), outbox_runner():
             self.get_success_response(

--- a/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
+++ b/tests/sentry/api/endpoints/test_project_custom_inbound_filters.py
@@ -572,6 +572,19 @@ class CustomInboundFilterDetailsTest(APITestCase):
         error_filter.refresh_from_db()
         assert error_filter.data_type == "error"
 
+    def test_get_returns_null_data_type_for_filter_written_before_the_column(self) -> None:
+        self.custom_filter.update(data_type=None)
+
+        with self.feature(self.features):
+            response = self.get_success_response(
+                self.organization.slug,
+                self.project.slug,
+                self.custom_filter.id,
+                method="get",
+            )
+
+        assert response.data["dataType"] is None
+
     def test_put_refuses_filter_without_data_type_until_one_is_sent(self) -> None:
         """A row written before the column existed carries no data type."""
         self.custom_filter.update(data_type=None)


### PR DESCRIPTION
- Take `dataType` on create and update, and returns it, instead of deriving the data type from the conditions. This makes `all` and `span` filters possible
- Move the ingestion feature check from the conditions to `dataType`
- Validate conditions against the data type, so a filter can only use conditions its data type carries a field for.
- Adds `data_type` to the audit log payload, and invalidates the project config when it changes.

Contributes to TET-2841

