### PR TITLE
build(ui): Add WebP asset support

### DIFF
--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -392,7 +392,7 @@ const appConfig: Configuration = {
         ],
       },
       {
-        test: /\.(?:woff2?|ttf|eot|svg|png|gif|ico|jpe?g|avif|mp4)$/,
+        test: /\.(?:woff2?|ttf|eot|svg|png|gif|ico|jpe?g|avif|webp|mp4)$/,
         type: 'asset',
       },
     ],

--- a/static/app/types/fileLoader.d.ts
+++ b/static/app/types/fileLoader.d.ts
@@ -3,6 +3,7 @@
 
 declare module '*.css';
 declare module '*.avif';
+declare module '*.webp';
 declare module '*.png';
 declare module '*.gif';
 declare module '*.jpg';


### PR DESCRIPTION
Adds WebP files to the frontend asset pipeline and declares their module type for TypeScript imports.