### PR TITLE
feat(onboarding): Rework the agentic progress card

### DIFF
--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.spec.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.spec.tsx
@@ -177,7 +177,6 @@ describe('AgenticProgressList', () => {
 
     expect(screen.getByText('Setup complete')).toBeInTheDocument();
     expect(await screen.findByText('react-frontend')).toBeInTheDocument();
-    // The stages collapse away rather than standing as nine finished rows.
     expect(screen.queryByText('Confirm test error')).not.toBeInTheDocument();
 
     expect(await screen.findByText('Check out your first issue')).toBeInTheDocument();

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.spec.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.spec.tsx
@@ -1,4 +1,5 @@
 import {AgenticProgressRunFixture} from 'sentry-fixture/agenticProgressRun';
+import {GroupFixture} from 'sentry-fixture/group';
 import {ProjectFixture} from 'sentry-fixture/project';
 
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -137,5 +138,81 @@ describe('AgenticProgressList', () => {
     expect(screen.getByText(/Last update/)).toBeInTheDocument();
     expect(screen.getByText('ID:Lg1iSt2qeQ')).toBeInTheDocument();
     await waitFor(() => expect(projectsRequest).toHaveBeenCalled());
+  });
+
+  it('collapses into a summary and hands back the first issue once complete', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [ProjectFixture({slug: 'react-frontend'})],
+    });
+    const issueRequest = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/issues/4815162342/',
+      body: GroupFixture({
+        id: '4815162342',
+        metadata: {type: 'TypeError', value: 'x is not a function'},
+      }),
+    });
+
+    render(
+      <AgenticProgress
+        run={AgenticProgressRunFixture({
+          runStatus: 'completed',
+          stages: [
+            {
+              stage: 'create_project',
+              status: 'completed',
+              eventNote: null,
+              extra: {projectSlugs: ['react-frontend']},
+            },
+            {
+              stage: 'receive_verification_error',
+              status: 'completed',
+              eventNote: null,
+              extra: {issueIds: ['4815162342']},
+            },
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByText('Setup complete')).toBeInTheDocument();
+    expect(await screen.findByText('react-frontend')).toBeInTheDocument();
+    // The stages collapse away rather than standing as nine finished rows.
+    expect(screen.queryByText('Confirm test error')).not.toBeInTheDocument();
+
+    expect(await screen.findByText('Check out your first issue')).toBeInTheDocument();
+    expect(screen.getByText('TypeError')).toBeInTheDocument();
+    expect(screen.getByText('x is not a function')).toBeInTheDocument();
+    expect(screen.getByRole('link')).toHaveAttribute(
+      'href',
+      '/organizations/org-slug/issues/4815162342/?referrer=onboarding-agentic-first-issue'
+    );
+    expect(issueRequest).toHaveBeenCalled();
+  });
+
+  it('leaves the issue card out when the run completed without one', () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/projects/',
+      body: [ProjectFixture({slug: 'react-frontend'})],
+    });
+
+    render(
+      <AgenticProgress
+        run={AgenticProgressRunFixture({
+          runStatus: 'completed',
+          stages: [
+            {
+              stage: 'receive_verification_error',
+              status: 'skipped',
+              eventNote: null,
+              extra: null,
+            },
+          ],
+        })}
+      />
+    );
+
+    expect(screen.getByText('Setup complete')).toBeInTheDocument();
+    expect(screen.queryByText('Check out your first issue')).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
@@ -45,9 +45,6 @@ const pendingStages: AgenticProgressStageState[] = [
 ];
 
 const createdProjectSlugs = ['react-frontend', 'python-backend'];
-// The issue the story's run reports back. Storybook has no group to resolve it
-// against, so the completed run's issue card stays out — driving the run to a
-// terminal state with the shape the agent actually sends is the point here.
 const verificationIssueIds = ['4815162342'];
 
 export default Storybook.story('Agentic Onboarding Progress', story => {

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
@@ -118,14 +118,6 @@ export default Storybook.story('Agentic Onboarding Progress', story => {
   story('Connecting an agent', () => <AgentConnectionStory />);
 });
 
-/**
- * The welcome step's own composition, driven by a toggle rather than a real
- * agent. Rendering WelcomeAgentSetup itself (not a copy of its markup) is what
- * makes this useful for the setup card to progress list transition: the card
- * swap, the box resizing between the two heights, and the manual path
- * collapsing are all the components' own, so what happens here is what happens
- * in onboarding.
- */
 function AgentConnectionStory() {
   const [isAgentConnected, setIsAgentConnected] = useState(false);
 
@@ -140,6 +132,7 @@ function AgentConnectionStory() {
             isAgentConnected={isAgentConnected}
             onboardingCode="Lg1iSt2qeQ"
             onCopyCommand={() => {}}
+            onRetry={() => setIsAgentConnected(false)}
             onSetupInBrowser={() => {}}
             run={makeAgenticProgressRun({
               sequence: 3,

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
@@ -126,6 +126,7 @@ function AgentConnectionStory() {
         </Button>
         <Container width="100%" maxWidth="480px">
           <WelcomeAgentSetup
+            hasInitFailed={false}
             isAgentConnected={isAgentConnected}
             onboardingCode="Lg1iSt2qeQ"
             onCopyCommand={() => {}}

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.stories.tsx
@@ -6,6 +6,7 @@ import {Container, Stack} from '@sentry/scraps/layout';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {IconChevron} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
+import {WelcomeAgentSetup} from 'sentry/views/onboarding/components/welcomeAgentSetup';
 
 import {AgenticProgress} from './agenticProgressList';
 import type {AgenticProgressRun} from './types';
@@ -44,6 +45,10 @@ const pendingStages: AgenticProgressStageState[] = [
 ];
 
 const createdProjectSlugs = ['react-frontend', 'python-backend'];
+// The issue the story's run reports back. Storybook has no group to resolve it
+// against, so the completed run's issue card stays out — driving the run to a
+// terminal state with the shape the agent actually sends is the point here.
+const verificationIssueIds = ['4815162342'];
 
 export default Storybook.story('Agentic Onboarding Progress', story => {
   story('All states', () => (
@@ -109,7 +114,53 @@ export default Storybook.story('Agentic Onboarding Progress', story => {
   ));
 
   story('Interactive progress', () => <InteractiveProgressStory />);
+
+  story('Connecting an agent', () => <AgentConnectionStory />);
 });
+
+/**
+ * The welcome step's own composition, driven by a toggle rather than a real
+ * agent. Rendering WelcomeAgentSetup itself (not a copy of its markup) is what
+ * makes this useful for the setup card to progress list transition: the card
+ * swap, the box resizing between the two heights, and the manual path
+ * collapsing are all the components' own, so what happens here is what happens
+ * in onboarding.
+ */
+function AgentConnectionStory() {
+  const [isAgentConnected, setIsAgentConnected] = useState(false);
+
+  return (
+    <StoryFrame>
+      <Stack gap="2xl" align="start">
+        <Button onClick={() => setIsAgentConnected(connected => !connected)}>
+          {isAgentConnected ? 'Disconnect agent' : 'Connect agent'}
+        </Button>
+        <Container width="100%" maxWidth="480px">
+          <WelcomeAgentSetup
+            isAgentConnected={isAgentConnected}
+            onboardingCode="Lg1iSt2qeQ"
+            onCopyCommand={() => {}}
+            onSetupInBrowser={() => {}}
+            run={makeAgenticProgressRun({
+              sequence: 3,
+              stages: pendingStages.map(stage =>
+                stage.stage === 'analyze_project'
+                  ? {
+                      ...stage,
+                      status: 'completed',
+                      eventNote: 'Detected a React application using Vite.',
+                    }
+                  : stage.stage === 'create_project'
+                    ? {...stage, status: 'active'}
+                    : stage
+              ),
+            })}
+          />
+        </Container>
+      </Stack>
+    </StoryFrame>
+  );
+}
 
 const terminalStatuses = new Set(['completed', 'skipped', 'bypassed', 'failed']);
 
@@ -152,6 +203,15 @@ function InteractiveProgressStory() {
               status,
               eventNote: noteForStatus(status),
               extra: {projectSlugs: createdProjectSlugs},
+            };
+          }
+
+          if (stage.stage === 'receive_verification_error' && status === 'completed') {
+            return {
+              ...stage,
+              status,
+              eventNote: noteForStatus(status),
+              extra: {issueIds: verificationIssueIds},
             };
           }
 

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
@@ -107,28 +107,17 @@ const ActiveLoadingIndicator = styled(LoadingIndicator)`
 const MotionGrid = motion.create(Grid);
 const MotionStack = motion.create(Stack);
 
-/**
- * Stage rows settle in one after another rather than all at once, so the list
- * reads as the agent's plan being laid out. Rows are keyed by stage, so this
- * runs when a row mounts — on the list's first appearance, and again for each
- * stage the agent reports later — not on every poll.
- */
 const STAGE_LIST_STAGGER_TRANSITION: MotionProps['transition'] = {
   staggerChildren: 0.03,
   delayChildren: 0.04,
 };
 
-// Transform and opacity only: the row's height stays put, so the card's own
-// resize is not fighting the rows arriving.
 const STAGE_ITEM_VARIANTS: MotionProps['variants'] = {
   initial: {opacity: 0, y: 12},
   animate: {
     opacity: 1,
     y: 0,
     transition: {
-      // `bounce` is how far the row overshoots before settling: 0 stops dead,
-      // 1 wobbles. Only the travel springs — a spring on opacity overshoots
-      // past full, which reads as a flicker rather than a bounce.
       y: {type: 'spring', duration: 0.3, bounce: 0.35},
       opacity: {duration: 0.12, ease: 'easeOut'},
     },
@@ -295,11 +284,6 @@ export function AgenticProgressList({
   extraContentByStage?: Partial<Record<AgenticProgressStage, React.ReactNode>>;
   header?: React.ReactNode;
 }) {
-  // An enclosing AnimatePresence with `initial={false}` puts `initial: false` on
-  // PresenceContext, which blocks the mount animation of every motion component
-  // beneath it — so the stagger silently vanishes whenever the list is already
-  // on screen at first paint. Flipping the label after mount makes it an
-  // ordinary animate change, which nothing upstream suppresses.
   const [hasEntered, setHasEntered] = useState(false);
   useEffect(() => {
     setHasEntered(true);
@@ -333,10 +317,6 @@ export function AgenticProgressList({
   );
 }
 
-/**
- * Run metadata. It sits below the card rather than inside it: the card is the
- * list of stages, and this is a caption on the run as a whole.
- */
 function AgenticProgressMeta({
   isComplete,
   onboardingCode,
@@ -346,15 +326,11 @@ function AgenticProgressMeta({
   onboardingCode: string | undefined;
   updatedAt: string;
 }) {
-  // Nothing left to caption once the run is done: the timestamp was there to
-  // show the stream was live, and the dot to show it was still arriving.
   if (isComplete && !onboardingCode) {
     return null;
   }
 
   return (
-    // The id holds the right edge in both states, so it does not jump across
-    // when the timestamp beside it goes away.
     <Flex align="center" justify={isComplete ? 'end' : 'between'} gap="md">
       {isComplete ? null : (
         <Flex align="center" gap="sm">
@@ -452,13 +428,8 @@ export function AgenticProgress({
   const firstIssueId = verificationStage?.extra?.issueIds?.[0];
   const isComplete = run.runStatus === 'completed';
 
-  // The metadata is bundled with the list rather than left to each caller, so
-  // anything rendering a run — the welcome step, the stories — gets both.
   return (
     <Stack width="100%" gap="md">
-      {/* popLayout takes the outgoing list out of flow so the summary occupies
-          the slot while the two cross-fade, leaving the caller's own layout
-          animation to tween the height the collapse frees up. */}
       <AnimatePresence initial={false} mode="popLayout">
         {isComplete ? (
           <MotionContainer
@@ -490,8 +461,6 @@ export function AgenticProgress({
         )}
       </AnimatePresence>
       {isComplete && firstIssueId ? (
-        // Delayed past the collapse so the issue arrives as the next thing to
-        // look at rather than as part of the swap.
         <MotionContainer
           width="100%"
           initial={{opacity: 0, y: 8}}

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
@@ -6,6 +6,7 @@ import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 import {Text} from '@sentry/scraps/text';
 
+import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {ProjectList} from 'sentry/components/projectList';
 import {TimeSince} from 'sentry/components/timeSince';
@@ -18,7 +19,9 @@ import {
   IconPieHalf,
 } from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
+import {useProjects} from 'sentry/utils/useProjects';
 
+import {FirstIssueCard} from './firstIssueCard';
 import type {AgenticProgressRun} from './types';
 
 type AgenticProgressStageState = AgenticProgressRun['stages'][number];
@@ -262,9 +265,9 @@ export function AgenticProgressList({
   header?: React.ReactNode;
 }) {
   return (
-    <Stack width="100%" border="muted" radius="lg" overflow="hidden" gap="0">
+    <Stack width="100%" border="primary" radius="lg" overflow="hidden" gap="0">
       {header ? (
-        <Container padding="lg" borderBottom="muted">
+        <Container padding="xl" borderBottom="muted">
           {header}
         </Container>
       ) : null}
@@ -280,29 +283,45 @@ export function AgenticProgressList({
   );
 }
 
+/**
+ * Run metadata. It sits below the card rather than inside it: the card is the
+ * list of stages, and this is a caption on the run as a whole.
+ */
 function AgenticProgressMeta({
+  isComplete,
   onboardingCode,
   updatedAt,
 }: {
+  isComplete: boolean;
   onboardingCode: string | undefined;
   updatedAt: string;
 }) {
+  // Nothing left to caption once the run is done: the timestamp was there to
+  // show the stream was live, and the dot to show it was still arriving.
+  if (isComplete && !onboardingCode) {
+    return null;
+  }
+
   return (
-    <Flex align="center" justify="between" gap="md">
-      <Flex align="center" gap="sm">
-        <StatusIndicator variant="accent" />
-        <Text size="sm" variant="muted">
-          {tct('Last update [time]', {
-            time: (
-              <TimeSince
-                date={updatedAt}
-                disabledAbsoluteTooltip
-                liveUpdateInterval="second"
-              />
-            ),
-          })}
-        </Text>
-      </Flex>
+    // The id holds the right edge in both states, so it does not jump across
+    // when the timestamp beside it goes away.
+    <Flex align="center" justify={isComplete ? 'end' : 'between'} gap="md">
+      {isComplete ? null : (
+        <Flex align="center" gap="sm">
+          <StatusIndicator variant="accent" />
+          <Text size="sm" variant="muted">
+            {tct('Last update [time]', {
+              time: (
+                <TimeSince
+                  date={updatedAt}
+                  disabledAbsoluteTooltip
+                  liveUpdateInterval="second"
+                />
+              ),
+            })}
+          </Text>
+        </Flex>
+      )}
       {onboardingCode ? (
         <RunId size="sm" variant="muted" monospace>
           {t('ID:%s', onboardingCode)}
@@ -315,6 +334,45 @@ function AgenticProgressMeta({
 const RunId = styled(Text)`
   opacity: 0.6;
 `;
+
+/**
+ * The finished run, collapsed. Nine rows all reading "Done" say no more than
+ * one row does, so what survives the collapse is the outcome and what it
+ * produced — the projects the agent created.
+ */
+function AgenticProgressSummary({projectSlugs}: {projectSlugs: string[]}) {
+  const {projects} = useProjects({slugs: projectSlugs});
+  // A single project is named outright; past that, the list's avatars and its
+  // count carry it, since a row of full badges would not fit.
+  const soleProjectSlug = projectSlugs.length === 1 ? projectSlugs[0] : undefined;
+  const soleProject = soleProjectSlug
+    ? (projects.find(project => project.slug === soleProjectSlug) ?? {
+        slug: soleProjectSlug,
+      })
+    : undefined;
+
+  return (
+    <Flex
+      width="100%"
+      border="primary"
+      radius="lg"
+      padding="lg"
+      gap="md"
+      align="center"
+      justify="between"
+    >
+      <Flex align="center" gap="md">
+        <IconCircleCheckmark size="md" variant="success" />
+        <Text bold>{t('Setup complete')}</Text>
+      </Flex>
+      {soleProject ? (
+        <ProjectBadge project={soleProject} avatarSize={16} disableLink />
+      ) : projectSlugs.length ? (
+        <CreatedProjects projectSlugs={projectSlugs} />
+      ) : null}
+    </Flex>
+  );
+}
 
 function CreatedProjects({projectSlugs}: {projectSlugs: string[]}) {
   return (
@@ -336,18 +394,68 @@ export function AgenticProgress({
 }) {
   const createProjectStage = run.stages.find(stage => stage.stage === 'create_project');
   const projectSlugs = createProjectStage?.extra?.projectSlugs ?? [];
+  const verificationStage = run.stages.find(
+    stage => stage.stage === 'receive_verification_error'
+  );
+  // The agent reports every issue the verification error grouped into; the
+  // first is the one it sent, and the one worth handing back.
+  const firstIssueId = verificationStage?.extra?.issueIds?.[0];
+  const isComplete = run.runStatus === 'completed';
 
+  // The metadata is bundled with the list rather than left to each caller, so
+  // anything rendering a run — the welcome step, the stories — gets both.
   return (
     <Stack width="100%" gap="md">
-      <AgenticProgressList
-        stages={run.stages}
-        extraContentByStage={
-          projectSlugs.length
-            ? {create_project: <CreatedProjects projectSlugs={projectSlugs} />}
-            : undefined
-        }
+      {/* popLayout takes the outgoing list out of flow so the summary occupies
+          the slot while the two cross-fade, leaving the caller's own layout
+          animation to tween the height the collapse frees up. */}
+      <AnimatePresence initial={false} mode="popLayout">
+        {isComplete ? (
+          <MotionContainer
+            key="summary"
+            width="100%"
+            initial={{opacity: 0}}
+            animate={{opacity: 1}}
+            exit={{opacity: 0}}
+          >
+            <AgenticProgressSummary projectSlugs={projectSlugs} />
+          </MotionContainer>
+        ) : (
+          <MotionContainer
+            key="list"
+            width="100%"
+            initial={{opacity: 0}}
+            animate={{opacity: 1}}
+            exit={{opacity: 0}}
+          >
+            <AgenticProgressList
+              stages={run.stages}
+              extraContentByStage={
+                projectSlugs.length
+                  ? {create_project: <CreatedProjects projectSlugs={projectSlugs} />}
+                  : undefined
+              }
+            />
+          </MotionContainer>
+        )}
+      </AnimatePresence>
+      {isComplete && firstIssueId ? (
+        // Delayed past the collapse so the issue arrives as the next thing to
+        // look at rather than as part of the swap.
+        <MotionContainer
+          width="100%"
+          initial={{opacity: 0, y: 8}}
+          animate={{opacity: 1, y: 0}}
+          transition={{delay: 0.15, duration: 0.25, ease: 'easeOut'}}
+        >
+          <FirstIssueCard issueId={firstIssueId} />
+        </MotionContainer>
+      ) : null}
+      <AgenticProgressMeta
+        isComplete={isComplete}
+        onboardingCode={onboardingCode}
+        updatedAt={run.updatedAt}
       />
-      <AgenticProgressMeta onboardingCode={onboardingCode} updatedAt={run.updatedAt} />
     </Stack>
   );
 }

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
@@ -361,15 +361,8 @@ const RunId = styled(Text)`
   opacity: 0.6;
 `;
 
-/**
- * The finished run, collapsed. Nine rows all reading "Done" say no more than
- * one row does, so what survives the collapse is the outcome and what it
- * produced — the projects the agent created.
- */
 function AgenticProgressSummary({projectSlugs}: {projectSlugs: string[]}) {
   const {projects} = useProjects({slugs: projectSlugs});
-  // A single project is named outright; past that, the list's avatars and its
-  // count carry it, since a row of full badges would not fit.
   const soleProjectSlug = projectSlugs.length === 1 ? projectSlugs[0] : undefined;
   const soleProject = soleProjectSlug
     ? (projects.find(project => project.slug === soleProjectSlug) ?? {
@@ -423,8 +416,6 @@ export function AgenticProgress({
   const verificationStage = run.stages.find(
     stage => stage.stage === 'receive_verification_error'
   );
-  // The agent reports every issue the verification error grouped into; the
-  // first is the one it sent, and the one worth handing back.
   const firstIssueId = verificationStage?.extra?.issueIds?.[0];
   const isComplete = run.runStatus === 'completed';
 

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
@@ -331,7 +331,7 @@ function AgenticProgressMeta({
   }
 
   return (
-    <Flex align="center" justify={isComplete ? 'end' : 'between'} gap="md">
+    <Flex align="center" justify={isComplete ? 'end' : 'between'} gap="md" padding="0 lg">
       {isComplete ? null : (
         <Flex align="center" gap="sm">
           <StatusIndicator variant="accent" />

--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
@@ -1,5 +1,6 @@
+import {useEffect, useState} from 'react';
 import styled from '@emotion/styled';
-import {AnimatePresence, motion} from 'framer-motion';
+import {AnimatePresence, motion, type MotionProps} from 'framer-motion';
 
 import {Tag} from '@sentry/scraps/badge';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
@@ -104,6 +105,35 @@ const ActiveLoadingIndicator = styled(LoadingIndicator)`
 `;
 
 const MotionGrid = motion.create(Grid);
+const MotionStack = motion.create(Stack);
+
+/**
+ * Stage rows settle in one after another rather than all at once, so the list
+ * reads as the agent's plan being laid out. Rows are keyed by stage, so this
+ * runs when a row mounts — on the list's first appearance, and again for each
+ * stage the agent reports later — not on every poll.
+ */
+const STAGE_LIST_STAGGER_TRANSITION: MotionProps['transition'] = {
+  staggerChildren: 0.03,
+  delayChildren: 0.04,
+};
+
+// Transform and opacity only: the row's height stays put, so the card's own
+// resize is not fighting the rows arriving.
+const STAGE_ITEM_VARIANTS: MotionProps['variants'] = {
+  initial: {opacity: 0, y: 12},
+  animate: {
+    opacity: 1,
+    y: 0,
+    transition: {
+      // `bounce` is how far the row overshoots before settling: 0 stops dead,
+      // 1 wobbles. Only the travel springs — a spring on opacity overshoots
+      // past full, which reads as a flicker rather than a bounce.
+      y: {type: 'spring', duration: 0.3, bounce: 0.35},
+      opacity: {duration: 0.12, ease: 'easeOut'},
+    },
+  },
+};
 const MotionContainer = motion.create(Container);
 const MotionTag = motion.create(Tag);
 const MotionText = motion.create(Text);
@@ -159,7 +189,8 @@ function ProgressItem({
         : 'muted';
 
   return (
-    <Grid
+    <MotionGrid
+      variants={STAGE_ITEM_VARIANTS}
       columns="max-content minmax(0, 1fr) max-content"
       rows="auto auto auto"
       align="center"
@@ -251,7 +282,7 @@ function ProgressItem({
           <ExtraContent key="extra-content">{extraContent}</ExtraContent>
         ) : null}
       </AnimatePresence>
-    </Grid>
+    </MotionGrid>
   );
 }
 
@@ -264,8 +295,27 @@ export function AgenticProgressList({
   extraContentByStage?: Partial<Record<AgenticProgressStage, React.ReactNode>>;
   header?: React.ReactNode;
 }) {
+  // An enclosing AnimatePresence with `initial={false}` puts `initial: false` on
+  // PresenceContext, which blocks the mount animation of every motion component
+  // beneath it — so the stagger silently vanishes whenever the list is already
+  // on screen at first paint. Flipping the label after mount makes it an
+  // ordinary animate change, which nothing upstream suppresses.
+  const [hasEntered, setHasEntered] = useState(false);
+  useEffect(() => {
+    setHasEntered(true);
+  }, []);
+
   return (
-    <Stack width="100%" border="primary" radius="lg" overflow="hidden" gap="0">
+    <MotionStack
+      width="100%"
+      border="primary"
+      radius="lg"
+      overflow="hidden"
+      gap="0"
+      initial="initial"
+      animate={hasEntered ? 'animate' : 'initial'}
+      transition={STAGE_LIST_STAGGER_TRANSITION}
+    >
       {header ? (
         <Container padding="xl" borderBottom="muted">
           {header}
@@ -279,7 +329,7 @@ export function AgenticProgressList({
           extraContent={extraContentByStage?.[stage.stage]}
         />
       ))}
-    </Stack>
+    </MotionStack>
   );
 }
 

--- a/static/app/views/onboarding/agenticProgress/firstIssueCard.tsx
+++ b/static/app/views/onboarding/agenticProgress/firstIssueCard.tsx
@@ -9,6 +9,7 @@ import {Placeholder} from 'sentry/components/placeholder';
 import {IconChevron} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {getMessage, getTitle} from 'sentry/utils/events';
+import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 
@@ -20,7 +21,9 @@ export function FirstIssueCard({issueId}: {issueId: string}) {
       organizationSlug: organization.slug,
       environments: [],
     }),
-    retry: false,
+    retry: (failureCount, error) =>
+      failureCount < 3 && error instanceof RequestError && error.status === 404,
+    retryDelay: 2000,
   });
 
   if (isPending) {

--- a/static/app/views/onboarding/agenticProgress/firstIssueCard.tsx
+++ b/static/app/views/onboarding/agenticProgress/firstIssueCard.tsx
@@ -1,0 +1,97 @@
+import styled from '@emotion/styled';
+import {useQuery} from '@tanstack/react-query';
+
+import {Grid, Stack} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
+import {Heading, Text} from '@sentry/scraps/text';
+
+import {Placeholder} from 'sentry/components/placeholder';
+import {IconChevron} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {getMessage, getTitle} from 'sentry/utils/events';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
+
+/**
+ * The verification error the agent sent, as the payoff for the finished run. It
+ * reads through issue details' own query options, so opening the issue lands on
+ * a warm cache rather than a second fetch of the same group.
+ */
+export function FirstIssueCard({issueId}: {issueId: string}) {
+  const organization = useOrganization();
+  const {data: group, isPending} = useQuery({
+    ...groupApiOptions({
+      groupId: issueId,
+      organizationSlug: organization.slug,
+      environments: [],
+    }),
+    retry: false,
+  });
+
+  if (isPending) {
+    return <Placeholder height="112px" />;
+  }
+
+  // A run can name an issue this viewer cannot read, and the agent reports the
+  // id before Sentry has finished processing the event. An empty card inviting
+  // a click that goes nowhere is worse than no card.
+  if (!group) {
+    return null;
+  }
+
+  const message = getMessage(group);
+
+  return (
+    <IssueCardLink
+      to={`/organizations/${organization.slug}/issues/${group.id}/?referrer=onboarding-agentic-first-issue`}
+    >
+      <Grid columns="minmax(0, 1fr) max-content" gap="lg" align="center">
+        <Stack gap="lg">
+          <Heading as="h3" size="md" variant="accent">
+            {t('Check out your first issue')}
+          </Heading>
+          <Stack gap="2xs">
+            <Text size="lg" bold ellipsis>
+              {getTitle(group).title}
+            </Text>
+            {message ? (
+              <Text size="sm" variant="muted" ellipsis>
+                {message}
+              </Text>
+            ) : null}
+          </Stack>
+        </Stack>
+        <IconChevron direction="right" size="sm" variant="muted" />
+      </Grid>
+    </IssueCardLink>
+  );
+}
+
+// An anchor rather than a layout primitive: the whole card is the click target,
+// so it carries the card's chrome itself and owns its hover state. The border
+// and radius match what `border="muted" radius="lg"` resolve to on the summary
+// card above it, so the two read as one stack.
+const IssueCardLink = styled(Link)`
+  display: block;
+  padding: ${p => p.theme.space.xl};
+  border: 1px solid ${p => p.theme.tokens.border.secondary};
+  border-radius: ${p => p.theme.radius.lg};
+  color: inherit;
+  background: linear-gradient(
+    90deg,
+    ${p => p.theme.tokens.background.secondary},
+    transparent
+  );
+
+  &:hover,
+  &:focus-visible {
+    color: inherit;
+    border-color: ${p => p.theme.tokens.border.primary};
+    /* The gradient fills in rather than being swapped for a flat colour. */
+    background: linear-gradient(
+      90deg,
+      ${p => p.theme.tokens.background.secondary},
+      ${p => p.theme.tokens.background.secondary}
+    );
+  }
+`;

--- a/static/app/views/onboarding/agenticProgress/firstIssueCard.tsx
+++ b/static/app/views/onboarding/agenticProgress/firstIssueCard.tsx
@@ -12,11 +12,6 @@ import {getMessage, getTitle} from 'sentry/utils/events';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {groupApiOptions} from 'sentry/views/issueDetails/useGroup';
 
-/**
- * The verification error the agent sent, as the payoff for the finished run. It
- * reads through issue details' own query options, so opening the issue lands on
- * a warm cache rather than a second fetch of the same group.
- */
 export function FirstIssueCard({issueId}: {issueId: string}) {
   const organization = useOrganization();
   const {data: group, isPending} = useQuery({
@@ -32,9 +27,6 @@ export function FirstIssueCard({issueId}: {issueId: string}) {
     return <Placeholder height="112px" />;
   }
 
-  // A run can name an issue this viewer cannot read, and the agent reports the
-  // id before Sentry has finished processing the event. An empty card inviting
-  // a click that goes nowhere is worse than no card.
   if (!group) {
     return null;
   }
@@ -67,10 +59,6 @@ export function FirstIssueCard({issueId}: {issueId: string}) {
   );
 }
 
-// An anchor rather than a layout primitive: the whole card is the click target,
-// so it carries the card's chrome itself and owns its hover state. The border
-// and radius match what `border="muted" radius="lg"` resolve to on the summary
-// card above it, so the two read as one stack.
 const IssueCardLink = styled(Link)`
   display: block;
   padding: ${p => p.theme.space.xl};
@@ -87,7 +75,6 @@ const IssueCardLink = styled(Link)`
   &:focus-visible {
     color: inherit;
     border-color: ${p => p.theme.tokens.border.primary};
-    /* The gradient fills in rather than being swapped for a flat colour. */
     background: linear-gradient(
       90deg,
       ${p => p.theme.tokens.background.secondary},

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -13,10 +13,12 @@ const INSTALL_PLUGIN_COMMAND = 'npx @sentry/agent-plugin install';
 interface AgentSetupCardProps {
   onCopyCommand: (source: AgentSetupCopySource) => void;
   prompt: string;
+  hasSetupFailed?: boolean;
   onboardingCode?: string;
 }
 
 export function AgentSetupCard({
+  hasSetupFailed,
   onboardingCode,
   onCopyCommand,
   prompt,
@@ -58,7 +60,8 @@ export function AgentSetupCard({
             <Stack gap="md">
               <Text size="md">{t('Then point your agent to your code and ask')}</Text>
               <CodeBlock
-                alwaysShowCopyButton
+                alwaysShowCopyButton={!hasSetupFailed}
+                hideCopyButton={hasSetupFailed}
                 onCopy={() => onCopyCommand('prompt')}
                 wrapMode="wrap"
               >

--- a/static/app/views/onboarding/components/newWelcome.tsx
+++ b/static/app/views/onboarding/components/newWelcome.tsx
@@ -170,6 +170,7 @@ export function NewWelcomeUI(props: StepProps) {
     isAgentConnected,
     isSetupComplete,
     hasRunFailed,
+    hasInitFailed,
     restartRun,
   } = useWelcomeAgentRun({enabled: showAgentSetup});
   const showAgentHeading = showAgentSetup && isAgentConnected;
@@ -266,6 +267,7 @@ export function NewWelcomeUI(props: StepProps) {
                 {...ONBOARDING_WELCOME_STAGGER_ITEM}
               >
                 <WelcomeAgentSetup
+                  hasInitFailed={hasInitFailed}
                   isAgentConnected={isAgentConnected}
                   onboardingCode={onboardingCode}
                   onCopyCommand={handleCopyCommand}

--- a/static/app/views/onboarding/components/welcomeAgentSetup.tsx
+++ b/static/app/views/onboarding/components/welcomeAgentSetup.tsx
@@ -1,5 +1,6 @@
 import {AnimatePresence, motion} from 'framer-motion';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -48,11 +49,13 @@ export function useWelcomeAgentRun({enabled}: {enabled: boolean}) {
     isAgentConnected: liveIsConnected,
     isSetupComplete: liveRun?.runStatus === 'completed',
     hasRunFailed: liveRun?.runStatus === 'failed' || liveRun?.runStatus === 'cancelled',
+    hasInitFailed: initialization.isError,
     restartRun,
   };
 }
 
 interface WelcomeAgentSetupProps {
+  hasInitFailed: boolean;
   isAgentConnected: boolean;
   /**
    * Fired when a command is copied out of one of the code blocks.
@@ -68,6 +71,7 @@ interface WelcomeAgentSetupProps {
 }
 
 export function WelcomeAgentSetup({
+  hasInitFailed,
   isAgentConnected,
   onboardingCode,
   onCopyCommand,
@@ -89,6 +93,20 @@ export function WelcomeAgentSetup({
 
   return (
     <Stack gap="2xl" width="100%" position="relative" align="center">
+      <ScmCollapsibleReveal open={hasInitFailed}>
+        <Alert
+          variant="danger"
+          showIcon
+          trailingItems={
+            <Button size="xs" onClick={onRetry}>
+              {t('Try again')}
+            </Button>
+          }
+        >
+          {t('Could not start setup, so the prompt below will not report progress.')}
+        </Alert>
+      </ScmCollapsibleReveal>
+
       <MotionContainer
         layout
         width="100%"
@@ -119,6 +137,7 @@ export function WelcomeAgentSetup({
               transition={CARD_MORPH_TRANSITION}
             >
               <AgentSetupCard
+                hasSetupFailed={hasInitFailed}
                 onboardingCode={onboardingCode}
                 onCopyCommand={onCopyCommand}
                 prompt={prompt}

--- a/static/app/views/onboarding/components/welcomeAgentSetup.tsx
+++ b/static/app/views/onboarding/components/welcomeAgentSetup.tsx
@@ -78,11 +78,12 @@ export function WelcomeAgentSetup({
   const hasRunFailed = run?.runStatus === 'failed' || run?.runStatus === 'cancelled';
   const prompt = onboardingCode
     ? [
-        t('Help me setup Sentry'),
-        t('Org ID: %s', organization.slug),
-        `[${onboardingCode}]`,
+        t('Please help me get started with sentry.'),
+        '',
+        t('org slug: %s', organization.slug),
+        t('run code: %s', onboardingCode),
       ].join('\n')
-    : t('Help me setup Sentry');
+    : t('Please help me get started with sentry.');
 
   return (
     <Stack gap="2xl" width="100%" position="relative" align="center">

--- a/static/app/views/onboarding/components/welcomeAgentSetup.tsx
+++ b/static/app/views/onboarding/components/welcomeAgentSetup.tsx
@@ -4,6 +4,7 @@ import {Button} from '@sentry/scraps/button';
 import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
+import {useOnboardingContext} from 'sentry/components/onboarding/onboardingContext';
 import {ScmCollapsibleReveal} from 'sentry/components/onboarding/scm/scmCollapsibleReveal';
 import {t} from 'sentry/locale';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -27,6 +28,7 @@ const CARD_MORPH_TRANSITION = {duration: 0.25, ease: 'easeOut'} as const;
 export function useWelcomeAgentRun({enabled}: {enabled: boolean}) {
   const initialization = useAgenticProgressInit({enabled});
   const restartRun = useRestartAgenticRun();
+  const {agenticProgressOnboardingCode} = useOnboardingContext();
   const progress = useAgenticProgress({
     runId: initialization.data?.runId ?? null,
     enabled,
@@ -42,7 +44,7 @@ export function useWelcomeAgentRun({enabled}: {enabled: boolean}) {
 
   return {
     run: liveRun,
-    onboardingCode: initialization.data?.onboardingCode,
+    onboardingCode: initialization.data?.onboardingCode ?? agenticProgressOnboardingCode,
     isAgentConnected: liveIsConnected,
     isSetupComplete: liveRun?.runStatus === 'completed',
     hasRunFailed: liveRun?.runStatus === 'failed' || liveRun?.runStatus === 'cancelled',


### PR DESCRIPTION
Stacked on the welcome step PR.

- Moved the card's header copy into the step headline, and the run's timestamp
  and id below the card
- A finished run collapses to its outcome, the projects created, and the issue
  it sent, instead of nine rows reading "Done"
- Stage rows stagger in
- Added a story for driving the whole transition without a real agent

Depends on the headline states from the welcome step PR — merging this alone
would leave the card headerless.