### PR TITLE
fix(api): Classify Seer callers ahead of unknown in client_kind

### DIFF
--- a/src/sentry/api/client_kind.py
+++ b/src/sentry/api/client_kind.py
@@ -21,7 +21,7 @@ from sentry.auth.system import is_system_auth
 from sentry.middleware import is_frontend_request
 from sentry.models.organization import Organization
 from sentry.seer.agent_token import is_agent_auth
-from sentry.utils.http import get_mcp_client_family, is_mcp_request
+from sentry.utils.http import SEER_REFERRER_HEADER, get_mcp_client_family, is_mcp_request
 
 FEATURE_FLAG = "organizations:api-client-kind-check"
 
@@ -77,16 +77,32 @@ def get_client_kind(request: Request, organization: Organization) -> ClientKind 
     if is_system_auth(auth):
         return ClientKind.INTERNAL_SERVICE
 
-    # Seer reaches us two ways: its own capability token, or by echoing back the
-    # viewer context Sentry signed for it (which leaves `request.auth` unset).
-    if is_agent_auth(auth) or request.META.get("HTTP_X_VIEWER_CONTEXT"):
-        return ClientKind.SEER
-
     # The first-party MCP server is only identifiable by its user agent today.
+    # Checked ahead of Seer, mirroring `resolve_action_source`: an MCP call that also
+    # carries a Seer signal is still an MCP call.
     # TODO: derive from the OAuth client_id of the MCP app instead, once MCP
     # traffic reliably carries one -- a user agent is strippable.
     if is_mcp_request(request):
         return ClientKind.MCP
+
+    # Seer reaches us four ways: its own capability token, the viewer context Sentry
+    # signed for it (which leaves `request.auth` unset), the referrer header it sets on
+    # API calls it makes for a user, or its RPC signature. Keep this list in step with
+    # `resolve_action_source` -- the two drifting is what let Seer read as UNKNOWN.
+    if (
+        is_agent_auth(auth)
+        or request.META.get("HTTP_X_VIEWER_CONTEXT")
+        or request.META.get(SEER_REFERRER_HEADER)
+    ):
+        return ClientKind.SEER
+
+    # Imported here, not at module load, to avoid a circular import.
+    from sentry.seer.endpoints.seer_rpc import SeerRpcSignatureAuthentication
+
+    if isinstance(
+        getattr(request, "successful_authenticator", None), SeerRpcSignatureAuthentication
+    ):
+        return ClientKind.SEER
 
     if auth is None:
         # Cookies and no token is the web UI. Share `is_frontend_request` with the
@@ -117,6 +133,16 @@ def get_client_kind(request: Request, organization: Organization) -> ClientKind 
         return ClientKind.SCRIPT
 
     return ClientKind.UNKNOWN
