### PR TITLE
ref(pr-iter): only consume feedback once a push lands

### DIFF
--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -100,6 +101,21 @@ STOPPING_POINT_TO_STEP: dict[AutofixStoppingPoint, AutofixStep] = {
     AutofixStoppingPoint.SOLUTION: AutofixStep.SOLUTION,
     AutofixStoppingPoint.CODE_CHANGES: AutofixStep.CODE_CHANGES,
 }
+
+
+class _PrIterationPushOutcome(StrEnum):
+    """Why this pass did or didn't push, decided before touching the PR.
+
+    ``ALREADY_PUSHED`` is the hand-back pass: a prior push's changes are now
+    synced, so this is also the only outcome that counts as this batch's
+    changes having landed.
+    """
+
+    ALREADY_PUSHED = "already_pushed"
+    NO_CODE_CHANGES = "no_code_changes"
+    NO_PULL_REQUEST = "no_pull_request"
+    PR_CREATION_ERRORED = "pr_creation_errored"
+    PUSH_FAILED = "push_failed"
 
 
 def _record_completion_reaction(outcome: str, amount: int = 1) -> None:
@@ -866,27 +882,38 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                     paused=paused,
                     failure_reason=state.failure_reason,
                 )
+                complete_pr_iteration_details(
+                    log_ctx=log_ctx,
+                    run_state=state,
+                    organization_id=organization.id,
+                    pushed_changes=False,
+                )
                 return
 
-            pushed = cls._push_iteration_changes(
-                log_ctx,
-                group,
-                run_id,
-                state,
-                author=cls._iteration_commit_author(state),
-            )
+            outcome = cls._pr_iteration_push_outcome(log_ctx, group, run_id, state)
 
-            # we assume that after we push, we'll get more feedback in the queue and we'll consume then
-            if not pushed:
-                # we want to consume queued feedback _after_ we know changes have been pushed
-                # because some feedback in the queue could be filtered out
+            if outcome is None:
+                # A push was attempted and succeeded. Not terminal yet -- we wait
+                # for the next completion hook, where the repos show as synced,
+                # to consume queued feedback and complete the iteration details.
+                return
+
+            # Only consume queued feedback once we know the PR reflects the
+            # agent's work: either this is the hand-back pass seeing a prior
+            # push's changes as synced, or there was never anything to push.
+            # A push that failed leaves the feedback queued rather than risk
+            # consuming it as if changes had landed.
+            if outcome in (
+                _PrIterationPushOutcome.ALREADY_PUSHED,
+                _PrIterationPushOutcome.NO_CODE_CHANGES,
+            ):
                 cls._consume_queued_feedback(log_ctx, organization, run_id)
 
             complete_pr_iteration_details(
                 log_ctx=log_ctx,
                 run_state=state,
                 organization_id=organization.id,
-                pushed_changes=pushed,
+                pushed_changes=outcome == _PrIterationPushOutcome.ALREADY_PUSHED,
             )
             return
 
@@ -1082,6 +1109,84 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         return parse_commit_author(metadata.get("commit_author"))
 
     @classmethod
