### PR TITLE
perf(ai-monitoring): Query unfiltered conversations once

### DIFF
--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
@@ -2,7 +2,6 @@ import logging
 import re
 from collections import defaultdict
 from collections.abc import Mapping
-from datetime import datetime
 from typing import Any, TypedDict
 
 import sentry_sdk
@@ -10,14 +9,16 @@ from drf_spectacular.utils import OpenApiParameter, extend_schema
 from rest_framework.request import Request
 from rest_framework.response import Response
 
+from sentry import features
 from sentry.ai_monitoring.conversation_titles import fetch_conversation_titles
-from sentry.ai_monitoring.message_normalizer import (
-    FILTERED,
-    extract_assistant_output,
-    normalize_to_messages,
-    stringify_message_content,
-)
 from sentry.ai_monitoring.serializers import OrganizationAIConversationsSerializer
+from sentry.ai_monitoring.utils import (
+    get_aggregated_first_input,
+    get_aggregated_last_output,
+    get_first_input_message,
+    get_last_output,
+    timestamp_to_float,
+)
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -36,7 +37,7 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.search.eap.occurrences.query_utils import build_escaped_term_filter
 from sentry.search.eap.resolver import SearchResolver
-from sentry.search.eap.types import EAPResponse, SearchResolverConfig
+from sentry.search.eap.types import EAPResponse, FieldsACL, SearchResolverConfig
 from sentry.search.events.constants import NON_FAILURE_STATUS
 from sentry.search.events.types import SAMPLING_MODES, SnubaParams
 from sentry.snuba.referrer import Referrer
@@ -122,80 +123,8 @@ def _extract_conversation_ids(results: EAPResponse) -> list[str]:
     ]
 
 
-def _to_timestamp_float(ts: Any) -> float:
-    """Convert timestamp to float (seconds since epoch)."""
-    if ts is None:
-        return 0.0
-    if isinstance(ts, (int, float)):
-        return float(ts)
-    if hasattr(ts, "timestamp"):
-        return ts.timestamp()
-    if isinstance(ts, str):
-        try:
-            dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
-            return dt.timestamp()
-        except (ValueError, TypeError):
-            return 0.0
-    return 0.0
-
-
 def _compute_timestamp_ms(finish_ts: float) -> int:
     return int(finish_ts * 1000) if finish_ts else 0
