### PR TITLE
ref(ui): Migrate QuestionTooltip to InfoTip

### DIFF
--- a/static/app/components/contentSliderDiff/contentSliderDiff.stories.tsx
+++ b/static/app/components/contentSliderDiff/contentSliderDiff.stories.tsx
@@ -3,9 +3,9 @@ import {Fragment} from 'react';
 import BadStackTraceExample from 'sentry-images/issue_details/bad-stack-trace-example.png';
 import GoodStackTraceExample from 'sentry-images/issue_details/good-stack-trace-example.png';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import * as Storybook from 'sentry/stories';
 
 import {ContentSliderDiff} from '.';
@@ -31,11 +31,11 @@ export default Storybook.story('ContentSliderDiff', story => {
           <ContentSliderDiff.Header>
             <Flex align="center" gap="xs">
               Before
-              <QuestionTooltip title="This is the before image" size="xs" />
+              <InfoTip title="This is the before image" size="xs" />
             </Flex>
             <Flex align="center" gap="xs">
               After
-              <QuestionTooltip title="This is the after image" size="xs" />
+              <InfoTip title="This is the after image" size="xs" />
             </Flex>
           </ContentSliderDiff.Header>
           <ContentSliderDiff.Body

--- a/static/app/components/events/eventProcessingErrors.spec.tsx
+++ b/static/app/components/events/eventProcessingErrors.spec.tsx
@@ -47,10 +47,10 @@ describe('EventProcessingErrors', () => {
       expect(screen.getByText(/discarded invalid value/i)).toBeInTheDocument();
 
       // Check that the tooltip icon is present
-      expect(screen.getByTestId('more-information')).toBeInTheDocument();
+      expect(screen.getByRole('img', {name: 'More information'})).toBeInTheDocument();
 
       // Hover over the tooltip to show the documentation link
-      await userEvent.hover(screen.getByTestId('more-information'));
+      await userEvent.hover(screen.getByRole('img', {name: 'More information'}));
 
       // Wait for the tooltip content to appear and check for the link
       const tooltipLink = await screen.findByRole('link');
@@ -80,7 +80,7 @@ describe('EventProcessingErrors', () => {
     );
 
     expect(screen.getByText('Discarded invalid value')).toBeInTheDocument();
-    expect(screen.queryByTestId('more-information')).not.toBeInTheDocument();
+    expect(screen.queryByRole('img', {name: 'More information'})).not.toBeInTheDocument();
   });
 
   it('handles non-string values gracefully', () => {
@@ -105,6 +105,6 @@ describe('EventProcessingErrors', () => {
     );
 
     expect(screen.getByText('Discarded invalid value')).toBeInTheDocument();
-    expect(screen.queryByTestId('more-information')).not.toBeInTheDocument();
+    expect(screen.queryByRole('img', {name: 'More information'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/eventProcessingErrors.tsx
+++ b/static/app/components/events/eventProcessingErrors.tsx
@@ -2,13 +2,13 @@ import {useMemo} from 'react';
 import startCase from 'lodash/startCase';
 import moment from 'moment-timezone';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import type {ErrorMessage} from 'sentry/components/events/interfaces/crashContent/exception/actionableItems';
 import {useActionableItemsWithProguardErrors} from 'sentry/components/events/interfaces/crashContent/exception/useActionableItems';
 import {KeyValueData} from 'sentry/components/keyValueData';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
 import type {Project} from 'sentry/types/project';
@@ -55,13 +55,12 @@ function EventErrorCard({
   const titleElement = docLink ? (
     <Flex gap="md" align="center">
       {title}
-      <QuestionTooltip
+      <InfoTip
         title={tct('Learn more about this error in our [docLink:documentation]', {
           docLink: <ExternalLink href={docLink} />,
         })}
         size="sm"
         position="top"
-        isHoverable
       />
     </Flex>
   ) : (

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -1,8 +1,9 @@
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
+
 import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconCheckmark, IconClose} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {
@@ -34,7 +35,7 @@ function addFingerprintInfo(
       t('Fingerprint rule'),
       <TextWithQuestionTooltip key="type">
         {variant.matched_rule}
-        <QuestionTooltip
+        <InfoTip
           size="xs"
           position="top"
           title={t('The server-side fingerprinting rule that produced the fingerprint.')}
@@ -86,7 +87,7 @@ export function GroupingVariant({
         t('Hash'),
         <TextWithQuestionTooltip key="hash">
           <Hash>{variant.hash}</Hash>
-          <QuestionTooltip
+          <InfoTip
             size="xs"
             position="top"
             title={t('Events with the same hash are grouped together')}

--- a/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidates.tsx
+++ b/static/app/components/events/interfaces/debugMeta/debugImageDetails/candidates.tsx
@@ -6,11 +6,11 @@ import pick from 'lodash/pick';
 
 import {Button} from '@sentry/scraps/button';
 import type {SelectOption, SelectSection} from '@sentry/scraps/compactSelect';
+import {InfoTip} from '@sentry/scraps/info';
 import {Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
 import {SearchBarAction} from 'sentry/components/events/interfaces/searchBarAction';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t, tct} from 'sentry/locale';
 import type {Image} from 'sentry/types/debugImage';
@@ -319,7 +319,7 @@ export class Candidates extends Component<Props, State> {
         <Header>
           <Title>
             {t('Debug File Candidates')}
-            <QuestionTooltip
+            <InfoTip
               title={tct(
                 'These are the Debug Information Files (DIFs) corresponding to this image which have been looked up on [docLink:symbol servers] during the processing of the stacktrace.',
                 {
@@ -330,7 +330,6 @@ export class Candidates extends Component<Props, State> {
               )}
               size="xs"
               position="top"
-              isHoverable
             />
           </Title>
           {!!candidates.length && (

--- a/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
+++ b/static/app/components/events/interfaces/spans/spanProfileDetails.tsx
@@ -2,9 +2,9 @@ import {useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button, ButtonBar, LinkButton} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 
 import {SectionHeading} from 'sentry/components/charts/styles';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {FrameContent} from 'sentry/components/stackTrace/frame/frameContent';
 import {IssueFrameActions} from 'sentry/components/stackTrace/issueStackTrace/issueFrameActions';
 import {StackTraceViewStateProvider} from 'sentry/components/stackTrace/stackTraceContext';
@@ -247,7 +247,7 @@ export function SpanProfileDetails({event, span}: SpanProfileDetailsProps) {
             })}
           </SectionSubtext>
         </SpanDetailsItem>
-        <QuestionTooltip
+        <InfoTip
           position="top"
           size="xs"
           title={t(

--- a/static/app/components/feedback/feedbackItem/feedbackItem.tsx
+++ b/static/app/components/feedback/feedbackItem/feedbackItem.tsx
@@ -1,6 +1,8 @@
 import {Fragment, useEffect, useMemo, useRef} from 'react';
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
+
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {getOrderedContextItems} from 'sentry/components/events/contexts';
@@ -21,7 +23,6 @@ import {MessageSection} from 'sentry/components/feedback/feedbackItem/messageSec
 import {MessageTitle} from 'sentry/components/feedback/feedbackItem/messageTitle';
 import {KeyValueData} from 'sentry/components/keyValueData';
 import {PanelItem} from 'sentry/components/panels/panelItem';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconChat, IconFire, IconSpan, IconTag} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -158,7 +159,7 @@ export function FeedbackItem({feedbackItem, eventData, onBackToList}: Props) {
               title={
                 <Fragment>
                   {t('Internal Activity')}
-                  <QuestionTooltip
+                  <InfoTip
                     size="xs"
                     title={t(
                       'Use this section to post comments that are visible only to your organization. It will also automatically update when someone resolves or assigns the feedback.'

--- a/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/aggregateFlamegraphTreeTable.tsx
@@ -2,10 +2,10 @@ import {useCallback, useEffect, useMemo, useState, type MouseEvent} from 'react'
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 
 import {PerformanceDuration} from 'sentry/components/performanceDuration';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -422,7 +422,7 @@ export function AggregateFlamegraphTreeTable({
               <InteractionStateLayer />
               <span>
                 {t('Samples')}{' '}
-                <QuestionTooltip
+                <InfoTip
                   title={t('How often this frame appeared in stack samples.')}
                   size="sm"
                   position="top"
@@ -438,7 +438,7 @@ export function AggregateFlamegraphTreeTable({
               <InteractionStateLayer />
               <span>
                 {t('Average Duration')}{' '}
-                <QuestionTooltip
+                <InfoTip
                   title={t('Average duration of this frame across different samples.')}
                   size="sm"
                   position="top"

--- a/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphDrawer/flamegraphTreeTable.tsx
@@ -2,6 +2,7 @@ import type React from 'react';
 import {useCallback, useEffect, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
 import InteractionStateLayer from '@sentry/scraps/interactionStateLayer';
 
 import {
@@ -19,7 +20,6 @@ import {
   makeCallTreeTableSortFunction,
   syncCallTreeTableScroll,
 } from 'sentry/components/profiling/flamegraph/callTreeTable';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconArrow} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {
@@ -287,7 +287,7 @@ export function FlamegraphTreeTable({
               <InteractionStateLayer />
               <span>
                 {t('Self Time')}{' '}
-                <QuestionTooltip
+                <InfoTip
                   title={t(
                     'Self time is the amount of time spent by this function excluding the time spent by other functions called within it.'
                   )}
@@ -305,7 +305,7 @@ export function FlamegraphTreeTable({
               <InteractionStateLayer />
               <span>
                 {t('Total Time')}{' '}
-                <QuestionTooltip
+                <InfoTip
                   title={t(
                     'Total time is the total amount of time spent by this function.'
                   )}

--- a/static/app/components/replays/diff/utils.tsx
+++ b/static/app/components/replays/diff/utils.tsx
@@ -1,9 +1,9 @@
 import type {ReactNode} from 'react';
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {ReplayTooltipTime} from 'sentry/components/replays/replayTooltipTime';
 import {t} from 'sentry/locale';
 
@@ -23,7 +23,7 @@ function ReplayDiffTooltip({
   startTimestampMs: number;
 }) {
   return (
-    <QuestionTooltip
+    <InfoTip
       size="xs"
       title={
         <LeftAligned>

--- a/static/app/components/replays/replayView.tsx
+++ b/static/app/components/replays/replayView.tsx
@@ -2,13 +2,13 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {NegativeSpaceContainer} from 'sentry/components/container/negativeSpaceContainer';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {CanvasSupportNotice} from 'sentry/components/replays/canvasSupportNotice';
 import {
   JetpackComposePiiNotice,
@@ -70,8 +70,7 @@ export function ReplayView({isLoading, layout, toggleFullscreen, toggleLayout}: 
             ) : isVideoReplay ? (
               <Flex align="center" flex="1" gap="md" width="100%">
                 {replay?.getReplay()?.sdk.name?.includes('flutter') ? (
-                  <QuestionTooltip
-                    isHoverable
+                  <InfoTip
                     title={tct(
                       'In order to see the correct screen name, you need to configure the [link:Sentry Routing Instrumentation].',
                       {

--- a/static/app/components/seer/projectDetails/autofixRepositoriesList.tsx
+++ b/static/app/components/seer/projectDetails/autofixRepositoriesList.tsx
@@ -3,6 +3,7 @@ import {useInfiniteQuery, useMutation, useQueryClient} from '@tanstack/react-que
 import seerConfigBug1 from 'getsentry-images/spot/seer-config-bug-1.svg';
 
 import {Button} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 import {useModal} from '@sentry/scraps/modal';
@@ -11,7 +12,6 @@ import {Heading} from '@sentry/scraps/text';
 
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {AddAutofixRepoModal} from 'sentry/components/seer/legacy/addAutofixRepoModal';
 import {AutofixRepositoriesItem} from 'sentry/components/seer/projectDetails/autofixRepositoriesItem';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
@@ -42,8 +42,7 @@ interface Props {
 const getTableHeaders = (organization: Organization): React.ReactNode[] => [
   <Flex key="connected-repositories" align="center" gap="md">
     {t('Connected Repositories')}
-    <QuestionTooltip
-      isHoverable
+    <InfoTip
       size="xs"
       title={tct(
         'Seer will only be able to see code from, and make PRs to, the repos connected here. The [link:GitHub integration] is required for Seer to access these repos.',

--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -347,6 +347,7 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'authorizations/',
+      name: t('Authorized Applications'),
       component: make(
         () => import('sentry/views/settings/account/accountAuthorizations')
       ),

--- a/static/app/utils/replays/getFrameDetails.tsx
+++ b/static/app/utils/replays/getFrameDetails.tsx
@@ -1,9 +1,9 @@
 import {Fragment, type ReactNode} from 'react';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {CrumbErrorTitle} from 'sentry/components/replays/breadcrumbs/errorTitle';
 import {SelectorList} from 'sentry/components/replays/breadcrumbs/selectorList';
 import {
@@ -520,8 +520,7 @@ function WebVitalTitle(frame: WebVitalFrame) {
   return (
     <Flex align="center" gap="xs">
       {t('Web Vital: ') + toTitleCase(explodeSlug(frame.description))}
-      <QuestionTooltip
-        isHoverable
+      <InfoTip
         size="xs"
         title={
           <Fragment>

--- a/static/app/views/detectors/components/uptime/assertions/opCommon.tsx
+++ b/static/app/views/detectors/components/uptime/assertions/opCommon.tsx
@@ -4,11 +4,11 @@ import {motion, type MotionProps} from 'framer-motion';
 
 import {Button} from '@sentry/scraps/button';
 import type {SelectOption} from '@sentry/scraps/compactSelect';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {DragReorderButton} from 'sentry/components/dnd/dragReorderButton';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconDelete} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {AssertionFormError} from 'sentry/views/detectors/components/uptime/formErrors';
@@ -92,7 +92,7 @@ export function OpContainer({
               {...listeners}
               {...attributes}
             />
-            {tooltip && <QuestionTooltip size="xs" title={tooltip} isHoverable />}
+            {tooltip && <InfoTip size="xs" title={tooltip} />}
           </Flex>
           <Grid columns="1fr max-content" align="center" gap="sm">
             {children}

--- a/static/app/views/detectors/components/uptime/assertions/opJsonPath.spec.tsx
+++ b/static/app/views/detectors/components/uptime/assertions/opJsonPath.spec.tsx
@@ -106,7 +106,7 @@ describe('AssertionOpJsonPath', () => {
     await renderOp(makeJsonPathOp());
 
     // Hover over the question mark icon to show tooltip
-    const questionIcon = screen.getByTestId('more-information');
+    const questionIcon = screen.getByRole('img', {name: 'More information'});
     await userEvent.hover(questionIcon);
 
     // Check that tooltip appears with the link

--- a/static/app/views/detectors/components/uptime/detailsTimelineLegend.tsx
+++ b/static/app/views/detectors/components/uptime/detailsTimelineLegend.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {tct} from 'sentry/locale';
 import {CheckIndicator} from 'sentry/views/detectors/components/uptime/checkIndicator';
 import {CheckStatus} from 'sentry/views/detectors/components/uptime/types';
@@ -16,8 +16,7 @@ export function DetailsTimelineLegend({showMissedLegend}: {showMissedLegend: boo
         <CheckIndicator status={CheckStatus.SUCCESS} />
         <Flex align="center" gap="md">
           {statusToText[CheckStatus.SUCCESS]}
-          <QuestionTooltip
-            isHoverable
+          <InfoTip
             size="sm"
             title={tct(
               'A check status is considered uptime when it meets the uptime check criteria. [link:Learn more].',
@@ -34,8 +33,7 @@ export function DetailsTimelineLegend({showMissedLegend}: {showMissedLegend: boo
         <CheckIndicator status={CheckStatus.FAILURE} />
         <Flex align="center" gap="md">
           {statusToText[CheckStatus.FAILURE]}
-          <QuestionTooltip
-            isHoverable
+          <InfoTip
             size="sm"
             title={tct(
               'A check status is considered as a failure when a check fails but hasn’t recorded three consecutive failures needed for Downtime. [link:Learn more].',
@@ -52,8 +50,7 @@ export function DetailsTimelineLegend({showMissedLegend}: {showMissedLegend: boo
         <CheckIndicator status={CheckStatus.FAILURE_INCIDENT} />
         <Flex align="center" gap="md">
           {statusToText[CheckStatus.FAILURE_INCIDENT]}
-          <QuestionTooltip
-            isHoverable
+          <InfoTip
             size="sm"
             title={tct(
               'A check status is considered downtime when it fails 3 consecutive times, meeting the Downtime threshold. [link:Learn more].',
@@ -71,8 +68,7 @@ export function DetailsTimelineLegend({showMissedLegend}: {showMissedLegend: boo
           <CheckIndicator status={CheckStatus.MISSED_WINDOW} />
           <Flex align="center" gap="md">
             {statusToText[CheckStatus.MISSED_WINDOW]}
-            <QuestionTooltip
-              isHoverable
+            <InfoTip
               size="sm"
               title={tct(
                 'A check status is unknown when Sentry is unable to execute an uptime check at the scheduled time. [link:Learn more].',

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseEventsChart.tsx
@@ -1,12 +1,13 @@
 import {Fragment} from 'react';
 import {useTheme} from '@emotion/react';
 
+import {InfoTip} from '@sentry/scraps/info';
+
 import {Client} from 'sentry/api';
 import {EventsChart} from 'sentry/components/charts/eventsChart';
 import {EventsRequest} from 'sentry/components/charts/eventsRequest';
 import {HeaderTitleLegend, HeaderValue} from 'sentry/components/charts/styles';
 import {getInterval} from 'sentry/components/charts/utils';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import type {ReleaseProject, ReleaseWithHealth} from 'sentry/types/release';
 import {ReleaseComparisonChartType} from 'sentry/types/release';
@@ -178,9 +179,7 @@ export function ReleaseEventsChart({
             <Fragment>
               <HeaderTitleLegend>
                 {releaseComparisonChartTitles[chartType]}
-                {getHelp() && (
-                  <QuestionTooltip size="sm" position="top" title={getHelp()} />
-                )}
+                {getHelp() && <InfoTip size="sm" position="top" title={getHelp()} />}
               </HeaderTitleLegend>
 
               <HeaderValue>

--- a/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
+++ b/static/app/views/explore/releases/detail/overview/releaseComparisonChart/releaseSessionsChart.tsx
@@ -4,6 +4,8 @@ import {withTheme} from '@emotion/react';
 import type {Location} from 'history';
 import round from 'lodash/round';
 
+import {InfoTip} from '@sentry/scraps/info';
+
 import type {AreaChartProps} from 'sentry/components/charts/areaChart';
 import {AreaChart} from 'sentry/components/charts/areaChart';
 import ChartZoom from 'sentry/components/charts/chartZoom';
@@ -11,7 +13,6 @@ import {StackedAreaChart} from 'sentry/components/charts/stackedAreaChart';
 import {HeaderTitleLegend, HeaderValue} from 'sentry/components/charts/styles';
 import {TransitionChart} from 'sentry/components/charts/transitionChart';
 import {TransparentLoadingMask} from 'sentry/components/charts/transparentLoadingMask';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import type {SessionApiResponse} from 'sentry/types/organization';
 import {SessionFieldWithOperation, SessionStatus} from 'sentry/types/organization';
@@ -649,7 +650,7 @@ class ReleaseSessionsChart extends Component<Props> {
         <HeaderTitleLegend aria-label={t('Chart Title')}>
           {releaseComparisonChartTitles[chartType]}
           {releaseComparisonChartHelp[chartType] && (
-            <QuestionTooltip
+            <InfoTip
               size="sm"
               position="top"
               title={releaseComparisonChartHelp[chartType]}

--- a/static/app/views/explore/releases/detail/overview/sidebar/releaseAdoption.tsx
+++ b/static/app/views/explore/releases/detail/overview/sidebar/releaseAdoption.tsx
@@ -2,6 +2,7 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
+import {InfoTip} from '@sentry/scraps/info';
 import {Container, Flex} from '@sentry/scraps/layout';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -13,7 +14,6 @@ import {TransitionChart} from 'sentry/components/charts/transitionChart';
 import {TransparentLoadingMask} from 'sentry/components/charts/transparentLoadingMask';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {NotAvailable} from 'sentry/components/notAvailable';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import * as SidebarSection from 'sentry/components/sidebarSection';
 import {IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -238,7 +238,7 @@ export function ReleaseAdoption({
           <SidebarSection.Title>
             {t('Adoption Stage')}
             {multipleEnvironments && (
-              <QuestionTooltip
+              <InfoTip
                 position="top"
                 title={t(
                   'See if a release has low adoption, been adopted by users, or replaced by another release. Select an environment above to view the stage this release is in.'
@@ -275,7 +275,7 @@ export function ReleaseAdoption({
                 <SidebarSection.Title>
                   {t('Sessions Adopted')}
                   <Container as="span" marginLeft="xs">
-                    <QuestionTooltip
+                    <InfoTip
                       position="top"
                       title={t(
                         'Adoption compares the sessions of a release with the total sessions for this project.'
@@ -292,7 +292,7 @@ export function ReleaseAdoption({
                 <SidebarSection.Title>
                   {t('Users Adopted')}
                   <Container as="span" marginLeft="xs">
-                    <QuestionTooltip
+                    <InfoTip
                       position="top"
                       title={t(
                         'Adoption compares the users of a release with the total users for this project.'

--- a/static/app/views/explore/replays/detail/network/details/sections.tsx
+++ b/static/app/views/explore/replays/detail/network/details/sections.tsx
@@ -2,9 +2,9 @@ import type {MouseEvent} from 'react';
 import {useEffect, useMemo} from 'react';
 import queryString from 'query-string';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex} from '@sentry/scraps/layout';
 
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {useReplayContext} from 'sentry/components/replays/replayContext';
 import {StructuredEventData} from 'sentry/components/structuredEventData';
 import {t} from 'sentry/locale';
@@ -122,7 +122,7 @@ export function RequestHeadersSection({item}: SectionProps) {
         value: warn ? (
           <Flex align="center" gap="xs">
             {value}
-            <QuestionTooltip
+            <InfoTip
               size="xs"
               title={t('The content-type of the request does not match the response.')}
             />
@@ -158,7 +158,7 @@ export function ResponseHeadersSection({item}: SectionProps) {
         value: warn ? (
           <Flex align="center" gap="xs">
             {value}
-            <QuestionTooltip
+            <InfoTip
               size="xs"
               title={t('The content-type of the request does not match the response.')}
             />

--- a/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
+++ b/static/app/views/explore/replays/list/replayOnboardingPanel.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import emptyStateImg from 'sentry-images/spot/replays-empty-state.svg';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Container, Grid, type GridProps} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Tooltip} from '@sentry/scraps/tooltip';
@@ -11,7 +12,6 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import {Accordion} from 'sentry/components/container/accordion';
 import {OverrideOrDefault} from 'sentry/components/overrideOrDefault';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {ReplayUnsupportedAlert} from 'sentry/components/replays/alerts/replayUnsupportedAlert';
 import {replayPlatforms} from 'sentry/data/platformCategories';
 import {t, tct} from 'sentry/locale';
@@ -260,9 +260,8 @@ export function SetupReplaysCTA({disabled, primaryAction}: SetupReplaysCTAProps)
       <StyledWidgetContainer>
         <StyledHeaderContainer>
           {t('FAQ')}
-          <QuestionTooltip
+          <InfoTip
             size="xs"
-            isHoverable
             title={tct('See a [link:full list of FAQs].', {
               link: (
                 <ExternalLink href="https://www.sentry.help/en/articles/13964404-session-replay-faq" />

--- a/static/app/views/explore/replays/selectors/deadRageSelectorCards.tsx
+++ b/static/app/views/explore/replays/selectors/deadRageSelectorCards.tsx
@@ -2,12 +2,12 @@ import type {ReactNode} from 'react';
 import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Container, Flex, Grid, Stack, type FlexProps} from '@sentry/scraps/layout';
 
 import {Accordion} from 'sentry/components/container/accordion';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
 import {Placeholder} from 'sentry/components/placeholder';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {TextOverflow} from 'sentry/components/textOverflow';
 import {IconCursorArrow, IconSearch} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -151,7 +151,7 @@ function SelectorCardHeader({deadOrRage}: {deadOrRage: DeadOrRage}) {
       <StyledWidgetHeader>
         <Flex align="center" gap="md">
           {deadOrRage === 'dead' ? t('Most Dead Clicks') : t('Most Rage Clicks')}
-          <QuestionTooltip
+          <InfoTip
             size="xs"
             position="top"
             title={
@@ -163,7 +163,6 @@ function SelectorCardHeader({deadOrRage}: {deadOrRage: DeadOrRage}) {
                     'The top selectors your users have rage clicked on (i.e., 5 or more clicks on a dead element, which exhibits no page activity after 7 seconds).'
                   )
             }
-            isHoverable
           />
         </Flex>
       </StyledWidgetHeader>

--- a/static/app/views/insights/crons/components/detailsTimelineLegend.tsx
+++ b/static/app/views/insights/crons/components/detailsTimelineLegend.tsx
@@ -1,9 +1,9 @@
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Text} from '@sentry/scraps/text';
 
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t, tct, tn} from 'sentry/locale';
 import {
   DEFAULT_CHECKIN_MARGIN,
@@ -57,9 +57,8 @@ export function DetailsTimelineLegend({
           <MonitorIndicator status={CheckInStatus.UNKNOWN} size={12} />
           <UnknownText>
             {t('Unknown Status')}
-            <QuestionTooltip
+            <InfoTip
               size="sm"
-              isHoverable
               title={tct(
                 'Sentry was unable to determine the check-in status. [link:Learn More].',
                 {

--- a/static/app/views/issueDetails/metricKitHangProfileSection.spec.tsx
+++ b/static/app/views/issueDetails/metricKitHangProfileSection.spec.tsx
@@ -78,6 +78,6 @@ describe('MetricKitHangProfileSection', () => {
 
     render(<MetricKitHangProfileSection data={data} />, {organization});
 
-    expect(screen.getByTestId('more-information')).toBeInTheDocument();
+    expect(screen.getByRole('img', {name: 'More information'})).toBeInTheDocument();
   });
 });

--- a/static/app/views/issueDetails/metricKitHangProfileSection.tsx
+++ b/static/app/views/issueDetails/metricKitHangProfileSection.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
+
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {
   hasFlamegraphData,
   StacktraceFlamegraph,
 } from 'sentry/components/events/interfaces/crashContent/stackTrace/flamegraph';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import type {Event, Frame} from 'sentry/types/event';
 import {EntryType} from 'sentry/types/event';
@@ -67,7 +68,7 @@ export function MetricKitHangProfileSection({data}: {data: HangProfileData}) {
           <span>
             {t('Hang Profile')}
             &nbsp;
-            <QuestionTooltip
+            <InfoTip
               position="bottom"
               size="sm"
               title={t('This profile was reported by MetricKit during the app hang.')}

--- a/static/app/views/issueDetails/profilePreviewSection.tsx
+++ b/static/app/views/issueDetails/profilePreviewSection.tsx
@@ -3,13 +3,13 @@ import styled from '@emotion/styled';
 
 import {Alert} from '@sentry/scraps/alert';
 import {LinkButton} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {ExternalLink} from '@sentry/scraps/link';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
 
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {FlamegraphPreview} from 'sentry/components/profiling/flamegraph/flamegraphPreview';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {allPlatforms as platforms} from 'sentry/data/platforms';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
@@ -89,7 +89,7 @@ export function ProfilePreviewSection({
                 <span>
                   {sectionTitle}
                   &nbsp;
-                  <QuestionTooltip
+                  <InfoTip
                     position="bottom"
                     size="sm"
                     title={t('This shows you a profile around the time of this event.')}

--- a/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
+++ b/static/app/views/issueDetails/sidebar/metricDetectorTriggeredSection.tsx
@@ -5,6 +5,7 @@ import type {LocationDescriptor} from 'history';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -16,7 +17,6 @@ import {AnnotatedText} from 'sentry/components/events/meta/annotatedText';
 import {FeedbackButton} from 'sentry/components/feedbackButton/feedbackButton';
 import {GroupList} from 'sentry/components/issues/groupList';
 import {Placeholder} from 'sentry/components/placeholder';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
 import {parseSearch, Token} from 'sentry/components/searchSyntax/parser';
 import {treeResultLocator} from 'sentry/components/searchSyntax/utils';
@@ -245,7 +245,7 @@ function BooleanLogicError({discoverUrl}: {discoverUrl: LocationDescriptor}) {
         }
       >
         {t('Contributing issues unavailable for this detector.')}{' '}
-        <QuestionTooltip
+        <InfoTip
           title={t(
             'Issues do not support AND/OR queries. Modify your query to see contributing issues.'
           )}

--- a/static/app/views/navigation/primary/organizationDropdown.tsx
+++ b/static/app/views/navigation/primary/organizationDropdown.tsx
@@ -5,13 +5,13 @@ import partition from 'lodash/partition';
 
 import {OrganizationAvatar} from '@sentry/scraps/avatar';
 import {AvatarButton} from '@sentry/scraps/avatarButton';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {useSizeContext} from '@sentry/scraps/sizeContext';
 import {Text} from '@sentry/scraps/text';
 
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {OrganizationBadge} from 'sentry/components/idBadge/organizationBadge';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {CUSTOM_REFERRER_KEY} from 'sentry/constants';
 import {IconAdd} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
@@ -191,7 +191,7 @@ function makeOrganizationMenuItem(org: OrganizationSummary): MenuItemProps {
 function makeInactiveOrganizationMenuItem(org: OrganizationSummary): MenuItemProps {
   return {
     ...makeOrganizationMenuItem(org),
-    trailingItems: <QuestionTooltip size="sm" title={org.status.name} />,
+    trailingItems: <InfoTip size="sm" title={org.status.name} />,
   };
 }
 

--- a/static/app/views/organizationStats/usageStatsOrg.tsx
+++ b/static/app/views/organizationStats/usageStatsOrg.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 import moment from 'moment-timezone';
 
 import {LinkButton} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Switch} from '@sentry/scraps/switch';
@@ -15,7 +16,6 @@ import {InlineContainer, SectionHeading} from 'sentry/components/charts/styles';
 import type {DateTimeObject} from 'sentry/components/charts/utils';
 import {getSeriesApiInterval} from 'sentry/components/charts/utils';
 import {NotAvailable} from 'sentry/components/notAvailable';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {ScoreCard} from 'sentry/components/scoreCard';
 import {DEFAULT_STATS_PERIOD} from 'sentry/constants';
 import {IconSettings} from 'sentry/icons';
@@ -178,7 +178,7 @@ export function getChartProps({
     title: (
       <Fragment>
         {t('Project(s) Stats')}
-        <QuestionTooltip
+        <InfoTip
           size="xs"
           title={tct(
             'You can find more information about each category in our [link:docs]',
@@ -191,7 +191,6 @@ export function getChartProps({
               ),
             }
           )}
-          isHoverable
         />
       </Fragment>
     ),

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/span/sections/generalInfo.tsx
@@ -2,10 +2,11 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
+import {InfoTip} from '@sentry/scraps/info';
+
 import {DateTime} from 'sentry/components/dateTime';
 import {getFormattedTimeRangeWithLeadingAndTrailingZero} from 'sentry/components/events/interfaces/spans/utils';
 import {Content} from 'sentry/components/keyValueData';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {getDuration} from 'sentry/utils/duration/getDuration';
@@ -203,10 +204,7 @@ export function GeneralInfo(props: GeneralnfoProps) {
       subjectNode: (
         <TraceDrawerComponents.FlexBox style={{gap: '5px'}}>
           {t('Self Time')}
-          <QuestionTooltip
-            title={t('Applicable to the children of this event only')}
-            size="xs"
-          />
+          <InfoTip title={t('Applicable to the children of this event only')} size="xs" />
         </TraceDrawerComponents.FlexBox>
       ),
       value: <SpanSelfTime node={props.node} />,

--- a/static/app/views/performance/transactionSummary/transactionOverview/statusBreakdown.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/statusBreakdown.tsx
@@ -2,12 +2,13 @@ import {Fragment} from 'react';
 import styled from '@emotion/styled';
 import type {Location} from 'history';
 
+import {InfoTip} from '@sentry/scraps/info';
+
 import {BreakdownBars} from 'sentry/components/charts/breakdownBars';
 import {ErrorPanel} from 'sentry/components/charts/errorPanel';
 import {SectionHeading} from 'sentry/components/charts/styles';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
 import {Placeholder} from 'sentry/components/placeholder';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
@@ -41,7 +42,7 @@ export function StatusBreakdown({eventView, location, organization}: Props) {
     <Fragment>
       <SectionHeading>
         {t('Status Breakdown')}
-        <QuestionTooltip
+        <InfoTip
           position="top"
           title={getTermHelp(organization, PerformanceTerm.STATUS_BREAKDOWN)}
           size="sm"

--- a/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseEventsChart.tsx
@@ -2,12 +2,13 @@ import {Component} from 'react';
 import * as Sentry from '@sentry/react';
 import isEqual from 'lodash/isEqual';
 
+import {InfoTip} from '@sentry/scraps/info';
+
 import {fetchTotalCount} from 'sentry/actionCreators/events';
 import type {EventsChartProps} from 'sentry/components/charts/eventsChart';
 import {EventsChart} from 'sentry/components/charts/eventsChart';
 import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import type {PageFilters, PageFilterDatetime} from 'sentry/types/core';
 import {axisLabelFormatter} from 'sentry/utils/discover/charts';
@@ -106,7 +107,7 @@ class ProjectBaseEventsChart extends Component<Props> {
           chartHeader={
             <HeaderTitleLegend>
               {title}
-              {help && <QuestionTooltip size="sm" position="top" title={help} />}
+              {help && <InfoTip size="sm" position="top" title={help} />}
             </HeaderTitleLegend>
           }
           legendOptions={{right: 10, top: 0}}

--- a/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
+++ b/static/app/views/projectDetail/charts/projectBaseSessionsChart.tsx
@@ -4,6 +4,8 @@ import {useTheme} from '@emotion/react';
 import type {LegendComponentOption, LineSeriesOption} from 'echarts';
 import isEqual from 'lodash/isEqual';
 
+import {InfoTip} from '@sentry/scraps/info';
+
 import type {Client} from 'sentry/api';
 import {BarChart} from 'sentry/components/charts/barChart';
 import type {ZoomRenderProps} from 'sentry/components/charts/chartZoom';
@@ -17,7 +19,6 @@ import {HeaderTitleLegend} from 'sentry/components/charts/styles';
 import {TransitionChart} from 'sentry/components/charts/transitionChart';
 import {TransparentLoadingMask} from 'sentry/components/charts/transparentLoadingMask';
 import {RELEASE_LINES_THRESHOLD} from 'sentry/components/charts/utils';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconWarning} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {PageFilters} from 'sentry/types/core';
@@ -119,9 +120,7 @@ function ProjectBaseSessionsChart({
 
                           <HeaderTitleLegend>
                             {title}
-                            {help && (
-                              <QuestionTooltip size="sm" position="top" title={help} />
-                            )}
+                            {help && <InfoTip size="sm" position="top" title={help} />}
                           </HeaderTitleLegend>
 
                           <Chart

--- a/static/app/views/projectsDashboard/projectCard.tsx
+++ b/static/app/views/projectsDashboard/projectCard.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import round from 'lodash/round';
 
 import {LinkButton} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Grid, Container} from '@sentry/scraps/layout';
 import {Link} from '@sentry/scraps/link';
 
@@ -10,7 +11,6 @@ import {IdBadge} from 'sentry/components/idBadge';
 import {Panel} from 'sentry/components/panels/panel';
 import {Placeholder} from 'sentry/components/placeholder';
 import {BookmarkStar} from 'sentry/components/projects/bookmarkStar';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {
   Score,
   ScoreCard,
@@ -140,7 +140,7 @@ export function ProjectCard({
                 >
                   {t('Transactions: %s', formatAbbreviatedNumber(totalTransactions))}
                   {totalTransactions === 0 && (
-                    <QuestionTooltip
+                    <InfoTip
                       title={t('Click here to learn more about performance monitoring')}
                       position="top"
                       size="xs"

--- a/static/app/views/settings/account/notifications/fields.tsx
+++ b/static/app/views/settings/account/notifications/fields.tsx
@@ -1,11 +1,11 @@
 import {Fragment} from 'react';
 import upperFirst from 'lodash/upperFirst';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {ExternalLink} from '@sentry/scraps/link';
 import type {SelectValue} from '@sentry/scraps/select';
 
 import type {Field} from 'sentry/components/forms/types';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {DATA_CATEGORY_INFO} from 'sentry/constants';
 import {t, tct} from 'sentry/locale';
 import {DataCategoryExact} from 'sentry/types/core';
@@ -318,7 +318,7 @@ export const QUOTA_FIELDS = [
     label: (
       <Fragment>
         {t('Spend Allocations')}{' '}
-        <QuestionTooltip
+        <InfoTip
           position="top"
           title="Notification settings only apply to data categories and features included in your plan. Check your subscription overview for details."
           size="xs"

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappings.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappings.spec.tsx
@@ -131,7 +131,7 @@ describe('IntegrationExternalMappings', () => {
     for (const user of MOCK_USER_SUGGESTIONS) {
       expect(screen.getByText(user)).toBeInTheDocument();
     }
-    expect(screen.getAllByTestId('more-information')).toHaveLength(3);
+    expect(screen.getAllByRole('img', {name: 'More information'})).toHaveLength(3);
   });
 
   it('renders suggestions along with the provided mappings', async () => {
@@ -161,7 +161,7 @@ describe('IntegrationExternalMappings', () => {
     for (const team of MOCK_TEAMS) {
       expect(await screen.findByText(team.slug)).toBeInTheDocument();
     }
-    expect(screen.getAllByTestId('more-information')).toHaveLength(3);
+    expect(screen.getAllByRole('img', {name: 'More information'})).toHaveLength(3);
   });
 
   it('uses the methods passed down from props appropriately', async () => {

--- a/static/app/views/settings/organizationIntegrations/integrationExternalMappings.tsx
+++ b/static/app/views/settings/organizationIntegrations/integrationExternalMappings.tsx
@@ -2,13 +2,13 @@ import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Pagination} from '@sentry/scraps/pagination';
 import type {TableColumnConfig} from '@sentry/scraps/table';
 
 import {Confirm} from 'sentry/components/confirm';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {IconAdd, IconArrow, IconDelete} from 'sentry/icons';
 import {PluginIcon} from 'sentry/icons/pluginIcon';
@@ -177,7 +177,7 @@ export function IntegrationExternalMappings(props: Props) {
         />
       </Confirm>
     ) : (
-      <QuestionTooltip
+      <InfoTip
         title={t('This %s mapping suggestion was generated from a CODEOWNERS file', type)}
         size="sm"
       />

--- a/static/app/views/settings/organizationMembers/inviteBanner.tsx
+++ b/static/app/views/settings/organizationMembers/inviteBanner.tsx
@@ -3,6 +3,7 @@ import styled from '@emotion/styled';
 import * as qs from 'query-string';
 
 import {Button} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
@@ -15,7 +16,6 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import type {MenuItemProps} from 'sentry/components/dropdownMenu';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {FloatingFeedbackButton} from 'sentry/components/feedbackButton/floatingFeedbackButton';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconCommit, IconEllipsis, IconGithub, IconMail} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {MissingMember, OrgRole} from 'sentry/types/organization';
@@ -177,7 +177,7 @@ export function InviteBanner({allowedRoles, onSendInvite, onModalClose}: Props) 
               {tct('[missingMemberCount] missing members', {
                 missingMemberCount: missingMembers.length,
               })}
-              <QuestionTooltip
+              <InfoTip
                 title={t(
                   "Based on the last 30 days of GitHub commit data, there are team members committing code to Sentry projects that aren't in your Sentry organization"
                 )}

--- a/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
+++ b/static/app/views/settings/organizationMembers/inviteMember/orgRoleSelect.tsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Stack} from '@sentry/scraps/layout';
 import {Radio} from '@sentry/scraps/radio';
 import {Text} from '@sentry/scraps/text';
@@ -8,7 +9,6 @@ import {Panel} from 'sentry/components/panels/panel';
 import {PanelBody} from 'sentry/components/panels/panelBody';
 import {PanelHeader} from 'sentry/components/panels/panelHeader';
 import {PanelItem} from 'sentry/components/panels/panelItem';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t} from 'sentry/locale';
 import type {OrgRole} from 'sentry/types/organization';
 
@@ -43,7 +43,7 @@ export function OrganizationRoleSelect({
     <Panel>
       <StyledPanelHeader>
         <div>{t('Organization Role')}</div>
-        {disabled && helpText && <QuestionTooltip size="sm" title={helpText} />}
+        {disabled && helpText && <InfoTip size="sm" title={helpText} />}
       </StyledPanelHeader>
 
       <PanelBody>

--- a/static/app/views/settings/organizationRelay/list/cardHeader.tsx
+++ b/static/app/views/settings/organizationRelay/list/cardHeader.tsx
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 
 import {ConfirmDelete} from 'sentry/components/confirmDelete';
 import {DateTime} from 'sentry/components/dateTime';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconCopyId, IconDelete, IconEdit} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {Relay} from 'sentry/types/relay';
@@ -46,9 +46,7 @@ export function CardHeader({
       <Stack gap="2xs">
         <Flex align="center" gap="md">
           {name}
-          {description && (
-            <QuestionTooltip position="top" size="sm" title={description} />
-          )}
+          {description && <InfoTip position="top" size="sm" title={description} />}
         </Flex>
         <DateCreated>
           {tct('Created on [date]', {date: <DateTime date={created} />})}

--- a/static/gsApp/components/billingDetails/form.tsx
+++ b/static/gsApp/components/billingDetails/form.tsx
@@ -4,6 +4,7 @@ import {AddressElement, useElements, useStripe} from '@stripe/react-stripe-js';
 import type {StripeAddressElementChangeEvent} from '@stripe/stripe-js';
 
 import {Alert} from '@sentry/scraps/alert';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
@@ -11,7 +12,6 @@ import {TextField} from 'sentry/components/forms/fields/textField';
 import {Form} from 'sentry/components/forms/form';
 import {FormModel} from 'sentry/components/forms/model';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {Organization} from 'sentry/types/organization';
@@ -210,7 +210,7 @@ function CustomBillingDetailsFormField({
         <Text size="sm" variant="muted">
           {label}
         </Text>
-        <QuestionTooltip title={help} size="sm" />
+        <InfoTip title={help} size="sm" />
       </Flex>
       <StyledTextField
         name={inputName}

--- a/static/gsApp/components/billingDetails/panel.tsx
+++ b/static/gsApp/components/billingDetails/panel.tsx
@@ -4,12 +4,12 @@ import * as Sentry from '@sentry/react';
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import type {CSS} from '@sentry/scraps/cssTypes';
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 
@@ -154,7 +154,7 @@ export function BillingDetailsPanel({
                 <Text>
                   {taxFieldInfo.label}: {billingDetails.taxNumber}
                 </Text>
-                <QuestionTooltip
+                <InfoTip
                   title={tct(
                     "Your company's [taxNumberName] will appear on all receipts. You may be subject to taxes depending on country specific tax policies.",
                     {taxNumberName: <Text bold>{taxFieldInfo.taxNumberName}</Text>}

--- a/static/gsApp/views/amCheckout/components/cart.tsx
+++ b/static/gsApp/views/amCheckout/components/cart.tsx
@@ -7,12 +7,12 @@ import moment from 'moment-timezone';
 import {Alert} from '@sentry/scraps/alert';
 import {Tag} from '@sentry/scraps/badge';
 import {Button} from '@sentry/scraps/button';
+import {InfoTip} from '@sentry/scraps/info';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {Placeholder} from 'sentry/components/placeholder';
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconChevron, IconLightning, IconLock, IconSentry} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
@@ -477,7 +477,7 @@ function SubtotalSummary({
                   price={
                     <Fragment>
                       {t('Variable cost')}{' '}
-                      <QuestionTooltip
+                      <InfoTip
                         size="xs"
                         position="bottom"
                         title={t(

--- a/static/gsApp/views/spendLimits/spendLimitSettings.tsx
+++ b/static/gsApp/views/spendLimits/spendLimitSettings.tsx
@@ -4,11 +4,11 @@ import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import upperFirst from 'lodash/upperFirst';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Input} from '@sentry/scraps/input';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {IconWarning} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
@@ -236,7 +236,7 @@ export function SharedSpendLimitPriceTable({
               {showPerformanceUnits
                 ? renderPerformanceHovercard()
                 : categoryInfo?.checkoutTooltip && (
-                    <QuestionTooltip
+                    <InfoTip
                       title={categoryInfo.checkoutTooltip}
                       position="top"
                       size="xs"
@@ -292,9 +292,7 @@ export function SharedSpendLimitPriceTable({
                   })}
                 </Text>
               )}
-              {tooltipText && (
-                <QuestionTooltip title={tooltipText} position="top" size="xs" />
-              )}
+              {tooltipText && <InfoTip title={tooltipText} position="top" size="xs" />}
             </Flex>
             <Container>
               {dataCategories.map((category, index) => {
@@ -462,7 +460,7 @@ function InnerSpendLimitSettings({
                     {showPerformanceUnits
                       ? renderPerformanceHovercard()
                       : categoryInfo?.checkoutTooltip && (
-                          <QuestionTooltip
+                          <InfoTip
                             title={categoryInfo.checkoutTooltip}
                             position="top"
                             size="xs"
@@ -537,7 +535,7 @@ function InnerSpendLimitSettings({
                   <Flex align="center" gap="xs">
                     <Text bold>{upperFirst(addOnInfo.productName)}</Text>
                     {tooltipText && (
-                      <QuestionTooltip title={tooltipText} position="top" size="xs" />
+                      <InfoTip title={tooltipText} position="top" size="xs" />
                     )}
                   </Flex>
                   <Text variant="muted">

--- a/static/gsApp/views/subscriptionPage/usageOverview/components/breakdownInfo.tsx
+++ b/static/gsApp/views/subscriptionPage/usageOverview/components/breakdownInfo.tsx
@@ -1,9 +1,9 @@
 import {Fragment} from 'react';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {t, tct} from 'sentry/locale';
 import {DataCategory} from 'sentry/types/core';
 import {defined} from 'sentry/utils/defined';
@@ -72,7 +72,7 @@ function UsageBreakdownField({
         <Text variant="muted" bold uppercase size="sm">
           {field}
         </Text>
-        {help && <QuestionTooltip title={help} size="xs" />}
+        {help && <InfoTip title={help} size="xs" />}
       </Flex>
       <Text size="lg">{value}</Text>
     </Stack>

--- a/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
@@ -2,11 +2,11 @@ import {Fragment} from 'react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {InfoTip} from '@sentry/scraps/info';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 import type {TooltipProps} from '@sentry/scraps/tooltip';
 
-import {QuestionTooltip} from 'sentry/components/questionTooltip';
 import {TextOverflow} from 'sentry/components/textOverflow';
 import {t, tct} from 'sentry/locale';
 import type {DataCategory} from 'sentry/types/core';
@@ -89,9 +89,7 @@ function OutcomeRow({
             <TextWrapper>
               <Text bold={bold}>{name}</Text>
             </TextWrapper>
-            {tooltipTitle && (
-              <QuestionTooltip size="xs" position="top" title={tooltipTitle} />
-            )}
+            {tooltipTitle && <InfoTip size="xs" position="top" title={tooltipTitle} />}
           </OutcomeType>
         </Flex>
       </td>

--- a/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
+++ b/static/gsApp/views/subscriptionPage/usageTotalsTable.tsx
@@ -78,7 +78,7 @@ function OutcomeRow({
 
   return (
     <tr>
-      <td>
+      <td aria-label={name}>
         <Flex
           gap="xs"
           align="center"


### PR DESCRIPTION
Straightforward `QuestionTooltip` usages now use the accessible `InfoTip` component. Affected tests use role and accessible-name selectors instead of `data-test-id="more-information"`, and the usage overview table keeps its row names free of tooltip text through an explicit cell accessible name. The settings route now names the authorizations page so its `Authorized Applications` breadcrumb is shown.