+    def _latest_iteration_touched_files(
+        cls, log_ctx: PrIterationLogContext, state: SeerRunState
+    ) -> bool:
+        """Whether the iteration that just finished produced any file patches.
+
+        ``state.has_code_changes()`` looks at the diff merged across the whole
+        run, which in PR iteration is almost never empty once the PR exists --
+        it would report changes even when this particular batch touched
+        nothing. This checks only the blocks the latest PR_ITERATION opened.
+        Fails open (assumes changes) so a lookup failure falls back to the
+        normal push path instead of silently skipping it.
+        """
+        try:
+            iterations = get_iterations(state)
+        except Exception:
+            log_ctx.error("autofix.pr_iteration.get_iterations_failed")
+            return True
+
+        if not iterations:
+            return True
+
+        return any(block.merged_file_patches for block in iterations[-1].blocks)
+
+    @classmethod
+    def _pr_iteration_push_outcome(
+        cls,
+        log_ctx: PrIterationLogContext,
+        group: Group,
+        run_id: int,
+        state: SeerRunState,
+    ) -> _PrIterationPushOutcome | None:
+        """Decide whether this pass needs to push, and how it ended.
+
+        ``None`` means a push was attempted and succeeded -- the iteration
+        isn't finished, we're waiting for the next completion hook to see the
+        repos as synced. Every other return is terminal: either there was
+        nothing to push (no PRs, no changes, already synced) or a push was
+        attempted (this pass or a prior one) and failed.
+        """
+        if not state.repo_pr_states:
+            log_ctx.error(
+                "autofix.pr_iteration.push",
+                outcome="not_pushed",
+                reason="no_pull_requests",
+                exc_info=False,
+            )
+            return _PrIterationPushOutcome.NO_PULL_REQUEST
+
+        if not cls._latest_iteration_touched_files(log_ctx, state):
+            log_ctx.info("autofix.pr_iteration.push", outcome="not_pushed", reason="no_changes")
+            return _PrIterationPushOutcome.NO_CODE_CHANGES
+
+        _, is_synced = state.has_code_changes()
+
+        if is_synced:
+            log_ctx.info("autofix.pr_iteration.push", outcome="not_pushed", reason="already_synced")
+            return _PrIterationPushOutcome.ALREADY_PUSHED
+
+        errored_repos = cls._iteration_terminal_errored_repos(state)
+        if errored_repos:
+            log_ctx.info(
+                "autofix.pr_iteration.push",
+                outcome="not_pushed",
+                reason="terminal_push_errors",
+                errored_repos=errored_repos,
+            )
+            return _PrIterationPushOutcome.PR_CREATION_ERRORED
+
+        pushed = cls._push_iteration_changes(
+            log_ctx,
+            group,
+            run_id,
+            state,
+            author=cls._iteration_commit_author(state),
+        )
+        return None if pushed else _PrIterationPushOutcome.PUSH_FAILED
+
+    @classmethod
     def _push_iteration_changes(
         cls,
         log_ctx: PrIterationLogContext,
@@ -1092,37 +1197,10 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
     ) -> bool:
         """Push an iteration's changes to the PRs it already has. True if it pushed.
 
-        Branched off :meth:`_push_changes`
+        Branched off :meth:`_push_changes`. Callers are expected to have
+        already checked that there's something to push -- this only attempts
+        the push and reports whether it worked.
         """
-        if not state.repo_pr_states:
-            log_ctx.error(
-                "autofix.pr_iteration.push",
-                outcome="not_pushed",
-                reason="no_pull_requests",
-                exc_info=False,
-            )
-            return False
-
-        has_changes, is_synced = state.has_code_changes()
-
-        if not has_changes:
-            log_ctx.info("autofix.pr_iteration.push", outcome="not_pushed", reason="no_changes")
-            return False
-
-        if is_synced:
-            log_ctx.info("autofix.pr_iteration.push", outcome="not_pushed", reason="already_synced")
-            return False
-
-        errored_repos = cls._iteration_terminal_errored_repos(state)
-        if errored_repos:
-            log_ctx.info(
-                "autofix.pr_iteration.push",
-                outcome="not_pushed",
-                reason="terminal_push_errors",
-                errored_repos=errored_repos,
-            )
-            return False
-
         try:
             trigger_push_changes(
                 group,

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -19,6 +19,7 @@ from sentry.seer.autofix.on_completion_hook import (
     STOPPING_POINT_TO_STEP,
     AutofixOnCompletionHook,
     _group_and_referrer_from_run,
+    _PrIterationPushOutcome,
     _stopping_point_from_run,
 )
 from sentry.seer.autofix.pr_iteration.constants import REVIEW_REQUEST_FLAG
@@ -452,10 +453,10 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
         "sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._consume_queued_feedback"
     )
     @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