-
-
-def _extract_first_user_message(messages: Any) -> str | None:
-    """Extract first user message, handling both old (content) and new (parts) formats."""
-    if isinstance(messages, str) and messages == FILTERED:
-        return FILTERED
-    parsed = normalize_to_messages(messages, "user")
-    if not parsed:
-        return None
-    for msg in parsed:
-        if msg.get("role") == "user":
-            content = stringify_message_content(msg.get("content"))
-            if content:
-                return content
-    return None
-
-
-def _get_first_input_message(row: QueryRow) -> str | None:
-    """
-    Gets first user message from input attributes, checking in priority order.
-    Priority: gen_ai.input.messages > gen_ai.request.messages
-    """
-    # 1. Check new format first (gen_ai.input.messages)
-    input_messages = row.get("gen_ai.input.messages")
-    if input_messages:
-        first_user = _extract_first_user_message(input_messages)
-        if first_user:
-            return first_user
-
-    # 2. Check current format (gen_ai.request.messages)
-    request_messages = row.get("gen_ai.request.messages")
-    if request_messages:
-        return _extract_first_user_message(request_messages)
-
-    return None
-
-
-def _get_last_output(row: QueryRow) -> str | None:
-    """
-    Gets output text from output attributes, checking in priority order.
-    Priority: gen_ai.output.messages > gen_ai.response.text
-    """
-    output_messages = row.get("gen_ai.output.messages")
-    if output_messages:
-        if output_messages == FILTERED:
-            return FILTERED
-        text = extract_assistant_output(output_messages, "assistant")["response_text"]
-        if text:
-            return text
-
-    response_text = row.get("gen_ai.response.text")
-    if response_text:
-        return response_text
-
-    return None
 
 
 def _build_user_response(
@@ -317,13 +246,25 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             return Response(as_validation_errors(serializer), status=400)
 
         validated_data = serializer.validated_data
+        user_query = validated_data.get("query", "")
+        # Filtered requests stay on the legacy path until one EAP query can apply
+        # conversation filters without dropping unrelated summary spans.
+        use_single_query = not user_query.strip() and features.has(
+            "organizations:gen-ai-conversations-single-query", organization
+        )
 
         def data_fn(offset: int, limit: int) -> list[AIConversationResponse]:
+            if use_single_query:
+                return self._get_conversations_single_query(
+                    snuba_params=snuba_params,
+                    offset=offset,
+                    limit=limit,
+                )
             return self._get_conversations(
                 snuba_params=snuba_params,
                 offset=offset,
                 limit=limit,
-                user_query=validated_data.get("query", ""),
+                user_query=user_query,
                 sampling_mode=validated_data.get("samplingMode", "NORMAL"),
             )
 
@@ -345,6 +286,112 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             response["X-Sentry-Direct-Hit"] = "1"
 
         return response
+
+    @trace
+    def _get_conversations_single_query(
+        self,
+        snuba_params: SnubaParams,
+        offset: int,
+        limit: int,
+    ) -> list[AIConversationResponse]:
+        config = SearchResolverConfig(
+            auto_fields=True,
+            disable_aggregate_extrapolation=True,
+            fields_acl=FieldsACL(functions={"collect_unique_if", "first_if", "last_if"}),
+        )
+        operation_filter = "has:gen_ai.operation.type"
+        ai_client_filter = "gen_ai.operation.type:ai_client"
+        agent_filter = "gen_ai.operation.type:agent"
+        tool_filter = "gen_ai.operation.type:tool"
+
+        results = Spans.run_table_query(
+            params=snuba_params,
+            query_string=(
+                "has:gen_ai.conversation.id count_if(`has:gen_ai.operation.type`, span.duration):>0"
+            ),
+            selected_columns=[
+                "gen_ai.conversation.id",
+                "failure_count() as errors",
+                "count_if(gen_ai.operation.type,equals,ai_client) as llm_calls",
+                "count_if(gen_ai.operation.type,equals,tool) as tool_calls",
+                "sum_if(gen_ai.usage.total_tokens,gen_ai.operation.type,equals,ai_client) as total_tokens",
+                "sum_if(gen_ai.usage.input_tokens,gen_ai.operation.type,equals,ai_client) as input_tokens",
+                "sum_if(gen_ai.usage.output_tokens,gen_ai.operation.type,equals,ai_client) as output_tokens",
+                "sum_if(gen_ai.cost.total_tokens,gen_ai.operation.type,equals,ai_client) as total_cost",
+                "sum_if(span.duration,gen_ai.operation.type,equals,ai_client) as generation_duration",
+                "min(precise.start_ts) as start_timestamp",
+                "max(precise.finish_ts) as end_timestamp",
+                "max(timestamp)",
+                f"collect_unique_if(`{operation_filter}`, trace) as trace_ids",
+                f"collect_unique_if(`{operation_filter}`, project.id) as project_ids",
+                f"collect_unique_if(`{agent_filter}`, gen_ai.agent.name) as flow",
+                f"collect_unique_if(`{tool_filter}`, gen_ai.tool.name) as tool_names",
+                "failure_count_if(gen_ai.operation.type,equals,tool) as tool_errors",
+                f"first_if(`{operation_filter}`, user.id, timestamp) as user_id",
+                f"first_if(`{operation_filter}`, user.email, timestamp) as user_email",
+                f"first_if(`{operation_filter}`, user.username, timestamp) as user_username",
+                f"first_if(`{operation_filter}`, user.ip, timestamp) as user_ip",
+                f"first_if(`{ai_client_filter}`, gen_ai.input.messages, timestamp) as input_messages",
+                f"min_if(`{ai_client_filter} has:gen_ai.input.messages`, timestamp) as input_messages_timestamp",
+                f"first_if(`{ai_client_filter}`, gen_ai.request.messages, timestamp) as request_messages",
+                f"min_if(`{ai_client_filter} has:gen_ai.request.messages`, timestamp) as request_messages_timestamp",
+                f"last_if(`{ai_client_filter}`, gen_ai.output.messages, timestamp) as output_messages",
+                f"max_if(`{ai_client_filter} has:gen_ai.output.messages`, timestamp) as output_messages_timestamp",
+                f"last_if(`{ai_client_filter}`, gen_ai.response.text, timestamp) as response_text",
+                f"max_if(`{ai_client_filter} has:gen_ai.response.text`, timestamp) as response_text_timestamp",
+            ],
+            orderby=["-max(timestamp)"],
+            offset=offset,
+            limit=limit,
+            referrer=Referrer.API_AI_CONVERSATIONS_COMPLETE.value,
+            config=config,
+            sampling_mode="HIGHEST_ACCURACY",
+        )
+
+        conversations_map: dict[str, AIConversationResponse] = {}
+        project_ids_by_conversation: dict[str, set[int]] = {}
+        for row in results.get("data", []):
+            conversation, project_ids = self._build_conversation_from_row(row)
+            conversations_map[conversation["conversationId"]] = conversation
+            project_ids_by_conversation[conversation["conversationId"]] = project_ids
+
+        self._apply_titles(conversations_map, project_ids_by_conversation)
+        return list(conversations_map.values())
+
+    def _build_conversation_from_row(
+        self, row: QueryRow
+    ) -> tuple[AIConversationResponse, set[int]]:
+        project_ids = {
+            project_id for project_id in row.get("project_ids", []) if isinstance(project_id, int)
+        }
+        trace_ids = sorted(row.get("trace_ids") or [])
+        conversation = _build_conversation_response(
+            conv_id=str(row.get("gen_ai.conversation.id") or ""),
+            start_timestamp=_compute_timestamp_ms(timestamp_to_float(row.get("start_timestamp"))),
+            end_timestamp=_compute_timestamp_ms(timestamp_to_float(row.get("end_timestamp"))),
+            errors=int(row.get("errors") or 0),
+            llm_calls=int(row.get("llm_calls") or 0),
+            tool_calls=int(row.get("tool_calls") or 0),
+            total_tokens=int(row.get("total_tokens") or 0),
+            input_tokens=int(row.get("input_tokens") or 0),
+            output_tokens=int(row.get("output_tokens") or 0),
+            total_cost=float(row.get("total_cost") or 0),
+            generation_duration=float(row.get("generation_duration") or 0),
+            trace_ids=trace_ids,
+            flow=sorted(row.get("flow") or []),
+            first_input=get_aggregated_first_input(row),
+            last_output=get_aggregated_last_output(row),
+            user=_build_user_response(
+                user_id=row.get("user_id"),
+                user_email=row.get("user_email"),
+                user_username=row.get("user_username"),
+                user_ip=row.get("user_ip"),
+            ),
+            tool_names=sorted(row.get("tool_names") or []),
+            tool_errors=int(row.get("tool_errors") or 0),
+            project_id=min(project_ids, default=None),
+        )
+        return conversation, project_ids
 
     @trace
     def _get_conversations(
@@ -652,15 +699,15 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
                 if not conv_id:
                     continue
 
-                ts = _to_timestamp_float(row.get("timestamp"))
+                ts = timestamp_to_float(row.get("timestamp"))
 
                 # Use the new helper functions for priority-based extraction
                 if conv_id not in first_input_by_conv:
-                    first_user_content = _get_first_input_message(row)
+                    first_user_content = get_first_input_message(row)
                     if first_user_content:
                         first_input_by_conv[conv_id] = first_user_content
 
-                output_content = _get_last_output(row)
+                output_content = get_last_output(row)
                 if output_content:
                     current = last_output_by_conv.get(conv_id)
                     if current is None or ts > current[0]:

--- a/src/sentry/ai_monitoring/utils.py
+++ b/src/sentry/ai_monitoring/utils.py
@@ -1,0 +1,87 @@
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Any
+
+from sentry.ai_monitoring.message_normalizer import (
+    FILTERED,
+    extract_assistant_output,
+    normalize_to_messages,
+    stringify_message_content,
+)
+
+
+def timestamp_to_float(value: Any) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if hasattr(value, "timestamp"):
+        return value.timestamp()
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value.replace("Z", "+00:00")).timestamp()
+        except ValueError:
+            pass
+    return 0.0
+
+
+def _extract_first_user_message(messages: Any) -> str | None:
+    if messages == FILTERED:
+        return FILTERED
+
+    for message in normalize_to_messages(messages, "user") or []:
+        if message.get("role") == "user":
+            return stringify_message_content(message.get("content"))
+    return None
+
+
+def get_first_input_message(row: Mapping[str, Any]) -> str | None:
+    first_input = _extract_first_user_message(row.get("gen_ai.input.messages"))
+    return first_input or _extract_first_user_message(row.get("gen_ai.request.messages"))
+
+
+def get_last_output(row: Mapping[str, Any]) -> str | None:
+    output_messages = row.get("gen_ai.output.messages")
+    if output_messages:
+        if output_messages == FILTERED:
+            return FILTERED
+        output = extract_assistant_output(output_messages, "assistant")["response_text"]
+        if output:
+            return output
+
+    response_text = row.get("gen_ai.response.text")
+    return response_text if isinstance(response_text, str) and response_text else None
+
+
+def get_aggregated_first_input(row: Mapping[str, Any]) -> str | None:
+    input_messages = row.get("input_messages")
+    input_timestamp = timestamp_to_float(row.get("input_messages_timestamp"))
+    request_messages = row.get("request_messages")
+    request_timestamp = timestamp_to_float(row.get("request_messages_timestamp"))
+
+    if (
+        input_messages
+        and input_timestamp
+        and (not request_messages or not request_timestamp or input_timestamp <= request_timestamp)
+    ):
+        return _extract_first_user_message(input_messages)
+    if request_messages and request_timestamp:
+        return _extract_first_user_message(request_messages)
+    return None
+
+
+def get_aggregated_last_output(row: Mapping[str, Any]) -> str | None:
+    output_messages = row.get("output_messages")
+    output_timestamp = timestamp_to_float(row.get("output_messages_timestamp"))
+    response_text = row.get("response_text")
+    response_timestamp = timestamp_to_float(row.get("response_text_timestamp"))
+
+    if (
+        output_messages
+        and output_timestamp
+        and (not response_text or not response_timestamp or output_timestamp >= response_timestamp)
+    ):
+        if output_messages == FILTERED:
+            return FILTERED
+        return extract_assistant_output(output_messages, "assistant")["response_text"]
+    if response_text and response_timestamp and isinstance(response_text, str):
+        return response_text
+    return None

--- a/src/sentry/ai_monitoring/utils.py
+++ b/src/sentry/ai_monitoring/utils.py
@@ -29,7 +29,9 @@ def _extract_first_user_message(messages: Any) -> str | None:
 
     for message in normalize_to_messages(messages, "user") or []:
         if message.get("role") == "user":
-            return stringify_message_content(message.get("content"))
+            content = stringify_message_content(message.get("content"))
+            if content:
+                return content
     return None
 
 
@@ -52,36 +54,37 @@ def get_last_output(row: Mapping[str, Any]) -> str | None:
 
 
 def get_aggregated_first_input(row: Mapping[str, Any]) -> str | None:
-    input_messages = row.get("input_messages")
     input_timestamp = timestamp_to_float(row.get("input_messages_timestamp"))
-    request_messages = row.get("request_messages")
     request_timestamp = timestamp_to_float(row.get("request_messages_timestamp"))
+    input_message = (
+        _extract_first_user_message(row.get("input_messages")) if input_timestamp else None
+    )
+    request_message = (
+        _extract_first_user_message(row.get("request_messages")) if request_timestamp else None
+    )
 
-    if (
-        input_messages
-        and input_timestamp
-        and (not request_messages or not request_timestamp or input_timestamp <= request_timestamp)
-    ):
-        return _extract_first_user_message(input_messages)
-    if request_messages and request_timestamp:
-        return _extract_first_user_message(request_messages)
-    return None
+    if input_message and request_message:
+        return input_message if input_timestamp <= request_timestamp else request_message
+    return input_message or request_message
 
 
 def get_aggregated_last_output(row: Mapping[str, Any]) -> str | None:
-    output_messages = row.get("output_messages")
     output_timestamp = timestamp_to_float(row.get("output_messages_timestamp"))
-    response_text = row.get("response_text")
     response_timestamp = timestamp_to_float(row.get("response_text_timestamp"))
-
-    if (
-        output_messages
-        and output_timestamp
-        and (not response_text or not response_timestamp or output_timestamp >= response_timestamp)
-    ):
+    output_messages = row.get("output_messages")
+    output = None
+    if output_timestamp:
         if output_messages == FILTERED:
-            return FILTERED
-        return extract_assistant_output(output_messages, "assistant")["response_text"]
-    if response_text and response_timestamp and isinstance(response_text, str):
-        return response_text
-    return None
+            output = FILTERED
+        else:
+            output = extract_assistant_output(output_messages, "assistant")["response_text"] or None
+    response_text = row.get("response_text")
+    response = (
+        response_text
+        if response_timestamp and isinstance(response_text, str) and response_text
+        else None
+    )
+
+    if output and response:
+        return output if output_timestamp >= response_timestamp else response
+    return output or response

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -467,6 +467,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:trace-waterfall-version-message", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable Conversation focused views in AI Insights
     manager.add("organizations:gen-ai-conversations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Use one EAP query for AI conversation lists
+    manager.add("organizations:gen-ai-conversations-single-query", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable AI conversation title generation from gen_ai spans
     manager.add("organizations:gen-ai-conversation-title-generation", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enables Conduit demo endpoint and UI

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -6,9 +6,15 @@ from uuid import uuid4
 
 from django.urls import reverse
 
-from sentry.ai_monitoring.endpoints.organization_ai_conversations import (
-    _get_first_input_message,
-    _get_last_output,
+from sentry.ai_monitoring.utils import (
+    get_aggregated_first_input,
+    get_aggregated_last_output,
+)
+from sentry.ai_monitoring.utils import (
+    get_first_input_message as _get_first_input_message,
+)
+from sentry.ai_monitoring.utils import (
+    get_last_output as _get_last_output,
 )
 from sentry.testutils.helpers import parse_link_header
 from sentry.testutils.helpers.datetime import before_now
@@ -111,6 +117,44 @@ class TestGetLastOutput:
         assert _get_last_output(row) == "Hello!"
 
 
+class TestGetAggregatedMessages:
+    def test_first_input_uses_earliest_timestamp(self) -> None:
+        row = {
+            "input_messages": json_string([{"role": "user", "content": "New"}]),
+            "input_messages_timestamp": 2,
+            "request_messages": json_string([{"role": "user", "content": "Old"}]),
+            "request_messages_timestamp": 1,
+        }
+        assert get_aggregated_first_input(row) == "Old"
+
+    def test_first_input_prefers_input_messages_when_timestamps_match(self) -> None:
+        row = {
+            "input_messages": json_string([{"role": "user", "content": "New"}]),
+            "input_messages_timestamp": 1,
+            "request_messages": json_string([{"role": "user", "content": "Old"}]),
+            "request_messages_timestamp": 1,
+        }
+        assert get_aggregated_first_input(row) == "New"
+
+    def test_last_output_uses_latest_timestamp(self) -> None:
+        row = {
+            "output_messages": json_string([{"role": "assistant", "content": "New"}]),
+            "output_messages_timestamp": 2,
+            "response_text": "Old",
+            "response_text_timestamp": 1,
+        }
+        assert get_aggregated_last_output(row) == "New"
+
+    def test_last_output_prefers_output_messages_when_timestamps_match(self) -> None:
+        row = {
+            "output_messages": json_string([{"role": "assistant", "content": "New"}]),
+            "output_messages_timestamp": 1,
+            "response_text": "Old",
+            "response_text_timestamp": 1,
+        }
+        assert get_aggregated_last_output(row) == "New"
+
+
 class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
     view = "sentry-api-0-organization-ai-conversations"
 
@@ -159,6 +203,46 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         response = self.do_request(query)
         assert response.status_code == 200, response.data
         assert len(response.data) == 0
+
+    def test_single_query_requires_operation_type(self) -> None:
+        now = before_now(days=10).replace(microsecond=0)
+        self.store_ai_span(conversation_id=uuid4().hex, timestamp=now)
+
+        query = {
+            "project": [self.project.id],
+            "start": now.isoformat(),
+            "end": (now + timedelta(hours=1)).isoformat(),
+        }
+        with self.feature("organizations:gen-ai-conversations-single-query"):
+            response = self.do_request(query)
+
+        assert response.status_code == 200, response.data
+        assert response.data == []
+
+    @patch(
+        "sentry.ai_monitoring.endpoints.organization_ai_conversations.Spans.run_table_query",
+        return_value={"data": []},
+    )
+    def test_single_query_flag_uses_one_eap_query(self, mock_run_table_query: MagicMock) -> None:
+        with self.feature("organizations:gen-ai-conversations-single-query"):
+            response = self.do_request({"project": [self.project.id]})
+
+        assert response.status_code == 200
+        mock_run_table_query.assert_called_once()
+
+    @patch(
+        "sentry.ai_monitoring.endpoints.organization_ai_conversations.OrganizationAIConversationsEndpoint._get_conversations_single_query"
+    )
+    def test_single_query_flag_keeps_filtered_requests_on_legacy_path(
+        self, single_query: MagicMock
+    ) -> None:
+        with self.feature("organizations:gen-ai-conversations-single-query"):
+            response = self.do_request(
+                {"project": [self.project.id], "query": "gen_ai.tool.name:search"}
+            )
+
+        assert response.status_code == 200
+        single_query.assert_not_called()
 
     def test_single_conversation_single_trace(self) -> None:
         """Test a conversation with all spans in a single trace"""
@@ -232,7 +316,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             "end": (now + timedelta(hours=1)).isoformat(),
         }
 
-        response = self.do_request(query)
+        with self.feature("organizations:gen-ai-conversations-single-query"):
+            response = self.do_request(query)
         assert response.status_code == 200
         assert len(response.data) == 1
 
@@ -286,7 +371,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             "query": f"gen_ai.conversation.id:{conversation_id_1}",
         }
 
-        response = self.do_request(query)
+        with self.feature("organizations:gen-ai-conversations-single-query"):
+            response = self.do_request(query)
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["conversationId"] == conversation_id_1
@@ -462,7 +548,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             "end": (now + timedelta(hours=1)).isoformat(),
         }
 
-        response = self.do_request(query)
+        with self.feature("organizations:gen-ai-conversations-single-query"):
+            response = self.do_request(query)
         assert response.status_code == 200
         assert len(response.data) == 2
 
@@ -472,7 +559,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert next_link["cursor"]
 
         query["cursor"] = next_link["cursor"]
-        response = self.do_request(query)
+        with self.feature("organizations:gen-ai-conversations-single-query"):
+            response = self.do_request(query)
         assert response.status_code == 200
         assert len(response.data) == 1
 
@@ -1475,7 +1563,8 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
             "end": (now + timedelta(hours=1)).isoformat(),
         }
 
-        response = self.do_request(query)
+        with self.feature("organizations:gen-ai-conversations-single-query"):
+            response = self.do_request(query)
         assert response.status_code == 200, response.data
         assert len(response.data) == 1
         assert response.data[0]["title"] == "Refund a duplicate charge"

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -73,6 +73,17 @@ class TestGetFirstInputMessage:
         row = {"gen_ai.request.messages": "[Filtered]"}
         assert _get_first_input_message(row) == "[Filtered]"
 
+    def test_skips_empty_user_message(self) -> None:
+        row = {
+            "gen_ai.input.messages": json_string(
+                [
+                    {"role": "user", "content": ""},
+                    {"role": "user", "content": "Hello"},
+                ]
+            )
+        }
+        assert _get_first_input_message(row) == "Hello"
+
 
 class TestGetLastOutput:
     def test_prefers_output_messages_text_part(self) -> None:
@@ -136,6 +147,15 @@ class TestGetAggregatedMessages:
         }
         assert get_aggregated_first_input(row) == "New"
 
