### PR TITLE
fix(grouping): Find the crash frame in multi-thread events

### DIFF
--- a/src/sentry/stacktraces/processing.py
+++ b/src/sentry/stacktraces/processing.py
@@ -10,6 +10,7 @@ import sentry_sdk
 
 from sentry.stacktraces.functions import set_in_app, trim_function_name
 from sentry.utils import metrics
+from sentry.utils.event_frames import get_crashing_thread
 from sentry.utils.safe import get_path, set_path, setdefault_path
 from sentry.utils.tracing import start_span
 
@@ -317,17 +318,17 @@ def get_crash_frame_from_event_data(data, frame_filter=None):
         - there are no frames
         - all frames fail the given filter test
         - we're unable to find any frames nested in either event.exception or
-          event.stacktrace, and there's anything other than exactly one thread
-          in the data
+          event.stacktrace, and the data doesn't contain a single identifiable
+          crashing thread
     """
 
     frames = get_path(data, "exception", "values", -1, "stacktrace", "frames") or get_path(
         data, "stacktrace", "frames"
     )
     if not frames:
-        threads = get_path(data, "threads", "values")
-        if threads and len(threads) == 1:
-            frames = get_path(threads, 0, "stacktrace", "frames")
+        thread = get_crashing_thread(get_path(data, "threads", "values", filter=True))
+        if thread is not None:
+            frames = get_path(thread, "stacktrace", "frames")
 
     default = None
     for frame in reversed(frames or ()):

--- a/tests/sentry/grouping/test_fingerprinting.py
+++ b/tests/sentry/grouping/test_fingerprinting.py
@@ -306,6 +306,61 @@ def test_variable_resolution() -> None:
         ], f"Entry {fingerprint_entry} resolved incorrectly"
 
 
+@django_db_all
+def test_variable_resolution_with_stacktrace_in_threads() -> None:
+    event = Event(
+        project_id=908415,
+        event_id="11211231",
+        data={
+            "platform": "cocoa",
+            "exception": {
+                "values": [
+                    {
+                        "type": "MyApp.SampleError",
+                        "value": "Code=0",
+                        "mechanism": {"type": "NSError"},
+                    }
+                ]
+            },
+            "threads": {
+                "values": [
+                    {"id": 0, "crashed": False, "current": False},
+                    {
+                        "id": 1,
+                        "crashed": False,
+                        "current": True,
+                        "stacktrace": {
+                            "frames": [
+                                {"function": "main", "in_app": False, "package": "/usr/lib/dyld"},
+                                {
+                                    "function": "ViewController.captureError",
+                                    "module": "MyApp.ViewController",
+                                    "abs_path": "/Users/me/MyApp/ViewController.swift",
+                                    "filename": "ViewController.swift",
+                                    "package": "/var/containers/MyApp.app/MyApp",
+                                    "in_app": True,
+                                },
+                            ]
+                        },
+                    },
+                ]
+            },
+        },
+    )
+    context = GroupingContext(StrategyConfiguration(), event)
+
+    for fingerprint_entry, expected_resolved_value in [
+        ("{{ stack.function }}", "ViewController.captureError"),
+        ("{{ stack.module }}", "MyApp.ViewController"),
+        ("{{ stack.abs_path }}", "/Users/me/MyApp/ViewController.swift"),
+        ("{{ stack.filename }}", "ViewController.swift"),
+        ("{{ stack.package }}", "MyApp"),
+    ]:
+        assert resolve_fingerprint_values([fingerprint_entry], event, context) == [
+            expected_resolved_value
+        ], f"Entry {fingerprint_entry} resolved incorrectly"
+
+
 # TODO: Once we have fully transitioned off of the `newstyle:2023-01-11` grouping config, we can
 # remove this test entirely, as the new behavior is also tested in `test_variable_resolution` above
 @django_db_all

--- a/tests/sentry/test_stacktraces.py
+++ b/tests/sentry/test_stacktraces.py
@@ -191,17 +191,37 @@ class TestFindStacktraces:
         assert infos[0].exception_type == "Error"
 
 
+def _thread(**kwargs):
+    return {"stacktrace": {"frames": [{"in_app": True, "marco": "polo"}]}, **kwargs}
+
+
 @pytest.mark.parametrize(
     "event",
     [
-        {"threads": {"values": [{"stacktrace": {"frames": [{"in_app": True, "marco": "polo"}]}}]}},
+        {"threads": {"values": [_thread()]}},
         {
             "exception": {
                 "values": [{"stacktrace": {"frames": [{"in_app": True, "marco": "polo"}]}}]
             }
         },
         {"stacktrace": {"frames": [{"in_app": True, "marco": "polo"}]}},
+        {"threads": {"values": [{"id": 0}, _thread(crashed=True), {"id": 2}]}},
+        {"threads": {"values": [{"id": 0}, _thread(current=True), {"id": 2}]}},
+        {"threads": {"values": [None, _thread()]}},
     ],
 )
 def test_get_crash_frame(event) -> None:
     assert get_crash_frame_from_event_data(event)["marco"] == "polo"
+
+
+@pytest.mark.parametrize(
+    "event",
+    [
+        {"threads": {"values": []}},
+        {"threads": {"values": [{"id": 0}, {"id": 1}]}},
+        {"threads": {"values": [_thread(crashed=True), _thread(crashed=True)]}},
+        {"threads": {"values": [_thread(current=True), _thread(current=True)]}},
+    ],
+)
+def test_get_crash_frame_returns_none(event) -> None:
+    assert get_crash_frame_from_event_data(event) is None


### PR DESCRIPTION
`get_crash_frame_from_event_data` only fell back to the threads interface when an event had exactly one thread. Apple SDKs snapshot every thread when reporting a handled error, so a `captureError` event arrives with ~10+ threads, the stack on the one marked `current`, and no stacktrace on the exception. That tripped the guard and the lookup returned nothing.

The consequence users see is that `{{ stack.function }}` and its siblings resolve to `<no-function>` in fingerprint rules, so grouping by frame is impossible for these events. The matcher side of the same rule already works, because it reads frames via `find_stack_frames`, which picks the crashed thread, else the current thread, else the only thread. Reuse that selection here so both halves of a rule see the same frame.

Also feeds `get_crash_location`, so event metadata now carries a filename and function for these events where it previously carried neither. For threads with no in-app frames the topmost frame can be an SDK internal; that needs in-app classification fixed in the enhancement layer, not here.

Projects using these variables on Apple currently fingerprint on a constant so this will result in these issues being split.

Fixes GH-122931