+
+
+def get_user_agent(request: Request) -> str | None:
+    """The raw user agent the caller sent, or None when it sent none.
+
+    Recorded alongside `client_kind` so a bucket can be explained without guessing:
+    `unknown` and `script` are only actionable next to the string that produced them.
+    Attacker-controlled, like every user agent here -- read it as a hint, not a fact.
+    """
+    return request.META.get("HTTP_USER_AGENT") or None
 
 
 def get_client_host(request: Request) -> str | None:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -9,12 +9,13 @@ from rest_framework import status
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
-from sentry.api.client_kind import get_client_host, get_client_kind
+from sentry.api.client_kind import get_client_host, get_client_kind, get_user_agent
 from sentry.api.helpers.error_upsampling import (
     is_errors_query_for_error_upsampled_projects,
     transform_orderby_for_error_upsampling,
@@ -225,6 +226,9 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
             if client_host is not None:
                 sentry_sdk.set_tag("client_host_test", client_host)
                 sentry_sdk.set_attribute("client_host_test", client_host)
+            user_agent = get_user_agent(request)
+            if user_agent is not None:
+                sentry_sdk.set_attribute(ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, user_agent)
 
         try:
             snuba_params = self.get_snuba_params(

--- a/src/sentry/issues/action_log/base.py
+++ b/src/sentry/issues/action_log/base.py
@@ -10,11 +10,14 @@ from sentry.issues.action_log.types import SYSTEM_ACTOR, ActionSource, GroupActi
 from sentry.middleware import is_frontend_request
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
-from sentry.utils.http import KNOWN_MCP_CLIENT_FAMILIES, get_mcp_client_family, is_mcp_request
+from sentry.utils.http import (
+    KNOWN_MCP_CLIENT_FAMILIES,
+    SEER_REFERRER_HEADER,
+    get_mcp_client_family,
+    is_mcp_request,
+)
 
 logger = logging.getLogger(__name__)
-
-SEER_REFERRER_HEADER = "HTTP_X_SEER_REFERRER"
 
 
 def resolve_action_source(request: Request) -> str:

--- a/src/sentry/utils/http.py
+++ b/src/sentry/utils/http.py
@@ -29,6 +29,11 @@ KNOWN_MCP_CLIENT_FAMILIES = frozenset(
 )
 MCP_CATCHALL_CLIENT_FAMILIES = frozenset({"other", "unknown"})
 
+# Header Seer sets on the API calls it makes on a user's behalf. Shared so that
+# every caller-attribution site keys off the same signal (see `sentry.api.client_kind`
+# and `sentry.issues.action_log`).
+SEER_REFERRER_HEADER = "HTTP_X_SEER_REFERRER"
+
 
 class ParsedUriMatch(NamedTuple):
     scheme: str

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -5,7 +5,13 @@ from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from rest_framework.request import Request
 
-from sentry.api.client_kind import FEATURE_FLAG, ClientKind, get_client_host, get_client_kind
+from sentry.api.client_kind import (
+    FEATURE_FLAG,
+    ClientKind,
+    get_client_host,
+    get_client_kind,
+    get_user_agent,
+)
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import SystemToken
 from sentry.seer.agent_token import AGENT_TOKEN_KIND
@@ -69,6 +75,21 @@ class GetClientKindTest(TestCase):
         request = make_request(user=session_user(), headers={"X-Viewer-Context": "a.b.c"})
         assert self.classify(request) == ClientKind.SEER
 
+    def test_seer_referrer_header_is_seer(self) -> None:
+        # Seer sets this on API calls it makes for a user; without it those calls
+        # carry an ordinary user token and used to read as UNKNOWN.
+        request = make_request(auth=api_token(), headers={"X-Seer-Referrer": "explorer"})
+        assert self.classify(request) == ClientKind.SEER
+
+    def test_mcp_wins_over_a_seer_signal(self) -> None:
+        # Priority matches `resolve_action_source`: MCP is checked before Seer.
+        request = make_request(
+            auth=api_token(application_id=42),
+            user_agent="sentry-mcp/0.35.0 (https://mcp.sentry.dev)",
+            headers={"X-Seer-Referrer": "explorer"},
+        )
+        assert self.classify(request) == ClientKind.MCP
+
     def test_mcp_user_agent_wins_over_the_oauth_token_it_carries(self) -> None:
         # MCP authenticates via OAuth, so its token would otherwise read as INTEGRATION.
         request = make_request(
@@ -105,6 +126,18 @@ class GetClientKindTest(TestCase):
         # Shares `is_frontend_request` with the `ui_request` tag on `view.response`.
         request = make_request(user=session_user(), cookies=False)
         assert self.classify(request) == ClientKind.UNKNOWN
+
+
+class GetUserAgentTest(TestCase):
+    def test_returns_the_raw_user_agent(self) -> None:
+        assert get_user_agent(make_request(user_agent="curl/8.7.1")) == "curl/8.7.1"
+
+    def test_absent_user_agent_is_none(self) -> None:
+        assert get_user_agent(make_request()) is None
+
+    def test_empty_user_agent_is_none(self) -> None:
+        # An empty header and no header at all mean the same thing to a reader.
+        assert get_user_agent(make_request(user_agent="")) is None
 
 
 class GetClientHostTest(TestCase):


### PR DESCRIPTION
`client_kind` only recognized Seer via its agent token or the `X-Viewer-Context` header, so calls carrying `X-Seer-Referrer` or a Seer RPC signature fell through to `UNKNOWN`. This aligns detection with `resolve_action_source` in `sentry.issues.action_log` (same MCP-before-Seer priority) and shares the referrer header constant between the two so they can't drift apart again.

Also records the caller's raw `User-Agent` as the standard `user_agent.original` attribute, since the `unknown`/`script` buckets aren't actionable without it.

Claude-Session: https://claude.ai/code/session_016MAWQkMcbwFxRqnLC4vG7c