### PR TITLE
ref(explore): Save queries with TS Query mutations

### DIFF
--- a/static/app/components/modals/explore/saveQueryModal.spec.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.spec.tsx
@@ -58,33 +58,11 @@ describe('SaveQueryModal', () => {
 
     await userEvent.click(screen.getByLabelText('Create a New Query'));
 
-    await waitFor(() => expect(saveQuery).toHaveBeenCalledWith('Query Name', true));
-  });
-
-  it('should call saveQuery without starring the query', async () => {
-    const saveQuery = jest.fn();
-    render(
-      <SaveQueryModal
-        Header={stubEl}
-        Footer={stubEl as ModalRenderProps['Footer']}
-        Body={stubEl as ModalRenderProps['Body']}
-        CloseButton={stubEl}
-        closeModal={() => {}}
-        organization={initialData.organization}
-        saveQuery={saveQuery}
-        traceItemDataset={TraceItemDataset.SPANS}
-      />
+    await waitFor(() =>
+      expect(saveQuery).toHaveBeenCalledWith(
+        expect.objectContaining({name: 'Query Name'})
+      )
     );
-
-    await userEvent.type(
-      screen.getByTitle('Enter a name for your new query'),
-      'Query Name'
-    );
-    await userEvent.click(screen.getByRole('checkbox', {name: 'Starred'}));
-
-    await userEvent.click(screen.getByLabelText('Create a New Query'));
-
-    await waitFor(() => expect(saveQuery).toHaveBeenCalledWith('Query Name', false));
   });
 
   it('should render rename ui', () => {

--- a/static/app/components/modals/explore/saveQueryModal.tsx
+++ b/static/app/components/modals/explore/saveQueryModal.tsx
@@ -14,7 +14,7 @@ import {
 } from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {t} from 'sentry/locale';
-import type {Organization, SavedQuery} from 'sentry/types/organization';
+import type {Organization} from 'sentry/types/organization';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {defined} from 'sentry/utils/defined';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -23,7 +23,7 @@ import {TraceItemDataset} from 'sentry/views/explore/types';
 
 export type SaveQueryModalProps = {
   organization: Organization;
-  saveQuery: (name: string, starred?: boolean) => Promise<SavedQuery>;
+  saveQuery: (variables: {name: string; starred?: boolean}) => Promise<{id: string}>;
   traceItemDataset: TraceItemDataset;
   name?: string;
   source?: 'toolbar' | 'table' | 'conversations';
@@ -53,7 +53,10 @@ function SaveQueryModal({
     try {
       setIsSaving(true);
       addLoadingMessage(t('Saving query...'));
-      const {id} = await saveQuery(name, initialName === undefined ? starred : undefined);
+      const {id} = await saveQuery({
+        name,
+        starred: initialName === undefined ? starred : undefined,
+      });
       if (initialName === undefined) {
         setQueryParamsSavedQuery(id, name);
       }

--- a/static/app/views/explore/conversations/components/saveConversationQueryButton.tsx
+++ b/static/app/views/explore/conversations/components/saveConversationQueryButton.tsx
@@ -31,7 +31,7 @@ export function SaveConversationQueryButton() {
       organization,
       source: 'conversations',
       traceItemDataset: TraceItemDataset.SPANS,
-      saveQuery: async (name, starred) => {
+      saveQuery: async ({name, starred}) => {
         const {datetime, projects, environments} = selection;
         const response = await api.requestPromise(
           getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/', {

--- a/static/app/views/explore/hooks/useSaveMultiQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveMultiQuery.tsx
@@ -56,7 +56,7 @@ export function useSaveMultiQuery() {
   }, [title, start, end, period, interval, projects, environments, queries]);
 
   const saveQuery = useCallback(
-    async (newTitle: string, starred = true) => {
+    async ({name, starred = true}: {name: string; starred?: boolean}) => {
       const response = await api.requestPromise(
         getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/', {
           path: {organizationIdOrSlug: organization.slug},
@@ -65,7 +65,7 @@ export function useSaveMultiQuery() {
           method: 'POST',
           data: {
             ...data,
-            name: newTitle,
+            name,
             starred,
           },
         }

--- a/static/app/views/explore/hooks/useSaveMultiQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveMultiQuery.tsx
@@ -1,10 +1,11 @@
-import {useCallback, useMemo} from 'react';
+import {useMemo} from 'react';
+import {useMutation} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {encodeSort} from 'sentry/utils/discover/eventView';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {useApi} from 'sentry/utils/useApi';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -26,7 +27,6 @@ export function useSaveMultiQuery() {
   const {start, end, period} = datetime;
   const [interval] = useChartInterval();
 
-  const api = useApi();
   const organization = useOrganization();
   const invalidateSavedQueries = useInvalidateSavedQueries();
 
@@ -55,39 +55,34 @@ export function useSaveMultiQuery() {
     };
   }, [title, start, end, period, interval, projects, environments, queries]);
 
-  const saveQuery = useCallback(
-    async ({name, starred = true}: {name: string; starred?: boolean}) => {
-      const response = await api.requestPromise(
-        getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/', {
+  const {mutateAsync: saveQuery} = useMutation({
+    mutationFn: ({name, starred = true}: {name: string; starred?: boolean}) =>
+      fetchMutation<{id: string}>({
+        url: getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/', {
           path: {organizationIdOrSlug: organization.slug},
         }),
-        {
-          method: 'POST',
-          data: {
-            ...data,
-            name,
-            starred,
-          },
-        }
-      );
-      invalidateSavedQueries();
-      return response;
-    },
-    [api, organization.slug, data, invalidateSavedQueries]
-  );
-
-  const updateQuery = useCallback(async () => {
-    const response = await api.requestPromise(
-      getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/$id/', {
-        path: {organizationIdOrSlug: organization.slug, id: String(id)},
+        method: 'POST',
+        data: {
+          ...data,
+          name,
+          starred,
+        },
       }),
-      {
+    onSuccess: () => {
+      invalidateSavedQueries();
+    },
+  });
+
+  const {mutateAsync: updateQuery} = useMutation({
+    mutationFn: () =>
+      fetchMutation<{id: string}>({
+        url: getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/$id/', {
+          path: {organizationIdOrSlug: organization.slug, id: String(id)},
+        }),
         method: 'PUT',
         data,
-      }
-    );
-    return response;
-  }, [api, organization.slug, id, data]);
+      }),
+  });
 
   return {saveQuery, updateQuery};
 }

--- a/static/app/views/explore/hooks/useSaveMultiQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveMultiQuery.tsx
@@ -9,7 +9,10 @@ import {decodeScalar} from 'sentry/utils/queryString';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useInvalidateSavedQueries} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {
+  useInvalidateSavedQueries,
+  useInvalidateSavedQuery,
+} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {MAX_QUERIES_ALLOWED} from 'sentry/views/explore/multiQueryMode/content';
 import {useReadQueriesFromLocation} from 'sentry/views/explore/multiQueryMode/locationUtils';
 
@@ -29,6 +32,7 @@ export function useSaveMultiQuery() {
 
   const organization = useOrganization();
   const invalidateSavedQueries = useInvalidateSavedQueries();
+  const invalidateSavedQuery = useInvalidateSavedQuery(id);
 
   const data = useMemo(() => {
     return {
@@ -82,6 +86,10 @@ export function useSaveMultiQuery() {
         method: 'PUT',
         data,
       }),
+    onSuccess: () => {
+      invalidateSavedQueries();
+      invalidateSavedQuery();
+    },
   });
 
   return {saveQuery, updateQuery};

--- a/static/app/views/explore/hooks/useSaveQuery.spec.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.spec.tsx
@@ -69,7 +69,7 @@ describe('useSpansSaveQuery', () => {
       },
     });
 
-    await result.current.saveQuery('New Query', true);
+    await result.current.saveQuery({name: 'New Query', starred: true});
 
     expect(saveQueryMock).toHaveBeenCalledWith(
       `/organizations/${organization.slug}/explore/saved/`,

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -1,10 +1,12 @@
 import {useCallback, useMemo} from 'react';
+import {useMutation} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {useCaseInsensitivity} from 'sentry/components/searchQueryBuilder/hooks';
 import type {DateString} from 'sentry/types/core';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {encodeSort} from 'sentry/utils/discover/eventView';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -73,6 +75,9 @@ function useSavedQueryForDataset(dataset: 'spans' | 'logs' | 'replays') {
 
   const [caseInsensitive] = useCaseInsensitivity();
   const {saveQueryFromSavedQuery, updateQueryFromSavedQuery} = useFromSavedQuery();
+  const organization = useOrganization();
+  const invalidateSavedQueries = useInvalidateSavedQueries();
+  const invalidateSavedQuery = useInvalidateSavedQuery(id);
 
   const requestData = useMemo((): ExploreSavedQueryRequest => {
     return convertQueryParamsToRequest({
@@ -85,71 +90,45 @@ function useSavedQueryForDataset(dataset: 'spans' | 'logs' | 'replays') {
     });
   }, [dataset, queryParams, pageFilters, interval, title, caseInsensitive]);
 
-  const {saveQueryApi, updateQueryApi} = useCreateOrUpdateSavedQuery(id);
-
-  const saveQuery = useCallback(
-    ({name, starred = true}: {name: string; starred?: boolean}) => {
-      return saveQueryApi({...requestData, name}, starred);
-    },
-    [saveQueryApi, requestData]
-  );
-
-  const updateQuery = useCallback(() => {
-    return updateQueryApi(requestData);
-  }, [updateQueryApi, requestData]);
-
-  return {saveQuery, updateQuery, saveQueryFromSavedQuery, updateQueryFromSavedQuery};
-}
-
-function useCreateOrUpdateSavedQuery(id?: string) {
-  const api = useApi();
-  const organization = useOrganization();
-  const invalidateSavedQueries = useInvalidateSavedQueries();
-  const invalidateSavedQuery = useInvalidateSavedQuery(id);
-
-  const saveQueryApi = useCallback(
-    async (data: ExploreSavedQueryRequest, starred = true) => {
-      const response = await api.requestPromise(
-        getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/', {
+  const {mutateAsync: saveQuery} = useMutation({
+    mutationFn: ({name, starred = true}: {name: string; starred?: boolean}) =>
+      fetchMutation<{id: string}>({
+        url: getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/', {
           path: {organizationIdOrSlug: organization.slug},
         }),
-        {
-          method: 'POST',
-          data: {
-            ...data,
-            starred,
-          },
-        }
-      );
+        method: 'POST',
+        data: {
+          ...requestData,
+          name,
+          starred,
+        },
+      }),
+    onSuccess: () => {
       invalidateSavedQueries();
       invalidateSavedQuery();
-      return response;
     },
-    [api, organization.slug, invalidateSavedQueries, invalidateSavedQuery]
-  );
+  });
 
-  const updateQueryApi = useCallback(
-    async (data: ExploreSavedQueryRequest) => {
-      const response = await api.requestPromise(
-        getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/$id/', {
+  const {mutateAsync: updateQuery} = useMutation({
+    mutationFn: () =>
+      fetchMutation<{id: string}>({
+        url: getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/$id/', {
           path: {organizationIdOrSlug: organization.slug, id: String(id)},
         }),
-        {
-          method: 'PUT',
-          data: {
-            ...data,
-            dataset: data.dataset === 'segment_spans' ? 'spans' : data.dataset,
-          },
-        }
-      );
+        method: 'PUT',
+        data: {
+          ...requestData,
+          dataset:
+            requestData.dataset === 'segment_spans' ? 'spans' : requestData.dataset,
+        },
+      }),
+    onSuccess: () => {
       invalidateSavedQueries();
       invalidateSavedQuery();
-      return response;
     },
-    [api, organization.slug, id, invalidateSavedQueries, invalidateSavedQuery]
-  );
+  });
 
-  return {saveQueryApi, updateQueryApi};
+  return {saveQuery, updateQuery, saveQueryFromSavedQuery, updateQueryFromSavedQuery};
 }
 
 /**

--- a/static/app/views/explore/hooks/useSaveQuery.tsx
+++ b/static/app/views/explore/hooks/useSaveQuery.tsx
@@ -88,8 +88,8 @@ function useSavedQueryForDataset(dataset: 'spans' | 'logs' | 'replays') {
   const {saveQueryApi, updateQueryApi} = useCreateOrUpdateSavedQuery(id);
 
   const saveQuery = useCallback(
-    (newTitle: string, starred = true) => {
-      return saveQueryApi({...requestData, name: newTitle}, starred);
+    ({name, starred = true}: {name: string; starred?: boolean}) => {
+      return saveQueryApi({...requestData, name}, starred);
     },
     [saveQueryApi, requestData]
   );

--- a/static/app/views/explore/logs/useSaveAsItems.spec.tsx
+++ b/static/app/views/explore/logs/useSaveAsItems.spec.tsx
@@ -295,7 +295,7 @@ describe('useSaveAsItems', () => {
     }
     const saveQueryFn = modalCall[0].saveQuery;
 
-    await saveQueryFn('Test Query Title', true);
+    await saveQueryFn({name: 'Test Query Title', starred: true});
 
     await waitFor(() => {
       expect(saveQueryMock).toHaveBeenCalledWith(

--- a/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.spec.tsx
+++ b/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.spec.tsx
@@ -2,12 +2,20 @@ import type {ReactNode} from 'react';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  act,
+  render,
+  renderHookWithProviders,
+  screen,
+  userEvent,
+  waitFor,
+} from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {
   useGetSavedQueries,
+  useGetSavedQuery,
   type ReadableSavedQuery,
 } from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {MockMetricQueryParamsContext} from 'sentry/views/explore/metrics/hooks/testUtils';
@@ -58,10 +66,12 @@ function Wrapper({children}: {children: ReactNode}) {
 function TestPage() {
   const {updateQuery} = useSaveMetricsMultiQuery();
   const {data: starredQueries} = useGetSavedQueries({starred: true});
+  const {data: query} = useGetSavedQuery('1');
 
   return (
     <div>
       <button onClick={() => void updateQuery()}>Update query</button>
+      <h1>{query?.name}</h1>
       {starredQueries && <ExploreSavedQueryNavigationItems queries={starredQueries} />}
     </div>
   );
@@ -78,10 +88,105 @@ describe('useSaveMetricsMultiQuery', () => {
     MockApiClient.clearMockResponses();
   });
 
+  it('creates a query and refreshes the saved queries', async () => {
+    const response = {...savedQuery('mockMetric'), id: '2', name: 'New Metrics'};
+    const createRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      method: 'POST',
+      body: response,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      body: [],
+    });
+    const {result} = renderHookWithProviders(
+      () => ({
+        ...useSaveMetricsMultiQuery(),
+        queries: useGetSavedQueries({}),
+      }),
+      {organization, additionalWrapper: Wrapper}
+    );
+    await waitFor(() => expect(result.current.queries.data).toEqual([]));
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      body: [response],
+    });
+    await act(async () => {
+      await expect(
+        result.current.saveQuery({name: 'New Metrics', starred: true})
+      ).resolves.toEqual(response);
+    });
+
+    expect(createRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/explore/saved/`,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          name: 'New Metrics',
+          dataset: 'metrics',
+          isMultiQuery: true,
+        }),
+      })
+    );
+    await waitFor(() =>
+      expect(result.current.queries.data?.[0]?.name).toBe('New Metrics')
+    );
+  });
+
+  it.each(['save', 'update'])(
+    'rejects a failed %s without refetching queries',
+    async action => {
+      const listRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/explore/saved/`,
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url:
+          action === 'save'
+            ? `/organizations/${organization.slug}/explore/saved/`
+            : `/organizations/${organization.slug}/explore/saved/1/`,
+        method: action === 'save' ? 'POST' : 'PUT',
+        statusCode: 400,
+        body: {detail: 'Unable to save query'},
+      });
+      const {result} = renderHookWithProviders(
+        () => ({
+          ...useSaveMetricsMultiQuery(),
+          queries: useGetSavedQueries({}),
+        }),
+        {
+          organization,
+          additionalWrapper: Wrapper,
+          initialRouterConfig: {
+            location: {
+              pathname: `/organizations/${organization.slug}/explore/metrics/`,
+              query: {id: '1'},
+            },
+          },
+        }
+      );
+      await waitFor(() => expect(result.current.queries.data).toEqual([]));
+
+      await act(async () => {
+        const request =
+          action === 'save'
+            ? result.current.saveQuery({name: 'New Metrics'})
+            : result.current.updateQuery();
+        await expect(request).rejects.toMatchObject({status: 400});
+      });
+
+      expect(listRequest).toHaveBeenCalledTimes(1);
+    }
+  );
+
   it('updates the starred-query URL after saving an existing query', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/explore/saved/`,
       body: [savedQuery('old.metric')],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/1/`,
+      body: {...savedQuery('old.metric'), name: 'Original Metrics'},
     });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/explore/saved/1/`,
@@ -104,10 +209,17 @@ describe('useSaveMetricsMultiQuery', () => {
       'href',
       expect.stringContaining('old.metric')
     );
+    expect(
+      await screen.findByRole('heading', {name: 'Original Metrics'})
+    ).toBeInTheDocument();
 
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/explore/saved/`,
       body: [savedQuery('mockMetric')],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/1/`,
+      body: savedQuery('mockMetric'),
     });
     await userEvent.click(screen.getByRole('button', {name: 'Update query'}));
 
@@ -117,5 +229,8 @@ describe('useSaveMetricsMultiQuery', () => {
         expect.stringContaining('mockMetric')
       );
     });
+    expect(
+      await screen.findByRole('heading', {name: 'Saved Metrics'})
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
+++ b/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
@@ -94,7 +94,7 @@ export function useSaveMetricsMultiQuery() {
   }, [title, start, end, period, interval, projects, environments, metricQueries]);
 
   const saveQuery = useCallback(
-    async (newTitle: string, starred = true) => {
+    async ({name, starred = true}: {name: string; starred?: boolean}) => {
       const response = await api.requestPromise(
         getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/', {
           path: {organizationIdOrSlug: organization.slug},
@@ -103,7 +103,7 @@ export function useSaveMetricsMultiQuery() {
           method: 'POST',
           data: {
             ...data,
-            name: newTitle,
+            name,
             starred,
           },
         }

--- a/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
+++ b/static/app/views/explore/metrics/hooks/useSaveMetricsMultiQuery.tsx
@@ -1,12 +1,13 @@
-import {useCallback, useMemo} from 'react';
+import {useMemo} from 'react';
 import * as Sentry from '@sentry/react';
+import {useMutation} from '@tanstack/react-query';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {defined} from 'sentry/utils/defined';
 import {encodeSort} from 'sentry/utils/discover/eventView';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {decodeScalar} from 'sentry/utils/queryString';
-import {useApi} from 'sentry/utils/useApi';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -35,7 +36,6 @@ export function useSaveMetricsMultiQuery() {
   const {start, end, period} = datetime;
   const [interval] = useChartInterval();
 
-  const api = useApi();
   const organization = useOrganization();
   const invalidateSavedQueries = useInvalidateSavedQueries();
   const invalidateSavedQuery = useInvalidateSavedQuery(id);
@@ -93,41 +93,38 @@ export function useSaveMetricsMultiQuery() {
     };
   }, [title, start, end, period, interval, projects, environments, metricQueries]);
 
-  const saveQuery = useCallback(
-    async ({name, starred = true}: {name: string; starred?: boolean}) => {
-      const response = await api.requestPromise(
-        getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/', {
+  const {mutateAsync: saveQuery} = useMutation({
+    mutationFn: ({name, starred = true}: {name: string; starred?: boolean}) =>
+      fetchMutation<{id: string}>({
+        url: getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/', {
           path: {organizationIdOrSlug: organization.slug},
         }),
-        {
-          method: 'POST',
-          data: {
-            ...data,
-            name,
-            starred,
-          },
-        }
-      );
-      invalidateSavedQueries();
-      return response;
-    },
-    [api, organization.slug, data, invalidateSavedQueries]
-  );
-
-  const updateQuery = useCallback(async () => {
-    const response = await api.requestPromise(
-      getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/$id/', {
-        path: {organizationIdOrSlug: organization.slug, id: String(id)},
+        method: 'POST',
+        data: {
+          ...data,
+          name,
+          starred,
+        },
       }),
-      {
+    onSuccess: () => {
+      invalidateSavedQueries();
+    },
+  });
+
+  const {mutateAsync: updateQuery} = useMutation({
+    mutationFn: () =>
+      fetchMutation<{id: string}>({
+        url: getApiUrl('/organizations/$organizationIdOrSlug/explore/saved/$id/', {
+          path: {organizationIdOrSlug: organization.slug, id: String(id)},
+        }),
         method: 'PUT',
         data,
-      }
-    );
-    invalidateSavedQueries();
-    invalidateSavedQuery();
-    return response;
-  }, [api, organization.slug, id, data, invalidateSavedQueries, invalidateSavedQuery]);
+      }),
+    onSuccess: () => {
+      invalidateSavedQueries();
+      invalidateSavedQuery();
+    },
+  });
 
   return {saveQuery, updateQuery};
 }

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -11,6 +11,7 @@ import {
 } from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {useGetSavedQueries} from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {MultiQueryModeContent} from 'sentry/views/explore/multiQueryMode/content';
 import {useReadQueriesFromLocation} from 'sentry/views/explore/multiQueryMode/locationUtils';
 
@@ -1116,7 +1117,11 @@ describe('MultiQueryModeContent', () => {
     expect(await screen.findByText('New Query')).toBeInTheDocument();
   });
 
-  it('highlights save button when query has changes', async () => {
+  it('clears the save highlight and refreshes saved queries after updating', async () => {
+    const listRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/`,
+      body: [],
+    });
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/explore/saved/123/`,
       method: 'GET',
@@ -1151,7 +1156,12 @@ describe('MultiQueryModeContent', () => {
       method: 'POST',
     });
 
-    render(<MultiQueryModeContent />, {
+    function Component() {
+      useGetSavedQueries({});
+      return <MultiQueryModeContent />;
+    }
+
+    render(<Component />, {
       organization,
       initialRouterConfig: {
         location: {
@@ -1160,11 +1170,48 @@ describe('MultiQueryModeContent', () => {
             queries:
               '{"groupBys":[],"query":"","sortBys":["-timestamp"],"yAxes":["avg(span.duration)"]}',
             id: '123',
+            project: project.id,
+            statsPeriod: '7d',
           },
         },
       },
     });
     // No good way to check for highlighted css, so we just check for the text
     expect(await screen.findByText('Save')).toBeInTheDocument();
+    await waitFor(() => expect(listRequest).toHaveBeenCalledTimes(1));
+
+    const updatedQuery = {
+      id: '123',
+      query: [
+        {
+          query: '',
+          fields: ['id', 'span.duration', 'timestamp'],
+          groupby: [],
+          orderby: '-timestamp',
+          visualize: [{yAxes: ['avg(span.duration)']}],
+          mode: 'samples',
+        },
+      ],
+      range: '7d',
+      projects: [Number(project.id)],
+      environment: [],
+    };
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/123/`,
+      method: 'PUT',
+      body: updatedQuery,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/explore/saved/123/`,
+      body: updatedQuery,
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+    await userEvent.click(
+      await screen.findByRole('menuitemradio', {name: 'Existing Query'})
+    );
+
+    expect(await screen.findByText('Save as…')).toBeInTheDocument();
+    await waitFor(() => expect(listRequest).toHaveBeenCalledTimes(2));
   });
 });

--- a/static/app/views/explore/savedQueries/savedQueriesTable.tsx
+++ b/static/app/views/explore/savedQueries/savedQueriesTable.tsx
@@ -118,7 +118,7 @@ export function SavedQueriesTable({
 
   const getHandleUpdateFromSavedQuery = useCallback(
     (savedQuery: SavedQuery) => {
-      return (name: string) => {
+      return ({name}: {name: string}) => {
         return updateQueryFromSavedQuery({
           ...savedQuery,
           name,


### PR DESCRIPTION
Migrate saved-query creation and updates in the metrics, trace comparison, spans, logs, and replays flows to TanStack Query's `useMutation` with `fetchMutation`, exposing `mutateAsync` directly. Update the shared save modal and its callers to pass `{name, starred}` as a single variables object, and inline the single-use request hook to remove the save/update wrappers.

Preserve existing request payloads and cache-invalidation behavior, running invalidation in `onSuccess` without awaiting refetches. Callers keep their existing success/error handling. Tests cover creation, error propagation, list/detail cache refreshes, and the trace comparison UI.
