### PR TITLE
feat(gsAdmin): route clear-pending and gift actions to dedicated endpoints

### DIFF
--- a/static/app/utils/api/knownGetsentryApiUrls.ts
+++ b/static/app/utils/api/knownGetsentryApiUrls.ts
@@ -11,6 +11,8 @@ export type KnownGetsentryApiUrls =
   | '/_admin/cells/$region/invoice-comparison/'
   | '/_admin/cells/$region/queue-spike-projection-batch/'
   | '/_admin/customers/$organizationIdOrSlug/balance-changes/'
+  | '/_admin/customers/$organizationIdOrSlug/clear-pending-changes/'
+  | '/_admin/customers/$organizationIdOrSlug/gift-units/'
   | '/_admin/customers/$organizationIdOrSlug/queue-spike-projection/'
   | '/_admin/instance-level-oauth/'
   | '/_admin/users/$userId/suspend/'

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -30,7 +30,6 @@ import {ConfigStore} from 'sentry/stores/configStore';
 import {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 
-import {getFreeEventsKey} from 'admin/components/addGiftEventsAction';
 import type {StatsGroup} from 'admin/components/customers/customerStats';
 import {populateChartData, useSeries} from 'admin/components/customers/customerStats';
 import {CustomerDetails} from 'admin/views/customerDetails';
@@ -1200,6 +1199,37 @@ describe('Customer Details', () => {
 
       expect(screen.getByText('Clear Pending Changes')).toBeInTheDocument();
     });
+
+    it('posts to the dedicated clear-pending-changes endpoint', async () => {
+      setUpMocks(pendingChangesOrg, {pendingChanges: true});
+      const clearMock = MockApiClient.addMockResponse({
+        url: `/_admin/customers/${pendingChangesOrg.slug}/clear-pending-changes/`,
+        method: 'POST',
+        body: OrganizationFixture(),
+      });
+
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${pendingChangesOrg.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization: pendingChangesOrg,
+      });
+      renderGlobalModal();
+
+      await openCustomerActions();
+      await userEvent.click(screen.getByText('Clear Pending Changes'));
+      await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+
+      await waitFor(() =>
+        expect(clearMock).toHaveBeenCalledWith(
+          `/_admin/customers/${pendingChangesOrg.slug}/clear-pending-changes/`,
+          expect.objectContaining({
+            method: 'POST',
+          })
+        )
+      );
+    });
   });
 
   describe('allow trial', () => {
@@ -2188,11 +2218,10 @@ describe('Customer Details', () => {
       for (const dataCategory of [DataCategory.ERRORS, DataCategory.TRANSACTIONS]) {
         await openCustomerActions();
 
-        const freeEventsKey = getFreeEventsKey(dataCategory);
         const updateMock = MockApiClient.addMockResponse({
-          url: `/customers/${organization.slug}/`,
-          method: 'PUT',
-          body: {...subscription, [freeEventsKey]: 26000},
+          url: `/_admin/customers/${organization.slug}/gift-units/`,
+          method: 'POST',
+          body: subscription,
         });
 
         await userEvent.click(screen.getByTestId(`gift-${dataCategory}`));
@@ -2208,10 +2237,10 @@ describe('Customer Details', () => {
 
         await waitFor(() =>
           expect(updateMock).toHaveBeenCalledWith(
-            `/customers/${organization.slug}/`,
+            `/_admin/customers/${organization.slug}/gift-units/`,
             expect.objectContaining({
-              method: 'PUT',
-              data: {[freeEventsKey]: 26000},
+              method: 'POST',
+              data: {category: dataCategory, amount: 26000},
             })
           )
         );
@@ -2241,11 +2270,10 @@ describe('Customer Details', () => {
       })[0]!
     );
 
-    const freeEventsKey = getFreeEventsKey(DataCategory.REPLAYS);
     const updateMock = MockApiClient.addMockResponse({
-      url: `/customers/${organization.slug}/`,
-      method: 'PUT',
-      body: {...organization, [freeEventsKey]: 50},
+      url: `/_admin/customers/${organization.slug}/gift-units/`,
+      method: 'POST',
+      body: {...organization},
     });
 
     await userEvent.click(screen.getByTestId(`gift-${DataCategory.REPLAYS}`));
@@ -2265,11 +2293,12 @@ describe('Customer Details', () => {
 
     await waitFor(() =>
       expect(updateMock).toHaveBeenCalledWith(
-        `/customers/${organization.slug}/`,
+        `/_admin/customers/${organization.slug}/gift-units/`,
         expect.objectContaining({
-          method: 'PUT',
+          method: 'POST',
           data: {
-            [freeEventsKey]: 50,
+            category: DataCategory.REPLAYS,
+            amount: 50,
           },
         })
       )
@@ -2298,11 +2327,10 @@ describe('Customer Details', () => {
       })[0]!
     );
 
-    const freeEventsKey = getFreeEventsKey(DataCategory.SPANS);
     const updateMock = MockApiClient.addMockResponse({
-      url: `/customers/${organization.slug}/`,
-      method: 'PUT',
-      body: {...organization, [freeEventsKey]: 50},
+      url: `/_admin/customers/${organization.slug}/gift-units/`,
+      method: 'POST',
+      body: {...organization},
     });
 
     await userEvent.click(screen.getByTestId(`gift-${DataCategory.SPANS}`));
@@ -2322,11 +2350,12 @@ describe('Customer Details', () => {
 
     await waitFor(() =>
       expect(updateMock).toHaveBeenCalledWith(
-        `/customers/${organization.slug}/`,
+        `/_admin/customers/${organization.slug}/gift-units/`,
         expect.objectContaining({
-          method: 'PUT',
+          method: 'POST',
           data: {
-            [freeEventsKey]: 5_000_000,
+            category: DataCategory.SPANS,
+            amount: 5_000_000,
           },
         })
       )
@@ -2380,11 +2409,10 @@ describe('Customer Details', () => {
       })[0]!
     );
 
-    const freeEventsKey = getFreeEventsKey(DataCategory.MONITOR_SEATS);
     const updateMock = MockApiClient.addMockResponse({
-      url: `/customers/${organization.slug}/`,
-      method: 'PUT',
-      body: {...organization, [freeEventsKey]: 50},
+      url: `/_admin/customers/${organization.slug}/gift-units/`,
+      method: 'POST',
+      body: {...organization},
     });
 
     await userEvent.click(screen.getByTestId(`gift-${DataCategory.MONITOR_SEATS}`));
@@ -2404,11 +2432,12 @@ describe('Customer Details', () => {
 
     await waitFor(() =>
       expect(updateMock).toHaveBeenCalledWith(
-        `/customers/${organization.slug}/`,
+        `/_admin/customers/${organization.slug}/gift-units/`,
         expect.objectContaining({
-          method: 'PUT',
+          method: 'POST',
           data: {
-            [freeEventsKey]: 50,
+            category: DataCategory.MONITOR_SEATS,
+            amount: 50,
           },
         })
       )

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -137,6 +137,24 @@ export function CustomerDetails() {
     isPending: isPendingBillingConfig,
   } = useApiQuery<BillingConfig>(BILLING_CONFIG_QUERY_KEY, {staleTime: Infinity});
 
+  const handleCustomerUpdateError = (error: RequestError) => {
+    if (error.status === 400 || error.status === 402) {
+      const errors = Object.values(error.responseJSON || {});
+      const err = errors.length && errors[0];
+
+      const message =
+        typeof err === 'string'
+          ? err
+          : Array.isArray(err) && err.length && err[0]
+            ? err[0]
+            : DEFAULT_ERROR_MESSAGE;
+
+      addErrorMessage(message);
+    } else {
+      addErrorMessage(DEFAULT_ERROR_MESSAGE);
+    }
+  };
+
   const onUpdateMutation = useMutation({
     mutationFn: (params: Record<string, any>) =>
       api.requestPromise(`/customers/${orgId}/`, {
@@ -151,23 +169,60 @@ export function CustomerDetails() {
       );
       setApiQueryData(queryClient, SUBSCRIPTION_QUERY_KEY, data);
     },
-    onError: (error: RequestError) => {
-      if (error.status === 400 || error.status === 402) {
-        const errors = Object.values(error.responseJSON || {});
-        const err = errors.length && errors[0];
+    onError: handleCustomerUpdateError,
+  });
 
-        const message =
-          typeof err === 'string'
-            ? err
-            : Array.isArray(err) && err.length && err[0]
-              ? err[0]
-              : DEFAULT_ERROR_MESSAGE;
-
-        addErrorMessage(message);
-      } else {
-        addErrorMessage(DEFAULT_ERROR_MESSAGE);
-      }
+  const onClearPendingChangesMutation = useMutation({
+    mutationFn: (params: Record<string, any>) =>
+      fetchMutation({
+        url: getApiUrl('/_admin/customers/$organizationIdOrSlug/clear-pending-changes/', {
+          path: {organizationIdOrSlug: orgId},
+        }),
+        method: 'POST',
+        data: params,
+      }),
+    onMutate: () => addLoadingMessage('Saving changes\u2026'),
+    onSuccess: (data, variables) => {
+      addSuccessMessage(
+        (data as {message?: string}).message ??
+          `Customer account has been updated with ${JSON.stringify(variables)}.`
+      );
+      setApiQueryData(queryClient, SUBSCRIPTION_QUERY_KEY, data);
     },
+    onError: handleCustomerUpdateError,
+  });
+
+  const onGiftUnitsMutation = useMutation({
+    mutationFn: (params: Record<string, any>) => {
+      const giftKey = Object.keys(params).find(key => key.startsWith('addFree'));
+      if (!giftKey) {
+        throw new Error('Missing gift category amount');
+      }
+      const titleCaseCategory = giftKey.slice('addFree'.length);
+      const category =
+        titleCaseCategory.charAt(0).toLowerCase() + titleCaseCategory.slice(1);
+      return fetchMutation({
+        url: getApiUrl('/_admin/customers/$organizationIdOrSlug/gift-units/', {
+          path: {organizationIdOrSlug: orgId},
+        }),
+        method: 'POST',
+        data: {
+          category,
+          amount: params[giftKey],
+          ticketURL: params.ticketURL,
+          notes: params.notes,
+        },
+      });
+    },
+    onMutate: () => addLoadingMessage('Saving changes\u2026'),
+    onSuccess: (data, variables) => {
+      addSuccessMessage(
+        (data as {message?: string}).message ??
+          `Customer account has been updated with ${JSON.stringify(variables)}.`
+      );
+      setApiQueryData(queryClient, SUBSCRIPTION_QUERY_KEY, data);
+    },
+    onError: handleCustomerUpdateError,
   });
 
   const onGenerateSpikeProjectionsMutation = useMutation({
@@ -452,8 +507,7 @@ export function CustomerDetails() {
             name: 'Clear Pending Changes',
             help: 'Remove pending subscription changes.',
             visible: !!subscription.pendingChanges,
-            onAction: params =>
-              onUpdateMutation.mutate({...params, clearPendingChanges: true}),
+            onAction: params => onClearPendingChangesMutation.mutate(params),
           },
           {
             key: 'changeBalance',
@@ -787,7 +841,7 @@ export function CustomerDetails() {
                   />
                 ),
               },
-              onAction: params => onUpdateMutation.mutate({...params}),
+              onAction: params => onGiftUnitsMutation.mutate(params),
             })
           ),
           {


### PR DESCRIPTION
## Summary
- Point gsAdmin **Clear Pending Changes** and **Gift {category}** actions at the new dedicated admin POST endpoints.
- Map gift modal `addFree{Category}` payloads to `{category, amount}` for the gift-units route.
- Leave product trials and other unsupported actions on the catch-all customer PUT.

## Test plan
- [x] `jest static/gsAdmin/views/customerDetails.spec.tsx` (gift + clear-pending coverage)
- [ ] Land after the getsentry backend PR is deployed

Depends on: getsentry clear-pending / gift-units endpoints PR


Made with [Cursor](https://cursor.com)