### PR TITLE
feat(attachments): Defer storage for attachments without event ID

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2597,15 +2597,32 @@ def save_pending_attachments(*, project: Project, event_id: str, group_id: int) 
     if not features.has("projects:defer-attachment-storage", project):
         return
 
-    pending_attachments = list(
-        PendingEventAttachment.objects.filter(project_id=project.id, event_id=event_id)
-    )
-    if not pending_attachments:
+    # This runs for every error event of a flagged project, and almost none of them have
+    # a pending attachment. Probe outside a transaction so the common case stays a single
+    # unlocked SELECT rather than a BEGIN/COMMIT round trip.
+    if not PendingEventAttachment.objects.filter(project_id=project.id, event_id=event_id).exists():
         return
 
-    metrics.incr("attachments.pending.persist", amount=len(pending_attachments))
-
     with transaction.atomic(router.db_for_write(EventAttachment)):
+        # Claim the rows under lock. The insert and the delete below are in the same
+        # transaction, so a concurrent promoter -- a duplicate `event_id`, or a sweep over
+        # rows the ingest-time promotion missed -- re-checks under the lock and finds them
+        # gone instead of inserting a second copy and billing the customer twice.
+        #
+        # The row locks live until this block commits, not for as long as the queryset
+        # object does, so materializing the queryset here is precisely what takes them.
+        # Leaving it lazy would take no locks at all.
+        #
+        # `order_by("id")` keeps the lock order deterministic between two callers claiming
+        # overlapping sets of rows.
+        pending_attachments = list(
+            PendingEventAttachment.objects.filter(project_id=project.id, event_id=event_id)
+            .order_by("id")
+            .select_for_update()
+        )
+        if not pending_attachments:
+            return
+
         EventAttachment.objects.bulk_create(
             EventAttachment(
                 project_id=pending.project_id,

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -618,13 +618,16 @@ class EventManager:
         if not is_reprocessed and attachments:
             save_attachments(cache_key, attachments, job)
 
+        # Attachments that were ingested before this event became a pending attachment;
+        # now that the event exists, they can be promoted to real attachments.
+        #
         # NOTE: this might work with is_reprocessed, but let's be conservative for now.
+        # Reprocessed events keep their existing attachments and have their `group_id`
+        # fixed up in `post_process_group` instead.
         if not is_reprocessed:
-            # TODO: Is querying `PendingEventAttachment` for every event feasible?
-            #       Do we need to guard this somehow?
             safe_execute(
                 save_pending_attachments,
-                project_id=job["event"].project_id,
+                project=project,
                 event_id=job["event"].event_id,
                 group_id=group_info.group.id,
             )
@@ -2518,9 +2521,16 @@ def save_attachment(
         date_expires=datetime.now(timezone.utc) + timedelta(days=attachment.retention_days),
     )
 
-    if is_pending and features.has("projects:defer-attachment-storage", project):
+    if (
+        is_pending
+        and group_id is None
+        and features.has("projects:defer-attachment-storage", project)
+    ):
+        # The event this attachment belongs to has not been ingested (yet), so we do not
+        # know whether it will be accepted at all. Park the attachment in
+        # `PendingEventAttachment` with a short TTL; `save_pending_attachments` promotes it
+        # to an `EventAttachment` (and emits the outcome) once the event is saved.
         metrics.incr("attachments.pending.create")
-        assert group_id is None
         db_fields.pop("group_id")
         db_fields["date_expires_retention"] = db_fields["date_expires"]
         db_fields["date_expires"] = datetime.now(timezone.utc) + PENDING_ATTACHMENT_TTL
@@ -2570,34 +2580,70 @@ def save_attachments(cache_key: str | None, attachments: list[Attachment], job: 
         )
 
 
-def save_pending_attachments(*, project_id: int, event_id: str, group_id: str | None) -> None:
-    with transaction.atomic():
-        metrics.incr("attachments.pending.persist")
-        pending_attachments = PendingEventAttachment.objects.filter(
-            project_id=project_id, event_id=event_id
-        )
-        summed_attachment_size = 0
-        for pending_attachment in pending_attachments:
-            EventAttachment.objects.create(
-                **pending_attachment,
-                date_expires=pending_attachment.date_expires_retention,
-                group_id=group_id,
-            )
-            summed_attachment_size += pending_attachment.size
-            pending_attachment.delete()
+def save_pending_attachments(*, project: Project, event_id: str, group_id: int) -> None:
+    """
+    Promote any :class:`PendingEventAttachment` rows for ``event_id`` into real
+    :class:`EventAttachment` rows, now that the event they belong to has been saved.
 
-        if summed_attachment_size > 0:
-            track_outcome(  # TODO
-                org_id=project.organization_id,
-                project_id=project_id,
-                key_id=key_id,
-                outcome=Outcome.ACCEPTED,
-                reason=None,
-                timestamp=now(),  # TODO: is it OK to use now time here?
-                event_id=event_id,
-                category=DataCategory.ATTACHMENT,
-                quantity=summed_attachment_size,
+    Pending attachments are written by the standalone attachment consumer when the
+    attachment arrives before its event (see :func:`save_attachment`). They carry a
+    short TTL in ``date_expires`` and the real retention date in
+    ``date_expires_retention``; promoting them restores the retention date and
+    attaches the ``group_id``.
+
+    Outcomes are only emitted here, on promotion: an attachment whose event never
+    arrives expires without ever being accepted.
+    """
+    if not features.has("projects:defer-attachment-storage", project):
+        return
+
+    pending_attachments = list(
+        PendingEventAttachment.objects.filter(project_id=project.id, event_id=event_id)
+    )
+    if not pending_attachments:
+        return
+
+    metrics.incr("attachments.pending.persist", amount=len(pending_attachments))
+
+    with transaction.atomic(router.db_for_write(EventAttachment)):
+        EventAttachment.objects.bulk_create(
+            EventAttachment(
+                project_id=pending.project_id,
+                group_id=group_id,
+                event_id=pending.event_id,
+                type=pending.type,
+                name=pending.name,
+                content_type=pending.content_type,
+                size=pending.size,
+                sha1=pending.sha1,
+                blob_path=pending.blob_path,
+                date_added=pending.date_added,
+                date_expires=pending.date_expires_retention,
             )
+            for pending in pending_attachments
+        )
+        # NOTE: A queryset delete does not run `Model.delete`, so the blobs referenced by
+        # these rows survive. That is intentional: the `EventAttachment` rows created above
+        # have taken ownership of them.
+        PendingEventAttachment.objects.filter(
+            id__in=[pending.id for pending in pending_attachments]
+        ).delete()
+
+    for pending in pending_attachments:
+        track_outcome(
+            org_id=project.organization_id,
+            project_id=project.id,
+            # NOTE: the standalone attachment consumer does not know the DSN that was used,
+            # so pending attachments are never attributed to a key.
+            key_id=None,
+            outcome=Outcome.ACCEPTED,
+            reason=None,
+            # Bill the attachment at the time it was ingested, not at promotion time.
+            timestamp=pending.date_added,
+            event_id=event_id,
+            category=DataCategory.ATTACHMENT,
+            quantity=pending.size or 1,
+        )
 
 
 @trace

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -630,6 +630,7 @@ class EventManager:
                 project=project,
                 event_id=job["event"].event_id,
                 group_id=group_info.group.id,
+                source="event_manager",
             )
 
         metric_tags = {"from_relay": str("_relay_processed" in job["data"])}
@@ -2580,7 +2581,9 @@ def save_attachments(cache_key: str | None, attachments: list[Attachment], job: 
         )
 
 
-def save_pending_attachments(*, project: Project, event_id: str, group_id: int) -> None:
+def save_pending_attachments(
+    *, project: Project, event_id: str, group_id: int, source: str
+) -> None:
     """
     Promote any :class:`PendingEventAttachment` rows for ``event_id`` into real
     :class:`EventAttachment` rows, now that the event they belong to has been saved.
@@ -2592,7 +2595,13 @@ def save_pending_attachments(*, project: Project, event_id: str, group_id: int) 
     attaches the ``group_id``.
 
     Outcomes are only emitted here, on promotion: an attachment whose event never
-    arrives expires without ever being accepted.
+    arrives expires without ever being accepted. That is what keeps the race described
+    in :func:`sentry.tasks.post_process.update_existing_attachments` from costing the
+    customer money -- an attachment we drop is an attachment we never billed for.
+
+    Safe to call more than once for the same event, and called from two places for
+    exactly that reason: once when the event is saved, and again in post-processing.
+    ``source`` tags the metric so the two can be told apart.
     """
     if not features.has("projects:defer-attachment-storage", project):
         return
@@ -2622,6 +2631,15 @@ def save_pending_attachments(*, project: Project, event_id: str, group_id: int) 
         )
         if not pending_attachments:
             return
