### PR TITLE
feat(action-log): Measure action log enqueue duration

### DIFF
--- a/src/sentry/issues/action_log/publish.py
+++ b/src/sentry/issues/action_log/publish.py
@@ -147,9 +147,10 @@ def publish_action(
         "issues.action_log.dedicated_outbox_rollout_rate", group_id
     )
     outbox_model = GroupActionLogOutbox if use_dedicated_outbox else CellOutbox
+    outbox_route = "dedicated" if use_dedicated_outbox else "shared"
     metrics.incr(
         "issues.action_log.outbox_write",
-        tags={"route": "dedicated" if use_dedicated_outbox else "shared"},
+        tags={"route": outbox_route},
     )
 
     payload: GroupActionLogPayload = {
@@ -166,16 +167,25 @@ def publish_action(
     if idempotency_key is not None:
         payload["idempotency_key"] = idempotency_key
 
-    outbox = outbox_model(
-        shard_scope=OutboxScope.GROUP_SCOPE,
-        shard_identifier=group_id,
-        category=OutboxCategory.GROUP_ACTION_LOG_EVENT,
-        object_identifier=outbox_model.next_object_identifier(),
-        payload=payload,
-    )
     # Flush on commit by default; callers can wrap in outbox_context(flush=False) to defer.
     with outbox_context(transaction.atomic(router.db_for_write(outbox_model))):
-        outbox.save()
+        with metrics.timer(
+            "issues.action_log.enqueue.duration",
+            tags={
+                "action": action_name,
+                "source": source,
+                "route": outbox_route,
+                "derived_strategy": "async" if force_async_derived else "inline",
+            },
+        ):
+            outbox = outbox_model(
+                shard_scope=OutboxScope.GROUP_SCOPE,
+                shard_identifier=group_id,
+                category=OutboxCategory.GROUP_ACTION_LOG_EVENT,
+                object_identifier=outbox_model.next_object_identifier(),
+                payload=payload,
+            )
+            outbox.save()
 
 
 def publish_action_from_context(

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -657,7 +657,8 @@ class TestPublishActionWrite(TestCase):
         assert entry.data == {}
         assert entry.date_added is not None
 
-    def test_shared_outbox_is_default(self) -> None:
+    @patch("sentry.utils.metrics.timer")
+    def test_shared_outbox_is_default(self, mock_timer: MagicMock) -> None:
         with self.feature("projects:issue-action-log-write-to-db"), outbox_context(flush=False):
             publish_action(
                 ViewAction(),
@@ -670,11 +671,24 @@ class TestPublishActionWrite(TestCase):
             CellOutbox.objects.filter(category=OutboxCategory.GROUP_ACTION_LOG_EVENT).count() == 1
         )
         assert not GroupActionLogOutbox.objects.exists()
+        mock_timer.assert_any_call(
+            "issues.action_log.enqueue.duration",
+            tags={
+                "action": "view",
+                "source": "api",
+                "route": "shared",
+                "derived_strategy": "inline",
+            },
+        )
 
     @patch("sentry.options.rollout.in_rollout_group", return_value=True)
     @patch("sentry.utils.metrics.incr")
+    @patch("sentry.utils.metrics.timer")
     def test_dedicated_outbox_rollout_routes_one_write(
-        self, mock_incr: MagicMock, mock_in_rollout_group: MagicMock
+        self,
+        mock_timer: MagicMock,
+        mock_incr: MagicMock,
+        mock_in_rollout_group: MagicMock,
     ) -> None:
         with (
             self.feature("projects:issue-action-log-write-to-db"),
@@ -685,6 +699,7 @@ class TestPublishActionWrite(TestCase):
                 source=ActionSource.API,
                 group_id=self.group.id,
                 project=self.group.project,
+                force_async_derived=True,
             )
 
         assert not CellOutbox.objects.filter(
@@ -695,6 +710,15 @@ class TestPublishActionWrite(TestCase):
             "issues.action_log.dedicated_outbox_rollout_rate", self.group.id
         )
         mock_incr.assert_any_call("issues.action_log.outbox_write", tags={"route": "dedicated"})
+        mock_timer.assert_called_once_with(
+            "issues.action_log.enqueue.duration",
+            tags={
+                "action": "view",
+                "source": "api",
+                "route": "dedicated",
+                "derived_strategy": "async",
+            },
+        )
 
     def test_dedicated_outbox_flushes_on_commit(self) -> None:
         with (


### PR DESCRIPTION
Add a metric for total action log enqueue latency. We have this new metric to measure outbox flush time ( https://github.com/getsentry/sentry/pull/123351), but I think it would also be useful to measure the perceived latency from publishing a new action in total