### PR TITLE
fix(loader): Default to system theme before React loads

### DIFF
--- a/src/sentry/templates/sentry/base-react.html
+++ b/src/sentry/templates/sentry/base-react.html
@@ -8,4 +8,4 @@
   </div>
 {% endblock %}
 
-{% block wrapperclass %}{{ user_theme }}{% endblock %}
+{% block wrapperclass %}{{ user_theme|default:"theme-system" }}{% endblock %}

--- a/static/index.ejs
+++ b/static/index.ejs
@@ -27,7 +27,6 @@
             return;
           }
         }
-        document.body.classList.remove('theme-system');
       }
       applySpaTheme();
     </script>

--- a/tests/sentry/web/frontend/test_auth_login.py
+++ b/tests/sentry/web/frontend/test_auth_login.py
@@ -69,6 +69,7 @@ class AuthLoginTest(TestCase, HybridCloudTestMixin):
         assert resp.status_code == 200
         self.assertTemplateUsed(resp, "sentry/base-react.html")
         self.assertTemplateNotUsed(resp, "sentry/login.html")
+        assert b'<body class="theme-system">' in resp.content
 
     @with_feature("system:multi-region")
     def test_customer_domain_login_redirects_to_primary_domain(self) -> None:


### PR DESCRIPTION
Anonymous React pages render their loading shell before client theme initialization. Without a server-provided theme class, dark-system users see the light loader; the dev SPA shell similarly discarded its system fallback when no explicit user preference existed.

Default the Django base template to `theme-system` when no user preference is available, retain that same fallback in the dev shell, and cover the anonymous auth response.