### PR TITLE
fix(api): avoid mutating CODEOWNERS schemas

### DIFF
--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -1,16 +1,46 @@
 import logging
-from typing import Any
 
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.api.serializers.models.projectownership import (
+    OwnershipRuleOwnerResponse,
+    OwnershipRuleResponse,
+    OwnershipSchemaResponse,
+)
 from sentry.integrations.api.serializers.models.repository_project_path_config import (
     RepositoryProjectPathConfigSerializer,
 )
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.source_code_management.repository import RepositoryIntegration
-from sentry.issues.ownership.grammar import convert_schema_to_rules_text
+from sentry.issues.ownership.grammar import OwnershipSchema, convert_schema_to_rules_text
 from sentry.models.projectcodeowners import ProjectCodeOwners
 
 logger = logging.getLogger(__name__)
+
+
+def _serialize_ownership_schema(schema: OwnershipSchema) -> OwnershipSchemaResponse:
+    serialized_rules: list[OwnershipRuleResponse] = []
+    for rule in schema["rules"]:
+        serialized_owners: list[OwnershipRuleOwnerResponse] = []
+        for owner in rule["owners"]:
+            serialized_owner: OwnershipRuleOwnerResponse = {
+                "type": owner["type"],
+                "name": owner["identifier"],
+            }
+            if "id" in owner:
+                serialized_owner["id"] = str(owner["id"])
+            serialized_owners.append(serialized_owner)
+
+        serialized_rules.append(
+            {
+                "matcher": {
+                    "type": rule["matcher"]["type"],
+                    "pattern": rule["matcher"]["pattern"],
+                },
+                "owners": serialized_owners,
+            }
+        )
+
+    return {"$version": schema["$version"], "rules": serialized_rules}
 
 
 @register(ProjectCodeOwners)
@@ -63,21 +93,6 @@ class ProjectCodeOwnersSerializer(Serializer):
 
         return attrs
 
-    def rename_schema_identifier_for_parsing(self, schema: dict[str, Any]) -> None:
-        """
-        Rename the attribute "identifier" to "name" in the schema response so that it can be parsed
-        in the frontend
-
-        `schema`: The schema containing the rules that will be renamed
-        """
-        if schema.get("rules"):
-            for rule in schema["rules"]:
-                for rule_owner in rule["owners"]:
-                    rule_owner["name"] = rule_owner.pop("identifier")
-                    # Stringify owner IDs for API response (stored as int in DB)
-                    if "id" in rule_owner:
-                        rule_owner["id"] = str(rule_owner["id"])
-
     def serialize(self, obj, attrs, user, **kwargs):
         from sentry.api.validators.project_codeowners import build_codeowners_associations
 
@@ -104,16 +119,8 @@ class ProjectCodeOwnersSerializer(Serializer):
             _, errors = build_codeowners_associations(obj.raw, obj.project)
             data["errors"] = errors
 
-        if "renameIdentifier" in self.expand and hasattr(obj, "schema") and obj.schema:
-            self.rename_schema_identifier_for_parsing(obj.schema)
-
         if "hasTargetingContext" in self.expand:
-            if obj.schema and obj.schema.get("rules"):
-                for rule in obj.schema["rules"]:
-                    for rule_owner in rule["owners"]:
-                        if "id" in rule_owner:
-                            rule_owner["id"] = str(rule_owner["id"])
-            data["schema"] = obj.schema
+            data["schema"] = _serialize_ownership_schema(obj.schema) if obj.schema else obj.schema
             data["codeOwnersUrl"] = attrs.get("codeOwnersUrl", "unknown")
 
         return data

--- a/src/sentry/issues/ownership/grammar.py
+++ b/src/sentry/issues/ownership/grammar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from collections import namedtuple
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from typing import TYPE_CHECKING, Any, NamedTuple, TypedDict
+from typing import TYPE_CHECKING, Any, NamedTuple, NotRequired, TypedDict
 
 from parsimonious.exceptions import ParseError
 from parsimonious.grammar import Grammar
@@ -41,9 +41,15 @@ class OwnershipRuleMatcher(TypedDict):
     pattern: str
 
 
+class OwnershipRuleOwner(TypedDict):
+    type: str
+    identifier: str
+    id: NotRequired[int]
+
+
 class OwnershipRule(TypedDict):
     matcher: OwnershipRuleMatcher
-    owners: list[dict[str, Any]]
+    owners: list[OwnershipRuleOwner]
 
 
 # $version is not a valid Python identifier, so we use the functional form.
@@ -264,7 +270,7 @@ class Owner(NamedTuple):
         return {"type": self.type, "identifier": self.identifier}
 
     @classmethod
-    def load(cls, data: Mapping[str, str]) -> Owner:
+    def load(cls, data: OwnershipRuleOwner) -> Owner:
         return cls(data["type"], data["identifier"])
 
 

--- a/tests/sentry/api/serializers/test_projectcodeowners.py
+++ b/tests/sentry/api/serializers/test_projectcodeowners.py
@@ -1,0 +1,43 @@
+from sentry.api.serializers.models.projectcodeowners import ProjectCodeOwnersSerializer
+from sentry.testutils.cases import TestCase
+
+
+class ProjectCodeOwnersSerializerTest(TestCase):
+    def test_schema_response(self) -> None:
+        code_mapping = self.create_code_mapping(project=self.project)
+        codeowners = self.create_codeowners(
+            project=self.project,
+            code_mapping=code_mapping,
+            schema={
+                "$version": 1,
+                "rules": [
+                    {
+                        "matcher": {"type": "codeowners", "pattern": "src/*"},
+                        "owners": [
+                            {"id": 1, "identifier": "user@example.com", "type": "user"},
+                            {"identifier": "backend", "type": "team"},
+                        ],
+                    }
+                ],
+            },
+        )
+        serializer = ProjectCodeOwnersSerializer(expand=["hasTargetingContext"])
+        response = serializer.serialize(
+            codeowners,
+            {"codeOwnersUrl": "unknown", "provider": "unknown"},
+            self.user,
+        )
+
+        expected_schema = {
+            "$version": 1,
+            "rules": [
+                {
+                    "matcher": {"type": "codeowners", "pattern": "src/*"},
+                    "owners": [
+                        {"id": "1", "name": "user@example.com", "type": "user"},
+                        {"name": "backend", "type": "team"},
+                    ],
+                }
+            ],
+        }
+        assert response["schema"] == expected_schema


### PR DESCRIPTION
When serializing the CODEOWNERS schema, we rename `identifier` to `name` for the frontend, but also end up mutating the original schema, which leads to some weird problems when trying to implement a pure GET endpoint. Make a copy of the schema instead, and type everything a little more strictly.

Refs ENG-7807