+    def test_first_input_falls_back_when_preferred_field_is_empty(self) -> None:
+        row = {
+            "input_messages": json_string([{"role": "assistant", "content": ""}]),
+            "input_messages_timestamp": 1,
+            "request_messages": json_string([{"role": "user", "content": "Fallback"}]),
+            "request_messages_timestamp": 2,
+        }
+        assert get_aggregated_first_input(row) == "Fallback"
+
     def test_last_output_uses_latest_timestamp(self) -> None:
         row = {
             "output_messages": json_string([{"role": "assistant", "content": "New"}]),
@@ -153,6 +173,15 @@ class TestGetAggregatedMessages:
             "response_text_timestamp": 1,
         }
         assert get_aggregated_last_output(row) == "New"
+
+    def test_last_output_falls_back_when_preferred_field_is_empty(self) -> None:
+        row = {
+            "output_messages": json_string([{"role": "assistant", "content": ""}]),
+            "output_messages_timestamp": 2,
+            "response_text": "Fallback",
+            "response_text_timestamp": 1,
+        }
+        assert get_aggregated_last_output(row) == "Fallback"
 
 
 class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):


### PR DESCRIPTION
Unfiltered AI conversation lists can now build complete summaries with one grouped EAP query instead of fetching conversation IDs and issuing several follow-up queries.

For now this will only work if there are no additional filters, as support for them is more complicated with a single EAP query. They will be implemented in a follow up PR.

Rollout is organization-scoped behind a backend feature flag.

Closes [TET-2907: Consolidate conversation list into one EAP query](https://linear.app/getsentry/issue/TET-2907/consolidate-conversation-list-into-one-eap-query)
