### PR TITLE
feat(event formatter): render the alert definition for metric issues

### DIFF
--- a/src/sentry/issues/formatting/adapter.py
+++ b/src/sentry/issues/formatting/adapter.py
@@ -111,6 +111,71 @@ def _evidence(data: Mapping[str, Any]) -> list[tuple[str, str]]:
     ]
 
 
+# occurrence type for a metric issue (sentry.incidents.grouptype.MetricIssue)
+_METRIC_ISSUE_TYPE = 8001
+
+
+def _metric_alert_threshold(conditions: Any) -> str | None:
+    """The triggered condition(s), as "above 500"."""
+    if not isinstance(conditions, list):
+        return None
+    parts: list[str] = []
+    for condition in conditions:
+        if not isinstance(condition, dict):
+            continue
+        comparison = condition.get("comparison")
+        if comparison is None:
+            continue
+        # detector conditions store the operator as an id or a name
+        label = {
+            0: "above",
+            1: "below",
+            "gt": "above",
+            "gte": "at or above",
+            "lt": "below",
+            "lte": "at or below",
+        }.get(condition.get("type"))
+        parts.append(f"{label} {comparison}" if label else str(comparison))
+    return ", ".join(parts) or None
+
+
+def _metric_alert(data: Mapping[str, Any]) -> list[tuple[str, str]]:
+    """The alert definition behind a metric issue.
+
+    ``evidenceDisplay`` only summarises the metric by name, so without this a metric issue
+    renders none of the query it fired on. Keys inside ``evidenceData`` are snake_case: the
+    detector serializes the data sources camelCased and converts them back before storing.
+    """
+    occurrence = data.get("occurrence") or {}
+    if occurrence.get("type") != _METRIC_ISSUE_TYPE:
+        return []
+    evidence = occurrence.get("evidenceData") or {}
+
+    snuba_query: Mapping[str, Any] = {}
+    for source in evidence.get("data_sources") or []:
+        query = (source or {}).get("query_obj") or {}
+        if isinstance(query.get("snuba_query"), dict):
+            snuba_query = query["snuba_query"]
+            break
+
+    time_window = snuba_query.get("time_window")
+    value = evidence.get("value")
+    if isinstance(value, dict):  # anomaly detection stores {"value": ...}
+        value = value.get("value")
+
+    candidates = [
+        ("Dataset", snuba_query.get("dataset")),
+        ("Aggregate", snuba_query.get("aggregate")),
+        ("Query", snuba_query.get("query")),
+        ("Interval", f"{time_window} second(s)" if time_window is not None else None),
+        ("Environment", snuba_query.get("environment")),
+        ("Evaluated Value", value),
+        ("Threshold", _metric_alert_threshold(evidence.get("conditions"))),
+        ("Alert Rule ID", evidence.get("alert_id")),
+    ]
+    return [(label, str(v)) for label, v in candidates if v is not None and str(v) != ""]
+
+
 def event_response_to_model(data: Mapping[str, Any]) -> EventObject:
     entries = _entries_by_type(data)
     tags, transaction_name = _tags(data)
@@ -146,4 +211,5 @@ def event_response_to_model(data: Mapping[str, Any]) -> EventObject:
         user=UserDetails.parse_obj(user) if user else None,
         spans=[EvidenceSpan.parse_obj(s) for s in entries.get("spans") or []],
         evidence=_evidence(data),
+        metric_alert=_metric_alert(data),
     )

--- a/src/sentry/issues/formatting/adapter.py
+++ b/src/sentry/issues/formatting/adapter.py
@@ -111,8 +111,20 @@ def _evidence(data: Mapping[str, Any]) -> list[tuple[str, str]]:
     ]
 
 
-# occurrence type for a metric issue (sentry.incidents.grouptype.MetricIssue)
+# ``MetricIssue.type_id``, inlined: sentry.incidents.grouptype pulls in sentry.features, the
+# alert rule models and a wildcard condition import, and this module is otherwise free of
+# Django so it stays cheap to import and to test.
 _METRIC_ISSUE_TYPE = 8001
+
+# ``Condition`` values (sentry.workflow_engine.models.data_condition), inlined for the same
+# reason. Only the comparison operators appear on a detector trigger; anything else falls
+# through to the bare comparison below.
+_COMPARISON_LABELS = {
+    "gt": "above",
+    "gte": "at or above",
+    "lt": "below",
+    "lte": "at or below",
+}
 
 
 def _metric_alert_threshold(conditions: Any) -> str | None:
@@ -126,15 +138,8 @@ def _metric_alert_threshold(conditions: Any) -> str | None:
         comparison = condition.get("comparison")
         if comparison is None:
             continue
