### PR TITLE
docs(agents): Check sentry_conventions before naming a new attribute

### DIFF
--- a/.agents/skills/backend-conventions/SKILL.md
+++ b/.agents/skills/backend-conventions/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: backend-conventions
-description: Sentry backend conventions for logging, tracing/spans, metrics tags, and the options system. Use when adding or editing Python in src/ that logs (logger.info/exception), records metrics (metrics.incr/timing with tags), instruments spans/transactions, or reads registered options with options.get(). Trigger on "add logging", "log an error", "add a metric", "add a span", "instrument tracing", "read an option", "LOG005", "LOG011", or metrics tag cardinality questions.
+description: Sentry backend conventions for logging, tracing/spans, span/tag attribute naming, metrics tags, and the options system. Use when adding or editing Python in src/ that logs (logger.info/exception), records metrics (metrics.incr/timing with tags), instruments spans/transactions, calls sentry_sdk.set_tag/set_attribute or set_span_tag/set_span_data, or reads registered options with options.get(). Trigger on "add logging", "log an error", "add a metric", "add a span", "instrument tracing", "set an attribute", "add a tag", "read an option", "LOG005", "LOG011", or metrics tag cardinality questions.
 ---
 
 # Backend Conventions: Logging, Tracing, Metrics, Options
@@ -103,6 +103,22 @@ with start_span(name="event_manager.save", op="save") as span:
 with start_span(name="monitors.consumer", op="process", transaction=True):
     process_batch()
 ```
+
+## Span / Tag Attribute Names
+
+Before inventing a key for `sentry_sdk.set_tag`/`set_attribute`, `set_span_tag`, or `set_span_data`, check whether OTel or Sentry already has a standard name for it in `sentry_conventions.attributes.ATTRIBUTE_NAMES`. Reusing a convention name keeps the attribute queryable and consistent with what other producers (SDKs, Relay) already emit for the same concept — a bespoke name fragments the same data across two keys.
+
+```python
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
+
+# WRONG: inventing a name for a concept the conventions already cover
+sentry_sdk.set_attribute("request_user_agent", user_agent)
+
+# RIGHT: use the existing convention name
+sentry_sdk.set_attribute(ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, user_agent)
+```
+
+`ATTRIBUTE_NAMES` is generated from the OTel semantic conventions plus Sentry's own model (`.venv/lib/python*/site-packages/sentry_conventions/attributes.py`); grep it for candidate keywords before adding a new one. Only fall back to a custom key when the concept genuinely isn't covered, and prefer a namespaced, descriptive name over a generic one. A key kept behind a `_test`/POC suffix while a feature is unreleased is a separate, deliberate case — that's about hiding the field, not about picking its name.
 
 ## Metrics Tags
 

--- a/static/AGENTS.md
+++ b/static/AGENTS.md
@@ -101,3 +101,21 @@ For worked examples of all of the above, use the **`design-system`** skill.
 ## React Testing
 
 Writing or editing frontend tests (`*.spec.tsx`, RTL, `MockApiClient`, routing/network tests) → use the **`react-testing`** skill for the full guide (query priority, no hook mocking, fixtures, async assertions, mocking network requests).
+
+## Sentry SDK Instrumentation
+
+Before inventing a key for `Sentry.setTag`/`setContext`, or a span's `setAttribute`, check whether OTel or Sentry already has a standard name for it in `@sentry/conventions`. Reusing a convention name keeps the attribute queryable and consistent with what other producers (SDKs, Relay) already emit for the same concept — a bespoke name fragments the same data across two keys. This mirrors the Python-side rule in the **`backend-conventions`** skill; the two must stay in sync since a frontend and backend span can describe the same request.
+
+The individual name constants (e.g. `USER_AGENT_ORIGINAL`) live at the `/attributes` subpath, not the package root — the root only re-exports `ATTRIBUTE_METADATA`/`ATTRIBUTE_SEARCH_METADATA` (the human-readable descriptions used for search-field UI, see `static/app/utils/fields/`), which is a separate concern from the name itself.
+
+```tsx
+import {USER_AGENT_ORIGINAL} from '@sentry/conventions/attributes';
+
+// WRONG: inventing a name for a concept the conventions already cover
+span.setAttribute('request_user_agent', navigator.userAgent);
+
+// RIGHT: use the existing convention name
+span.setAttribute(USER_AGENT_ORIGINAL, navigator.userAgent);
+```
+
+These are generated from the OTel semantic conventions plus Sentry's own model — grep `node_modules/@sentry/conventions/dist/attributes.d.ts` for candidate keywords before adding a new one.

--- a/static/AGENTS.md
+++ b/static/AGENTS.md
@@ -106,7 +106,7 @@ Writing or editing frontend tests (`*.spec.tsx`, RTL, `MockApiClient`, routing/n
 
 Before inventing a key for `Sentry.setTag`/`setContext`, or a span's `setAttribute`, check whether OTel or Sentry already has a standard name for it in `@sentry/conventions`. Reusing a convention name keeps the attribute queryable and consistent with what other producers (SDKs, Relay) already emit for the same concept — a bespoke name fragments the same data across two keys. This mirrors the Python-side rule in the **`backend-conventions`** skill; the two must stay in sync since a frontend and backend span can describe the same request.
 
-The individual name constants (e.g. `USER_AGENT_ORIGINAL`) live at the `/attributes` subpath, not the package root — the root only re-exports `ATTRIBUTE_METADATA`/`ATTRIBUTE_SEARCH_METADATA` (the human-readable descriptions used for search-field UI, see `static/app/utils/fields/`), which is a separate concern from the name itself.
+The individual name constants (e.g. `USER_AGENT_ORIGINAL`) live at the `/attributes` subpath, not the package root — the root only re-exports the metadata tables: `ATTRIBUTE_METADATA` (the full per-attribute record — brief, type, aliases, deprecation) and `ATTRIBUTE_SEARCH_METADATA` (the descriptions the search-field UI renders, see `static/app/utils/fields/`). Both are a separate concern from the name itself.
 
 ```tsx
 import {USER_AGENT_ORIGINAL} from '@sentry/conventions/attributes';


### PR DESCRIPTION
Adds a rule to `backend-conventions` and `static/AGENTS.md` to check `sentry_conventions.attributes.ATTRIBUTE_NAMES` (backend) / `@sentry/conventions/attributes` (frontend) for an existing OTel/Sentry name before inventing a tag or attribute key. Motivated by #123578, where a new attribute could have collided with the existing `user_agent.original` convention.