### PR TITLE
fix(onboarding): Send the MS Teams channel name as the alert action target

### DIFF
--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -10,17 +10,13 @@ import {t} from 'sentry/locale';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {
   providerDetails,
-  RAW_CHANNEL_FIELD,
   type IntegrationChannel,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {
   ChannelField,
   ChannelSelect,
 } from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
-import {
-  type Channel,
-  useMessagingChannel,
-} from 'sentry/views/projectInstall/useMessagingChannel';
+import {useMessagingChannel} from 'sentry/views/projectInstall/useMessagingChannel';
 
 import type {ScmMessagingProviderKey} from './messagingProviders';
 import type {ScmMessagingSetup} from './scmMessagingSetup';
@@ -48,8 +44,8 @@ export function ScmMessagingChannelPicker({
 }: ScmMessagingChannelPickerProps) {
   const {channelSelectedBy} = providerDetails[providerKey];
 
-  // The saved destination we're editing, if any. Drives both the dropdown seed
-  // and the preserve-on-no-op-save logic below.
+  // The saved destination we're editing, if any. Seeds the workspace and the
+  // channel, whose stored identifiers a no-op save then keeps.
   const savedSelection =
     existingSetup?.mode === 'selected' && existingSetup.providerKey === providerKey
       ? existingSetup
@@ -73,9 +69,15 @@ export function ScmMessagingChannelPicker({
   }>(() => ({
     integrationId: savedSelection?.integrationId,
     // Only seed the channel when the default workspace is the saved one. Switching
-    // workspaces starts blank.
+    // workspaces starts blank. The seed carries both stored identifiers, so a
+    // no-op save keeps them even when the channel list cannot resolve it.
     channel: savedSelection
-      ? {label: savedSelection.channelName, value: savedSelection[channelSelectedBy]}
+      ? {
+          label: savedSelection.channelName,
+          value: savedSelection[channelSelectedBy],
+          channelId: savedSelection.channelId,
+          channelName: savedSelection.channelName,
+        }
       : undefined,
   }));
 
@@ -99,7 +101,6 @@ export function ScmMessagingChannelPicker({
     channelOptions,
     isChannelLoading,
     isChannelsError,
-    channelsData,
     channelError,
     clearChannelValidation,
     onChannelChange,
@@ -127,40 +128,15 @@ export function ScmMessagingChannelPicker({
       return;
     }
 
-    // Match the selected value against whichever field this provider's options
-    // are keyed on. Manual entries (channel.new) are not in the list.
-    const rawChannel = channel.new
-      ? undefined
-      : channelsData?.results.find(
-          (ch: Channel) => ch[RAW_CHANNEL_FIELD[channelSelectedBy]] === channel.value
-        );
-
-    // Prefer the resolved raw channel. If it can't be resolved (empty/errored
-    // /channels/ or a dropped channel) but the selection and workspace are unchanged,
-    // keep the stored identifiers — otherwise id-keyed providers (msteams, discord)
-    // would overwrite channelName with the id and break name-based revalidation.
-    // A new value falls through to itself.
-    let stored: {channelId: string; channelName: string};
-
-    if (rawChannel) {
-      stored = {channelId: rawChannel.id, channelName: rawChannel.display};
-    } else if (
-      selectedIntegration.id === savedSelection?.integrationId &&
-      channel.value === savedSelection?.[channelSelectedBy]
-    ) {
-      stored = {
-        channelId: savedSelection.channelId,
-        channelName: savedSelection.channelName,
-      };
-    } else {
-      stored = {channelId: channel.value, channelName: channel.value};
-    }
-
+    // A channel from the list, or the seeded saved one, carries both
+    // identifiers. A typed channel has only its text, which is stored under
+    // both so name-based revalidation reads what the user entered.
     onConfigured({
       mode: 'selected',
       providerKey,
       integrationId: selectedIntegration.id,
-      ...stored,
+      channelId: channel.channelId ?? channel.value,
+      channelName: channel.channelName ?? channel.value,
     });
   };
 

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -44,8 +44,7 @@ export function ScmMessagingChannelPicker({
 }: ScmMessagingChannelPickerProps) {
   const {channelSelectedBy} = providerDetails[providerKey];
 
-  // The saved destination we're editing, if any. Seeds the workspace and the
-  // channel, whose stored identifiers a no-op save then keeps.
+  // The saved destination we're editing, if any.
   const savedSelection =
     existingSetup?.mode === 'selected' && existingSetup.providerKey === providerKey
       ? existingSetup

--- a/static/app/components/onboarding/scm/scmMessagingSetup.ts
+++ b/static/app/components/onboarding/scm/scmMessagingSetup.ts
@@ -34,8 +34,8 @@ export type ScmMessagingSetup =
       channelId: string;
       /**
        * Human-readable display name shown in the UI.
-       * Also the channel-validate param for Slack and msteams, which both
-       * resolve channels by name rather than ID.
+       * Also the channel-validate param and the action value for Slack and
+       * msteams, which both resolve channels by name rather than ID.
        */
       channelName: string;
       integrationId: string;

--- a/static/app/components/onboarding/scm/scmMessagingSetup.ts
+++ b/static/app/components/onboarding/scm/scmMessagingSetup.ts
@@ -27,8 +27,9 @@ export type ScmMessagingSetup =
   | {mode: 'skipped'}
   | {
       /**
-       * The real backend channel ID for all providers (e.g. C123 for Slack,
-       * a numeric string for Discord, a UUID-like string for msteams).
+       * The backend channel ID for a channel picked from the list (e.g. C123
+       * for Slack, a numeric string for Discord, a UUID-like string for
+       * msteams). A typed channel stores its text here as well.
        * Used as the Discord channel-validate param and as the Discord action value.
        */
       channelId: string;

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -701,6 +701,68 @@ describe('ScmMessaging', () => {
     );
   });
 
+  it('Continue targets an MS Teams channel by its name', async () => {
+    // The picker keys Teams channels by id, but the backend resolves a Teams
+    // channel by name only, so the workflow must carry the name.
+    const msteamsSetup: ScmMessagingSetup = {
+      mode: 'selected',
+      providerKey: 'msteams',
+      integrationId: '15',
+      channelId: '19:abc@thread.tacv2',
+      channelName: 'General',
+    };
+    mockIntegration({
+      provider: msteamsIntegration.provider,
+      configData: msteamsIntegration.configData,
+    });
+    mockChannelValidate(true, 'General');
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,
+      method: 'POST',
+      body: createdProject,
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/`,
+      body: [IssueStreamDetectorFixture({projectId: createdProject.id})],
+    });
+    const createWorkflowRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      body: AutomationFixture({id: 'workflow-id'}),
+    });
+    const onCreatedProjectChange = jest.fn();
+    renderMessaging({messagingSetup: msteamsSetup, onCreatedProjectChange});
+
+    const continueButton = screen.getByRole('button', {name: 'Continue'});
+    await waitFor(() => expect(continueButton).toBeEnabled());
+    await userEvent.click(continueButton);
+
+    await waitFor(() => expect(createWorkflowRequest).toHaveBeenCalled());
+    expect(createWorkflowRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/workflows/`,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          actionFilters: [
+            expect.objectContaining({
+              actions: [
+                expect.objectContaining({type: 'email'}),
+                expect.objectContaining({
+                  type: 'msteams',
+                  integrationId: '15',
+                  config: expect.objectContaining({targetDisplay: 'General'}),
+                }),
+              ],
+            }),
+          ],
+        }),
+      })
+    );
+    expect(onCreatedProjectChange).toHaveBeenCalledWith({
+      slug: createdProject.slug,
+      messagingSelection: {provider: 'msteams', integrationId: '15', channel: 'General'},
+    });
+  });
+
   it('Set up later creates the email-only project before completing', async () => {
     const createProjectRequest = MockApiClient.addMockResponse({
       url: `/teams/${organization.slug}/${adminTeam.slug}/projects/`,

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -1,3 +1,4 @@
+import {AutomationFixture} from 'sentry-fixture/automations';
 import {IssueStreamDetectorFixture} from 'sentry-fixture/detectors';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
@@ -809,6 +810,131 @@ describe('CreateProject', () => {
     ).toBeInTheDocument();
     expect(addErrorMessage).toHaveBeenCalledWith('Failed to create project apple-ios');
     expect(addErrorMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('targets an MS Teams channel picked from the list by its name', async () => {
+    // The picker keys Teams channels by id, but the backend resolves a Teams
+    // channel by name only, so the workflow must carry the name.
+    const {organization} = initializeOrg({
+      organization: {
+        access: ['project:read'],
+        features: ['team-roles'],
+        allowMemberProjectCreation: true,
+      },
+    });
+
+    const msteamsIntegration = OrganizationIntegrationsFixture({
+      id: '338731',
+      name: "Moo Deng's Team",
+      provider: {
+        key: 'msteams',
+        slug: 'msteams',
+        name: 'MS Teams',
+        canAdd: true,
+        canDisable: false,
+        features: ['alert-rule', 'chat-unfurl'],
+        aspects: {
+          alerts: [],
+        },
+      },
+    });
+
+    TeamStore.loadUserTeams([teamWithAccess]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [TeamFixture({slug: teamWithAccess.slug})],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [msteamsIntegration],
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${msteamsIntegration.id}/channels/`,
+      body: {
+        results: [
+          {
+            id: '19:abc@thread.tacv2',
+            name: 'General',
+            display: 'General',
+            type: 'standard',
+          },
+        ],
+      },
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: {id: '1', slug: 'testProj', name: 'Test Project'},
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/`,
+      body: [IssueStreamDetectorFixture({projectId: '1'})],
+    });
+
+    const ruleCreationMockRequest = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/workflows/`,
+      method: 'POST',
+      body: AutomationFixture(),
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [
+        {
+          id: '1',
+          slug: 'testProj',
+          name: 'Test Project',
+        },
+      ],
+    });
+
+    render(<CreateProject />, {organization});
+
+    await userEvent.click(screen.getByTestId('platform-apple-ios'));
+    await userEvent.click(screen.getByText(/When there are more than/));
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: /Notify via integration/,
+      })
+    );
+    await selectEvent.select(
+      screen.getByLabelText('channel'),
+      'General (19:abc@thread.tacv2)'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Create Project'}));
+
+    await waitFor(() => {
+      expect(ruleCreationMockRequest).toHaveBeenCalled();
+    });
+    expect(ruleCreationMockRequest).toHaveBeenCalledWith(
+      `/organizations/${organization.slug}/workflows/`,
+      expect.objectContaining({
+        data: expect.objectContaining({
+          actionFilters: [
+            expect.objectContaining({
+              actions: expect.arrayContaining([
+                expect.objectContaining({
+                  type: 'msteams',
+                  integrationId: msteamsIntegration.id,
+                  config: expect.objectContaining({targetDisplay: 'General'}),
+                }),
+              ]),
+            }),
+          ],
+        }),
+      })
+    );
   });
 
   describe('Issue Alerts Options', () => {

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -147,6 +147,101 @@ describe('CreateProject', () => {
     return {organization, routeAnalytics};
   }
 
+  /**
+   * Mocks the requests made when a project is created with a messaging
+   * integration selected, up to the workflow request each test controls.
+   */
+  function mockMessagingProjectCreation({
+    provider,
+    channels,
+  }: {
+    channels: Array<{display: string; id: string; name: string; type: string}>;
+    provider: {key: string; name: string};
+  }) {
+    const {organization} = initializeOrg({
+      organization: {
+        access: ['project:read'],
+        features: ['team-roles'],
+        allowMemberProjectCreation: true,
+      },
+    });
+
+    const messagingIntegration = OrganizationIntegrationsFixture({
+      id: '338731',
+      name: "Moo Deng's Workspace",
+      provider: {
+        key: provider.key,
+        slug: provider.key,
+        name: provider.name,
+        canAdd: true,
+        canDisable: false,
+        features: ['alert-rule', 'chat-unfurl'],
+        aspects: {
+          alerts: [],
+        },
+      },
+    });
+
+    TeamStore.loadUserTeams([teamWithAccess]);
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/teams/`,
+      body: [TeamFixture({slug: teamWithAccess.slug})],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/`,
+      body: organization,
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/`,
+      body: [messagingIntegration],
+      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/integrations/${messagingIntegration.id}/channels/`,
+      body: {results: channels},
+    });
+
+    const projectCreationMockRequest = MockApiClient.addMockResponse({
+      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
+      method: 'POST',
+      body: {id: '1', slug: 'testProj', name: 'Test Project'},
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/detectors/`,
+      body: [IssueStreamDetectorFixture({projectId: '1'})],
+    });
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [
+        {
+          id: '1',
+          slug: 'testProj',
+          name: 'Test Project',
+        },
+      ],
+    });
+
+    return {organization, messagingIntegration, projectCreationMockRequest};
+  }
+
+  async function createProjectWithChannel(channelLabel: string) {
+    await userEvent.click(screen.getByTestId('platform-apple-ios'));
+    await userEvent.click(screen.getByText(/When there are more than/));
+    await userEvent.click(
+      screen.getByRole('checkbox', {
+        name: /Notify via integration/,
+      })
+    );
+    await selectEvent.select(screen.getByLabelText('channel'), channelLabel);
+    await userEvent.click(screen.getByRole('button', {name: 'Create Project'}));
+  }
+
   it('sets page-view origin to org_creation from the org-create seed param', () => {
     const {routeAnalytics} = renderCreateWithOriginQuery({
       projectCreationOrigin: 'org_creation',
@@ -684,71 +779,16 @@ describe('CreateProject', () => {
   });
 
   it('should rollback project when rule creation fails', async () => {
-    const {organization} = initializeOrg({
-      organization: {
-        access: ['project:read'],
-        features: ['team-roles'],
-        allowMemberProjectCreation: true,
-      },
-    });
-
-    const discordIntegration = OrganizationIntegrationsFixture({
-      id: '338731',
-      name: "Moo Deng's Server",
-      provider: {
-        key: 'discord',
-        slug: 'discord',
-        name: 'Discord',
-        canAdd: true,
-        canDisable: false,
-        features: ['alert-rule', 'chat-unfurl'],
-        aspects: {
-          alerts: [],
+    const {organization, projectCreationMockRequest} = mockMessagingProjectCreation({
+      provider: {key: 'discord', name: 'Discord'},
+      channels: [
+        {
+          id: '1437461639900303454',
+          name: 'general',
+          display: '#general',
+          type: 'text',
         },
-      },
-    });
-
-    TeamStore.loadUserTeams([teamWithAccess]);
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/teams/`,
-      body: [TeamFixture({slug: teamWithAccess.slug})],
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/`,
-      body: organization,
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/`,
-      body: [discordIntegration],
-      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/${discordIntegration.id}/channels/`,
-      body: {
-        results: [
-          {
-            id: '1437461639900303454',
-            name: 'general',
-            display: '#general',
-            type: 'text',
-          },
-        ],
-      },
-    });
-
-    const projectCreationMockRequest = MockApiClient.addMockResponse({
-      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
-      method: 'POST',
-      body: {id: '1', slug: 'testProj', name: 'Test Project'},
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/detectors/`,
-      body: [IssueStreamDetectorFixture({projectId: '1'})],
+      ],
     });
 
     const ruleCreationMockRequest = MockApiClient.addMockResponse({
@@ -773,28 +813,9 @@ describe('CreateProject', () => {
       method: 'DELETE',
     });
 
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/projects/`,
-      body: [
-        {
-          id: '1',
-          slug: 'testProj',
-          name: 'Test Project',
-        },
-      ],
-    });
-
     render(<CreateProject />, {organization});
 
-    await userEvent.click(screen.getByTestId('platform-apple-ios'));
-    await userEvent.click(screen.getByText(/When there are more than/));
-    await userEvent.click(
-      screen.getByRole('checkbox', {
-        name: /Notify via integration/,
-      })
-    );
-    await selectEvent.select(screen.getByLabelText('channel'), /#general/);
-    await userEvent.click(screen.getByRole('button', {name: 'Create Project'}));
+    await createProjectWithChannel('#general (1437461639900303454)');
     await waitFor(() => {
       expect(projectCreationMockRequest).toHaveBeenCalledTimes(1);
     });
@@ -815,71 +836,16 @@ describe('CreateProject', () => {
   it('targets an MS Teams channel picked from the list by its name', async () => {
     // The picker keys Teams channels by id, but the backend resolves a Teams
     // channel by name only, so the workflow must carry the name.
-    const {organization} = initializeOrg({
-      organization: {
-        access: ['project:read'],
-        features: ['team-roles'],
-        allowMemberProjectCreation: true,
-      },
-    });
-
-    const msteamsIntegration = OrganizationIntegrationsFixture({
-      id: '338731',
-      name: "Moo Deng's Team",
-      provider: {
-        key: 'msteams',
-        slug: 'msteams',
-        name: 'MS Teams',
-        canAdd: true,
-        canDisable: false,
-        features: ['alert-rule', 'chat-unfurl'],
-        aspects: {
-          alerts: [],
+    const {organization, messagingIntegration} = mockMessagingProjectCreation({
+      provider: {key: 'msteams', name: 'MS Teams'},
+      channels: [
+        {
+          id: '19:abc@thread.tacv2',
+          name: 'General',
+          display: 'General',
+          type: 'standard',
         },
-      },
-    });
-
-    TeamStore.loadUserTeams([teamWithAccess]);
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/teams/`,
-      body: [TeamFixture({slug: teamWithAccess.slug})],
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/`,
-      body: organization,
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/`,
-      body: [msteamsIntegration],
-      match: [MockApiClient.matchQuery({integrationType: 'messaging'})],
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/${msteamsIntegration.id}/channels/`,
-      body: {
-        results: [
-          {
-            id: '19:abc@thread.tacv2',
-            name: 'General',
-            display: 'General',
-            type: 'standard',
-          },
-        ],
-      },
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/teams/${organization.slug}/${teamWithAccess.slug}/projects/`,
-      method: 'POST',
-      body: {id: '1', slug: 'testProj', name: 'Test Project'},
-    });
-
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/detectors/`,
-      body: [IssueStreamDetectorFixture({projectId: '1'})],
+      ],
     });
 
     const ruleCreationMockRequest = MockApiClient.addMockResponse({
@@ -888,31 +854,9 @@ describe('CreateProject', () => {
       body: AutomationFixture(),
     });
 
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/projects/`,
-      body: [
-        {
-          id: '1',
-          slug: 'testProj',
-          name: 'Test Project',
-        },
-      ],
-    });
-
     render(<CreateProject />, {organization});
 
-    await userEvent.click(screen.getByTestId('platform-apple-ios'));
-    await userEvent.click(screen.getByText(/When there are more than/));
-    await userEvent.click(
-      screen.getByRole('checkbox', {
-        name: /Notify via integration/,
-      })
-    );
-    await selectEvent.select(
-      screen.getByLabelText('channel'),
-      'General (19:abc@thread.tacv2)'
-    );
-    await userEvent.click(screen.getByRole('button', {name: 'Create Project'}));
+    await createProjectWithChannel('General (19:abc@thread.tacv2)');
 
     await waitFor(() => {
       expect(ruleCreationMockRequest).toHaveBeenCalled();
@@ -926,7 +870,7 @@ describe('CreateProject', () => {
               actions: expect.arrayContaining([
                 expect.objectContaining({
                   type: 'msteams',
-                  integrationId: msteamsIntegration.id,
+                  integrationId: messagingIntegration.id,
                   config: expect.objectContaining({targetDisplay: 'General'}),
                 }),
               ]),

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -18,6 +18,7 @@ import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {
   buildIntegrationAction,
   buildNotificationSelection,
+  getChannelTarget,
   IssueAlertNotificationOptions,
   type IssueAlertNotificationProps,
   MultipleCheckboxOptions,
@@ -47,11 +48,11 @@ describe('buildIntegrationAction', () => {
     ],
     [
       'msteams',
-      '19:abc@thread.tacv2',
+      'General',
       {
         id: IssueAlertActionType.MS_TEAMS,
         team: '15',
-        channel: '19:abc@thread.tacv2',
+        channel: 'General',
       },
     ],
   ])('serializes a %s destination', (provider, channel, expectedAction) => {
@@ -69,6 +70,44 @@ describe('buildIntegrationAction', () => {
         channel: '#alerts',
       })
     ).toBeUndefined();
+  });
+});
+
+describe('getChannelTarget', () => {
+  it.each([
+    [
+      'slack',
+      {label: '#alerts', value: '#alerts', channelId: 'C123', channelName: '#alerts'},
+      '#alerts',
+    ],
+    [
+      'discord',
+      {
+        label: '#alerts (123456789)',
+        value: '123456789',
+        channelId: '123456789',
+        channelName: '#alerts',
+      },
+      '123456789',
+    ],
+    [
+      'msteams',
+      {
+        label: 'General (19:abc@thread.tacv2)',
+        value: '19:abc@thread.tacv2',
+        channelId: '19:abc@thread.tacv2',
+        channelName: 'General',
+      },
+      'General',
+    ],
+  ])('targets the field the %s backend resolves', (provider, channel, target) => {
+    expect(getChannelTarget(provider, channel)).toBe(target);
+  });
+
+  it('falls back to the picker value for a typed channel', () => {
+    expect(
+      getChannelTarget('msteams', {label: 'General', value: 'General', new: true})
+    ).toBe('General');
   });
 });
 
@@ -658,5 +697,21 @@ describe('buildNotificationSelection', () => {
         channel: {label: '#eng', value: '#eng'},
       })
     ).toEqual({provider: 'slack', integrationId: '5', channel: '#eng'});
+  });
+
+  it('stores the action target rather than the picker key', () => {
+    const integration = OrganizationIntegrationsFixture({id: '5'});
+    expect(
+      buildNotificationSelection({
+        provider: 'msteams',
+        integration,
+        channel: {
+          label: 'General (19:abc@thread.tacv2)',
+          value: '19:abc@thread.tacv2',
+          channelId: '19:abc@thread.tacv2',
+          channelName: 'General',
+        },
+      })
+    ).toEqual({provider: 'msteams', integrationId: '5', channel: 'General'});
   });
 });

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -114,9 +114,9 @@ export function getChannelSelectedBy(provider: string | undefined): ChannelIdent
 
 /**
  * The value an action carries for a channel: the field the provider's backend
- * resolves (`channelTargetedBy`) when the channel came from the `/channels/`
- * list, else the value itself. A typed channel, or one restored from a
- * persisted target, already is that value.
+ * resolves (`channelTargetedBy`) when the channel carries both identifiers,
+ * else `value`, which for a typed channel or one restored from an action
+ * target already is the target.
  */
 export function getChannelTarget(
   provider: string | undefined,
@@ -139,9 +139,9 @@ export type IntegrationChannel = {
   /** The picker key: the field named by the provider's `channelSelectedBy`. */
   value: string;
   /**
-   * Both identifiers of a channel chosen from the `/channels/` list. Absent
-   * for a typed channel and for one restored from a persisted target, whose
-   * `value` already is the target.
+   * Both identifiers, when the channel was resolved from the `/channels/` list
+   * or seeded from a saved destination. Absent for a typed channel and for one
+   * restored from an action target alone, whose `value` already is the target.
    */
   channelId?: string;
   channelName?: string;

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -30,7 +30,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import type {RequestDataFragment} from 'sentry/views/projectInstall/issueAlertOptions';
 import {MessagingIntegrationAlertRule} from 'sentry/views/projectInstall/messagingIntegrationAlertRule';
 
-type ChannelIdentityField = 'channelId' | 'channelName';
+export type ChannelIdentityField = 'channelId' | 'channelName';
 
 interface MessagingProviderDetail {
   action: IssueAlertActionType;
@@ -43,18 +43,10 @@ interface MessagingProviderDetail {
 }
 
 /**
- * Maps a stored destination field onto its counterpart in the raw `/channels/`
- * response, so a stored value can be matched back to a channel.
- */
-export const RAW_CHANNEL_FIELD = {
-  channelName: 'display',
-  channelId: 'id',
-} as const satisfies Record<ChannelIdentityField, 'display' | 'id'>;
-
-/**
  * Providers disagree on what identifies a channel. MS Teams is the only row
- * that is not uniform: it validates by name but is addressed by id, because
- * Sentry built a name-to-id resolver for it while all three send by id.
+ * that is not uniform: the picker keys it by id, since two Teams channels can
+ * share a name, but the backend resolves a Teams channel by name only
+ * (`find_channel_id`), so it is validated and targeted by name.
  */
 export const providerDetails = {
   slack: {
@@ -97,7 +89,7 @@ export const providerDetails = {
     placeholder: t('channel name'),
     channelSelectedBy: 'channelId',
     channelValidatedBy: 'channelName',
-    channelTargetedBy: 'channelId',
+    channelTargetedBy: 'channelName',
     makeSentence: ({providerName, integrationName, target}: any) =>
       tct('Send [providerName] notification to the [integrationName] team to [target]', {
         providerName,
@@ -120,6 +112,23 @@ export function getChannelSelectedBy(provider: string | undefined): ChannelIdent
   );
 }
 
+/**
+ * The value an action carries for a channel: the field the provider's backend
+ * resolves (`channelTargetedBy`) when the channel came from the `/channels/`
+ * list, else the value itself. A typed channel, or one restored from a
+ * persisted target, already is that value.
+ */
+export function getChannelTarget(
+  provider: string | undefined,
+  channel: IntegrationChannel | undefined
+): string | undefined {
+  if (!channel) {
+    return undefined;
+  }
+  const targetedBy = providerDetails[provider as MessagingProviderKey]?.channelTargetedBy;
+  return (targetedBy && channel[targetedBy]) || channel.value;
+}
+
 export const enum MultipleCheckboxOptions {
   EMAIL = 'email',
   INTEGRATION = 'integration',
@@ -127,7 +136,14 @@ export const enum MultipleCheckboxOptions {
 
 export type IntegrationChannel = {
   label: ReactNode;
+  /** The picker key: the field named by the provider's `channelSelectedBy`. */
   value: string;
+  /**
+   * Both identifiers of a channel chosen from the `/channels/` list. Absent
+   * for a typed channel and for one restored from a persisted target, whose
+   * `value` already is the target.
+   */
+  channelId?: string;
   channelName?: string;
   new?: boolean;
 };
@@ -148,6 +164,7 @@ export type IssueAlertNotificationProps = {
 };
 
 export type NotificationSelection = {
+  /** The action target for the channel (see `getChannelTarget`). */
   channel: string;
   integrationId: string;
   provider: string;
@@ -193,7 +210,8 @@ export function buildIntegrationAction({
 
 /**
  * Builds the raw {provider, integrationId, channel} snapshot of the current
- * messaging selection. Returns undefined if any of the three fields are absent.
+ * messaging selection, with `channel` as the action target. Returns undefined
+ * if any of the three fields are absent.
  */
 export function buildNotificationSelection({
   provider,
@@ -202,10 +220,11 @@ export function buildNotificationSelection({
 }: Pick<IssueAlertNotificationProps, 'provider' | 'integration' | 'channel'>):
   | NotificationSelection
   | undefined {
-  if (!provider || !integration || !channel?.value) {
+  const target = getChannelTarget(provider, channel);
+  if (!provider || !integration || !target) {
     return undefined;
   }
-  return {provider, integrationId: integration.id, channel: channel.value};
+  return {provider, integrationId: integration.id, channel: target};
 }
 
 /**
@@ -336,12 +355,7 @@ function useNotificationPicker(resolveRestore: RestoreResolver) {
       const integrationAction = buildIntegrationAction({
         provider,
         integrationId: integration?.id,
-        // MS Teams is resolved by channel name on the backend, while the
-        // picker keys it by id.
-        channel:
-          provider === 'msteams'
-            ? (channel?.channelName ?? channel?.value)
-            : channel?.value,
+        channel: getChannelTarget(provider, channel),
       });
       if (!integrationAction) {
         return;

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
@@ -162,10 +162,11 @@ describe('MessagingIntegrationAlertRule', () => {
     expect(screen.getByText('#alerts (2)')).toBeInTheDocument();
     await selectEvent.select(getChannelSelect(), /#alerts/);
     expect(mockSetChannel).toHaveBeenCalledWith({
-      channelName: 'alerts',
       label: '#alerts (2)',
       value: '2',
       new: false,
+      channelId: '2',
+      channelName: '#alerts',
     });
   });
 
@@ -355,7 +356,7 @@ describe('MessagingIntegrationAlertRule', () => {
     expect(mockSetIntegration).toHaveBeenCalledWith(slackIntegrations[1]);
   });
 
-  it('keeps the channel name when selecting a Microsoft Teams channel', async () => {
+  it('keys Microsoft Teams channels by id and keeps the name for the action', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/integrations/${msteamsIntegrations[0]!.id}/channels/`,
       body: {
@@ -382,10 +383,11 @@ describe('MessagingIntegrationAlertRule', () => {
     expect(screen.getByText('#alerts (2)')).toBeInTheDocument();
     await selectEvent.select(getChannelSelect(), /#alerts/);
     expect(mockSetChannel).toHaveBeenCalledWith({
-      channelName: 'alerts',
       label: '#alerts (2)',
       value: '2',
       new: false,
+      channelId: '2',
+      channelName: '#alerts',
     });
   });
 });

--- a/static/app/views/projectInstall/useMessagingChannel.spec.tsx
+++ b/static/app/views/projectInstall/useMessagingChannel.spec.tsx
@@ -73,7 +73,8 @@ describe('useMessagingChannel', () => {
       await waitFor(() => expect(result.current.channelOptions).toBeDefined());
       expect(result.current.channelOptions).toEqual([
         {
-          channelName: 'general',
+          channelId: 'C123',
+          channelName: '#general',
           label: '#general',
           value: '#general',
         },
@@ -90,7 +91,8 @@ describe('useMessagingChannel', () => {
       await waitFor(() => expect(result.current.channelOptions).toBeDefined());
       expect(result.current.channelOptions).toEqual([
         {
-          channelName: 'general',
+          channelId: '1234567890',
+          channelName: '#general',
           label: '#general (1234567890)',
           value: '1234567890',
         },
@@ -112,10 +114,11 @@ describe('useMessagingChannel', () => {
 
       await waitFor(() =>
         expect(mockSetChannel).toHaveBeenCalledWith({
-          channelName: 'alerts',
           label: '#alerts (2)',
           value: '2',
           new: false,
+          channelId: '2',
+          channelName: '#alerts',
         })
       );
     });
@@ -128,7 +131,8 @@ describe('useMessagingChannel', () => {
       const mockSetChannel = jest.fn();
       const {result} = renderChannel('slack', slackIntegration, {
         channel: {
-          channelName: 'general',
+          channelId: '1',
+          channelName: '#general',
           label: '#general',
           value: '#general',
           new: false,
@@ -181,7 +185,8 @@ describe('useMessagingChannel', () => {
       expect(result.current.isChannelsError).toBe(false);
       expect(result.current.channelOptions).toEqual([
         {
-          channelName: 'general',
+          channelId: 'C123',
+          channelName: '#general',
           label: '#general',
           value: '#general',
         },

--- a/static/app/views/projectInstall/useMessagingChannel.ts
+++ b/static/app/views/projectInstall/useMessagingChannel.ts
@@ -7,6 +7,7 @@ import {trackAnalytics} from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
+  type ChannelIdentityField,
   getChannelSelectedBy,
   type IntegrationChannel,
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
@@ -22,6 +23,25 @@ export type Channel = {
 type ChannelListResponse = {
   results: Channel[];
 };
+
+/**
+ * A picker entry for a raw channel, carrying both identifiers so a caller can
+ * target whichever field the provider's backend resolves (`channelTargetedBy`).
+ * Id-keyed providers show the id alongside the name, since the name alone
+ * cannot tell two same-named channels apart.
+ */
+function toChannelOption(
+  channel: Channel,
+  channelSelectedBy: ChannelIdentityField
+): IntegrationChannel {
+  const keyedByName = channelSelectedBy === 'channelName';
+  return {
+    label: keyedByName ? channel.display : `${channel.display} (${channel.id})`,
+    value: keyedByName ? channel.display : channel.id,
+    channelId: channel.id,
+    channelName: channel.display,
+  };
+}
 
 type Input = {
   channel: IntegrationChannel | undefined;
@@ -60,6 +80,9 @@ export type UseMessagingChannelResult = {
  *   - channelOptions shaping (Slack keyed by display name; Discord and MS Teams
  *     keyed by id with `display (id)` labels, since the name alone cannot
  *     disambiguate same-named channels)
+ *   - A channel chosen from the list carries both `channelId` and
+ *     `channelName`, so a caller can target whichever field the provider's
+ *     backend resolves (`channelTargetedBy`)
  *   - Label-upgrade effect: restores raw-id labels to human-readable once the
  *     channel list loads; never touches user-created (channel.new) entries
  *   - onChannelChange / onCreateChannel with optional variant analytics
@@ -117,29 +140,25 @@ export function useMessagingChannel({
   const clearChannelValidation = () =>
     queryClient.removeQueries({queryKey: validateChannelOptions.queryKey});
 
-  const channelOptions = useMemo(() => {
-    // Id-keyed providers show the id alongside the name, since the name alone
-    // cannot tell two same-named channels apart.
-    const keyedByName = getChannelSelectedBy(provider) === 'channelName';
-    return channels?.results.map(ch => ({
-      channelName: ch.name,
-      label: keyedByName ? ch.display : `${ch.display} (${ch.id})`,
-      value: keyedByName ? ch.display : ch.id,
-    }));
-  }, [channels, provider]);
+  const channelSelectedBy = getChannelSelectedBy(provider);
+  const channelOptions = useMemo(
+    () => channels?.results.map(ch => toChannelOption(ch, channelSelectedBy)),
+    [channels, channelSelectedBy]
+  );
 
   useEffect(() => {
     // A restored channel (e.g. from persisted/default actions) only has a raw
     // id as its label until the channel list loads. Upgrade it to the
-    // human-readable label once we can resolve it. Skips user-created
-    // channels, which intentionally keep their typed-in label.
-    if (!channel || channel.new || !channelOptions) {
+    // human-readable label, and both identifiers, once we can resolve it.
+    // Skips user-created channels, which intentionally keep their typed-in
+    // label.
+    if (!channel || channel.new) {
       return;
     }
-    const match = channelOptions.find(option => option.value === channel.value);
+    const match = channelOptions?.find(option => option.value === channel.value);
     if (
       match &&
-      (match.label !== channel.label || match.channelName !== channel.channelName)
+      (match.label !== channel.label || match.channelId !== channel.channelId)
     ) {
       setChannel({...match, new: false});
     }

--- a/static/app/views/projectInstall/useMessagingChannel.ts
+++ b/static/app/views/projectInstall/useMessagingChannel.ts
@@ -13,7 +13,7 @@ import {
 } from 'sentry/views/projectInstall/issueAlertNotificationOptions';
 import {validateChannelQueryOptions} from 'sentry/views/projectInstall/useValidateChannel';
 
-export type Channel = {
+type Channel = {
   display: string;
   id: string;
   name: string;
@@ -80,9 +80,6 @@ export type UseMessagingChannelResult = {
  *   - channelOptions shaping (Slack keyed by display name; Discord and MS Teams
  *     keyed by id with `display (id)` labels, since the name alone cannot
  *     disambiguate same-named channels)
- *   - A channel chosen from the list carries both `channelId` and
- *     `channelName`, so a caller can target whichever field the provider's
- *     backend resolves (`channelTargetedBy`)
  *   - Label-upgrade effect: restores raw-id labels to human-readable once the
  *     channel list loads; never touches user-created (channel.new) entries
  *   - onChannelChange / onCreateChannel with optional variant analytics


### PR DESCRIPTION
A Microsoft Teams channel chosen from the channel list must reach the backend as its name, because `MsTeamsNotifyServiceForm` resolves Teams channels by name only (`find_channel_id`). #123074 covered the create project page by carrying `channelName` on the picker option and reading it inside `buildIntegrationAction`. The onboarding messaging step builds its action from the stored destination through the string-based `buildIntegrationAction` from #122596, so it still sent the channel id as `targetDisplay`, workflow validation failed, and the new project was rolled back.

Each provider row in `providerDetails` now names the field its backend resolves (`channelTargetedBy`): the name for Slack and MS Teams, the id for Discord. A channel picked from the list carries both `channelId` and `channelName` on the option, and every caller builds the action target through `getChannelTarget`: the create project page, the SCM project details page, and the onboarding messaging step. The MS Teams row moves from targeting by id to targeting by name; Slack and Discord send what they sent before. `channelName` is the display name, so a Slack target keeps its `#`.

The picker stays keyed by id for MS Teams so two same-named Teams channels remain distinguishable in the list. A typed channel, or one restored from a persisted action, has no separate identifiers and is sent as entered. The SCM channel picker stores the two identifiers from the selection instead of resolving them again on save.

Surfaced by Bugbot on #123074: https://github.com/getsentry/sentry/pull/123074#discussion_r3918119942

Fixes VDY-199
