### PR TITLE
feat(pr-iter): record iteration outcome instead of a bool

### DIFF
--- a/src/sentry/analytics/events/pr_iteration_events.py
+++ b/src/sentry/analytics/events/pr_iteration_events.py
@@ -45,10 +45,8 @@ class AiAutofixPrIterationFeedbackBatchCompletedEvent(analytics.Event):
     dropped_count: int
     automated_feedback_count: int
 
-    # Outcome, written when the iteration ends. ``outcome`` is a plain str
-    # rather than a Literal: its failure values are Seer's own, so a reason Seer
-    # adds mid-deploy still records instead of failing validation. See
-    # ``PrIterationOutcome`` for the values Sentry knows about.
+    # Outcome, written when the iteration ends. See ``PrIterationOutcome`` for
+    # the values Sentry knows about.
     duration_ms: int
     outcome: str
 

--- a/src/sentry/analytics/events/pr_iteration_events.py
+++ b/src/sentry/analytics/events/pr_iteration_events.py
@@ -45,9 +45,12 @@ class AiAutofixPrIterationFeedbackBatchCompletedEvent(analytics.Event):
     dropped_count: int
     automated_feedback_count: int
 
-    # Outcome, written when the iteration ends.
+    # Outcome, written when the iteration ends. ``outcome`` is a plain str
+    # rather than a Literal: its failure values are Seer's own, so a reason Seer
+    # adds mid-deploy still records instead of failing validation. See
+    # ``PrIterationOutcome`` for the values Sentry knows about.
     duration_ms: int
-    pushed_changes: bool
+    outcome: str
 
 
 analytics.register(AiAutofixPrIterationMissingPermissionsEvent)

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 from collections import Counter
-from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 from uuid import uuid4
 
@@ -40,7 +39,11 @@ from sentry.seer.autofix.coding_agent import IntegrationNotFound
 from sentry.seer.autofix.commit_author import SeerCommitAuthor, parse_commit_author
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.github_perms import failed_tool_calls
-from sentry.seer.autofix.pr_iteration.emit import complete_pr_iteration_details
+from sentry.seer.autofix.pr_iteration.emit import (
+    PrIterationOutcome,
+    complete_pr_iteration_details,
+    outcome_for_failed_run,
+)
 from sentry.seer.autofix.pr_iteration.feedback import parse_feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTriggerSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
@@ -101,21 +104,6 @@ STOPPING_POINT_TO_STEP: dict[AutofixStoppingPoint, AutofixStep] = {
     AutofixStoppingPoint.SOLUTION: AutofixStep.SOLUTION,
     AutofixStoppingPoint.CODE_CHANGES: AutofixStep.CODE_CHANGES,
 }
-
-
-class _PrIterationPushOutcome(StrEnum):
-    """Why this pass did or didn't push, decided before touching the PR.
-
-    ``ALREADY_PUSHED`` is the hand-back pass: a prior push's changes are now
-    synced, so this is also the only outcome that counts as this batch's
-    changes having landed.
-    """
-
-    ALREADY_PUSHED = "already_pushed"
-    NO_CODE_CHANGES = "no_code_changes"
-    NO_PULL_REQUEST = "no_pull_request"
-    PR_CREATION_ERRORED = "pr_creation_errored"
-    PUSH_FAILED = "push_failed"
 
 
 def _record_completion_reaction(outcome: str, amount: int = 1) -> None:
@@ -886,7 +874,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                     log_ctx=log_ctx,
                     run_state=state,
                     organization_id=organization.id,
-                    pushed_changes=False,
+                    outcome=outcome_for_failed_run(state),
                 )
                 return
 
@@ -904,8 +892,8 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             # A push that failed leaves the feedback queued rather than risk
             # consuming it as if changes had landed.
             if outcome in (
-                _PrIterationPushOutcome.ALREADY_PUSHED,
-                _PrIterationPushOutcome.NO_CODE_CHANGES,
+                PrIterationOutcome.ALREADY_PUSHED,
+                PrIterationOutcome.NO_CODE_CHANGES,
             ):
                 cls._consume_queued_feedback(log_ctx, organization, run_id)
 
