### PR TITLE
fix(pr-iter): wait for pending push before draining feedback

### DIFF
--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -475,6 +475,24 @@ def _drain_queued_autofix_feedback(
         )
         return
 
+    # The previous iteration's push (triggered separately, from the
+    # on_completion_hook) races this drain. If it left unpushed changes
+    # behind, wait for it rather than starting a new iteration against a PR
+    # that's about to change underneath it. has_code_changes() reports
+    # synced when there was nothing to push, so that case is unaffected.
+    _, all_changes_pushed = state.has_code_changes()
+    if not all_changes_pushed:
+        log_ctx.info(
+            "autofix.pr_iteration.consume_feedback.drain",
+            outcome="skipped",
+            reason="push_pending",
+            run_status=state.status,
+            trigger_id=trigger_id,
+            trigger_source=trigger_source,
+            left_queued_count=count_queued_autofix_feedback(run_id),
+        )
+        return
+
     # Claim before the pop, so feedback arriving mid-drain opens its own row.
     iteration_id = trigger_pr_iteration_details(
         log_ctx=log_ctx, run_id=run_id, organization_id=organization_id

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -8,7 +8,14 @@ from scm.errors import ResourceNotFound
 from scm.types import ReviewComment
 
 from sentry.models.pullrequest import PullRequest
-from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
+from sentry.seer.agent.client_models import (
+    AgentFilePatch,
+    FilePatch,
+    MemoryBlock,
+    Message,
+    RepoPRState,
+    SeerRunState,
+)
 from sentry.seer.autofix.autofix_agent import (
     PrIterationNoPullRequestException,
 )
@@ -1048,6 +1055,53 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
 
         mock_pop.assert_not_called()
         mock_trigger.assert_not_called()
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_returns_when_previous_push_has_not_landed(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        state = self._state(
+            blocks=[
+                MemoryBlock(
+                    id="iter0",
+                    message=Message(role="assistant"),
+                    timestamp="2024-01-01T00:00:00Z",
+                    merged_file_patches=[
+                        AgentFilePatch(
+                            repo_name="owner/repo",
+                            patch=FilePatch(path="src/sentry/foo.py", type="M", added=1, removed=0),
+                        )
+                    ],
+                )
+            ]
+        )
+        mock_fetch.return_value = state
+
+        self._call()
+
+        mock_pop.assert_not_called()
+        mock_trigger.assert_not_called()
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_drains_when_previous_iteration_had_no_code_changes(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        mock_trigger: MagicMock,
+    ) -> None:
+        mock_fetch.return_value = self._state()
+        mock_pop.return_value = [self._ui_queued()]
+
+        self._call()
+
+        mock_trigger.assert_called_once()
 
     @patch(f"{TASK_PATH}.trigger_autofix_agent")
     @patch(f"{TASK_PATH}.fetch_run_status", side_effect=SeerApiError("nope", 500))


### PR DESCRIPTION
The drain task only checked whether the run itself was still
processing, not whether the previous iteration's code changes
had finished pushing to the PR. A drain could start iterating
while that push was still in flight. Now it also waits on that,
since an unsynced run means a push is still outstanding.

