### PR TITLE
fix(preprod): Disallow logical operators in builds search

### DIFF
--- a/static/app/components/preprod/preprodBuildsSearchControls.tsx
+++ b/static/app/components/preprod/preprodBuildsSearchControls.tsx
@@ -95,6 +95,7 @@ export function PreprodBuildsSearchControls({
           onChange={onChange}
           onSearch={onSearch}
           projects={projects}
+          disallowLogicalOperators
         />
       </Container>
       {onExportCsv && (


### PR DESCRIPTION
The `/builds/` endpoint rejects `AND`/`OR` and parenthetical expressions ([artifact_search.py](https://github.com/getsentry/sentry/blob/master/src/sentry/preprod/artifact_search.py#L275-L282)), so the builds search bar shouldn't offer them.