### PR TITLE
feat(auth): Add Auth V2 frontend analytics

### DIFF
--- a/static/app/utils/analytics.tsx
+++ b/static/app/utils/analytics.tsx
@@ -44,6 +44,8 @@ import {
 
 import type {AgentMonitoringEventParameters} from './analytics/agentMonitoringAnalyticsEvents';
 import {agentMonitoringEventMap} from './analytics/agentMonitoringAnalyticsEvents';
+import type {AuthV2EventParameters} from './analytics/authV2AnalyticsEvents';
+import {authV2EventMap} from './analytics/authV2AnalyticsEvents';
 import type {BreadcrumbsAnalyticsEventParameters} from './analytics/breadcrumbsAnalyticsEvents';
 import {breadcrumbsAnalyticsEventMap} from './analytics/breadcrumbsAnalyticsEvents';
 import type {ConversationsEventParameters} from './analytics/conversationsAnalyticsEvents';
@@ -109,6 +111,7 @@ import {workflowEventMap} from './analytics/workflowAnalyticsEvents';
 interface EventParameters
   extends
     CommandPaletteEventParameters,
+    AuthV2EventParameters,
     GrowthEventParameters,
     AgentMonitoringEventParameters,
     AlertsEventParameters,
@@ -152,6 +155,7 @@ interface EventParameters
 
 const allEventMap: Record<string, string | null> = {
   ...commandPaletteEventMap,
+  ...authV2EventMap,
   ...agentMonitoringEventMap,
   ...alertsEventMap,
   ...conversationsEventMap,

--- a/static/app/utils/analytics/authV2AnalyticsEvents.tsx
+++ b/static/app/utils/analytics/authV2AnalyticsEvents.tsx
@@ -1,0 +1,22 @@
+type AuthV2LoginState =
+  | 'auth_config_error'
+  | 'login'
+  | 'mfa'
+  | 'organization_error'
+  | 'organization_sso';
+
+export type AuthV2EventParameters = {
+  'auth.login.rendered': {
+    entrypoint: 'generic' | 'organization';
+    state: AuthV2LoginState;
+  };
+  'auth_v2.rollout.changed': {
+    source: 'feature_flag' | 'help_menu';
+    state: 'disabled' | 'enabled' | 'unset';
+  };
+};
+
+export const authV2EventMap: Record<keyof AuthV2EventParameters, string> = {
+  'auth.login.rendered': 'Auth: Login Rendered',
+  'auth_v2.rollout.changed': 'Auth V2: Rollout Changed',
+};

--- a/static/app/utils/useAuthV2Rollout.spec.tsx
+++ b/static/app/utils/useAuthV2Rollout.spec.tsx
@@ -4,9 +4,12 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {act, renderHook, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {OrganizationStore} from 'sentry/stores/organizationStore';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 import {useAuthV2Rollout} from 'sentry/utils/useAuthV2Rollout';
 import {AuthV2CookieState, useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
+
+jest.mock('sentry/utils/analytics');
 
 const AUTH_V2_ROLLOUT_ORGANIZATION = 'sentry_react_auth_rollout_organization';
 
@@ -22,6 +25,7 @@ function setRolloutOrganization(organizationSlug: string) {
 
 describe('useAuthV2Rollout', () => {
   beforeEach(() => {
+    jest.mocked(trackAnalytics).mockClear();
     OrganizationStore.init();
     Cookies.remove('sentry_react_auth', {path: '/'});
     localStorage.removeItem(AUTH_V2_ROLLOUT_ORGANIZATION);
@@ -38,6 +42,11 @@ describe('useAuthV2Rollout', () => {
 
     await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBe('1'));
     expect(getRolloutOrganization()).toBe('rollout-org');
+    expect(trackAnalytics).toHaveBeenCalledWith('auth_v2.rollout.changed', {
+      organization: expect.objectContaining({slug: 'rollout-org'}),
+      source: 'feature_flag',
+      state: 'enabled',
+    });
   });
 
   it('preserves an explicit opt-out while the organization has the rollout feature', async () => {
@@ -117,5 +126,10 @@ describe('useAuthV2Rollout', () => {
 
     await waitFor(() => expect(Cookies.get('sentry_react_auth')).toBeUndefined());
     expect(getRolloutOrganization()).toBeNull();
+    expect(trackAnalytics).toHaveBeenCalledWith('auth_v2.rollout.changed', {
+      organization: expect.objectContaining({slug: 'rollout-org'}),
+      source: 'feature_flag',
+      state: 'unset',
+    });
   });
 });

--- a/static/app/utils/useAuthV2Rollout.ts
+++ b/static/app/utils/useAuthV2Rollout.ts
@@ -2,6 +2,7 @@ import {useEffect} from 'react';
 
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   AuthV2CookieState,
   getAuthV2CookieState,
@@ -24,12 +25,22 @@ export function useAuthV2Rollout() {
         authV2RolloutOrganization === organization.slug
       ) {
         setAuthV2CookieState(AuthV2CookieState.UNSET);
+        trackAnalytics('auth_v2.rollout.changed', {
+          organization,
+          source: 'feature_flag',
+          state: 'unset',
+        });
       }
       return;
     }
 
     if (authV2CookieState === AuthV2CookieState.UNSET) {
       setAuthV2CookieState(AuthV2CookieState.ENABLED, organization.slug);
+      trackAnalytics('auth_v2.rollout.changed', {
+        organization,
+        source: 'feature_flag',
+        state: 'enabled',
+      });
     }
   }, [authV2RolloutOrganization, loading, organization, setAuthV2CookieState]);
 }

--- a/static/app/views/authV2/authLogin/components/sms2faMethod.tsx
+++ b/static/app/views/authV2/authLogin/components/sms2faMethod.tsx
@@ -68,6 +68,9 @@ export function Sms2FAMethod({
             </Alert>
           </Alert.Container>
           <Button
+            analyticsEventKey="auth.login.retry_clicked"
+            analyticsEventName="Auth: Login Retry Clicked"
+            analyticsParams={{stage: 'mfa_challenge', method: 'sms'}}
             disabled={isProcessing}
             size="xs"
             variant="transparent"
@@ -81,6 +84,9 @@ export function Sms2FAMethod({
           {tct('A code has been sent by text message. [resend]', {
             resend: (
               <Button
+                analyticsEventKey="auth.login.mfa_challenge_requested"
+                analyticsEventName="Auth: MFA Challenge Requested"
+                analyticsParams={{method: 'sms', request: 'resend'}}
                 disabled={isProcessing || resendCooldown > 0}
                 size="zero"
                 variant="transparent"

--- a/static/app/views/authV2/authLogin/components/webAuthn2faMethod.tsx
+++ b/static/app/views/authV2/authLogin/components/webAuthn2faMethod.tsx
@@ -139,7 +139,18 @@ export function WebAuthn2FAMethod({
           </Text>
         )}
         {retry && (
-          <Button disabled={isProcessing} size="xs" variant="transparent" onClick={retry}>
+          <Button
+            analyticsEventKey="auth.login.retry_clicked"
+            analyticsEventName="Auth: Login Retry Clicked"
+            analyticsParams={{
+              stage: submissionFailed ? 'mfa_verify' : 'mfa_challenge',
+              method: 'u2f',
+            }}
+            disabled={isProcessing}
+            size="xs"
+            variant="transparent"
+            onClick={retry}
+          >
             {t('Try again')}
           </Button>
         )}

--- a/static/app/views/authV2/authLogin/index.spec.tsx
+++ b/static/app/views/authV2/authLogin/index.spec.tsx
@@ -6,11 +6,18 @@ import {setWindowLocation} from 'sentry-test/utils';
 
 import {BrandPageLayout} from 'sentry/components/brandPageLayout';
 import type {AuthConfig} from 'sentry/types/auth';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 
 import AuthLogin from './index';
 
+jest.mock('sentry/utils/analytics');
+
 describe('AuthLogin', () => {
+  beforeEach(() => {
+    jest.mocked(trackAnalytics).mockClear();
+  });
+
   beforeAll(() => {
     Object.defineProperty(document, 'elementFromPoint', {
       configurable: true,
@@ -69,6 +76,15 @@ describe('AuthLogin', () => {
     expect(
       await screen.findByRole('heading', {name: 'Sign in to Sentry'})
     ).toBeInTheDocument();
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'auth.login.rendered',
+      {
+        organization: null,
+        entrypoint: 'generic',
+        state: 'login',
+      },
+      {startSession: true}
+    );
   });
 
   it('shows a retry when the initial auth config request fails', async () => {

--- a/static/app/views/authV2/authLogin/index.tsx
+++ b/static/app/views/authV2/authLogin/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useState} from 'react';
+import {Fragment, useCallback, useEffect, useRef, useState} from 'react';
 import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {AnimatePresence, motion} from 'framer-motion';
@@ -14,6 +14,7 @@ import {IconGithub, IconGoogle, IconLab, IconSentry, IconVsts} from 'sentry/icon
 import {t, tct} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import type {AuthConfig} from 'sentry/types/auth';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {MarkedText} from 'sentry/utils/marked/markedText';
 import {isNotFoundError} from 'sentry/utils/requestError/requestError';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
@@ -48,6 +49,7 @@ export default function AuthLogin() {
   const location = useLocation();
   const sentryUrl = ConfigStore.get('links').sentryUrl;
   const {setAuthV2CookieState} = useEnableAuthV2();
+  const hasStartedAnalyticsSession = useRef(false);
 
   const returnToLegacyLogin = () => {
     setAuthV2CookieState(AuthV2CookieState.DISABLED);
@@ -150,20 +152,39 @@ export default function AuthLogin() {
   );
 
   const mainState = hasInitialAuthConfigError
-    ? 'auth-config-error'
+    ? 'auth_config_error'
     : hasAuthOrganizationError
-      ? 'organization-error'
+      ? 'organization_error'
       : pendingMfaMethods
         ? 'mfa'
         : organizationSsoOnly
-          ? 'organization-sso'
+          ? 'organization_sso'
           : 'login';
-
-  if (
+  const isLoginRenderable = !(
     isAuthConfigPending ||
     (orgSlug && isAuthOrganizationPending) ||
     (nextUri && !focusedOrgAuth && !hasAuthOrganizationError)
-  ) {
+  );
+
+  useEffect(() => {
+    if (!isLoginRenderable) {
+      return;
+    }
+
+    const startSession = !hasStartedAnalyticsSession.current;
+    hasStartedAnalyticsSession.current = true;
+    trackAnalytics(
+      'auth.login.rendered',
+      {
+        organization: null,
+        entrypoint: orgSlug ? 'organization' : 'generic',
+        state: mainState,
+      },
+      startSession ? {startSession: true} : undefined
+    );
+  }, [isLoginRenderable, mainState, orgSlug]);
+
+  if (!isLoginRenderable) {
     return null;
   }
 
@@ -181,7 +202,14 @@ export default function AuthLogin() {
           <Text as="div" align="right" size="sm" variant="muted">
             {tct('Having problems logging in? [legacyLogin]', {
               legacyLogin: (
-                <Button size="zero" variant="link" onClick={returnToLegacyLogin}>
+                <Button
+                  analyticsEventKey="auth.login.legacy_fallback_clicked"
+                  analyticsEventName="Auth: Legacy Login Fallback Clicked"
+                  analyticsParams={{state: mainState}}
+                  size="zero"
+                  variant="link"
+                  onClick={returnToLegacyLogin}
+                >
                   {t('Return to the old login experience')}
                 </Button>
               ),
@@ -211,7 +239,13 @@ export default function AuthLogin() {
                   <Alert variant="danger">
                     {t('Unable to load the login page. Try again.')}
                   </Alert>
-                  <Button busy={isAuthConfigFetching} onClick={() => refetchAuthConfig()}>
+                  <Button
+                    analyticsEventKey="auth.login.retry_clicked"
+                    analyticsEventName="Auth: Login Retry Clicked"
+                    analyticsParams={{stage: 'auth_config'}}
+                    busy={isAuthConfigFetching}
+                    onClick={() => refetchAuthConfig()}
+                  >
                     {t('Retry')}
                   </Button>
                 </Stack>
@@ -221,6 +255,9 @@ export default function AuthLogin() {
                     {t('Unable to load organization authentication. Please try again.')}
                   </Alert>
                   <Button
+                    analyticsEventKey="auth.login.retry_clicked"
+                    analyticsEventName="Auth: Login Retry Clicked"
+                    analyticsParams={{stage: 'organization_config'}}
                     busy={isAuthOrganizationFetching}
                     onClick={() => refetchAuthOrganization()}
                   >

--- a/static/app/views/navigation/primary/helpMenu.spec.tsx
+++ b/static/app/views/navigation/primary/helpMenu.spec.tsx
@@ -12,6 +12,7 @@ import {setWindowLocation} from 'sentry-test/utils';
 
 import {ConfigStore} from 'sentry/stores/configStore';
 import {ModalStore} from 'sentry/stores/modalStore';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import * as intercom from 'sentry/utils/intercom';
 import {
   PrimaryNavigationHelpMenu,
@@ -26,6 +27,7 @@ function HelpMenuWithWhatsNew() {
 jest.mock('sentry/utils/intercom', () => ({
   showIntercom: jest.fn(),
 }));
+jest.mock('sentry/utils/analytics');
 
 async function expandResourcesSubmenu() {
   await userEvent.click(screen.getByRole('button', {name: 'Help'}));
@@ -50,11 +52,21 @@ describe('PrimaryNavigationHelpMenu', () => {
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Enable new login'}));
 
     expect(Cookies.get('sentry_react_auth')).toBe('1');
+    expect(trackAnalytics).toHaveBeenCalledWith('auth_v2.rollout.changed', {
+      organization,
+      source: 'help_menu',
+      state: 'enabled',
+    });
 
     await userEvent.click(screen.getByRole('button', {name: 'Help'}));
     await userEvent.click(screen.getByRole('menuitemradio', {name: 'Disable new login'}));
 
     expect(Cookies.get('sentry_react_auth')).toBe('0');
+    expect(trackAnalytics).toHaveBeenCalledWith('auth_v2.rollout.changed', {
+      organization,
+      source: 'help_menu',
+      state: 'disabled',
+    });
   });
 
   it('hides the new login toggle when the feature is disabled', async () => {

--- a/static/app/views/navigation/primary/helpMenu.tsx
+++ b/static/app/views/navigation/primary/helpMenu.tsx
@@ -200,9 +200,16 @@ export function PrimaryNavigationHelpMenu({
             </MenuIcon>
           ),
           onAction() {
-            setAuthV2CookieState(
-              isAuthV2Enabled ? AuthV2CookieState.DISABLED : AuthV2CookieState.ENABLED
-            );
+            const state = isAuthV2Enabled
+              ? AuthV2CookieState.DISABLED
+              : AuthV2CookieState.ENABLED;
+
+            trackAnalytics('auth_v2.rollout.changed', {
+              organization,
+              source: 'help_menu',
+              state,
+            });
+            setAuthV2CookieState(state);
           },
         },
       ],


### PR DESCRIPTION
Auth V2 needs frontend funnel visibility before customer rollout so we can distinguish enrollment from actual exposure and understand where users encounter friction.

Add typed events for rollout changes and rendered login states, starting an analytics session on the first render. Instrument the legacy fallback, configuration and MFA retries, and SMS challenge resend actions through button analytics props.

The rollout events distinguish automatic feature-flag changes from manual help-menu changes, while login render events identify generic versus organization entry points and the active authentication state.

Validation:

- Targeted ESLint
- Full TypeScript typecheck
- Focused rollout, navigation, SMS MFA, and WebAuthn Jest suites
- Pre-commit hooks