### PR TITLE
ref(onboarding): Compact the onboarding header chrome

### DIFF
--- a/static/app/components/onboarding/stepper.tsx
+++ b/static/app/components/onboarding/stepper.tsx
@@ -4,23 +4,22 @@ import {motion} from 'framer-motion';
 const StepperContainer = styled('div')`
   display: flex;
   flex-direction: row;
+  align-items: center;
   gap: ${p => p.theme.space.md};
-  border-radius: 4px;
   position: relative;
-  overflow: hidden;
 `;
 
 const StepperIndicator = styled('span')<{clickable?: boolean}>`
-  height: 5px;
-  width: 48px;
+  height: 6px;
+  width: 6px;
   background-color: ${p => p.theme.tokens.graphics.neutral.muted};
   cursor: ${p => (p.clickable ? 'pointer' : 'default')};
   border-radius: ${p => p.theme.radius.full};
 `;
 
 const StepperTransitionIndicator = styled(motion.span)`
-  height: 5px;
-  width: 48px;
+  height: 6px;
+  width: 6px;
   background-color: ${p => p.theme.tokens.background.accent.vibrant};
   position: absolute;
   border-radius: ${p => p.theme.radius.full};

--- a/static/app/views/onboarding/components/onboardingSkipButton.tsx
+++ b/static/app/views/onboarding/components/onboardingSkipButton.tsx
@@ -67,6 +67,7 @@ export function OnboardingSkipButton({stepId}: OnboardingSkipButtonProps) {
   return (
     <LinkButton
       variant="transparent"
+      size="xs"
       onClick={handleClick}
       to={`/organizations/${organization.slug}/issues/?referrer=${config.referrer}`}
     >

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -642,10 +642,9 @@ const OnboardingContainer = styled('div')<{
 
 const Header = styled(Grid)`
   background: ${p => p.theme.tokens.background.primary};
-  padding-left: ${p => p.theme.space['3xl']};
-  padding-right: ${p => p.theme.space['3xl']};
+  padding: ${p => p.theme.space.md} ${p => p.theme.space['3xl']};
   position: sticky;
-  height: 80px;
+  min-height: 60px;
   align-items: center;
   top: 0;
   z-index: 100;
@@ -653,7 +652,7 @@ const Header = styled(Grid)`
 `;
 
 const LogoSvg = styled(LogoSentry)`
-  height: 30px;
+  height: 24px;
   color: ${p => p.theme.tokens.content.primary};
 `;
 

--- a/static/gsApp/overrides/targetedOnboardingHeader.tsx
+++ b/static/gsApp/overrides/targetedOnboardingHeader.tsx
@@ -2,9 +2,8 @@ import styled from '@emotion/styled';
 
 import {LinkButton} from '@sentry/scraps/button';
 import {Grid, type GridProps} from '@sentry/scraps/layout';
-import {ExternalLink} from '@sentry/scraps/link';
 
-import {IconBusiness} from 'sentry/icons';
+import {IconBusiness, IconQuestion} from 'sentry/icons';
 import {t, tn} from 'sentry/locale';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -45,21 +44,28 @@ function TargetedOnboardingHeader({source, subscription}: Props) {
       <div>{tn('%s Day Left', '%s Days Left', getTrialDaysLeft(subscription) || 0)}</div>
     </ActiveTrialWrapper>
   ) : (
-    <NeedHelpLink href="https://www.sentry.help" onClick={trackClickNeedHelp}>
-      {t('Need help?')}
-    </NeedHelpLink>
+    <LinkButton
+      href="https://www.sentry.help"
+      external
+      onClick={trackClickNeedHelp}
+      size="xs"
+      icon={<IconQuestion />}
+      variant="transparent"
+      aria-label={t('Help Center')}
+      tooltipProps={{title: t('Help Center')}}
+    />
   );
 
   return (
-    <HeaderActionBar gap="xl">
-      <SecondaryCTAWrapper>{cta}</SecondaryCTAWrapper>
+    <HeaderActionBar>
+      {cta}
       <LinkButton
         onClick={trackClickUpgrade}
         href={normalizeUrl(`/checkout/${organization.slug}/?referrer=upgrade-${source}`)}
         external
-        size="sm"
+        size="xs"
         icon={<IconBusiness />}
-        variant="secondary"
+        variant="transparent"
       >
         {t('Upgrade Now')}
       </LinkButton>
@@ -75,16 +81,6 @@ const HeaderActionBar = styled((props: GridProps) => (
   <Grid flow="column" align="center" gap="md" {...props} />
 ))`
   margin-left: ${p => p.theme.space.xl};
-`;
-
-const SecondaryCTAWrapper = styled('div')`
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
-    display: none;
-  }
-`;
-
-const NeedHelpLink = styled(ExternalLink)`
-  white-space: nowrap;
 `;
 
 const ActiveTrialHeader = styled('div')`


### PR DESCRIPTION
Compacts the onboarding header so it reads as chrome rather than page content.

- Shorter header with a smaller wordmark
- Secondary actions drop to xs transparent buttons
- "Need help?" becomes an icon button, so it stays visible at narrow widths
  instead of being hidden outright
- Stepper progress bars become dots

No behaviour change.