-        # detector conditions store the operator as an id or a name
-        label = {
-            0: "above",
-            1: "below",
-            "gt": "above",
-            "gte": "at or above",
-            "lt": "below",
-            "lte": "at or below",
-        }.get(condition.get("type"))
+        condition_type = condition.get("type")
+        label = _COMPARISON_LABELS.get(condition_type) if isinstance(condition_type, str) else None
         parts.append(f"{label} {comparison}" if label else str(comparison))
     return ", ".join(parts) or None
 

--- a/src/sentry/issues/formatting/adapter.py
+++ b/src/sentry/issues/formatting/adapter.py
@@ -143,8 +143,9 @@ def _metric_alert(data: Mapping[str, Any]) -> list[tuple[str, str]]:
     """The alert definition behind a metric issue.
 
     ``evidenceDisplay`` only summarises the metric by name, so without this a metric issue
-    renders none of the query it fired on. Keys inside ``evidenceData`` are snake_case: the
-    detector serializes the data sources camelCased and converts them back before storing.
+    renders none of the query it fired on. The detector stores ``evidence_data`` snake_cased,
+    but ``EventSerializer`` camelCases the whole occurrence recursively on the way out, so what
+    arrives here is ``dataSources[].queryObj.snubaQuery`` and ``alertId``.
     """
     occurrence = data.get("occurrence") or {}
     if occurrence.get("type") != _METRIC_ISSUE_TYPE:
@@ -152,13 +153,13 @@ def _metric_alert(data: Mapping[str, Any]) -> list[tuple[str, str]]:
     evidence = occurrence.get("evidenceData") or {}
 
     snuba_query: Mapping[str, Any] = {}
-    for source in evidence.get("data_sources") or []:
-        query = (source or {}).get("query_obj") or {}
-        if isinstance(query.get("snuba_query"), dict):
-            snuba_query = query["snuba_query"]
+    for source in evidence.get("dataSources") or []:
+        query = (source or {}).get("queryObj") or {}
+        if isinstance(query.get("snubaQuery"), dict):
+            snuba_query = query["snubaQuery"]
             break
 
-    time_window = snuba_query.get("time_window")
+    time_window = snuba_query.get("timeWindow")
     value = evidence.get("value")
     if isinstance(value, dict):  # anomaly detection stores {"value": ...}
         value = value.get("value")
@@ -171,7 +172,7 @@ def _metric_alert(data: Mapping[str, Any]) -> list[tuple[str, str]]:
         ("Environment", snuba_query.get("environment")),
         ("Evaluated Value", value),
         ("Threshold", _metric_alert_threshold(evidence.get("conditions"))),
-        ("Alert Rule ID", evidence.get("alert_id")),
+        ("Alert Rule ID", evidence.get("alertId")),
     ]
     return [(label, str(v)) for label, v in candidates if v is not None and str(v) != ""]
 

--- a/src/sentry/issues/formatting/models.py
+++ b/src/sentry/issues/formatting/models.py
@@ -163,4 +163,6 @@ class EventObject(BaseModel):
     spans: list[EvidenceSpan] = []
     # occurrence evidence (name/value pairs) for perf & generic/regression issues
     evidence: list[tuple[str, str]] = []
+    # the alert definition behind a metric issue, as ordered label/value pairs
+    metric_alert: list[tuple[str, str]] = []
     culprit: str | None = None

--- a/src/sentry/issues/formatting/sections.py
+++ b/src/sentry/issues/formatting/sections.py
@@ -287,6 +287,14 @@ def spans_section(model: EventObject, limits: Limits) -> Section | None:
     )
 
 
+def metric_alert_section(model: EventObject, limits: Limits) -> Section | None:
+    # the query a metric issue fired on; evidence_section only names the metric
+    if not model.metric_alert:
+        return None
+    items = tuple(Field(label, value) for label, value in model.metric_alert)
+    return Section(title="Metric Alert Details", groups=(Group(items=items),))
+
+
 def evidence_section(model: EventObject, limits: Limits) -> Section | None:
     if not model.evidence:
         return None
