### PR TITLE
fix(ui): Respect reduced motion preference

### DIFF
--- a/static/app/main.tsx
+++ b/static/app/main.tsx
@@ -1,6 +1,7 @@
 import {lazy, Suspense, useEffect, useState} from 'react';
 import {createBrowserRouter, RouterProvider} from 'react-router-dom';
 import {wrapCreateBrowserRouterV6} from '@sentry/react';
+import {MotionConfig} from 'framer-motion';
 import {NuqsAdapter} from 'nuqs/adapters/react-router/v6';
 
 import {setApiNavigate} from 'sentry/api';
@@ -46,27 +47,29 @@ export function Main() {
   }, [router.routes]);
 
   return (
-    <AppQueryClientProvider>
-      <DocumentTitleManager>
-        <FrontendVersionProvider releaseVersion={SENTRY_RELEASE_VERSION ?? null}>
-          <ServiceWorkerProvider>
-            <ThemeAndStyleProvider>
-              <NuqsAdapter defaultOptions={{shallow: false}}>
-                <CommandPaletteProvider>
-                  <RouteConfigProvider value={router.routes}>
-                    <RouterProvider router={router} />
-                  </RouteConfigProvider>
-                </CommandPaletteProvider>
-              </NuqsAdapter>
-              {SentryTanStackDevtools ? (
-                <Suspense fallback={null}>
-                  <SentryTanStackDevtools />
-                </Suspense>
-              ) : null}
-            </ThemeAndStyleProvider>
-          </ServiceWorkerProvider>
-        </FrontendVersionProvider>
-      </DocumentTitleManager>
-    </AppQueryClientProvider>
+    <MotionConfig reducedMotion="user">
+      <AppQueryClientProvider>
+        <DocumentTitleManager>
+          <FrontendVersionProvider releaseVersion={SENTRY_RELEASE_VERSION ?? null}>
+            <ServiceWorkerProvider>
+              <ThemeAndStyleProvider>
+                <NuqsAdapter defaultOptions={{shallow: false}}>
+                  <CommandPaletteProvider>
+                    <RouteConfigProvider value={router.routes}>
+                      <RouterProvider router={router} />
+                    </RouteConfigProvider>
+                  </CommandPaletteProvider>
+                </NuqsAdapter>
+                {SentryTanStackDevtools ? (
+                  <Suspense fallback={null}>
+                    <SentryTanStackDevtools />
+                  </Suspense>
+                ) : null}
+              </ThemeAndStyleProvider>
+            </ServiceWorkerProvider>
+          </FrontendVersionProvider>
+        </DocumentTitleManager>
+      </AppQueryClientProvider>
+    </MotionConfig>
   );
 }


### PR DESCRIPTION
Framer Motion defaults to running animations regardless of the user's system accessibility preference, and the existing global CSS rule only affects CSS animations and transitions.

Configure Framer Motion at the application root so motion components in every routed view respect `prefers-reduced-motion`.