### PR TITLE
fix(settings): Show authorizations breadcrumb

### DIFF
--- a/static/app/router/routes.tsx
+++ b/static/app/router/routes.tsx
@@ -347,6 +347,7 @@ function buildRoutes(): RouteObject[] {
     },
     {
       path: 'authorizations/',
+      name: t('Authorized Applications'),
       component: make(
         () => import('sentry/views/settings/account/accountAuthorizations')
       ),


### PR DESCRIPTION
The account authorizations route now has the `Authorized Applications` name. This adds the current page to the settings breadcrumb (`Settings → Account → Authorized Applications`), matching the other account subpages.