+
+        # Pair this against `attachments.pending.create` to see how many pending
+        # attachments are actually making it back out of the table, and split it by
+        # `source` to see how many only got there on the second attempt.
+        metrics.incr(
+            "attachments.pending.persist",
+            amount=len(pending_attachments),
+            tags={"source": source},
+        )
 
         EventAttachment.objects.bulk_create(
             EventAttachment(

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -97,7 +97,12 @@ from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL, convert_crashrepor
 from sentry.models.activity import Activity
 from sentry.models.environment import Environment
 from sentry.models.event import EventDict
-from sentry.models.eventattachment import CRASH_REPORT_TYPES, EventAttachment, get_crashreport_key
+from sentry.models.eventattachment import (
+    CRASH_REPORT_TYPES,
+    EventAttachment,
+    PendingEventAttachment,
+    get_crashreport_key,
+)
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.grouphash import GroupHash
@@ -176,6 +181,10 @@ CRASH_REPORT_TIMEOUT = 24 * 3600  # one day
 HIGH_SEVERITY_THRESHOLD = 0.1
 
 SEER_ERROR_COUNT_KEY = ERROR_COUNT_CACHE_KEY("sentry.seer.severity-failures")
+
+
+# How long attachments may live if their corresponding event is not ingested.
+PENDING_ATTACHMENT_TTL = timedelta(hours=1)
 
 
 @dataclass
@@ -608,6 +617,8 @@ class EventManager:
         # this because of indiv. attachments.
         if not is_reprocessed and attachments:
             save_attachments(cache_key, attachments, job)
+
+        acknowledge_pending_attachments(job["event"].event_id)
 
         metric_tags = {"from_relay": str("_relay_processed" in job["data"])}
 
@@ -2399,6 +2410,7 @@ def save_attachment(
     key_id: int | None = None,
     group_id: int | None = None,
     start_time: float | None = None,
+    is_pending: bool = False,
 ) -> None:
     """
     Persists a cached event attachments into the file store.
@@ -2481,7 +2493,7 @@ def save_attachment(
 
     file = EventAttachment.putfile(project.id, attachment)
 
-    EventAttachment.objects.create(
+    db_fields = dict(
         # lookup:
         project_id=project.id,
         group_id=group_id,
@@ -2496,6 +2508,15 @@ def save_attachment(
         blob_path=file.blob_path,
         date_expires=datetime.now(timezone.utc) + timedelta(days=attachment.retention_days),
     )
+
+    if is_pending:
+        assert group_id is None
+        db_fields.pop("group_id")
+        PendingEventAttachment.objects.create(**db_fields)
+
+        return
+
+    EventAttachment.objects.create()
 
     track_outcome(
         org_id=project.organization_id,
@@ -2533,6 +2554,7 @@ def save_attachments(cache_key: str | None, attachments: list[Attachment], job: 
             key_id=job["key_id"],
             group_id=event.group_id,
             start_time=job["start_time"],
+            is_pending=False,  # we have an event
         )
 
 

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -618,7 +618,16 @@ class EventManager:
         if not is_reprocessed and attachments:
             save_attachments(cache_key, attachments, job)
 
-        acknowledge_pending_attachments(job["event"].event_id)
+        # NOTE: this might work with is_reprocessed, but let's be conservative for now.
+        if not is_reprocessed:
+            # TODO: Is querying `PendingEventAttachment` for every event feasible?
+            #       Do we need to guard this somehow?
+            safe_execute(
+                save_pending_attachments,
+                project_id=job["event"].project_id,
+                event_id=job["event"].event_id,
+                group_id=group_info.group.id,
+            )
 
         metric_tags = {"from_relay": str("_relay_processed" in job["data"])}
 
@@ -2509,14 +2518,17 @@ def save_attachment(
         date_expires=datetime.now(timezone.utc) + timedelta(days=attachment.retention_days),
     )
 
-    if is_pending:
+    if is_pending and features.has("projects:defer-attachment-storage", project):
+        metrics.incr("attachments.pending.create")
         assert group_id is None
         db_fields.pop("group_id")
+        db_fields["date_expires_retention"] = db_fields["date_expires"]
+        db_fields["date_expires"] = datetime.now(timezone.utc) + PENDING_ATTACHMENT_TTL
         PendingEventAttachment.objects.create(**db_fields)
 
         return
 
-    EventAttachment.objects.create()
+    EventAttachment.objects.create(**db_fields)
 
     track_outcome(
         org_id=project.organization_id,
@@ -2556,6 +2568,36 @@ def save_attachments(cache_key: str | None, attachments: list[Attachment], job: 
             start_time=job["start_time"],
             is_pending=False,  # we have an event
         )
+
+
+def save_pending_attachments(*, project_id: int, event_id: str, group_id: str | None) -> None:
+    with transaction.atomic():
+        metrics.incr("attachments.pending.persist")
+        pending_attachments = PendingEventAttachment.objects.filter(
+            project_id=project_id, event_id=event_id
+        )
+        summed_attachment_size = 0
+        for pending_attachment in pending_attachments:
+            EventAttachment.objects.create(
+                **pending_attachment,
+                date_expires=pending_attachment.date_expires_retention,
+                group_id=group_id,
+            )
+            summed_attachment_size += pending_attachment.size
+            pending_attachment.delete()
+
+        if summed_attachment_size > 0:
+            track_outcome(  # TODO
+                org_id=project.organization_id,
+                project_id=project_id,
+                key_id=key_id,
+                outcome=Outcome.ACCEPTED,
+                reason=None,
+                timestamp=now(),  # TODO: is it OK to use now time here?
+                event_id=event_id,
+                category=DataCategory.ATTACHMENT,
+                quantity=summed_attachment_size,
+            )
 
 
 @trace

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2523,7 +2523,8 @@ def save_attachment(
     )
 
     if is_pending and features.has("projects:defer-attachment-storage", project):
-        assert group_id is None
+        if group_id is not None:
+            logger.warning("group_id %s with is_pending=True", group_id)
 
         # The event this attachment belongs to has not been ingested (yet), so we do not
         # know whether it will be accepted at all. Park the attachment in

--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2522,11 +2522,9 @@ def save_attachment(
         date_expires=datetime.now(timezone.utc) + timedelta(days=attachment.retention_days),
     )
 
-    if (
-        is_pending
-        and group_id is None
-        and features.has("projects:defer-attachment-storage", project)
-    ):
+    if is_pending and features.has("projects:defer-attachment-storage", project):
+        assert group_id is None
+
         # The event this attachment belongs to has not been ingested (yet), so we do not
         # know whether it will be accepted at all. Park the attachment in
         # `PendingEventAttachment` with a short TTL; `save_pending_attachments` promotes it

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -531,6 +531,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
 
     manager.add("projects:workflow-engine-performance-detectors", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
+    manager.add("projects:defer-attachment-storage", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+
     manager.add("organizations:relay-generate-billing-outcome", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
 
     manager.add("organizations:claude-code-vault-reuse", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)

--- a/src/sentry/ingest/consumer/processors.py
+++ b/src/sentry/ingest/consumer/processors.py
@@ -395,6 +395,7 @@ def process_individual_attachment(message: IngestMessage, project: Project) -> N
             key_id=None,  # TODO: Inject this from Relay
             group_id=group_id,
             start_time=None,  # TODO: Inject this from Relay
+            is_pending=event is None,
         )
     else:
         logger.error("invalid individual attachment type: %s", attachment_type)

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -123,6 +123,38 @@ class EventAttachmentBase(Model):
     class Meta:
         abstract = True
 
+    def delete_blob(self) -> None:
+        """
+        Delete this attachment's payload from its backing store.
+
+        Only call this when no other row references the blob. Promoting a
+        `PendingEventAttachment` to an `EventAttachment` hands the blob over to the new
+        row, so the pending row must be deleted without touching the blob (a queryset
+        delete does that, since it does not run `Model.delete`).
+        """
+        if not self.blob_path:
+            return
+
+        if self.blob_path.startswith(":"):
+            pass  # nothing to do for inline-stored attachments
+
+        elif self.blob_path.startswith(V1_PREFIX):
+            storage = get_storage()
+            with measure_storage_operation("delete", "attachments"):
+                storage.delete(self.blob_path)
+
+        elif self.blob_path.startswith(V2_PREFIX):
+            # During cleanup, V2 objectstore blobs expire via TTL — skip the
+            # explicit delete to avoid unnecessary load on the objectstore service.
+            if not os.environ.get("_SENTRY_CLEANUP"):
+                organization_id = _get_organization(self.project_id)
+                get_session(UsecaseId.ATTACHMENTS, self.project_id, org=organization_id).delete(
+                    self.blob_path.removeprefix(V2_PREFIX)
+                )
+
+        else:
+            raise NotImplementedError()
+
 
 @cell_silo_model
 class EventAttachment(EventAttachmentBase):
@@ -161,26 +193,7 @@ class EventAttachment(EventAttachmentBase):
             # repopulated with the next incoming crash report.
             cache.delete(get_crashreport_key(self.group_id))
 
-        if self.blob_path:
-            if self.blob_path.startswith(":"):
-                pass  # nothing to do for inline-stored attachments
-
-            elif self.blob_path.startswith(V1_PREFIX):
-                storage = get_storage()
-                with measure_storage_operation("delete", "attachments"):
-                    storage.delete(self.blob_path)
-
-            elif self.blob_path.startswith(V2_PREFIX):
-                # During cleanup, V2 objectstore blobs expire via TTL — skip the
-                # explicit delete to avoid unnecessary load on the objectstore service.
-                if not os.environ.get("_SENTRY_CLEANUP"):
-                    organization_id = _get_organization(self.project_id)
-                    get_session(UsecaseId.ATTACHMENTS, self.project_id, org=organization_id).delete(
-                        self.blob_path.removeprefix(V2_PREFIX)
-                    )
-
-            else:
-                raise NotImplementedError()
+        self.delete_blob()
 
         return rv
 
@@ -326,6 +339,13 @@ class PendingEventAttachment(EventAttachmentBase):
         indexes = (models.Index(fields=("project_id", "event_id")),)
 
     __repr__ = sane_repr("event_id", "name")
+
+    def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
+        # A pending attachment that is deleted rather than promoted (its event never
+        # arrived, so `cleanup` reaped it once `date_expires` passed) still owns its blob.
+        rv = super().delete(*args, **kwargs)
+        self.delete_blob()
+        return rv
 
 
 def normalize_content_type(content_type: str | None, name: str) -> str:

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -146,6 +146,8 @@ class EventAttachmentBase(Model):
         elif self.blob_path.startswith(V2_PREFIX):
             # During cleanup, V2 objectstore blobs expire via TTL — skip the
             # explicit delete to avoid unnecessary load on the objectstore service.
+            # 
+            # We want to special-case pending attachments in a follow-up. See INGEST-1176.
             if not os.environ.get("_SENTRY_CLEANUP"):
                 organization_id = _get_organization(self.project_id)
                 get_session(UsecaseId.ATTACHMENTS, self.project_id, org=organization_id).delete(

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -10,7 +10,7 @@ from typing import IO, Any
 
 import zstandard
 from django.core.cache import cache
-from django.db import models
+from django.db import models, router, transaction
 from django.db.models.expressions import DatabaseDefault
 from django.db.models.functions import Now
 from django.http import HttpRequest
@@ -345,8 +345,17 @@ class PendingEventAttachment(EventAttachmentBase):
     def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
         # A pending attachment that is deleted rather than promoted (its event never
         # arrived, so `cleanup` reaped it once `date_expires` passed) still owns its blob.
-        rv = super().delete(*args, **kwargs)
-        self.delete_blob()
+        #
+        # Lock the row for update to ensure that a `save_pending_attachment` call is not concurrently
+        # promoting the attachment to `EventAttachment`.
+        with transaction.atomic(router.db_for_write(PendingEventAttachment)):
+            is_owner = (
+                PendingEventAttachment.objects.filter(id=self.id).select_for_update().exists()
+            )
+            rv = super().delete(*args, **kwargs)
+
+        if is_owner:
+            self.delete_blob()
         return rv
 
 

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -146,7 +146,7 @@ class EventAttachmentBase(Model):
         elif self.blob_path.startswith(V2_PREFIX):
             # During cleanup, V2 objectstore blobs expire via TTL — skip the
             # explicit delete to avoid unnecessary load on the objectstore service.
-            # 
+            #
             # We want to special-case pending attachments in a follow-up. See INGEST-1176.
             if not os.environ.get("_SENTRY_CLEANUP"):
                 organization_id = _get_organization(self.project_id)

--- a/src/sentry/runner/commands/cleanup.py
+++ b/src/sentry/runner/commands/cleanup.py
@@ -716,7 +716,7 @@ def models_which_use_deletions_code_path() -> list[tuple[type[BaseModel], str, s
 
 
 def models_which_use_expiry_deletions() -> list[tuple[type[BaseModel], str, str]]:
-    from sentry.models.eventattachment import EventAttachment
+    from sentry.models.eventattachment import EventAttachment, PendingEventAttachment
     from sentry.models.profilechunkattachment import ProfileChunkAttachment
 
     # Models deleted based on their per-record expiry date, independent of --days.
@@ -724,6 +724,7 @@ def models_which_use_expiry_deletions() -> list[tuple[type[BaseModel], str, str]
     # regardless of the --days value passed to the cleanup command.
     return [
         (EventAttachment, "date_expires", "date_expires"),
+        (PendingEventAttachment, "date_expires", "date_expires"),
         (ProfileChunkAttachment, "date_expires", "date_expires"),
     ]
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -463,6 +463,8 @@ def update_existing_attachments(job: PostProcessJob) -> None:
 
     event = job["event"]
 
+    # NOTE: This update can probably be removed once `defer-attachment-storage` has graduated
+    # (need to verify post_processing behavior). See INGEST-1173.
     EventAttachment.objects.filter(project_id=event.project_id, event_id=event.event_id).exclude(
         group_id=event.group_id
     ).update(group_id=event.group_id)

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -463,6 +463,10 @@ def update_existing_attachments(job: PostProcessJob) -> None:
 
     event = job["event"]
 
+    EventAttachment.objects.filter(project_id=event.project_id, event_id=event.event_id).exclude(
+        group_id=event.group_id
+    ).update(group_id=event.group_id)
+
     # `process_individual_attachment` decides whether an attachment is "pending" by asking
     # eventstore -- i.e. Snuba -- whether the event exists yet. Snuba lags, so an
     # attachment arriving in the seconds right after its event still looks orphaned and
@@ -482,16 +486,13 @@ def update_existing_attachments(job: PostProcessJob) -> None:
     #
     # NOTE: guarded on `is_reprocessed` to match the call in `save_error_events`.
     if not job["is_reprocessed"] and event.group_id is not None:
-        save_pending_attachments(
+        safe_execute(
+            save_pending_attachments,
             project=event.project,
             event_id=event.event_id,
             group_id=event.group_id,
             source="post_process",
         )
-
-    EventAttachment.objects.filter(project_id=event.project_id, event_id=event.event_id).update(
-        group_id=event.group_id
-    )
 
 
 def fetch_buffered_group_stats(group: Group) -> None:

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -454,10 +454,40 @@ def update_existing_attachments(job: PostProcessJob) -> None:
 
     1) ingested prior to the event via the standalone attachment endpoint.
     2) part of a different group before reprocessing started.
+
+    Also makes a second attempt at promoting pending attachments, for projects on
+    `projects:defer-attachment-storage`. See the comment below for why.
     """
+    from sentry.event_manager import save_pending_attachments
     from sentry.models.eventattachment import EventAttachment
 
     event = job["event"]
+
+    # `process_individual_attachment` decides whether an attachment is "pending" by asking
+    # eventstore -- i.e. Snuba -- whether the event exists yet. Snuba lags, so an
+    # attachment arriving in the seconds right after its event still looks orphaned and
+    # gets parked in `PendingEventAttachment`. If that happens *after* the promotion pass
+    # in `EventManager.save_error_events`, nobody promotes the row and it expires.
+    #
+    # Retrying here narrows that window a lot, because post-processing is dispatched
+    # through the same eventstream that feeds Snuba: by the time we run, the attachment
+    # consumer can usually see the event and never takes the pending path at all.
+    #
+    # It does NOT close the window. An attachment can still be parked after this runs, and
+    # it will be dropped when `PENDING_ATTACHMENT_TTL` expires. What that costs is the
+    # attachment, not the customer's money: `save_pending_attachments` only emits the
+    # ACCEPTED outcome on promotion, so an attachment we lose is one we never billed for.
+    # Closing it properly needs a periodic sweep over pending rows that re-checks
+    # eventstore once Snuba has certainly caught up.
+    #
+    # NOTE: guarded on `is_reprocessed` to match the call in `save_error_events`.
+    if not job["is_reprocessed"] and event.group_id is not None:
+        save_pending_attachments(
+            project=event.project,
+            event_id=event.event_id,
+            group_id=event.group_id,
+            source="post_process",
+        )
 
     EventAttachment.objects.filter(project_id=event.project_id, event_id=event.event_id).update(
         group_id=event.group_id

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -4688,6 +4688,7 @@ class SavePendingAttachmentsTest(TestCase):
                 project=self.project,
                 event_id=self.event_id,
                 group_id=group_id if group_id is not None else self.group.id,
+                source="test",
             )
         return track
 
@@ -4739,7 +4740,10 @@ class SavePendingAttachmentsTest(TestCase):
             connections[router.db_for_write(PendingEventAttachment)]
         ) as queries:
             save_pending_attachments(
-                project=self.project, event_id=self.event_id, group_id=self.group.id
+                project=self.project,
+                event_id=self.event_id,
+                group_id=self.group.id,
+                source="test",
             )
 
         assert not [
@@ -4757,7 +4761,10 @@ class SavePendingAttachmentsTest(TestCase):
         ) as queries:
             with self.feature("projects:defer-attachment-storage"):
                 save_pending_attachments(
-                    project=self.project, event_id=self.event_id, group_id=self.group.id
+                    project=self.project,
+                    event_id=self.event_id,
+                    group_id=self.group.id,
+                    source="test",
                 )
 
         # A single unlocked probe, and no `FOR UPDATE` claim behind it.

--- a/tests/sentry/event_manager/test_event_manager.py
+++ b/tests/sentry/event_manager/test_event_manager.py
@@ -16,7 +16,9 @@ from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.types import Partition, Topic
 from django.conf import settings
 from django.core.cache import cache
+from django.db import OperationalError, connections, router
 from django.db.models import F
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from sentry import analytics, nodestore, tsdb
@@ -58,6 +60,7 @@ from sentry.issues.issue_occurrence import IssueEvidence
 from sentry.models.activity import Activity
 from sentry.models.commit import Commit
 from sentry.models.environment import Environment
+from sentry.models.eventattachment import EventAttachment, PendingEventAttachment
 from sentry.models.group import Group, GroupStatus
 from sentry.models.groupenvironment import GroupEnvironment
 from sentry.models.grouphash import GroupHash
@@ -4648,3 +4651,120 @@ class SaveAttachmentTest(TestCase):
 
         mock_rate_limit.assert_not_called()
         mock_putfile.assert_called_once()
+
+
+class SavePendingAttachmentsTest(TestCase):
+    """
+    Promotion of `PendingEventAttachment` rows must happen exactly once, even though two
+    callers can race for the same rows: the same `event_id` can be saved twice, and any
+    sweep that retries promotion for rows missed at ingest time is a second promoter by
+    construction. Promoting twice would show the attachment twice and bill it twice.
+    """
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.event_id = "a" * 32
+        self.pending = PendingEventAttachment.objects.create(
+            project_id=self.project.id,
+            event_id=self.event_id,
+            type="event.attachment",
+            name="foo.txt",
+            content_type="text/plain",
+            size=5,
+            sha1="abc",
+            blob_path=":hello",
+            date_expires=timezone.now() + timedelta(hours=1),
+            date_expires_retention=timezone.now() + timedelta(days=66),
+        )
+
+    def promote(self, group_id: int | None = None) -> mock.MagicMock:
+        from sentry.event_manager import save_pending_attachments
+
+        with (
+            self.feature("projects:defer-attachment-storage"),
+            mock.patch("sentry.event_manager.track_outcome") as track,
+        ):
+            save_pending_attachments(
+                project=self.project,
+                event_id=self.event_id,
+                group_id=group_id if group_id is not None else self.group.id,
+            )
+        return track
+
+    def test_promotes_only_once_when_called_twice(self) -> None:
+        first = self.promote()
+        second = self.promote()
+
+        # The first caller claimed the row; the second found it already gone.
+        (attachment,) = EventAttachment.objects.filter(project_id=self.project.id)
+        assert attachment.event_id == self.event_id
+        assert attachment.group_id == self.group.id
+        assert not PendingEventAttachment.objects.exists()
+
+        assert first.call_count == 1
+        assert first.mock_calls[0].kwargs["outcome"] == Outcome.ACCEPTED
+        assert first.mock_calls[0].kwargs["category"] == DataCategory.ATTACHMENT
+        # Crucially, the second caller does not bill the attachment again.
+        assert second.call_count == 0
+
+    def test_claims_rows_for_update(self) -> None:
+        with CaptureQueriesContext(
+            connections[router.db_for_write(PendingEventAttachment)]
+        ) as queries:
+            self.promote()
+
+        claims = [
+            q["sql"]
+            for q in queries.captured_queries
+            if "sentry_pendingeventattachment" in q["sql"] and "FOR UPDATE" in q["sql"]
+        ]
+        assert len(claims) == 1, [q["sql"] for q in queries.captured_queries]
+
+    def test_nothing_is_claimed_if_the_insert_fails(self) -> None:
+        with pytest.raises(OperationalError):
+            with mock.patch.object(
+                EventAttachment.objects, "bulk_create", side_effect=OperationalError("nope")
+            ):
+                self.promote()
+
+        # The whole promotion rolls back as one unit, so the row stays claimable by a
+        # retry instead of being dropped with its blob still in storage.
+        assert PendingEventAttachment.objects.filter(id=self.pending.id).exists()
+        assert not EventAttachment.objects.filter(project_id=self.project.id).exists()
+
+    def test_no_query_without_the_feature(self) -> None:
+        from sentry.event_manager import save_pending_attachments
+
+        with CaptureQueriesContext(
+            connections[router.db_for_write(PendingEventAttachment)]
+        ) as queries:
+            save_pending_attachments(
+                project=self.project, event_id=self.event_id, group_id=self.group.id
+            )
+
+        assert not [
+            q for q in queries.captured_queries if "sentry_pendingeventattachment" in q["sql"]
+        ]
+        assert PendingEventAttachment.objects.filter(id=self.pending.id).exists()
+
+    def test_probe_does_not_open_a_transaction_when_there_is_nothing_to_promote(self) -> None:
+        from sentry.event_manager import save_pending_attachments
+
+        PendingEventAttachment.objects.all().delete()
+
+        with CaptureQueriesContext(
+            connections[router.db_for_write(PendingEventAttachment)]
+        ) as queries:
+            with self.feature("projects:defer-attachment-storage"):
+                save_pending_attachments(
+                    project=self.project, event_id=self.event_id, group_id=self.group.id
+                )
+
+        # A single unlocked probe, and no `FOR UPDATE` claim behind it.
+        pending_queries = [
+            q["sql"]
+            for q in queries.captured_queries
+            if "sentry_pendingeventattachment" in q["sql"]
+        ]
+        assert len(pending_queries) == 1
+        assert "FOR UPDATE" not in pending_queries[0]

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -16,7 +16,9 @@ from arroyo.backends.local.backend import LocalBroker
 from arroyo.backends.local.storages.memory import MemoryMessageStorage
 from arroyo.types import Partition, Topic
 from django.conf import settings
+from django.utils import timezone
 
+from sentry.constants import DataCategory
 from sentry.event_manager import EventManager
 from sentry.ingest.consumer.processors import (
     collect_span_metrics,
@@ -33,7 +35,7 @@ from sentry.ingest.consumer.simple_event import (
 from sentry.ingest.types import ConsumerType
 from sentry.lang.native.utils import STORE_CRASH_REPORTS_ALL
 from sentry.models.debugfile import create_files_from_dif_zip
-from sentry.models.eventattachment import EventAttachment
+from sentry.models.eventattachment import EventAttachment, PendingEventAttachment
 from sentry.models.userreport import UserReport
 from sentry.objectstore import UsecaseId, get_session
 from sentry.services import eventstore
@@ -729,7 +731,12 @@ def test_individual_attachments(
 ):
     retention_days = 66
 
-    with patch("sentry.features.has", return_value=feature_enabled):
+    with patch(
+        "sentry.features.has",
+        side_effect=lambda name, *a, **kw: (
+            feature_enabled if name == "organizations:event-attachments" else False
+        ),
+    ):
         event_id = uuid.uuid4().hex
         attachment_id = "ca90fb45-6dd9-40a0-a18f-8693aa621abb"
         project_id = default_project.id
@@ -833,6 +840,111 @@ def test_userreport(django_cache, default_project) -> None:
 
     (report,) = UserReport.objects.all()
     assert report.comments == "hello world"
+
+
+@django_db_all
+@pytest.mark.parametrize("deferred", [True, False], ids=["deferred", "not_deferred"])
+def test_individual_attachment_before_event(
+    django_cache, default_project, factories, deferred
+) -> None:
+    """
+    An attachment that is ingested before its event is parked in
+    `PendingEventAttachment` and promoted once the event arrives.
+
+    Without `projects:defer-attachment-storage` the attachment is stored as an
+    `EventAttachment` right away and only has its `group_id` backfilled later.
+    """
+    from sentry.utils.outcomes import Outcome, track_outcome
+
+    event_id = uuid.uuid4().hex
+    retention_days = 66
+    payload = b"Hello World!"
+
+    mock_track_outcome = patch("sentry.event_manager.track_outcome", wraps=track_outcome)
+
+    with (
+        Feature(
+            {
+                "organizations:event-attachments": True,
+                "projects:defer-attachment-storage": deferred,
+            }
+        ),
+        mock_track_outcome as track,
+    ):
+        process_individual_attachment(
+            {
+                "type": "attachment",
+                "attachment": {
+                    "id": "ca90fb45-6dd9-40a0-a18f-8693aa621abb",
+                    "name": "foo.txt",
+                    "content_type": "text/plain",
+                    "attachment_type": "event.attachment",
+                    "chunks": 0,
+                    "data": payload,
+                    "size": len(payload),
+                    "retention_days": retention_days,
+                },
+                "event_id": event_id,
+                "project_id": default_project.id,
+            },
+            project=default_project,
+        )
+
+        pending = list(PendingEventAttachment.objects.filter(project_id=default_project.id))
+        stored = list(EventAttachment.objects.filter(project_id=default_project.id))
+
+        if deferred:
+            # Parked, not stored, and not billed yet.
+            (pending_attachment,) = pending
+            assert not stored
+            assert pending_attachment.event_id == event_id
+            assert pending_attachment.name == "foo.txt"
+            # Short TTL so it gets reaped if the event never shows up, but the real
+            # retention date is kept around for the promoted row.
+            assert pending_attachment.date_expires < timezone.now() + datetime.timedelta(hours=2)
+            assert pending_attachment.date_expires_retention > timezone.now() + datetime.timedelta(
+                days=retention_days - 1
+            )
+            assert track.call_count == 0
+        else:
+            (attachment,) = stored
+            assert not pending
+            assert attachment.group_id is None
+
+        # Now the event arrives.
+        manager = EventManager({"event_id": event_id, "message": "existence is pain"})
+        manager.normalize()
+        event = manager.save(default_project.id)
+
+    assert not PendingEventAttachment.objects.filter(project_id=default_project.id).exists()
+
+    (attachment,) = EventAttachment.objects.filter(project_id=default_project.id)
+    assert attachment.event_id == event_id
+    assert attachment.name == "foo.txt"
+    assert attachment.content_type == "text/plain"
+    assert attachment.size == len(payload)
+    with attachment.getfile() as file_contents:
+        assert file_contents.read() == payload
+    # The promoted row carries the full retention, not the pending TTL.
+    delta = attachment.date_expires - (timezone.now() + datetime.timedelta(days=retention_days))
+    assert abs(delta.total_seconds()) < 3600
+
+    if deferred:
+        # The promoted attachment is linked to the group and billed on promotion.
+        assert attachment.group_id == event.group_id
+        attachment_outcomes = [
+            call.kwargs
+            for call in track.mock_calls
+            if call.kwargs.get("category") == DataCategory.ATTACHMENT
+        ]
+        assert len(attachment_outcomes) == 1
+        assert attachment_outcomes[0]["outcome"] == Outcome.ACCEPTED
+        assert attachment_outcomes[0]["quantity"] == len(payload)
+        assert attachment_outcomes[0]["event_id"] == event_id
+    else:
+        # `group_id` is backfilled by `update_existing_attachments` in post-processing,
+        # which does not run here.
+        assert attachment.group_id is None
 
 
 @django_db_all

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -731,10 +731,14 @@ def test_individual_attachments(
 ):
     retention_days = 66
 
+    # This patches `features.has` wholesale, which also switches on
+    # `projects:defer-attachment-storage` and would route the `without_group` cases into
+    # `PendingEventAttachment`. Force just that flag off so this test keeps covering the
+    # non-deferred path; `test_individual_attachment_before_event` covers the other one.
     with patch(
         "sentry.features.has",
         side_effect=lambda name, *a, **kw: (
-            feature_enabled if name == "organizations:event-attachments" else False
+            False if name == "projects:defer-attachment-storage" else feature_enabled
         ),
     ):
         event_id = uuid.uuid4().hex

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -4,8 +4,15 @@ import os
 from unittest import mock
 from uuid import uuid4
 
+from django.db import connections, router
+from django.test.utils import CaptureQueriesContext
+
 from sentry.attachments.base import CachedAttachment
-from sentry.models.eventattachment import EventAttachment, normalize_content_type
+from sentry.models.eventattachment import (
+    EventAttachment,
+    PendingEventAttachment,
+    normalize_content_type,
+)
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 
@@ -50,6 +57,73 @@ class EventAttachmentDeleteTest(TestCase):
 
         mock_get_session.return_value.delete.assert_not_called()
         assert not EventAttachment.objects.filter(id=attachment.id).exists()
+
+
+class PendingEventAttachmentDeleteTest(TestCase):
+    """
+    `cleanup` deletes pending attachments through a stale instance: it selects ids in one
+    pass and deletes them in a later one. `save_pending_attachments` can promote the row
+    in between, handing the blob to the `EventAttachment` it creates -- so deleting the
+    blob is only safe while we still own the row.
+    """
+
+    def _create_pending(self) -> PendingEventAttachment:
+        return PendingEventAttachment.objects.create(
+            event_id=uuid4().hex,
+            project_id=self.project.id,
+            type="event.attachment",
+            name="test.txt",
+            blob_path="eventattachments/v1/some-key",
+        )
+
+    @mock.patch("sentry.models.eventattachment.get_storage")
+    def test_delete_removes_the_blob_it_still_owns(self, mock_get_storage: mock.Mock) -> None:
+        pending = self._create_pending()
+
+        pending.delete()
+
+        assert not PendingEventAttachment.objects.filter(id=pending.id).exists()
+        mock_get_storage.return_value.delete.assert_called_once_with("eventattachments/v1/some-key")
+
+    @mock.patch("sentry.models.eventattachment.get_storage")
+    def test_delete_keeps_the_blob_a_promotion_took_over(self, mock_get_storage: mock.Mock) -> None:
+        pending = self._create_pending()
+
+        # Promotion, as `save_pending_attachments` performs it: the blob moves to a new
+        # `EventAttachment`, and the pending row goes away via a queryset delete so that
+        # `Model.delete` -- and with it `delete_blob` -- never runs.
+        promoted = EventAttachment.objects.create(
+            event_id=pending.event_id,
+            project_id=pending.project_id,
+            type=pending.type,
+            name=pending.name,
+            blob_path=pending.blob_path,
+        )
+        PendingEventAttachment.objects.filter(id=pending.id).delete()
+
+        # `pending` is now the stale instance `cleanup` is holding.
+        pending.delete()
+
+        mock_get_storage.return_value.delete.assert_not_called()
+        assert EventAttachment.objects.filter(id=promoted.id).exists()
+
+    def test_delete_locks_the_row_before_dropping_the_blob(self) -> None:
+        pending = self._create_pending()
+
+        with (
+            mock.patch("sentry.models.eventattachment.get_storage"),
+            CaptureQueriesContext(
+                connections[router.db_for_write(PendingEventAttachment)]
+            ) as queries,
+        ):
+            pending.delete()
+
+        claims = [
+            q["sql"]
+            for q in queries.captured_queries
+            if "sentry_pendingeventattachment" in q["sql"] and "FOR UPDATE" in q["sql"]
+        ]
+        assert len(claims) == 1, [q["sql"] for q in queries.captured_queries]
 
 
 class EventAttachmentPutfileTest(TestCase):

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -32,6 +32,7 @@ from sentry.issues.ingest import save_issue_occurrence
 from sentry.issues.ownership.grammar import Matcher, Owner, Rule, dump_schema
 from sentry.models.activity import Activity, ActivityIntegration
 from sentry.models.environment import Environment
+from sentry.models.eventattachment import EventAttachment
 from sentry.models.group import GROUP_SUBSTATUS_TO_STATUS_MAP, Group, GroupStatus
 from sentry.models.groupassignee import GroupAssignee
 from sentry.models.groupinbox import GroupInbox, GroupInboxReason
@@ -2474,6 +2475,66 @@ class UserReportEventLinkTestMixin(BasePostProcessGroupMixin):
         assert len(mock_produce_occurrence_to_kafka.mock_calls) == 0
 
 
+class UpdateExistingAttachmentsTestMixin(BasePostProcessGroupMixin):
+    def create_attachment(self, event_id: str, group_id: int | None) -> EventAttachment:
+        return EventAttachment.objects.create(
+            project_id=self.project.id,
+            event_id=event_id,
+            group_id=group_id,
+            type="event.attachment",
+            name="hello.txt",
+            content_type="text/plain",
+            size=5,
+            blob_path=":hello",
+        )
+
+    def test_links_attachment_ingested_before_event(self) -> None:
+        """
+        An attachment sent to the standalone endpoint before its event is stored with a
+        null `group_id`. Post-processing must link it to the group.
+
+        This pins the NULL semantics of the `.exclude(group_id=...)` in
+        `update_existing_attachments`: Django renders it as
+        `NOT (group_id = %s AND group_id IS NOT NULL)`, which matches null rows. A bare
+        `NOT (group_id = %s)` would silently skip them and leave the attachment unlinked.
+        """
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
+        attachment = self.create_attachment(event.event_id, group_id=None)
+
+        self.call_post_process_group(
+            is_new=True, is_regression=False, is_new_group_environment=True, event=event
+        )
+
+        attachment.refresh_from_db()
+        assert attachment.group_id == event.group_id
+
+    def test_relinks_attachment_from_a_different_group(self) -> None:
+        """Reprocessing moves an event to a new group; its attachments must follow."""
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
+        other_group = self.create_group(project=self.project)
+        assert other_group.id != event.group_id
+        attachment = self.create_attachment(event.event_id, group_id=other_group.id)
+
+        self.call_post_process_group(
+            is_new=True, is_regression=False, is_new_group_environment=True, event=event
+        )
+
+        attachment.refresh_from_db()
+        assert attachment.group_id == event.group_id
+
+    def test_leaves_other_events_attachments_alone(self) -> None:
+        """The update is scoped to the event being processed."""
+        event = self.create_event(data={"message": "testing"}, project_id=self.project.id)
+        unrelated = self.create_attachment("b" * 32, group_id=None)
+
+        self.call_post_process_group(
+            is_new=True, is_regression=False, is_new_group_environment=True, event=event
+        )
+
+        unrelated.refresh_from_db()
+        assert unrelated.group_id is None
+
+
 class DetectBaseUrlsForUptimeTestMixin(BasePostProcessGroupMixin):
     def assert_organization_key(self, organization: Organization, exists: bool) -> None:
         key = get_organization_bucket_key(organization)
@@ -3377,6 +3438,7 @@ class PostProcessGroupErrorTest(
     ReplayLinkageTestMixin,
     DetectNewEscalationTestMixin,
     UserReportEventLinkTestMixin,
+    UpdateExistingAttachmentsTestMixin,
     DetectBaseUrlsForUptimeTestMixin,
     ProcessSimilarityTestMixin,
     PipelineKillswitchTestMixin,

--- a/tests/sentry/tasks/test_post_process.py
+++ b/tests/sentry/tasks/test_post_process.py
@@ -2870,7 +2870,7 @@ class ProcessSimilarityTestMixin(BasePostProcessGroupMixin):
             event=event,
         )
 
-        mock_safe_execute.assert_called_with(similarity.record, mock.ANY, mock.ANY)
+        mock_safe_execute.assert_any_call(similarity.record, mock.ANY, mock.ANY)
 
     def assert_not_called_with(self, mock_function: Mock):
         """


### PR DESCRIPTION
1. Introduce a new **feature flag** for deferring saving attachments.
1. On **ingestion**, park attachments in a separate table if they don't have an event yet.
1. On ingestion of an **event**, check for parked attachments and promote them to `EventAttachment`.  This also creates the billing-relevant "accepted" outcomes.
1. In **post-process**, check for parked attachments again. This mediates a race condition between event and attachment storage.
1. In **cleanup**, delete the pending attachment.

ref: INGEST-1167