### PR TITLE
fix(auth): Show pending state for organization SSO

### DIFF
--- a/static/app/views/authV2/authLogin/components/organizationAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationAuth.spec.tsx
@@ -33,13 +33,18 @@ describe('OrganizationAuth', () => {
       'Requires sign in with SAML'
     );
     const ssoButton = screen.getByRole('button', {name: 'SSO'});
+    const ssoForm = ssoButton.closest('form')!;
     expect(ssoButton).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Request to join'})).toHaveAttribute(
       'href',
       '/join-request/acme/'
     );
-    expect(ssoButton.closest('form')).toHaveAttribute('method', 'POST');
-    expect(ssoButton.closest('form')).toHaveFormValues({init: '1'});
+    expect(ssoForm).toHaveAttribute('method', 'POST');
+    expect(ssoForm).toHaveFormValues({init: '1'});
+
+    ssoForm.addEventListener('submit', event => event.preventDefault());
+    await userEvent.click(ssoButton);
+    expect(ssoButton).toHaveAttribute('aria-busy', 'true');
 
     const clearButton = screen.getByRole('button', {
       name: 'Clear organization login context',

--- a/static/app/views/authV2/authLogin/components/organizationAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationAuth.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
@@ -25,6 +26,7 @@ export function OrganizationAuth({
   hideClearButton = false,
   onClear,
 }: OrganizationAuthProps) {
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const theme = useTheme();
   const isSmallScreen = useMedia(`(max-width: ${theme.breakpoints.sm})`);
   const {organization, provider, joinRequestUrl, ssoRequired} = authOrganization;
@@ -70,7 +72,7 @@ export function OrganizationAuth({
     </Flex>
   );
   const ssoAction = (
-    <form method="POST">
+    <form method="POST" onSubmit={() => setIsSubmitting(true)}>
       <input type="hidden" name="csrfmiddlewaretoken" value={getCsrfToken()} />
       <input type="hidden" name="init" value="1" />
       <Tooltip
@@ -78,6 +80,7 @@ export function OrganizationAuth({
         title={t('This organization does not have Single Sign-On configured')}
       >
         <Button
+          busy={isSubmitting}
           disabled={!provider}
           type="submit"
           variant={provider ? 'primary' : undefined}


### PR DESCRIPTION
Organization SSO begins native navigation after form submission and needs progress feedback during that transition.

Set the SSO button to its busy state when the form submits and cover the transition with an interaction test.