### PR TITLE
feat(issues): use AvatarButton for compact controls

### DIFF
--- a/static/app/components/assigneeBadge.tsx
+++ b/static/app/components/assigneeBadge.tsx
@@ -178,7 +178,7 @@ function AssignedIcon({
   );
 }
 
-function AssignedTooltip({
+export function AssignedTooltip({
   assignedTo,
   assignmentDetails,
 }: {
@@ -238,7 +238,7 @@ function UnassignedIcon({
   );
 }
 
-function UnassignedTooltip() {
+export function UnassignedTooltip() {
   return (
     <Stack gap="xs">
       <Text as="div" align="left">

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -9,7 +9,6 @@ import {
   getUserAvatarProps,
 } from '@sentry/scraps/avatar';
 import {AvatarButton} from '@sentry/scraps/avatarButton';
-import {Button} from '@sentry/scraps/button';
 import {
   CompactSelect,
   MenuComponents,
@@ -240,15 +239,12 @@ function AvatarButtonTooltip({
   if (suggestion) {
     return (
       <Stack gap="xs" align="start">
-        <Text as="div" align="left">
-          {tn(
-            'Suggested assignee: %2$s',
-            'Suggested assignees: %2$s',
-            suggestedActors.length,
-            suggestedActors
-              .map(actor => (actor.type === 'team' ? `#${actor.name}` : actor.name))
-              .join(', ')
-          )}
+        <Text as="div" align="left" wrap="nowrap">
+          {tct('Suggestion: [name]', {
+            name: suggestion.type === 'team' ? `#${suggestion.name}` : suggestion.name,
+          })}
+          {suggestedActors.length > 1 &&
+            tn(' + %s other', ' + %s others', suggestedActors.length - 1)}
         </Text>
         <Text as="div" align="left" variant="muted">
           {suggestion.suggestedReasonText ??
@@ -572,40 +568,6 @@ export function AssigneeSelectorDropdown({
           ? currentMemberList.find(member => member.id === group.assignedTo?.id)
           : getAssignableTeams().find(team => team.team.id === group.assignedTo?.id)
         : suggestedActors[0]?.assignee;
-      const tooltipProps = {
-        isHoverable: true,
-        maxWidth: 300,
-        title: (
-          <AvatarButtonTooltip
-            assignedTo={group.assignedTo}
-            assignmentDetails={assignmentDetails}
-            suggestedActors={suggestedActors}
-          />
-        ),
-      };
-
-      if (!group.assignedTo && suggestedActors.length > 1) {
-        return (
-          <SuggestedAssigneesButton
-            {...triggerProps}
-            aria-label={t('Modify issue assignee')}
-            busy={loading}
-            data-test-id="assignee-selector"
-            disabled={loading}
-            icon={
-              <SuggestedAvatarStack
-                owners={suggestedActors}
-                size={18}
-                tooltipOptions={{disabled: true}}
-              />
-            }
-            ref={ref as Ref<HTMLButtonElement>}
-            size="xs"
-            tooltipProps={tooltipProps}
-            variant="secondary"
-          />
-        );
-      }
 
       return (
         <AssigneeAvatarButton
@@ -625,7 +587,17 @@ export function AssigneeSelectorDropdown({
           disabled={loading}
           ref={ref as Ref<HTMLButtonElement>}
           size="xs"
-          tooltipProps={tooltipProps}
+          tooltipProps={{
+            isHoverable: true,
+            maxWidth: 300,
+            title: (
+              <AvatarButtonTooltip
+                assignedTo={group.assignedTo}
+                assignmentDetails={assignmentDetails}
+                suggestedActors={suggestedActors}
+              />
+            ),
+          }}
         />
       );
     }
@@ -706,10 +678,6 @@ const AssigneeWrapper = styled('div')`
 `;
 
 const AssigneeAvatarButton = styled(AvatarButton)`
-  display: flex;
-`;
-
-const SuggestedAssigneesButton = styled(Button)`
   display: flex;
 `;
 

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -629,6 +629,7 @@ export function AssigneeSelectorDropdown({
   return (
     <AssigneeWrapper>
       <CompactSelect
+        style={shouldUseNewUI ? {display: 'flex'} : undefined}
         search={{placeholder: 'Search users or teams...'}}
         clearable
         className={className}

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -1,8 +1,14 @@
-import {Fragment} from 'react';
+import {Fragment, type Ref} from 'react';
 import styled from '@emotion/styled';
 import uniqBy from 'lodash/uniqBy';
 
-import {ActorAvatar} from '@sentry/scraps/avatar';
+import {
+  ActorAvatar,
+  type BaseAvatarProps,
+  getTeamAvatarProps,
+  getUserAvatarProps,
+} from '@sentry/scraps/avatar';
+import {AvatarButton} from '@sentry/scraps/avatarButton';
 import {
   CompactSelect,
   MenuComponents,
@@ -16,6 +22,11 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {openInviteMembersModal} from 'sentry/actionCreators/modal';
+import {
+  AssignedTooltip,
+  type AssignmentDetails,
+  UnassignedTooltip,
+} from 'sentry/components/assigneeBadge';
 import {TeamBadge} from 'sentry/components/idBadge/teamBadge';
 import {UserBadge} from 'sentry/components/idBadge/userBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
@@ -77,6 +88,7 @@ interface AssigneeSelectorDropdownProps {
    * Additional items to render in the menu footer
    */
   additionalMenuFooterItems?: React.ReactNode;
+  assignmentDetails?: AssignmentDetails;
   /**
    * Additional styles to apply to the dropdown
    */
@@ -108,6 +120,7 @@ interface AssigneeSelectorDropdownProps {
    * the default trigger will be used
    */
   trigger?: (props: TriggerProps, isOpen: boolean) => React.ReactNode;
+  useAvatarButton?: boolean;
 }
 
 function AssigneeAvatar({
@@ -207,7 +220,73 @@ function AssigneeAvatar({
   );
 }
 
+function AvatarButtonTooltip({
+  assignedTo,
+  assignmentDetails,
+  suggestedActors,
+}: {
+  suggestedActors: SuggestedAssignee[];
+  assignedTo?: Actor | null;
+  assignmentDetails?: AssignmentDetails;
+}) {
+  if (assignedTo) {
+    return (
+      <AssignedTooltip assignedTo={assignedTo} assignmentDetails={assignmentDetails} />
+    );
+  }
+
+  const suggestion = suggestedActors[0];
+  if (suggestion) {
+    return (
+      <Stack gap="xs" align="start">
+        <Text as="div" align="left" wrap="nowrap">
+          {tct('Suggestion: [name]', {
+            name: suggestion.type === 'team' ? `#${suggestion.name}` : suggestion.name,
+          })}
+          {suggestedActors.length > 1 &&
+            tn(' + %s other', ' + %s others', suggestedActors.length - 1)}
+        </Text>
+        <Text as="div" align="left" variant="muted">
+          {suggestion.suggestedReasonText ??
+            suggestedReasonTable[suggestion.suggestedReason]}
+        </Text>
+      </Stack>
+    );
+  }
+
+  return <UnassignedTooltip />;
+}
+
+function isAssignableTeam(assignee: AssignableTeam | User): assignee is AssignableTeam {
+  return 'team' in assignee;
+}
+
+function getAvatarButtonAvatar({
+  actor,
+  assignee,
+  suggested,
+}: {
+  actor: Actor;
+  suggested: boolean;
+  assignee?: AssignableTeam | User;
+}): BaseAvatarProps {
+  const avatar =
+    actor.type === 'user'
+      ? getUserAvatarProps(assignee && !isAssignableTeam(assignee) ? assignee : actor)
+      : assignee && isAssignableTeam(assignee)
+        ? getTeamAvatarProps(assignee.team)
+        : {
+            type: 'letter_avatar' as const,
+            identifier: actor.name,
+            name: actor.name,
+            title: actor.name,
+          };
+
+  return {...avatar, round: actor.type === 'user', suggested};
+}
+
 export function AssigneeSelectorDropdown({
+  assignmentDetails,
   className,
   group,
   loading,
@@ -217,6 +296,7 @@ export function AssigneeSelectorDropdown({
   owners,
   sizeLimit = 150,
   trigger,
+  useAvatarButton = false,
   additionalMenuFooterItems,
 }: AssigneeSelectorDropdownProps) {
   const sessionUser = useUser();
@@ -479,6 +559,49 @@ export function AssigneeSelectorDropdown({
   };
 
   const makeTrigger = (props: TriggerProps) => {
+    if (useAvatarButton) {
+      const {children: _, ref, ...triggerProps} = props;
+      const suggestedActors = getSuggestedAssignees();
+      const actor = group.assignedTo ?? suggestedActors[0];
+      const assignee = group.assignedTo
+        ? group.assignedTo.type === 'user'
+          ? currentMemberList.find(member => member.id === group.assignedTo?.id)
+          : getAssignableTeams().find(team => team.team.id === group.assignedTo?.id)
+        : suggestedActors[0]?.assignee;
+
+      return (
+        <AvatarButton
+          {...triggerProps}
+          aria-label={t('Modify issue assignee')}
+          avatar={
+            actor
+              ? getAvatarButtonAvatar({
+                  actor,
+                  assignee,
+                  suggested: !group.assignedTo,
+                })
+              : undefined
+          }
+          busy={loading}
+          data-test-id="assignee-selector"
+          disabled={loading}
+          ref={ref as Ref<HTMLButtonElement>}
+          size="xs"
+          tooltipProps={{
+            isHoverable: true,
+            maxWidth: 300,
+            title: (
+              <AvatarButtonTooltip
+                assignedTo={group.assignedTo}
+                assignmentDetails={assignmentDetails}
+                suggestedActors={suggestedActors}
+              />
+            ),
+          }}
+        />
+      );
+    }
+
     const avatarElement = (
       <AssigneeAvatar
         assignedTo={group.assignedTo}
@@ -514,7 +637,9 @@ export function AssigneeSelectorDropdown({
         onClick={e => e.stopPropagation()}
         value={
           group.assignedTo
-            ? `${group.assignedTo?.type === 'user' ? 'user:' : 'team:'}${group.assignedTo.id}`
+            ? `${group.assignedTo?.type === 'user' ? 'user:' : 'team:'}${
+                group.assignedTo.id
+              }`
             : ''
         }
         menuTitle={t('Assignee')}

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -113,6 +113,10 @@ interface AssigneeSelectorDropdownProps {
    */
   owners?: Array<Omit<SuggestedAssignee, 'assignee'>>;
   /**
+   * Show the assignee name next to the avatar.
+   */
+  showLabel?: boolean;
+  /**
    * Maximum number of teams/users to display in the dropdown
    */
   sizeLimit?: number;
@@ -294,6 +298,7 @@ export function AssigneeSelectorDropdown({
   onAssign,
   onClear,
   owners,
+  showLabel = false,
   sizeLimit = 150,
   trigger,
   additionalMenuFooterItems,
@@ -568,11 +573,23 @@ export function AssigneeSelectorDropdown({
           ? currentMemberList.find(member => member.id === group.assignedTo?.id)
           : getAssignableTeams().find(team => team.team.id === group.assignedTo?.id)
         : suggestedActors[0]?.assignee;
+      const triggerLabel = loading
+        ? t('Loading…')
+        : actor
+          ? `${actor.type === 'team' ? '#' : ''}${actor.name}`
+          : t('Unassigned');
+      const tooltipTitle = (
+        <AvatarButtonTooltip
+          assignedTo={group.assignedTo}
+          assignmentDetails={assignmentDetails}
+          suggestedActors={suggestedActors}
+        />
+      );
 
-      return (
+      const avatarButton = (
         <AvatarButton
           {...triggerProps}
-          aria-label={t('Modify issue assignee')}
+          aria-label={t('Modify issue assignee: %s', triggerLabel)}
           avatar={
             actor
               ? getAvatarButtonAvatar({
@@ -587,18 +604,25 @@ export function AssigneeSelectorDropdown({
           disabled={loading}
           ref={ref as Ref<HTMLButtonElement>}
           size="xs"
-          tooltipProps={{
-            isHoverable: true,
-            maxWidth: 300,
-            title: (
-              <AvatarButtonTooltip
-                assignedTo={group.assignedTo}
-                assignmentDetails={assignmentDetails}
-                suggestedActors={suggestedActors}
-              />
-            ),
-          }}
+          tooltipProps={
+            showLabel
+              ? undefined
+              : {isHoverable: true, maxWidth: 300, title: tooltipTitle}
+          }
         />
+      );
+
+      if (!showLabel) {
+        return avatarButton;
+      }
+
+      return (
+        <Tooltip isHoverable maxWidth={300} skipWrapper title={tooltipTitle}>
+          <Flex as="label" align="center" gap="sm" htmlFor={triggerProps.id}>
+            {avatarButton}
+            <AssigneeLabel ellipsis>{triggerLabel}</AssigneeLabel>
+          </Flex>
+        </Tooltip>
       );
     }
 
@@ -682,6 +706,10 @@ const AssigneeTrigger = styled(OverlayTrigger.Button)`
   z-index: 0;
   padding-left: ${p => p.theme.space.xs};
   padding-right: ${p => p.theme.space.xs};
+`;
+
+const AssigneeLabel = styled(Text)`
+  max-width: 114px;
 `;
 
 const StyledIconUser = styled(IconUser)`

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -39,6 +39,7 @@ import type {Group, SuggestedOwnerReason} from 'sentry/types/group';
 import type {Team} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {buildTeamId} from 'sentry/utils';
+import {useNewIssuePriorityAndAssigneeUI} from 'sentry/utils/useNewIssuePriorityAndAssigneeUI';
 import {useUser} from 'sentry/utils/useUser';
 
 const suggestedReasonTable: Record<SuggestedOwnerReason, string> = {
@@ -120,7 +121,6 @@ interface AssigneeSelectorDropdownProps {
    * the default trigger will be used
    */
   trigger?: (props: TriggerProps, isOpen: boolean) => React.ReactNode;
-  useAvatarButton?: boolean;
 }
 
 function AssigneeAvatar({
@@ -296,9 +296,9 @@ export function AssigneeSelectorDropdown({
   owners,
   sizeLimit = 150,
   trigger,
-  useAvatarButton = false,
   additionalMenuFooterItems,
 }: AssigneeSelectorDropdownProps) {
+  const shouldUseNewUI = useNewIssuePriorityAndAssigneeUI();
   const sessionUser = useUser();
 
   const currentMemberList = memberList ?? [];
@@ -559,7 +559,7 @@ export function AssigneeSelectorDropdown({
   };
 
   const makeTrigger = (props: TriggerProps) => {
-    if (useAvatarButton) {
+    if (shouldUseNewUI) {
       const {children: _, ref, ...triggerProps} = props;
       const suggestedActors = getSuggestedAssignees();
       const actor = group.assignedTo ?? suggestedActors[0];
@@ -570,7 +570,7 @@ export function AssigneeSelectorDropdown({
         : suggestedActors[0]?.assignee;
 
       return (
-        <AssigneeAvatarButton
+        <AvatarButton
           {...triggerProps}
           aria-label={t('Modify issue assignee')}
           avatar={
@@ -675,10 +675,6 @@ const AssigneeWrapper = styled('div')`
   display: flex;
   justify-content: flex-end;
   text-align: left;
-`;
-
-const AssigneeAvatarButton = styled(AvatarButton)`
-  display: flex;
 `;
 
 const AssigneeTrigger = styled(OverlayTrigger.Button)`

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -9,6 +9,7 @@ import {
   getUserAvatarProps,
 } from '@sentry/scraps/avatar';
 import {AvatarButton} from '@sentry/scraps/avatarButton';
+import {Button} from '@sentry/scraps/button';
 import {
   CompactSelect,
   MenuComponents,
@@ -239,12 +240,15 @@ function AvatarButtonTooltip({
   if (suggestion) {
     return (
       <Stack gap="xs" align="start">
-        <Text as="div" align="left" wrap="nowrap">
-          {tct('Suggestion: [name]', {
-            name: suggestion.type === 'team' ? `#${suggestion.name}` : suggestion.name,
-          })}
-          {suggestedActors.length > 1 &&
-            tn(' + %s other', ' + %s others', suggestedActors.length - 1)}
+        <Text as="div" align="left">
+          {tn(
+            'Suggested assignee: %2$s',
+            'Suggested assignees: %2$s',
+            suggestedActors.length,
+            suggestedActors
+              .map(actor => (actor.type === 'team' ? `#${actor.name}` : actor.name))
+              .join(', ')
+          )}
         </Text>
         <Text as="div" align="left" variant="muted">
           {suggestion.suggestedReasonText ??
@@ -568,6 +572,40 @@ export function AssigneeSelectorDropdown({
           ? currentMemberList.find(member => member.id === group.assignedTo?.id)
           : getAssignableTeams().find(team => team.team.id === group.assignedTo?.id)
         : suggestedActors[0]?.assignee;
+      const tooltipProps = {
+        isHoverable: true,
+        maxWidth: 300,
+        title: (
+          <AvatarButtonTooltip
+            assignedTo={group.assignedTo}
+            assignmentDetails={assignmentDetails}
+            suggestedActors={suggestedActors}
+          />
+        ),
+      };
+
+      if (!group.assignedTo && suggestedActors.length > 1) {
+        return (
+          <SuggestedAssigneesButton
+            {...triggerProps}
+            aria-label={t('Modify issue assignee')}
+            busy={loading}
+            data-test-id="assignee-selector"
+            disabled={loading}
+            icon={
+              <SuggestedAvatarStack
+                owners={suggestedActors}
+                size={18}
+                tooltipOptions={{disabled: true}}
+              />
+            }
+            ref={ref as Ref<HTMLButtonElement>}
+            size="xs"
+            tooltipProps={tooltipProps}
+            variant="secondary"
+          />
+        );
+      }
 
       return (
         <AssigneeAvatarButton
@@ -587,17 +625,7 @@ export function AssigneeSelectorDropdown({
           disabled={loading}
           ref={ref as Ref<HTMLButtonElement>}
           size="xs"
-          tooltipProps={{
-            isHoverable: true,
-            maxWidth: 300,
-            title: (
-              <AvatarButtonTooltip
-                assignedTo={group.assignedTo}
-                assignmentDetails={assignmentDetails}
-                suggestedActors={suggestedActors}
-              />
-            ),
-          }}
+          tooltipProps={tooltipProps}
         />
       );
     }
@@ -678,6 +706,10 @@ const AssigneeWrapper = styled('div')`
 `;
 
 const AssigneeAvatarButton = styled(AvatarButton)`
+  display: flex;
+`;
+
+const SuggestedAssigneesButton = styled(Button)`
   display: flex;
 `;
 

--- a/static/app/components/assigneeSelectorDropdown.tsx
+++ b/static/app/components/assigneeSelectorDropdown.tsx
@@ -570,7 +570,7 @@ export function AssigneeSelectorDropdown({
         : suggestedActors[0]?.assignee;
 
       return (
-        <AvatarButton
+        <AssigneeAvatarButton
           {...triggerProps}
           aria-label={t('Modify issue assignee')}
           avatar={
@@ -675,6 +675,10 @@ const AssigneeWrapper = styled('div')`
   display: flex;
   justify-content: flex-end;
   text-align: left;
+`;
+
+const AssigneeAvatarButton = styled(AvatarButton)`
+  display: flex;
 `;
 
 const AssigneeTrigger = styled(OverlayTrigger.Button)`

--- a/static/app/components/badge/groupPriority.spec.tsx
+++ b/static/app/components/badge/groupPriority.spec.tsx
@@ -1,4 +1,5 @@
 import {ActivityFeedFixture} from 'sentry-fixture/activityFeed';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -16,9 +17,15 @@ describe('GroupPriority', () => {
     };
 
     it('skips request when sent lastEditedBy', async () => {
-      render(<GroupPriorityDropdown {...defaultProps} lastEditedBy="system" />);
+      render(<GroupPriorityDropdown {...defaultProps} lastEditedBy="system" />, {
+        organization: OrganizationFixture({
+          features: ['issue-priority-assignee-ui'],
+        }),
+      });
 
-      await userEvent.click(screen.getByRole('button', {name: 'Modify issue priority'}));
+      await userEvent.click(
+        screen.getByRole('button', {name: 'Modify issue priority: High'})
+      );
 
       expect(
         screen.getByText(textWithMarkupMatcher('Last edited by Sentry'))

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -171,7 +171,10 @@ export function GroupPriorityDropdown({
         shouldUseNewUI ? (
           <Button
             {...triggerProps}
-            aria-label={t('Modify issue priority')}
+            aria-label={t(
+              'Modify issue priority: %s',
+              PRIORITY_KEY_TO_LABEL[value] ?? t('Unknown')
+            )}
             disabled={disabled}
             icon={<IconCellSignal bars={GROUP_PRIORITY_BARS[value]} />}
             size="xs"

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -21,6 +21,7 @@ import type {AvatarUser} from 'sentry/types/user';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {defined} from 'sentry/utils/defined';
 import {useApiQuery} from 'sentry/utils/queryClient';
+import {useNewIssuePriorityAndAssigneeUI} from 'sentry/utils/useNewIssuePriorityAndAssigneeUI';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
 type GroupPriorityDropdownProps = {
@@ -148,12 +149,11 @@ export function GroupPriorityDropdown({
   lastEditedBy,
   disabled = false,
 }: GroupPriorityDropdownProps) {
-  const organization = useOrganization();
+  const shouldUseNewUI = useNewIssuePriorityAndAssigneeUI();
   const options: MenuItemProps[] = useMemo(
     () => makeGroupPriorityDropdownOptions({onChange}),
     [onChange]
   );
-  const useCompactButton = organization.features.includes('issue-priority-assignee-ui');
   const tooltip = disabled
     ? t('You cannot manually update the priority of a metric issue.')
     : t('Update the priority of this issue.');
@@ -168,7 +168,7 @@ export function GroupPriorityDropdown({
       }
       minMenuWidth={230}
       trigger={(triggerProps, isOpen) =>
-        useCompactButton ? (
+        shouldUseNewUI ? (
           <Button
             {...triggerProps}
             aria-label={t('Modify issue priority')}

--- a/static/app/components/badge/groupPriority.tsx
+++ b/static/app/components/badge/groupPriority.tsx
@@ -45,6 +45,12 @@ const PRIORITY_KEY_TO_LABEL: Record<PriorityLevel, string> = {
 
 const PRIORITY_OPTIONS = [PriorityLevel.HIGH, PriorityLevel.MEDIUM, PriorityLevel.LOW];
 
+const GROUP_PRIORITY_BARS: Record<PriorityLevel, 1 | 2 | 3> = {
+  [PriorityLevel.HIGH]: 3,
+  [PriorityLevel.MEDIUM]: 2,
+  [PriorityLevel.LOW]: 1,
+};
+
 function useLastEditedBy({
   groupId,
   lastEditedBy: incomingLastEditedBy,
@@ -98,8 +104,7 @@ export function GroupPriorityBadge({
   showLabel = true,
   children,
 }: GroupPriorityBadgeProps) {
-  const bars =
-    priority === PriorityLevel.HIGH ? 3 : priority === PriorityLevel.MEDIUM ? 2 : 1;
+  const bars = GROUP_PRIORITY_BARS[priority];
   const label = PRIORITY_KEY_TO_LABEL[priority] ?? t('Unknown');
 
   return (
@@ -143,10 +148,15 @@ export function GroupPriorityDropdown({
   lastEditedBy,
   disabled = false,
 }: GroupPriorityDropdownProps) {
+  const organization = useOrganization();
   const options: MenuItemProps[] = useMemo(
     () => makeGroupPriorityDropdownOptions({onChange}),
     [onChange]
   );
+  const useCompactButton = organization.features.includes('issue-priority-assignee-ui');
+  const tooltip = disabled
+    ? t('You cannot manually update the priority of a metric issue.')
+    : t('Update the priority of this issue.');
 
   return (
     <DropdownMenu
@@ -157,23 +167,31 @@ export function GroupPriorityDropdown({
         </Flex>
       }
       minMenuWidth={230}
-      trigger={(triggerProps, isOpen) => (
-        <DropdownButton
-          {...triggerProps}
-          aria-label={t('Modify issue priority')}
-          size="zero"
-          disabled={disabled}
-          tooltipProps={{
-            title: disabled
-              ? t('You cannot manually update the priority of a metric issue.')
-              : t('Update the priority of this issue.'),
-          }}
-        >
-          <GroupPriorityBadge showLabel={false} priority={value}>
-            <IconChevron direction={isOpen ? 'up' : 'down'} size="xs" variant="muted" />
-          </GroupPriorityBadge>
-        </DropdownButton>
-      )}
+      trigger={(triggerProps, isOpen) =>
+        useCompactButton ? (
+          <Button
+            {...triggerProps}
+            aria-label={t('Modify issue priority')}
+            disabled={disabled}
+            icon={<IconCellSignal bars={GROUP_PRIORITY_BARS[value]} />}
+            size="xs"
+            tooltipProps={{title: tooltip}}
+            variant="secondary"
+          />
+        ) : (
+          <DropdownButton
+            {...triggerProps}
+            aria-label={t('Modify issue priority')}
+            size="zero"
+            disabled={disabled}
+            tooltipProps={{title: tooltip}}
+          >
+            <GroupPriorityBadge showLabel={false} priority={value}>
+              <IconChevron direction={isOpen ? 'up' : 'down'} size="xs" variant="muted" />
+            </GroupPriorityBadge>
+          </DropdownButton>
+        )
+      }
       items={options}
       menuFooter={
         <Fragment>

--- a/static/app/components/core/avatar/index.tsx
+++ b/static/app/components/core/avatar/index.tsx
@@ -7,6 +7,6 @@ export {LetterAvatar} from './letterAvatar/letterAvatar';
 export {OrganizationAvatar} from './organizationAvatar';
 export {ProjectAvatar} from './projectAvatar';
 export {SentryAppAvatar} from './sentryAppAvatar';
-export {TeamAvatar} from './teamAvatar';
+export {getTeamAvatarProps, TeamAvatar} from './teamAvatar';
 export {useAvatar} from './useAvatar';
-export {UserAvatar} from './userAvatar';
+export {getUserAvatarProps, UserAvatar} from './userAvatar';

--- a/static/app/components/core/avatar/teamAvatar.tsx
+++ b/static/app/components/core/avatar/teamAvatar.tsx
@@ -21,7 +21,7 @@ export function TeamAvatar({team, tooltip: tooltipProp, ...props}: TeamAvatarPro
   );
 }
 
-function getTeamAvatarProps(
+export function getTeamAvatarProps(
   team: Team
 ): LetterBaseAvatarProps | UploadBaseAvatarProps | GravatarBaseAvatarProps {
   const identifier = team.slug;

--- a/static/app/components/core/avatar/userAvatar.tsx
+++ b/static/app/components/core/avatar/userAvatar.tsx
@@ -34,7 +34,7 @@ export function UserAvatar({renderTooltip, user, ...props}: UserAvatarProps) {
   );
 }
 
-function getUserAvatarProps(
+export function getUserAvatarProps(
   user: Actor | AvatarUser
 ): GravatarBaseAvatarProps | LetterBaseAvatarProps | UploadBaseAvatarProps {
   if (isActor(user)) {

--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -183,7 +183,6 @@ function AvatarButtonBase({
 }
 
 const StyledAvatarButton = styled(AvatarButtonBase)`
-  display: flex;
   padding: 0;
   width: ${p => p.theme.form[p.size].height};
   min-width: ${p => p.theme.form[p.size].height};

--- a/static/app/components/core/avatarButton/avatarButton.tsx
+++ b/static/app/components/core/avatarButton/avatarButton.tsx
@@ -183,6 +183,7 @@ function AvatarButtonBase({
 }
 
 const StyledAvatarButton = styled(AvatarButtonBase)`
+  display: flex;
   padding: 0;
   width: ${p => p.theme.form[p.size].height};
   min-width: ${p => p.theme.form[p.size].height};

--- a/static/app/components/group/assigneeSelector.spec.tsx
+++ b/static/app/components/group/assigneeSelector.spec.tsx
@@ -1,4 +1,5 @@
 import {GroupFixture} from 'sentry-fixture/group';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {UserFixture} from 'sentry-fixture/user';
 
 import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
@@ -30,7 +31,12 @@ describe('AssigneeSelector', () => {
         assigneeLoading={false}
         handleAssigneeChange={jest.fn()}
         showLabel
-      />
+      />,
+      {
+        organization: OrganizationFixture({
+          features: ['issue-priority-assignee-ui'],
+        }),
+      }
     );
 
     await userEvent.hover(await screen.findByText(assignedUser.name));

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -16,6 +16,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
 import {selectUsersFromMembers} from 'sentry/utils/members/shared';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {useAssignIssueMutation} from 'sentry/views/issueDetails/useAssignIssueMutation';
 
 interface AssigneeSelectorProps {
@@ -89,6 +90,7 @@ export function AssigneeSelector({
   showLabel = false,
   useOwnerAssignmentDetails = true,
 }: AssigneeSelectorProps) {
+  const organization = useOrganization();
   const {data: defaultMemberList = [], isPending: defaultMemberListLoading} = useQuery({
     ...useProjectMembersQueryOptions([group.project.id]),
     select: resp => selectUsersFromMembers(resp.json),
@@ -102,9 +104,11 @@ export function AssigneeSelector({
   const currentAssignmentDetails =
     assignmentDetails ??
     (useOwnerAssignmentDetails ? getOwnerAssignmentDetails(group) : undefined);
+  const useAvatarButton = organization.features.includes('issue-priority-assignee-ui');
 
   return (
     <AssigneeSelectorDropdown
+      assignmentDetails={currentAssignmentDetails}
       group={group}
       loading={assigneeLoading || (memberList === undefined && defaultMemberListLoading)}
       memberList={currentMemberList}
@@ -113,23 +117,28 @@ export function AssigneeSelector({
         handleAssigneeChange(assignedActor)
       }
       onClear={() => handleAssigneeChange(null)}
-      trigger={(props, isOpen) => (
-        <StyledTrigger
-          {...props}
-          showChevron={false}
-          aria-label={t('Modify issue assignee')}
-          size="zero"
-        >
-          <AssigneeBadge
-            assignedTo={group.assignedTo ?? undefined}
-            assignedUser={assignedUser}
-            assignmentDetails={currentAssignmentDetails}
-            loading={assigneeLoading}
-            showLabel={showLabel}
-            chevronDirection={isOpen ? 'up' : 'down'}
-          />
-        </StyledTrigger>
-      )}
+      trigger={
+        useAvatarButton
+          ? undefined
+          : (props, isOpen) => (
+              <StyledTrigger
+                {...props}
+                showChevron={false}
+                aria-label={t('Modify issue assignee')}
+                size="zero"
+              >
+                <AssigneeBadge
+                  assignedTo={group.assignedTo ?? undefined}
+                  assignedUser={assignedUser}
+                  assignmentDetails={currentAssignmentDetails}
+                  loading={assigneeLoading}
+                  showLabel={showLabel}
+                  chevronDirection={isOpen ? 'up' : 'down'}
+                />
+              </StyledTrigger>
+            )
+      }
+      useAvatarButton={useAvatarButton}
       additionalMenuFooterItems={additionalMenuFooterItems}
     />
   );

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -112,6 +112,7 @@ export function AssigneeSelector({
       loading={assigneeLoading || (memberList === undefined && defaultMemberListLoading)}
       memberList={currentMemberList}
       owners={owners}
+      showLabel={showLabel}
       onAssign={(assignedActor: AssignableEntity | null) =>
         handleAssigneeChange(assignedActor)
       }

--- a/static/app/components/group/assigneeSelector.tsx
+++ b/static/app/components/group/assigneeSelector.tsx
@@ -16,7 +16,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {User} from 'sentry/types/user';
 import {useProjectMembersQueryOptions} from 'sentry/utils/members/projectMembers';
 import {selectUsersFromMembers} from 'sentry/utils/members/shared';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import {useNewIssuePriorityAndAssigneeUI} from 'sentry/utils/useNewIssuePriorityAndAssigneeUI';
 import {useAssignIssueMutation} from 'sentry/views/issueDetails/useAssignIssueMutation';
 
 interface AssigneeSelectorProps {
@@ -90,7 +90,7 @@ export function AssigneeSelector({
   showLabel = false,
   useOwnerAssignmentDetails = true,
 }: AssigneeSelectorProps) {
-  const organization = useOrganization();
+  const shouldUseNewUI = useNewIssuePriorityAndAssigneeUI();
   const {data: defaultMemberList = [], isPending: defaultMemberListLoading} = useQuery({
     ...useProjectMembersQueryOptions([group.project.id]),
     select: resp => selectUsersFromMembers(resp.json),
@@ -104,7 +104,6 @@ export function AssigneeSelector({
   const currentAssignmentDetails =
     assignmentDetails ??
     (useOwnerAssignmentDetails ? getOwnerAssignmentDetails(group) : undefined);
-  const useAvatarButton = organization.features.includes('issue-priority-assignee-ui');
 
   return (
     <AssigneeSelectorDropdown
@@ -118,7 +117,7 @@ export function AssigneeSelector({
       }
       onClear={() => handleAssigneeChange(null)}
       trigger={
-        useAvatarButton
+        shouldUseNewUI
           ? undefined
           : (props, isOpen) => (
               <StyledTrigger
@@ -138,7 +137,6 @@ export function AssigneeSelector({
               </StyledTrigger>
             )
       }
-      useAvatarButton={useAvatarButton}
       additionalMenuFooterItems={additionalMenuFooterItems}
     />
   );

--- a/static/app/utils/useNewIssuePriorityAndAssigneeUI.ts
+++ b/static/app/utils/useNewIssuePriorityAndAssigneeUI.ts
@@ -1,0 +1,7 @@
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+export function useNewIssuePriorityAndAssigneeUI() {
+  const organization = useOrganization();
+
+  return organization.features.includes('issue-priority-assignee-ui');
+}

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
@@ -23,6 +23,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {getAnalyticsDataForGroup, getMessage, getTitle} from 'sentry/utils/events';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useNavigate} from 'sentry/utils/useNavigate';
+import {useNewIssuePriorityAndAssigneeUI} from 'sentry/utils/useNewIssuePriorityAndAssigneeUI';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {ActivitySection} from 'sentry/views/issueDetails/activitySection';
@@ -158,7 +159,7 @@ function IssuePreviewContent() {
     ReprocessingStatus.REPROCESSING,
     ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT,
   ].includes(getGroupReprocessingStatus(group));
-  const useCompactControls = organization.features.includes('issue-priority-assignee-ui');
+  const shouldUseNewUI = useNewIssuePriorityAndAssigneeUI();
 
   const issueDetailsUrl = normalizeUrl(
     `/organizations/${organization.slug}/issues/${group.id}/`
@@ -247,7 +248,7 @@ function IssuePreviewContent() {
           onContinueInSeer={() => openSeerDrawer()}
           onRetryCodeChanges={() => openSeerDrawer('retry_code_changes')}
         />
-        <Flex align="center" wrap="wrap" gap={useCompactControls ? 'md' : 'lg'}>
+        <Flex align="center" wrap="wrap" gap={shouldUseNewUI ? 'md' : 'lg'}>
           <GroupPriority group={group} />
           <GroupHeaderAssigneeSelector
             group={group}

--- a/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
+++ b/static/app/views/issueList/pages/inbox/issuePreview/issuePreview.tsx
@@ -158,6 +158,7 @@ function IssuePreviewContent() {
     ReprocessingStatus.REPROCESSING,
     ReprocessingStatus.REPROCESSED_AND_HASNT_EVENT,
   ].includes(getGroupReprocessingStatus(group));
+  const useCompactControls = organization.features.includes('issue-priority-assignee-ui');
 
   const issueDetailsUrl = normalizeUrl(
     `/organizations/${organization.slug}/issues/${group.id}/`
@@ -246,7 +247,7 @@ function IssuePreviewContent() {
           onContinueInSeer={() => openSeerDrawer()}
           onRetryCodeChanges={() => openSeerDrawer('retry_code_changes')}
         />
-        <Flex align="center" wrap="wrap" gap="lg">
+        <Flex align="center" wrap="wrap" gap={useCompactControls ? 'md' : 'lg'}>
           <GroupPriority group={group} />
           <GroupHeaderAssigneeSelector
             group={group}


### PR DESCRIPTION
Uses the shared `AvatarButton` added in #123352 and hardened in #123245 instead of reimplementing the assignee button geometry.

- gates the compact assignee and priority triggers together behind `issue-priority-assignee-ui`, with the legacy controls unchanged when the flag is off
- preserves real user and team avatars, user/team shape, suggested and unassigned states, assignment tooltips, and a mounted loading trigger
- uses the same `xs` size for both controls and tightens their spacing in the Inbox preview

Fixes ISWF-3216