-    def test_pr_iteration_does_not_consume_feedback_when_pushed(
+    def test_pr_iteration_does_not_consume_feedback_when_just_pushed(
         self, mock_push_changes, mock_consume
     ):
-        """When PR iteration pushes new changes, queued feedback is left for the next run."""
+        """A push that just landed waits for the next hook pass to consume feedback."""
         state = run_state(
             blocks=[pr_iteration_memory_block()],
             metadata={
@@ -492,10 +493,10 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
         "sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._consume_queued_feedback"
     )
     @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
-    def test_pr_iteration_consumes_feedback_when_nothing_pushed(
+    def test_pr_iteration_consumes_feedback_on_the_hand_back_pass(
         self, mock_push_changes, mock_consume
     ):
-        """When PR iteration has no new changes to push, queued feedback is consumed now."""
+        """Seeing a prior push's changes already synced is what consumes feedback."""
         state = run_state(
             blocks=[pr_iteration_memory_block(commit_sha="synced-sha")],
             metadata={
@@ -509,7 +510,36 @@ class TestAutofixOnCompletionHookPipeline(TestCase):
         AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
         mock_push_changes.assert_not_called()
         mock_consume.assert_called_once()
-        assert mock_consume.call_args.args[1:] == (self.organization, 123)
+
+    @patch(
+        "sentry.seer.autofix.on_completion_hook.AutofixOnCompletionHook._consume_queued_feedback"
+    )
+    @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
+    def test_pr_iteration_consumes_feedback_when_no_code_changes(
+        self, mock_push_changes, mock_consume
+    ):
+        """There was never anything to push, so nothing landing is expected."""
+        state = run_state(
+            blocks=[
+                MemoryBlock(
+                    id="block-pr-iteration",
+                    message=Message(
+                        role="assistant", content="nothing to do", metadata={"step": "pr_iteration"}
+                    ),
+                    timestamp="2026-02-10T00:00:00Z",
+                )
+            ],
+            metadata={
+                "group_id": self.group.id,
+                "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
+            },
+        )
+        state.repo_pr_states = {
+            "test-repo": RepoPRState(repo_name="test-repo", commit_sha="synced-sha")
+        }
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+        mock_push_changes.assert_not_called()
+        mock_consume.assert_called_once()
 
     @patch("sentry.seer.autofix.on_completion_hook.trigger_push_changes")
     def test_push_changes_skips_when_all_unsynced_repos_errored(self, mock_push_changes):
@@ -622,12 +652,14 @@ class TestPrIterationCompletionHook(TestCase):
         return state
 
     def _push(self, state: SeerRunState) -> bool:
-        return AutofixOnCompletionHook._push_iteration_changes(
+        """True when a push happened (or was attempted and succeeded)."""
+        outcome = AutofixOnCompletionHook._pr_iteration_push_outcome(
             AutofixOnCompletionHook._iteration_log_context(self.organization, self.group, state),
             self.group,
             123,
             state,
         )
+        return outcome is None
 
     def _webhook(self, state: SeerRunState) -> None:
         AutofixOnCompletionHook._send_step_webhook(self.organization, 123, state, self.group)
@@ -680,7 +712,7 @@ class TestPrIterationCompletionHook(TestCase):
         AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
 
         mock_push.assert_not_called()
-        mock_consume.assert_called_once()
+        mock_consume.assert_not_called()
 
     @patch(f"{HOOK_PATH}.trigger_push_changes")
     def test_a_pass_that_pushes(self, mock_push):
@@ -703,23 +735,38 @@ class TestPrIterationCompletionHook(TestCase):
 
     @patch(f"{HOOK_PATH}.trigger_push_changes")
     def test_an_iteration_that_changed_nothing_does_not_push(self, mock_push):
+        """The run's cumulative diff is not the question -- the *latest*
+        iteration's own blocks are, so a prior iteration's patches (still on
+        the merged diff) must not make this one look like it pushed."""
         state = run_state(
             blocks=[
+                pr_iteration_memory_block(iteration_index=1, commit_sha="stale-sha"),
                 MemoryBlock(
-                    id="block-pr-iteration",
+                    id="block-pr-iteration-2",
                     message=Message(
-                        role="assistant", content="nothing to do", metadata={"step": "pr_iteration"}
+                        role="assistant",
+                        content="nothing to do",
+                        metadata={
+                            "step": "pr_iteration",
+                            "iteration_index": "2",
+                            "feedback": "double check the fix",
+                        },
                     ),
                     timestamp="2026-02-10T00:00:00Z",
-                )
+                ),
             ],
             metadata={"group_id": self.group.id},
         )
-        state.repo_pr_states = self._pr_state("synced-sha")
+        state.repo_pr_states = self._pr_state("stale-sha")
 
-        pushed = self._push(state)
+        outcome = AutofixOnCompletionHook._pr_iteration_push_outcome(
+            AutofixOnCompletionHook._iteration_log_context(self.organization, self.group, state),
+            self.group,
+            123,
+            state,
+        )
 
-        assert pushed is False
+        assert outcome == _PrIterationPushOutcome.NO_CODE_CHANGES
         mock_push.assert_not_called()
 
     @patch(f"{HOOK_PATH}.trigger_push_changes")
@@ -745,14 +792,13 @@ class TestPrIterationCompletionHook(TestCase):
         f"{HOOK_PATH}.AutofixOnCompletionHook._consume_queued_feedback",
     )
     @patch(f"{HOOK_PATH}.trigger_push_changes", side_effect=ValueError("boom"))
-    def test_a_failed_push_still_hands_back_to_the_queue(self, mock_push, mock_consume):
-        """Feedback already waiting should not be stranded by a push that broke."""
+    def test_a_failed_push_does_not_consume_queued_feedback(self, mock_push, mock_consume):
+        """A broken push should not hand queued feedback off as if it landed."""
         AutofixOnCompletionHook._maybe_continue_pipeline(
             self.organization, 123, self._unsynced(), self.group
         )
 
-        mock_consume.assert_called_once()
-        assert mock_consume.call_args.args[1:] == (self.organization, 123)
+        mock_consume.assert_not_called()
 
     @patch(f"{HOOK_PATH}.AutofixOnCompletionHook._consume_queued_feedback")
     @patch(f"{HOOK_PATH}.trigger_push_changes")
@@ -795,6 +841,58 @@ class TestPrIterationCompletionHook(TestCase):
         assert task_kwargs["organization_id"] == self.organization.id
         assert task_kwargs["trigger_id"]
         assert task_kwargs["trigger_source"] == ConsumeTriggerSource.FEEDBACK
+
+    @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
+    def test_no_pull_request_reaches_completion_details_as_not_pushed(self, mock_complete):
+        state = run_state(
+            blocks=[pr_iteration_memory_block()], metadata={"group_id": self.group.id}
+        )
+
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+
+        assert mock_complete.call_args.kwargs["pushed_changes"] is False
+
+    @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
+    def test_already_synced_reaches_completion_details_as_pushed(self, mock_complete):
+        AutofixOnCompletionHook._maybe_continue_pipeline(
+            self.organization, 123, self._synced(), self.group
+        )
+
+        assert mock_complete.call_args.kwargs["pushed_changes"] is True
+
+    @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
+    @patch(f"{HOOK_PATH}.trigger_push_changes")
+    def test_a_terminally_errored_repo_reaches_completion_details_as_not_pushed(
+        self, mock_push, mock_complete
+    ):
+        state = self._unsynced()
+        state.repo_pr_states["test-repo"].pr_creation_status = "error"
+
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+
+        assert mock_complete.call_args.kwargs["pushed_changes"] is False
+
+    @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
+    @patch(f"{HOOK_PATH}.trigger_push_changes", side_effect=ValueError("boom"))
+    def test_a_failed_push_reaches_completion_details_as_not_pushed(self, mock_push, mock_complete):
+        AutofixOnCompletionHook._maybe_continue_pipeline(
+            self.organization, 123, self._unsynced(), self.group
+        )
+
+        assert mock_complete.call_args.kwargs["pushed_changes"] is False
+
+    @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
+    def test_an_errored_run_now_reaches_completion_details(self, mock_complete):
+        self.create_seer_run(
+            organization=self.organization, seer_run_state_id=123, user_id=self.user.id
+        )
+        state = self._unsynced()
+        state.status = "error"
+
+        AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
+
+        mock_complete.assert_called_once()
+        assert mock_complete.call_args.kwargs["pushed_changes"] is False
 
 
 class TestPipelineConstants(TestCase):


### PR DESCRIPTION
Hoists the push checks out of _push_iteration_changes so the hook
can tell a successful push apart from one that never happened or
failed. Feedback now drains only when a push actually landed, a
failed push leaves it queued, and an errored run finally records
its outcome instead of going unrecorded.