### PR TITLE
fix(auth): Simplify organization auth card copy

### DIFF
--- a/static/app/views/authV2/authLogin/components/organizationAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationAuth.spec.tsx
@@ -29,9 +29,7 @@ describe('OrganizationAuth', () => {
     render(<OrganizationAuth authOrganization={authOrganization} onClear={onClear} />);
 
     expect(screen.getByText('Acme')).toBeInTheDocument();
-    expect(screen.getByText('Requires').parentElement).toHaveTextContent(
-      'Requires sign in with SAML'
-    );
+    expect(screen.getByText('Members log in with SAML')).toBeInTheDocument();
     const ssoButton = screen.getByRole('button', {name: 'SSO'});
     const ssoForm = ssoButton.closest('form')!;
     expect(ssoButton).toBeInTheDocument();
@@ -87,17 +85,5 @@ describe('OrganizationAuth', () => {
     expect(
       screen.queryByRole('button', {name: 'Request to join'})
     ).not.toBeInTheDocument();
-  });
-
-  it('describes optional SSO for members', () => {
-    render(
-      <OrganizationAuth
-        authOrganization={{...authOrganization, ssoRequired: false}}
-        onClear={jest.fn()}
-      />
-    );
-
-    expect(screen.getByText('Members sign in with SAML')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'SSO'})).toBeEnabled();
   });
 });

--- a/static/app/views/authV2/authLogin/components/organizationAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationAuth.tsx
@@ -29,7 +29,7 @@ export function OrganizationAuth({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const theme = useTheme();
   const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.sm})`);
-  const {organization, provider, joinRequestUrl, ssoRequired} = authOrganization;
+  const {organization, provider, joinRequestUrl} = authOrganization;
   const avatarProps = organization.avatarUrl
     ? ({
         type: 'upload',
@@ -43,20 +43,10 @@ export function OrganizationAuth({
         name: organization.name,
       } as const);
   const description = provider
-    ? ssoRequired
-      ? tct('[requires:Requires] sign in with [icon] [provider]', {
-          requires: (
-            <Text as="span" bold>
-              {null}
-            </Text>
-          ),
-          icon: <InlineIdentityIcon providerId={provider.key} />,
-          provider: provider.name,
-        })
-      : tct('Members sign in with [icon] [provider]', {
-          icon: <InlineIdentityIcon providerId={provider.key} />,
-          provider: provider.name,
-        })
+    ? tct('Members log in with [icon] [provider]', {
+        icon: <InlineIdentityIcon providerId={provider.key} />,
+        provider: provider.name,
+      })
     : t('Members sign in with email and password');
   const orgBadge = (
     <Flex align="center" gap="md" flex="1" minWidth="0">

--- a/tests/acceptance/test_auth_react.py
+++ b/tests/acceptance/test_auth_react.py
@@ -81,7 +81,7 @@ class ReactAuthTest(AcceptanceTestCase):
     def select_organization_sso(self, organization_slug: str) -> None:
         self.locate_organization_sso(organization_slug)
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Requires sign in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
         )
 
     def leave_organization_sso(self) -> None:
@@ -285,7 +285,7 @@ class ReactAuthTest(AcceptanceTestCase):
 
         self.locate_organization_sso(self.organization.slug)
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Members sign in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
         )
         assert self.browser.element_exists('[aria-label="Email"]')
         assert self.browser.element_exists('[aria-label="Password"]')
@@ -311,7 +311,7 @@ class ReactAuthTest(AcceptanceTestCase):
             f"return window.location.pathname === '/auth/login/{organization.slug}/'"
         )
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Requires sign in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
         )
 
     def test_password_login_uses_organization_without_sso(self) -> None:
@@ -354,7 +354,7 @@ class ReactAuthTest(AcceptanceTestCase):
             f"return window.location.pathname === '/auth/login/{sso_organization.slug}/'"
         )
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Requires sign in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
         )
 
         # SSO authentication returns to the protected organization destination.
@@ -386,7 +386,7 @@ class ReactAuthTest(AcceptanceTestCase):
         # The current session cannot access the selected organization until SSO completes, so
         # the login page keeps the organization in focus and offers no alternative auth method.
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Requires sign in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
         )
         assert not self.browser.element_exists('[aria-label="Email"]')
         assert not self.browser.element_exists('[aria-label="Password"]')


### PR DESCRIPTION
The organization auth card only needs to identify how members authenticate; whether SSO is required does not change that context.

Use `Members log in with ...` for every configured provider and align component and acceptance coverage.