@@ -330,6 +338,7 @@ EVENT_SECTIONS_WITH_USER: list[SectionFn] = [
     csp_section,
     threads_section,
     spans_section,
+    metric_alert_section,
     evidence_section,
     breadcrumbs_section,
     request_section,

--- a/tests/sentry/issues/formatting/test_adapter.py
+++ b/tests/sentry/issues/formatting/test_adapter.py
@@ -3,6 +3,10 @@ from typing import Any
 
 import pytest
 
+from sentry.api.serializers.rest_framework.base import (
+    convert_dict_key_case,
+    snake_to_camel_case,
+)
 from sentry.issues.formatting.adapter import event_response_to_model
 from sentry.issues.formatting.sections import EVENT_SECTIONS_WITH_USER, format_issue
 
@@ -359,17 +363,17 @@ def test_non_mapping_context_is_dropped_without_sinking_the_render(value: Any) -
 
 def _metric_issue(**evidence_overrides: Any) -> dict[str, Any]:
     evidence: dict[str, Any] = {
-        "alert_id": 77,
+        "alertId": 77,
         "value": 812.4,
         "conditions": [{"type": 0, "comparison": 500}],
-        "data_sources": [
+        "dataSources": [
             {
-                "query_obj": {
-                    "snuba_query": {
+                "queryObj": {
+                    "snubaQuery": {
                         "dataset": "events_analytics_platform",
                         "aggregate": "p95(span.duration)",
                         "query": "transaction:/api/checkout",
-                        "time_window": 3600,
+                        "timeWindow": 3600,
                         "environment": "prod",
                     }
                 }
@@ -399,19 +403,28 @@ def test_metric_alert_maps_the_whole_alert_definition() -> None:
     ]
 
 
-def test_metric_alert_reads_snake_case_keys() -> None:
-    # the detector serializes data sources camelCased then converts them back before storing,
-    # so camelCase keys here would silently match nothing
-    camel = {
-        "alertId": 77,
-        "dataSources": [{"queryObj": {"snubaQuery": {"dataset": "x", "timeWindow": 60}}}],
+def test_metric_alert_reads_the_keys_the_serializer_emits() -> None:
+    # the detector stores evidence_data snake_cased, but EventSerializer camelCases the whole
+    # occurrence recursively on the way out. Build the fixture through that same conversion so
+    # the shape is the one the adapter really receives, not one written by hand.
+    stored = {
+        "type": 8001,
+        "evidence_data": {
+            "alert_id": 77,
+            "value": 1.5,
+            "conditions": [],
+            "data_sources": [{"query_obj": {"snuba_query": {"dataset": "x", "time_window": 60}}}],
+        },
     }
-    assert (
-        event_response_to_model(
-            {"title": "t", "occurrence": {"type": 8001, "evidenceData": camel}}
-        ).metric_alert
-        == []
+    model = event_response_to_model(
+        {"title": "t", "occurrence": convert_dict_key_case(stored, snake_to_camel_case)}
     )
+    assert ("Dataset", "x") in model.metric_alert
+    assert ("Interval", "60 second(s)") in model.metric_alert
+    assert ("Alert Rule ID", "77") in model.metric_alert
+
+    # the snake_case shape the detector stores matches nothing by the time it reaches here
+    assert event_response_to_model({"title": "t", "occurrence": stored}).metric_alert == []
 
 
 @pytest.mark.parametrize(
@@ -436,7 +449,7 @@ def test_metric_alert_unwraps_anomaly_detection_value() -> None:
 
 
 def test_metric_alert_skips_missing_pieces() -> None:
-    model = event_response_to_model(_metric_issue(data_sources=[], conditions=[]))
+    model = event_response_to_model(_metric_issue(dataSources=[], conditions=[]))
     assert model.metric_alert == [("Evaluated Value", "812.4"), ("Alert Rule ID", "77")]
 
 

--- a/tests/sentry/issues/formatting/test_adapter.py
+++ b/tests/sentry/issues/formatting/test_adapter.py
@@ -365,7 +365,7 @@ def _metric_issue(**evidence_overrides: Any) -> dict[str, Any]:
     evidence: dict[str, Any] = {
         "alertId": 77,
         "value": 812.4,
-        "conditions": [{"type": 0, "comparison": 500}],
+        "conditions": [{"type": "gt", "comparison": 500}],
         "dataSources": [
             {
                 "queryObj": {
@@ -430,11 +430,15 @@ def test_metric_alert_reads_the_keys_the_serializer_emits() -> None:
 @pytest.mark.parametrize(
     "condition,expected",
     [
-        ({"type": 0, "comparison": 500}, "above 500"),
-        ({"type": 1, "comparison": 2}, "below 2"),
+        ({"type": "gt", "comparison": 500}, "above 500"),
+        ({"type": "lt", "comparison": 2}, "below 2"),
         ({"type": "gte", "comparison": 10}, "at or above 10"),
         ({"type": "lte", "comparison": 10}, "at or below 10"),
-        ({"comparison": 7}, "7"),  # no operator recorded
+        # DataConditionSnapshot types `type` as str, so a Condition value is what arrives;
+        # anything else (including a legacy int) falls through to the bare comparison
+        ({"comparison": 7}, "7"),
+        ({"type": "eq", "comparison": 7}, "7"),
+        ({"type": 0, "comparison": 7}, "7"),
     ],
 )
 def test_metric_alert_threshold_labels(condition: Any, expected: str) -> None:

--- a/tests/sentry/issues/formatting/test_adapter.py
+++ b/tests/sentry/issues/formatting/test_adapter.py
@@ -355,3 +355,100 @@ def test_non_mapping_context_is_dropped_without_sinking_the_render(value: Any) -
     m = event_response_to_model(data)
     assert m.contexts == {"browser": {"name": "Firefox"}}
     assert "boom" in format_issue(data, sections=EVENT_SECTIONS_WITH_USER)
+
+
+def _metric_issue(**evidence_overrides: Any) -> dict[str, Any]:
+    evidence: dict[str, Any] = {
+        "alert_id": 77,
+        "value": 812.4,
+        "conditions": [{"type": 0, "comparison": 500}],
+        "data_sources": [
+            {
+                "query_obj": {
+                    "snuba_query": {
+                        "dataset": "events_analytics_platform",
+                        "aggregate": "p95(span.duration)",
+                        "query": "transaction:/api/checkout",
+                        "time_window": 3600,
+                        "environment": "prod",
+                    }
+                }
+            }
+        ],
+    }
+    evidence.update(evidence_overrides)
+    return {
+        "title": "transaction.duration above 500",
+        "occurrence": {"type": 8001, "evidenceData": evidence, "evidenceDisplay": []},
+    }
+
+
+def test_metric_alert_maps_the_whole_alert_definition() -> None:
+    # evidenceDisplay only names the metric, so without evidenceData a metric issue renders
+    # none of the query it fired on
+    model = event_response_to_model(_metric_issue())
+    assert model.metric_alert == [
+        ("Dataset", "events_analytics_platform"),
+        ("Aggregate", "p95(span.duration)"),
+        ("Query", "transaction:/api/checkout"),
+        ("Interval", "3600 second(s)"),
+        ("Environment", "prod"),
+        ("Evaluated Value", "812.4"),
+        ("Threshold", "above 500"),
+        ("Alert Rule ID", "77"),
+    ]
+
+
+def test_metric_alert_reads_snake_case_keys() -> None:
+    # the detector serializes data sources camelCased then converts them back before storing,
+    # so camelCase keys here would silently match nothing
+    camel = {
+        "alertId": 77,
+        "dataSources": [{"queryObj": {"snubaQuery": {"dataset": "x", "timeWindow": 60}}}],
+    }
+    assert (
+        event_response_to_model(
+            {"title": "t", "occurrence": {"type": 8001, "evidenceData": camel}}
+        ).metric_alert
+        == []
+    )
+
+
+@pytest.mark.parametrize(
+    "condition,expected",
+    [
+        ({"type": 0, "comparison": 500}, "above 500"),
+        ({"type": 1, "comparison": 2}, "below 2"),
+        ({"type": "gte", "comparison": 10}, "at or above 10"),
+        ({"type": "lte", "comparison": 10}, "at or below 10"),
+        ({"comparison": 7}, "7"),  # no operator recorded
+    ],
+)
+def test_metric_alert_threshold_labels(condition: Any, expected: str) -> None:
+    model = event_response_to_model(_metric_issue(conditions=[condition]))
+    assert ("Threshold", expected) in model.metric_alert
+
+
+def test_metric_alert_unwraps_anomaly_detection_value() -> None:
+    # anomaly detection stores the evaluated value as {"value": ...}
+    model = event_response_to_model(_metric_issue(value={"value": 9.5, "source_id": "s"}))
+    assert ("Evaluated Value", "9.5") in model.metric_alert
+
+
+def test_metric_alert_skips_missing_pieces() -> None:
+    model = event_response_to_model(_metric_issue(data_sources=[], conditions=[]))
+    assert model.metric_alert == [("Evaluated Value", "812.4"), ("Alert Rule ID", "77")]
+
+
+def test_metric_alert_only_applies_to_metric_issues() -> None:
+    event = _metric_issue()
+    event["occurrence"]["type"] = 1001  # a perf issue
+    assert event_response_to_model(event).metric_alert == []
+    assert event_response_to_model({"title": "t"}).metric_alert == []
+
+
+def test_metric_alert_renders_in_the_output() -> None:
+    out = format_issue(_metric_issue(), sections=EVENT_SECTIONS_WITH_USER)
+    assert "## Metric Alert Details" in out
+    assert "**Aggregate:** p95(span.duration)" in out
+    assert "**Threshold:** above 500" in out


### PR DESCRIPTION
prevents losing Evaluated Value and Threshold when MCP moves to the shared formatter, and renders the six more fields MCP's own reader has been silently missing