@@ -913,7 +901,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 log_ctx=log_ctx,
                 run_state=state,
                 organization_id=organization.id,
-                pushed_changes=outcome == _PrIterationPushOutcome.ALREADY_PUSHED,
+                outcome=outcome.value,
             )
             return
 
@@ -1139,7 +1127,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         group: Group,
         run_id: int,
         state: SeerRunState,
-    ) -> _PrIterationPushOutcome | None:
+    ) -> PrIterationOutcome | None:
         """Decide whether this pass needs to push, and how it ended.
 
         ``None`` means a push was attempted and succeeded -- the iteration
@@ -1155,17 +1143,17 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 reason="no_pull_requests",
                 exc_info=False,
             )
-            return _PrIterationPushOutcome.NO_PULL_REQUEST
+            return PrIterationOutcome.NO_PULL_REQUEST
 
         if not cls._latest_iteration_touched_files(log_ctx, state):
             log_ctx.info("autofix.pr_iteration.push", outcome="not_pushed", reason="no_changes")
-            return _PrIterationPushOutcome.NO_CODE_CHANGES
+            return PrIterationOutcome.NO_CODE_CHANGES
 
         _, is_synced = state.has_code_changes()
 
         if is_synced:
             log_ctx.info("autofix.pr_iteration.push", outcome="not_pushed", reason="already_synced")
-            return _PrIterationPushOutcome.ALREADY_PUSHED
+            return PrIterationOutcome.ALREADY_PUSHED
 
         errored_repos = cls._iteration_terminal_errored_repos(state)
         if errored_repos:
@@ -1175,7 +1163,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 reason="terminal_push_errors",
                 errored_repos=errored_repos,
             )
-            return _PrIterationPushOutcome.PR_CREATION_ERRORED
+            return PrIterationOutcome.PR_CREATION_ERRORED
 
         pushed = cls._push_iteration_changes(
             log_ctx,
@@ -1184,7 +1172,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             state,
             author=cls._iteration_commit_author(state),
         )
-        return None if pushed else _PrIterationPushOutcome.PUSH_FAILED
+        return None if pushed else PrIterationOutcome.PUSH_FAILED
 
     @classmethod
     def _push_iteration_changes(

--- a/src/sentry/seer/autofix/pr_iteration/emit.py
+++ b/src/sentry/seer/autofix/pr_iteration/emit.py
@@ -15,6 +15,7 @@ own failures: a caller records what it can and carries on regardless.
 from __future__ import annotations
 
 from dataclasses import fields
+from enum import StrEnum
 
 from django.utils import timezone
 
@@ -37,6 +38,37 @@ from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
 from sentry.seer.models.run import SeerRun, SeerRunPrIteration
 
 ITERATION_ID_METADATA_KEY = "iteration_id"
+
+
+class PrIterationOutcome(StrEnum):
+    """How a batch ended.
+
+    ``ALREADY_PUSHED`` is the success: the batch is recorded on the hook pass
+    where its changes are on the PR, not on the earlier pass that only asked
+    for the push.
+
+    The failure values are Seer's own ``ExplorerFailureReason`` spellings, so a
+    reason Seer adds since is recorded under its own outcome by
+    :func:`outcome_for_failed_run` rather than folded into ``ERRORED``.
+    """
+
+    ALREADY_PUSHED = "already_pushed"
+    NO_CODE_CHANGES = "no_code_changes"
+    NO_PULL_REQUEST = "no_pull_request"
+    PR_CREATION_ERRORED = "pr_creation_errored"
+    PUSH_FAILED = "push_failed"
+    TIMEOUT = "timeout"
+    STALLED = "stalled"
+    ERRORED = "errored"
+
+
+def outcome_for_failed_run(run_state: SeerRunState) -> str:
+    """Seer's reason for a failed run, or ``ERRORED`` when it did not give one.
+
+    Only a failed run carries a reason; every other ending is decided from what
+    the batch left on the PR.
+    """
+    return run_state.failure_reason or PrIterationOutcome.ERRORED.value
 
 
 def _seer_run(*, run_id: int, organization_id: int) -> SeerRun | None:
@@ -202,7 +234,7 @@ def _build_event(
     iteration: SeerRunPrIteration,
     *,
     iteration_index: int,
-    pushed_changes: bool,
+    outcome: str,
 ) -> AiAutofixPrIterationFeedbackBatchCompletedEvent | None:
     """The event for a finished iteration. None when its row is incomplete."""
     known = {f.name for f in fields(AiAutofixPrIterationFeedbackBatchCompletedEvent)}
@@ -213,7 +245,7 @@ def _build_event(
             iteration_id=iteration.id,
             iteration_index=iteration_index,
             duration_ms=duration_ms,
-            pushed_changes=pushed_changes,
+            outcome=outcome,
             **payload,
         )
     except TypeError:
@@ -221,7 +253,7 @@ def _build_event(
             "iteration_id",
             "iteration_index",
             "duration_ms",
-            "pushed_changes",
+            "outcome",
         }
         log_ctx.error(
             "autofix.pr_iteration.details.incomplete_row",
@@ -237,9 +269,13 @@ def complete_pr_iteration_details(
     log_ctx: PrIterationLogContext,
     run_state: SeerRunState,
     organization_id: int,
-    pushed_changes: bool,
+    outcome: str,
 ) -> None:
-    """Emit the row for the iteration that just finished, and drop it."""
+    """Emit the row for the iteration that just ended, and drop it.
+
+    The row goes however the batch ended: leaving it behind would let the next
+    completion hook emit this batch under a later iteration's outcome.
+    """
     iteration_id = state_iteration_id(log_ctx, run_state)
     if iteration_id is None:
         log_ctx.error(
@@ -264,7 +300,7 @@ def complete_pr_iteration_details(
             log_ctx,
             iteration,
             iteration_index=get_latest_iteration_index(run_state),
-            pushed_changes=pushed_changes,
+            outcome=outcome,
         )
         if event is None or not remove_iteration(iteration):
             return

--- a/tests/sentry/seer/autofix/pr_iteration/test_emit.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_emit.py
@@ -312,6 +312,7 @@ class PrIterationDetailsTest(TestCase):
                 run_id=RUN_ID,
                 referrer="github_pr_comment",
                 iteration_index=0,
+                trigger_source="feedback",
                 feedback_count=2,
                 queued_count=3,
                 dropped_count=1,

--- a/tests/sentry/seer/autofix/pr_iteration/test_emit.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_emit.py
@@ -14,9 +14,11 @@ from sentry.seer.autofix.pr_iteration.details_store import (
     update_iteration,
 )
 from sentry.seer.autofix.pr_iteration.emit import (
+    PrIterationOutcome,
     complete_pr_iteration_details,
     discard_pr_iteration_details,
     open_pr_iteration_details,
+    outcome_for_failed_run,
     record_pr_iteration_counts,
     trigger_pr_iteration_details,
 )
@@ -95,12 +97,17 @@ class PrIterationDetailsTest(TestCase):
             )
         return iteration_id
 
-    def _complete(self, iteration_id: int, *, pushed_changes: bool = True) -> None:
+    def _complete(
+        self,
+        iteration_id: int,
+        *,
+        outcome: str = PrIterationOutcome.ALREADY_PUSHED.value,
+    ) -> None:
         complete_pr_iteration_details(
             log_ctx=self.log_ctx,
             run_state=_run_state(blocks=[_iteration_block(iteration_id)]),
             organization_id=self.organization.id,
-            pushed_changes=pushed_changes,
+            outcome=outcome,
         )
 
     def _open_rows(self) -> list:
@@ -151,7 +158,7 @@ class PrIterationDetailsTest(TestCase):
                 dropped_count=1,
                 automated_feedback_count=1,
                 duration_ms=0,
-                pushed_changes=True,
+                outcome="already_pushed",
             ),
         )
         # A surviving row is an iteration still owing an event.
@@ -165,11 +172,11 @@ class PrIterationDetailsTest(TestCase):
         row.update(date_added=timezone.now() - timedelta(seconds=30))
 
         with patch("sentry.analytics.record") as mock_record:
-            self._complete(iteration_id, pushed_changes=False)
+            self._complete(iteration_id, outcome=PrIterationOutcome.PUSH_FAILED.value)
 
         event = mock_record.call_args.args[0]
         assert 30_000 <= event.duration_ms < 60_000
-        assert event.pushed_changes is False
+        assert event.outcome == "push_failed"
 
     def test_an_incomplete_row_keeps_its_row_and_emits_nothing(self) -> None:
         self._open()
@@ -285,3 +292,65 @@ class PrIterationDetailsTest(TestCase):
             self._complete(iteration_id)
 
         assert mock_record.called
+
+    @freeze_time("2024-01-01 00:00:00")
+    def test_an_iteration_that_produced_nothing_records_that_outcome(self) -> None:
+        self._open()
+        iteration_id = self._trigger()
+        assert iteration_id is not None
+
+        with patch("sentry.analytics.record") as mock_record:
+            self._complete(iteration_id, outcome=PrIterationOutcome.NO_CODE_CHANGES.value)
+
+        assert_last_analytics_event(
+            mock_record,
+            AiAutofixPrIterationFeedbackBatchCompletedEvent(
+                iteration_id=iteration_id,
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                group_id=self.group.id,
+                run_id=RUN_ID,
+                referrer="github_pr_comment",
+                iteration_index=0,
+                feedback_count=2,
+                queued_count=3,
+                dropped_count=1,
+                automated_feedback_count=1,
+                duration_ms=0,
+                outcome="no_code_changes",
+            ),
+        )
+        assert self._open_rows() == []
+
+    def test_a_second_ending_emits_nothing(self) -> None:
+        """The row is the claim: one batch never lands under two outcomes."""
+        self._open()
+        iteration_id = self._trigger()
+        assert iteration_id is not None
+        self._complete(iteration_id)
+
+        with patch("sentry.analytics.record") as mock_record:
+            self._complete(iteration_id, outcome=PrIterationOutcome.TIMEOUT.value)
+
+        assert not mock_record.called
+
+    def test_seers_reason_is_the_outcome_of_a_failed_run(self) -> None:
+        state = _run_state()
+        state.status = "error"
+        state.failure_reason = "stalled"
+
+        assert outcome_for_failed_run(state) == PrIterationOutcome.STALLED.value
+
+    def test_a_failure_seer_did_not_classify_is_recorded_as_errored(self) -> None:
+        state = _run_state()
+        state.status = "error"
+
+        assert outcome_for_failed_run(state) == PrIterationOutcome.ERRORED.value
+
+    def test_a_reason_seer_added_since_is_passed_through(self) -> None:
+        """Folding an unknown reason into ``errored`` would hide a new failure."""
+        state = _run_state()
+        state.status = "error"
+        state.failure_reason = "out_of_credits"
+
+        assert outcome_for_failed_run(state) == "out_of_credits"

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -19,10 +19,10 @@ from sentry.seer.autofix.on_completion_hook import (
     STOPPING_POINT_TO_STEP,
     AutofixOnCompletionHook,
     _group_and_referrer_from_run,
-    _PrIterationPushOutcome,
     _stopping_point_from_run,
 )
 from sentry.seer.autofix.pr_iteration.constants import REVIEW_REQUEST_FLAG
+from sentry.seer.autofix.pr_iteration.emit import PrIterationOutcome
 from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import ConsumeTriggerSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
@@ -787,7 +787,7 @@ class TestPrIterationCompletionHook(TestCase):
             state,
         )
 
-        assert outcome == _PrIterationPushOutcome.NO_CODE_CHANGES
+        assert outcome == PrIterationOutcome.NO_CODE_CHANGES
         mock_push.assert_not_called()
 
     @patch(f"{HOOK_PATH}.trigger_push_changes")
@@ -864,26 +864,26 @@ class TestPrIterationCompletionHook(TestCase):
         assert task_kwargs["trigger_source"] == ConsumeTriggerSource.FEEDBACK
 
     @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
-    def test_no_pull_request_reaches_completion_details_as_not_pushed(self, mock_complete):
+    def test_no_pull_request_reaches_completion_details_as_that_outcome(self, mock_complete):
         state = run_state(
             blocks=[pr_iteration_memory_block()], metadata={"group_id": self.group.id}
         )
 
         AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
 
-        assert mock_complete.call_args.kwargs["pushed_changes"] is False
+        assert mock_complete.call_args.kwargs["outcome"] == PrIterationOutcome.NO_PULL_REQUEST.value
 
     @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
-    def test_already_synced_reaches_completion_details_as_pushed(self, mock_complete):
+    def test_already_synced_reaches_completion_details_as_that_outcome(self, mock_complete):
         AutofixOnCompletionHook._maybe_continue_pipeline(
             self.organization, 123, self._synced(), self.group
         )
 
-        assert mock_complete.call_args.kwargs["pushed_changes"] is True
+        assert mock_complete.call_args.kwargs["outcome"] == PrIterationOutcome.ALREADY_PUSHED.value
 
     @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
     @patch(f"{HOOK_PATH}.trigger_push_changes")
-    def test_a_terminally_errored_repo_reaches_completion_details_as_not_pushed(
+    def test_a_terminally_errored_repo_reaches_completion_details_as_that_outcome(
         self, mock_push, mock_complete
     ):
         state = self._unsynced()
@@ -891,29 +891,35 @@ class TestPrIterationCompletionHook(TestCase):
 
         AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
 
-        assert mock_complete.call_args.kwargs["pushed_changes"] is False
+        assert (
+            mock_complete.call_args.kwargs["outcome"]
+            == PrIterationOutcome.PR_CREATION_ERRORED.value
+        )
 
     @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
     @patch(f"{HOOK_PATH}.trigger_push_changes", side_effect=ValueError("boom"))
-    def test_a_failed_push_reaches_completion_details_as_not_pushed(self, mock_push, mock_complete):
+    def test_a_failed_push_reaches_completion_details_as_that_outcome(
+        self, mock_push, mock_complete
+    ):
         AutofixOnCompletionHook._maybe_continue_pipeline(
             self.organization, 123, self._unsynced(), self.group
         )
 
-        assert mock_complete.call_args.kwargs["pushed_changes"] is False
+        assert mock_complete.call_args.kwargs["outcome"] == PrIterationOutcome.PUSH_FAILED.value
 
     @patch(f"{HOOK_PATH}.complete_pr_iteration_details")
-    def test_an_errored_run_now_reaches_completion_details(self, mock_complete):
+    def test_an_errored_run_reaches_completion_details_with_its_failure_reason(self, mock_complete):
         self.create_seer_run(
             organization=self.organization, seer_run_state_id=123, user_id=self.user.id
         )
         state = self._unsynced()
         state.status = "error"
+        state.failure_reason = "timeout"
 
         AutofixOnCompletionHook._maybe_continue_pipeline(self.organization, 123, state, self.group)
 
         mock_complete.assert_called_once()
-        assert mock_complete.call_args.kwargs["pushed_changes"] is False
+        assert mock_complete.call_args.kwargs["outcome"] == "timeout"
 
 
 class TestPipelineConstants(TestCase):


### PR DESCRIPTION
Replaces the batch-completed event's pushed_changes bool with an
outcome string, backed by a new PrIterationOutcome enum covering why
a push did or didn't happen -- no PR, no changes, already synced, a
failed push -- plus Seer's own failure reasons for an errored run.