### PR TITLE
ref(api): Set client_kind attributes for all org events endpoints

### DIFF
--- a/src/sentry/api/bases/organization_events.py
+++ b/src/sentry/api/bases/organization_events.py
@@ -21,6 +21,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.base import CURSOR_LINK_HEADER
 from sentry.api.bases import NoProjects
 from sentry.api.bases.organization import FilterParamsDateNotNull, OrganizationEndpoint
+from sentry.api.client_kind import set_client_kind_attributes
 from sentry.api.helpers.error_upsampling import (
     are_any_projects_error_upsampled,
     convert_fields_for_upsampling,
@@ -111,6 +112,19 @@ def resolve_axis_column(
 
 class OrganizationEventsEndpointBase(OrganizationEndpoint):
     owner = ApiOwner.DATA_BROWSING
+
+    def convert_args(
+        self,
+        request: Request,
+        *args: Any,
+        **kwargs: Any,
+    ) -> tuple[tuple[Any, ...], dict[str, Any]]:
+        (args, kwargs) = super().convert_args(request, *args, **kwargs)
+        # Runs after authentication, so the credential-based checks in
+        # `get_client_kind` see the resolved auth. Done here rather than in each
+        # handler so every events endpoint reports the caller the same way.
+        set_client_kind_attributes(request, kwargs["organization"])
+        return (args, kwargs)
 
     def has_feature(self, organization: Organization, request: Request) -> bool:
         return (

--- a/src/sentry/api/client_kind.py
+++ b/src/sentry/api/client_kind.py
@@ -13,7 +13,9 @@ from __future__ import annotations
 import re
 from enum import StrEnum
 
+import sentry_sdk
 from rest_framework.request import Request
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry import features
 from sentry.auth.services.auth import AuthenticatedToken
@@ -133,6 +135,32 @@ def get_client_kind(request: Request, organization: Organization) -> ClientKind 
         return ClientKind.SCRIPT
 
     return ClientKind.UNKNOWN
+
+
+def set_client_kind_attributes(request: Request, organization: Organization) -> None:
+    """Tag the current transaction with who called the endpoint.
+
+    A no-op when the org has not opted into ``client_kind``. Wired into
+    ``OrganizationEventsEndpointBase.convert_args`` so every events endpoint
+    reports the same set of attributes without hand-wiring them per handler.
+    """
+    client_kind = get_client_kind(request, organization)
+    if client_kind is None:
+        return
+
+    # `_test` suffix while this is a POC, to keep it out of the way of a
+    # real `client_kind` attribute later.
+    sentry_sdk.set_tag("client_kind_test", client_kind.value)
+    sentry_sdk.set_attribute("client_kind_test", client_kind.value)
+
+    client_host = get_client_host(request)
+    if client_host is not None:
+        sentry_sdk.set_tag("client_host_test", client_host)
+        sentry_sdk.set_attribute("client_host_test", client_host)
+
+    user_agent = get_user_agent(request)
+    if user_agent is not None:
+        sentry_sdk.set_attribute(ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, user_agent)
 
 
 def get_user_agent(request: Request) -> str | None:

--- a/src/sentry/api/endpoints/organization_events.py
+++ b/src/sentry/api/endpoints/organization_events.py
@@ -9,13 +9,11 @@ from rest_framework import status
 from rest_framework.exceptions import ParseError
 from rest_framework.request import Request
 from rest_framework.response import Response
-from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEventsEndpointBase
-from sentry.api.client_kind import get_client_host, get_client_kind, get_user_agent
 from sentry.api.helpers.error_upsampling import (
     is_errors_query_for_error_upsampled_projects,
     transform_orderby_for_error_upsampling,
@@ -215,20 +213,6 @@ class OrganizationEventsEndpoint(OrganizationEventsEndpointBase):
 
         referrer = request.GET.get("referrer")
         sentry_sdk.set_attribute("query.raw_referrer", referrer or "")
-
-        client_kind = get_client_kind(request, organization)
-        if client_kind is not None:
-            # `_test` suffix while this is a POC, to keep it out of the way of a
-            # real `client_kind` attribute later.
-            sentry_sdk.set_tag("client_kind_test", client_kind.value)
-            sentry_sdk.set_attribute("client_kind_test", client_kind.value)
-            client_host = get_client_host(request)
-            if client_host is not None:
-                sentry_sdk.set_tag("client_host_test", client_host)
-                sentry_sdk.set_attribute("client_host_test", client_host)
-            user_agent = get_user_agent(request)
-            if user_agent is not None:
-                sentry_sdk.set_attribute(ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, user_agent)
 
         try:
             snuba_params = self.get_snuba_params(

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -1,9 +1,11 @@
 from types import SimpleNamespace
 from typing import Any
+from unittest import mock
 
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from rest_framework.request import Request
+from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.api.client_kind import (
     FEATURE_FLAG,
@@ -11,6 +13,7 @@ from sentry.api.client_kind import (
     get_client_host,
     get_client_kind,
     get_user_agent,
+    set_client_kind_attributes,
 )
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import SystemToken
@@ -151,3 +154,55 @@ class GetClientHostTest(TestCase):
 
     def test_absent_header_is_none(self) -> None:
         assert get_client_host(make_request()) is None
+
+
+class SetClientKindAttributesTest(TestCase):
+    def test_noop_when_feature_is_disabled(self) -> None:
+        request = make_request(auth=api_token(), user_agent="curl/8.7.1")
+        with (
+            self.feature({FEATURE_FLAG: False}),
+            mock.patch("sentry.api.client_kind.sentry_sdk") as sdk,
+        ):
+            set_client_kind_attributes(request, self.organization)
+        sdk.set_tag.assert_not_called()
+        sdk.set_attribute.assert_not_called()
+
+    def test_records_kind_and_user_agent(self) -> None:
+        request = make_request(auth=api_token(), user_agent="curl/8.7.1")
+        with (
+            self.feature(FEATURE_FLAG),
+            mock.patch("sentry.api.client_kind.sentry_sdk") as sdk,
+        ):
+            set_client_kind_attributes(request, self.organization)
+        assert sdk.set_tag.call_args_list == [mock.call("client_kind_test", "script")]
+        assert sdk.set_attribute.call_args_list == [
+            mock.call("client_kind_test", "script"),
+            mock.call(ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, "curl/8.7.1"),
+        ]
+
+    def test_records_client_host_for_mcp(self) -> None:
+        request = make_request(
+            auth=api_token(),
+            user_agent="sentry-mcp/1.0",
+            headers={
+                "X-Sentry-MCP-Version": "1.0",
+                "X-Sentry-MCP-Client-Family": "Claude-Code",
+            },
+        )
+        with (
+            self.feature(FEATURE_FLAG),
+            mock.patch("sentry.api.client_kind.sentry_sdk") as sdk,
+        ):
+            set_client_kind_attributes(request, self.organization)
+        assert mock.call("client_host_test", "claude-code") in sdk.set_tag.call_args_list
+        assert mock.call("client_host_test", "claude-code") in sdk.set_attribute.call_args_list
+
+    def test_omits_user_agent_when_absent(self) -> None:
+        request = make_request(auth=api_token())
+        with (
+            self.feature(FEATURE_FLAG),
+            mock.patch("sentry.api.client_kind.sentry_sdk") as sdk,
+        ):
+            set_client_kind_attributes(request, self.organization)
+        for call in sdk.set_attribute.call_args_list:
+            assert call.args[0] != ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL


### PR DESCRIPTION
Follow-up to #123578. The `client_kind`/`client_host`/`user_agent.original` tagging lived inline in `OrganizationEventsEndpoint.get`, so only `/events/` reported who called it.

This extracts the block to `set_client_kind_attributes` in `sentry.api.client_kind` and wires it into `OrganizationEventsEndpointBase.convert_args`, so every subclassed endpoint — events-stats, events-timeseries, events-meta, traces, facets, histogram, tag values, profiling, and the rest — reports the same attributes without hand-wiring them per handler. `convert_args` runs after authentication in `Endpoint.dispatch`, so the credential-based checks in `get_client_kind` see the resolved auth, same as the old inline placement.

No behavior change on `/events/` itself: the same tags and attributes are set, still gated on the `organizations:api-client-kind-check` flag inside `get_client_kind` (the `query.raw_referrer` line stays in the handler since the local is reused there). The one subclass overriding `convert_args` (`OrganizationEventDetailsEndpoint`) already calls `super()`, so it is covered too.