### PR TITLE
fix(seer): refresh issue progress views when an autofix step lands

### DIFF
--- a/static/app/components/events/autofix/useRefreshAutofixProgressQueries.spec.tsx
+++ b/static/app/components/events/autofix/useRefreshAutofixProgressQueries.spec.tsx
@@ -1,0 +1,141 @@
+import {useInfiniteQuery, useQuery} from '@tanstack/react-query';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {act, renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {useRefreshAutofixProgressQueries} from 'sentry/components/events/autofix/useRefreshAutofixProgressQueries';
+import {linkedPullRequestsApiOptions} from 'sentry/components/group/externalIssuesList/linkedPullRequests';
+import type {Group} from 'sentry/types/group';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+const organization = OrganizationFixture({slug: 'org-slug'});
+const GROUP_ID = '1337';
+
+/**
+ * Mounts the queries the panel slides over, in the shapes their real call sites
+ * use, so the assertions exercise key matching rather than a copy of the hook's
+ * own URL list.
+ */
+function useSubjectQueries() {
+  const org = useOrganization();
+  const path = {organizationIdOrSlug: org.slug};
+
+  // Two inbox sections: proves one invalidation covers every section's query.
+  useInfiniteQuery(
+    apiOptions.asInfinite<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
+      path,
+      query: {query: 'issue.progress:diagnosed is:unresolved', sort: 'progress'},
+      staleTime: 0,
+    })
+  );
+  useInfiniteQuery(
+    apiOptions.asInfinite<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
+      path,
+      query: {query: 'issue.progress:fix_proposed is:unresolved', sort: 'progress'},
+      staleTime: 0,
+    })
+  );
+
+  useQuery(
+    apiOptions.as<Record<string, number>>()(
+      '/organizations/$organizationIdOrSlug/issues-count/',
+      {path, query: {query: ['is:unresolved']}, staleTime: 180_000}
+    )
+  );
+
+  useQuery(
+    linkedPullRequestsApiOptions({
+      groupId: GROUP_ID,
+      organizationSlug: org.slug,
+      includeChecksAndReview: false,
+    })
+  );
+
+  // Two overview expands: the status one polls on its own, the stats one never
+  // does, and both must be reached by the single autofix-overview entry.
+  useQuery(
+    apiOptions.as<unknown>()(
+      '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
+      {path, query: {expand: ['status']}, staleTime: 30_000}
+    )
+  );
+  useQuery(
+    apiOptions.as<unknown>()(
+      '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
+      {path, query: {expand: ['issueStats']}, staleTime: 30_000}
+    )
+  );
+
+  // Control: an endpoint autofix does not affect, to catch over-broad matching.
+  useQuery(
+    apiOptions.as<unknown>()('/organizations/$organizationIdOrSlug/projects/', {
+      path,
+      staleTime: 30_000,
+    })
+  );
+
+  return useRefreshAutofixProgressQueries(GROUP_ID);
+}
+
+describe('useRefreshAutofixProgressQueries', () => {
+  let issuesMock: jest.Mock;
+  let issuesCountMock: jest.Mock;
+  let pullRequestsMock: jest.Mock;
+  let overviewMock: jest.Mock;
+  let projectsMock: jest.Mock;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    issuesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      body: [],
+    });
+    issuesCountMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues-count/`,
+      body: {},
+    });
+    pullRequestsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${GROUP_ID}/pull-requests/`,
+      body: {pullRequests: []},
+    });
+    overviewMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      body: {runsByMilestone: {}},
+    });
+    projectsMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/projects/`,
+      body: [],
+    });
+  });
+
+  it('refetches every view that reports autofix progress', async () => {
+    const {result} = renderHookWithProviders(useSubjectQueries, {organization});
+
+    await waitFor(() => expect(issuesMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(overviewMock).toHaveBeenCalledTimes(2));
+    expect(issuesCountMock).toHaveBeenCalledTimes(1);
+    expect(pullRequestsMock).toHaveBeenCalledTimes(1);
+    expect(projectsMock).toHaveBeenCalledTimes(1);
+
+    act(() => result.current());
+
+    // Both inbox sections and both overview expands, despite differing query params.
+    await waitFor(() => expect(issuesMock).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(overviewMock).toHaveBeenCalledTimes(4));
+    await waitFor(() => expect(issuesCountMock).toHaveBeenCalledTimes(2));
+    await waitFor(() => expect(pullRequestsMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('leaves unrelated queries alone', async () => {
+    const {result} = renderHookWithProviders(useSubjectQueries, {organization});
+
+    await waitFor(() => expect(projectsMock).toHaveBeenCalledTimes(1));
+
+    act(() => result.current());
+
+    await waitFor(() => expect(issuesCountMock).toHaveBeenCalledTimes(2));
+    expect(projectsMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/components/events/autofix/useRefreshAutofixProgressQueries.ts
+++ b/static/app/components/events/autofix/useRefreshAutofixProgressQueries.ts
@@ -16,7 +16,10 @@ import {useOrganization} from 'sentry/utils/useOrganization';
  *
  * `apiOptions` puts the resolved URL first in the query key, so matching on the
  * URL alone reaches every filter, sort, cursor and expand variant these pages
- * mount. That breadth is deliberate: the panel can't see which page is behind it.
+ * mount. That breadth is deliberate — the panel can't see which page is behind
+ * it — and it does sweep in other readers of the same endpoints, such as the
+ * feedback inbox and the dashboard issue widget. They refetch a list they were
+ * already showing, which is cheaper than working out which one is on screen.
  */
 export function useRefreshAutofixProgressQueries(groupId: string) {
   const queryClient = useQueryClient();
@@ -26,8 +29,9 @@ export function useRefreshAutofixProgressQueries(groupId: string) {
     const path = {organizationIdOrSlug: organization.slug};
 
     const urls = [
-      // Inbox sections and the issue stream, bucketed and sorted on
-      // `issue.progress:`, which each completed step advances.
+      // The inbox sections, bucketed and sorted on `issue.progress:`, which each
+      // completed step advances. Not the legacy issue stream — that reads
+      // through GroupStore and IssueListCacheStore, which this cannot reach.
       getApiUrl('/organizations/$organizationIdOrSlug/issues/', {path}),
       // Counts on the inbox's my / my teams / all tabs.
       getApiUrl('/organizations/$organizationIdOrSlug/issues-count/', {path}),

--- a/static/app/components/events/autofix/useRefreshAutofixProgressQueries.ts
+++ b/static/app/components/events/autofix/useRefreshAutofixProgressQueries.ts
@@ -1,0 +1,47 @@
+import {useCallback} from 'react';
+import {useQueryClient} from '@tanstack/react-query';
+
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+/**
+ * Invalidates the endpoints that report an issue's autofix progress from the
+ * outside, rather than the run state itself.
+ *
+ * These back the pages the Seer chat panel slides over, so they stay mounted
+ * holding whatever they last fetched, and only the workflows overview polls —
+ * for its `status` expand alone. Without this, a run that finishes under the
+ * panel leaves the inbox showing the issue in its old bucket until the reader
+ * navigates or refocuses the window.
+ *
+ * `apiOptions` puts the resolved URL first in the query key, so matching on the
+ * URL alone reaches every filter, sort, cursor and expand variant these pages
+ * mount. That breadth is deliberate: the panel can't see which page is behind it.
+ */
+export function useRefreshAutofixProgressQueries(groupId: string) {
+  const queryClient = useQueryClient();
+  const organization = useOrganization();
+
+  return useCallback(() => {
+    const path = {organizationIdOrSlug: organization.slug};
+
+    const urls = [
+      // Inbox sections and the issue stream, bucketed and sorted on
+      // `issue.progress:`, which each completed step advances.
+      getApiUrl('/organizations/$organizationIdOrSlug/issues/', {path}),
+      // Counts on the inbox's my / my teams / all tabs.
+      getApiUrl('/organizations/$organizationIdOrSlug/issues-count/', {path}),
+      // Pull request badge on the inbox row, filled in once a PR is opened.
+      getApiUrl('/organizations/$organizationIdOrSlug/issues/$issueId/pull-requests/', {
+        path: {...path, issueId: groupId},
+      }),
+      // Seer workflows overview cards, including the issue stats and project
+      // config expands that never poll.
+      getApiUrl('/organizations/$organizationIdOrSlug/seer/autofix-overview/', {path}),
+    ];
+
+    for (const url of urls) {
+      queryClient.invalidateQueries({queryKey: [url]});
+    }
+  }, [groupId, organization.slug, queryClient]);
+}

--- a/static/app/components/seer/markdown/embeds/components/autofix.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/autofix.spec.tsx
@@ -1,0 +1,139 @@
+import {useInfiniteQuery} from '@tanstack/react-query';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {AutofixRef} from 'sentry/components/seer/markdown/embeds/components/autofix';
+import type {Group} from 'sentry/types/group';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+const organization = OrganizationFixture({slug: 'org-slug'});
+const GROUP_ID = '1337';
+
+function makeRun(status: ExplorerAutofixState['status']): ExplorerAutofixState {
+  const finished = status !== 'processing';
+
+  return {
+    run_id: 42,
+    status,
+    updated_at: '2026-01-01T00:00:00Z',
+    blocks: [
+      {
+        id: 'block-1',
+        timestamp: '2026-01-01T00:00:00Z',
+        loading: !finished,
+        message: {
+          role: 'assistant',
+          // 'Thinking...' is what keeps an unfinished section out of the
+          // completed state; any other assistant content closes the section.
+          content: finished ? 'Here is what went wrong' : 'Thinking...',
+          metadata: {step: 'root_cause'},
+        },
+        artifacts: finished
+          ? [
+              {
+                key: 'artifact-1',
+                reason: 'Found a root cause',
+                data: {
+                  one_line_description: 'The cache key collides across orgs',
+                  five_whys: ['The key omits the org slug'],
+                },
+              },
+            ]
+          : [],
+      },
+    ],
+  };
+}
+
+/**
+ * Stands in for a page the chat panel slides over: it holds an issue-list query
+ * open so the refetch triggered by a finished step is observable.
+ */
+function InboxBehindThePanel() {
+  const org = useOrganization();
+
+  useInfiniteQuery(
+    apiOptions.asInfinite<Group[]>()('/organizations/$organizationIdOrSlug/issues/', {
+      path: {organizationIdOrSlug: org.slug},
+      query: {query: 'issue.progress:diagnosed is:unresolved'},
+      staleTime: 0,
+    })
+  );
+
+  return (
+    <AutofixRef
+      name="autofixRef"
+      level="block"
+      data={{id: GROUP_ID, shortId: 'JAVASCRIPT-1', runId: 42, step: 'root_cause'}}
+    />
+  );
+}
+
+describe('AutofixRef embed', () => {
+  let issuesMock: jest.Mock;
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+
+    issuesMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${GROUP_ID}/pull-requests/`,
+      body: {pullRequests: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues-count/`,
+      body: {},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/seer/autofix-overview/`,
+      body: {runsByMilestone: {}},
+    });
+  });
+
+  it('refreshes the page behind it when the step result lands', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${GROUP_ID}/autofix/`,
+      body: {autofix: makeRun('processing')},
+    });
+
+    render(<InboxBehindThePanel />, {organization});
+
+    expect(await screen.findByText('Finding the root cause…')).toBeInTheDocument();
+    await waitFor(() => expect(issuesMock).toHaveBeenCalledTimes(1));
+
+    // The run finishes while the panel is open; the embed polls it up.
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${GROUP_ID}/autofix/`,
+      body: {autofix: makeRun('completed')},
+    });
+
+    expect(
+      await screen.findByText('The cache key collides across orgs', undefined, {
+        timeout: 5000,
+      })
+    ).toBeInTheDocument();
+    await waitFor(() => expect(issuesMock).toHaveBeenCalledTimes(2));
+  });
+
+  it('leaves the page alone while the step is still running', async () => {
+    const autofixMock = MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${GROUP_ID}/autofix/`,
+      body: {autofix: makeRun('processing')},
+    });
+
+    render(<InboxBehindThePanel />, {organization});
+
+    expect(await screen.findByText('Finding the root cause…')).toBeInTheDocument();
+
+    // Let the 1s status poll come round more than once: a partial result must
+    // not yank the list out from under whoever is reading it.
+    await waitFor(() => expect(autofixMock).toHaveBeenCalledTimes(3), {timeout: 5000});
+    expect(issuesMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/components/seer/markdown/embeds/components/autofix.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/autofix.spec.tsx
@@ -49,10 +49,55 @@ function makeRun(status: ExplorerAutofixState['status']): ExplorerAutofixState {
 }
 
 /**
+ * A run parked in `processing` so the embed keeps polling, whose code_changes
+ * section already reads as completed. `withPullRequest` adds the PR state that
+ * makes `findStepSection` swap a `pr_iteration` embed off that section.
+ */
+function makePrIterationRun({
+  withPullRequest,
+}: {
+  withPullRequest: boolean;
+}): ExplorerAutofixState {
+  return {
+    run_id: 42,
+    status: 'processing',
+    updated_at: '2026-01-01T00:00:00Z',
+    blocks: [
+      {
+        id: 'block-1',
+        timestamp: '2026-01-01T00:00:00Z',
+        message: {
+          role: 'assistant',
+          content: 'Applied the patch',
+          metadata: {step: 'code_changes'},
+        },
+      },
+    ],
+    ...(withPullRequest
+      ? {
+          repo_pr_states: {
+            'getsentry/sentry': {
+              branch_name: 'seer/fix',
+              commit_sha: 'abc123',
+              pr_creation_error: null,
+              pr_creation_status: 'completed',
+              pr_id: 1,
+              pr_number: 1,
+              pr_url: 'https://github.com/getsentry/sentry/pull/1',
+              repo_name: 'getsentry/sentry',
+              title: 'Fix the cache key',
+            },
+          } satisfies ExplorerAutofixState['repo_pr_states'],
+        }
+      : {}),
+  };
+}
+
+/**
  * Stands in for a page the chat panel slides over: it holds an issue-list query
  * open so the refetch triggered by a finished step is observable.
  */
-function InboxBehindThePanel() {
+function InboxBehindThePanel({step = 'root_cause'}: {step?: string}) {
   const org = useOrganization();
 
   useInfiniteQuery(
@@ -67,7 +112,7 @@ function InboxBehindThePanel() {
     <AutofixRef
       name="autofixRef"
       level="block"
-      data={{id: GROUP_ID, shortId: 'JAVASCRIPT-1', runId: 42, step: 'root_cause'}}
+      data={{id: GROUP_ID, shortId: 'JAVASCRIPT-1', runId: 42, step}}
     />
   );
 }
@@ -119,7 +164,7 @@ describe('AutofixRef embed', () => {
       })
     ).toBeInTheDocument();
     await waitFor(() => expect(issuesMock).toHaveBeenCalledTimes(2));
-  });
+  }, 20_000);
 
   it('leaves the page alone while the step is still running', async () => {
     const autofixMock = MockApiClient.addMockResponse({
@@ -135,5 +180,32 @@ describe('AutofixRef embed', () => {
     // not yank the list out from under whoever is reading it.
     await waitFor(() => expect(autofixMock).toHaveBeenCalledTimes(3), {timeout: 5000});
     expect(issuesMock).toHaveBeenCalledTimes(1);
-  });
+  }, 20_000);
+
+  it('refreshes again when a pr_iteration embed swaps onto the PR section', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${GROUP_ID}/autofix/`,
+      body: {autofix: makePrIterationRun({withPullRequest: false})},
+    });
+
+    render(<InboxBehindThePanel step="pr_iteration" />, {organization});
+
+    // With no PR yet, the embed falls back to the completed code_changes
+    // section, so it refreshes once on that.
+    await waitFor(() => expect(issuesMock).toHaveBeenCalledTimes(2));
+
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${GROUP_ID}/autofix/`,
+      body: {autofix: makePrIterationRun({withPullRequest: true})},
+    });
+
+    // The PR section is `completed` too, so only the section identity changes.
+    // Keying the effect on status alone would sit still right here.
+    // Queried by text, not role: the disclosure panel renders collapsed, so role
+    // queries skip its contents as inaccessible.
+    expect(
+      await screen.findByText('View getsentry/sentry#1', undefined, {timeout: 5000})
+    ).toBeInTheDocument();
+    await waitFor(() => expect(issuesMock).toHaveBeenCalledTimes(3));
+  }, 20_000);
 });

--- a/static/app/components/seer/markdown/embeds/components/autofix.tsx
+++ b/static/app/components/seer/markdown/embeds/components/autofix.tsx
@@ -1,4 +1,4 @@
-import {useMemo, type ReactNode} from 'react';
+import {useEffect, useMemo, type ReactNode} from 'react';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Disclosure} from '@sentry/scraps/disclosure';
@@ -24,6 +24,7 @@ import {
   type RootCauseArtifact,
   type SolutionArtifact,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
+import {useRefreshAutofixProgressQueries} from 'sentry/components/events/autofix/useRefreshAutofixProgressQueries';
 import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {useAutofixChat} from 'sentry/components/seer/autofixChatContext';
@@ -133,6 +134,27 @@ interface AutofixRefContentProps extends Pick<Group, 'id' | 'shortId'> {
   step: AutofixExplorerStep;
 }
 
+/**
+ * Refreshes the pages behind the chat panel once this step's result lands.
+ *
+ * Keyed on the status alone, so reopening a chat history also refreshes on the
+ * already-finished steps it renders. That extra refetch is worth accepting: the
+ * embed can't tell which page is behind it, let alone whether that page has
+ * fetched anything since the run started.
+ */
+function useRefreshOnStepResult(
+  groupId: string,
+  status: AutofixSection['status'] | undefined
+) {
+  const refreshAutofixProgressQueries = useRefreshAutofixProgressQueries(groupId);
+
+  useEffect(() => {
+    if (status === 'completed') {
+      refreshAutofixProgressQueries();
+    }
+  }, [status, refreshAutofixProgressQueries]);
+}
+
 function AutofixRefContent({id, shortId, step}: AutofixRefContentProps) {
   const autofix = useExplorerAutofix({id, shortId});
   const {runState, isLoading, isPolling} = autofix;
@@ -140,6 +162,8 @@ function AutofixRefContent({id, shortId, step}: AutofixRefContentProps) {
 
   const sections = useMemo(() => getOrderedAutofixSections(runState), [runState]);
   const section = useMemo(() => findStepSection(sections, step), [sections, step]);
+
+  useRefreshOnStepResult(id, section?.status);
 
   const handleRetry = () => {
     sendMessage?.(t('Retry the %s step for %s.', STEP_LABELS[step], shortId));

--- a/static/app/components/seer/markdown/embeds/components/autofix.tsx
+++ b/static/app/components/seer/markdown/embeds/components/autofix.tsx
@@ -137,22 +137,25 @@ interface AutofixRefContentProps extends Pick<Group, 'id' | 'shortId'> {
 /**
  * Refreshes the pages behind the chat panel once this step's result lands.
  *
- * Keyed on the status alone, so reopening a chat history also refreshes on the
- * already-finished steps it renders. That extra refetch is worth accepting: the
- * embed can't tell which page is behind it, let alone whether that page has
- * fetched anything since the run started.
+ * Watches the section identity as well as its status. A `pr_iteration` embed
+ * resolves to the code_changes section until a PR exists, then swaps to the
+ * pull_request one; both report `completed`, so a status-only dependency would
+ * sit still through the swap — the moment the PR badge actually has news.
+ *
+ * Refires for a run that was already finished when the embed mounted, so
+ * reopening a chat history refreshes once per step it renders. That extra
+ * refetch is worth accepting: the embed can't tell which page is behind it, let
+ * alone whether that page has fetched anything since the run started.
  */
-function useRefreshOnStepResult(
-  groupId: string,
-  status: AutofixSection['status'] | undefined
-) {
+function useRefreshOnStepResult(groupId: string, section: AutofixSection | undefined) {
   const refreshAutofixProgressQueries = useRefreshAutofixProgressQueries(groupId);
+  const {step, status} = section ?? {};
 
   useEffect(() => {
     if (status === 'completed') {
       refreshAutofixProgressQueries();
     }
-  }, [status, refreshAutofixProgressQueries]);
+  }, [step, status, refreshAutofixProgressQueries]);
 }
 
 function AutofixRefContent({id, shortId, step}: AutofixRefContentProps) {
@@ -163,7 +166,7 @@ function AutofixRefContent({id, shortId, step}: AutofixRefContentProps) {
   const sections = useMemo(() => getOrderedAutofixSections(runState), [runState]);
   const section = useMemo(() => findStepSection(sections, step), [sections, step]);
 
-  useRefreshOnStepResult(id, section?.status);
+  useRefreshOnStepResult(id, section);
 
   const handleRetry = () => {
     sendMessage?.(t('Retry the %s step for %s.', STEP_LABELS[step], shortId));


### PR DESCRIPTION
The Seer chat panel slides **over** whatever page you were on, and that page stays mounted holding the data it fetched before the run started. So an autofix step that finished under the panel left the issues inbox showing the issue in its old `issue.progress:` bucket, with stale section counts and no PR badge, until you navigated away or refocused the window. The Seer workflows overview had the same gap for everything except its `status` expand, which is the only query there that polls.

The live `autofixRef` embed now invalidates those queries as each step's result becomes available.

## How

Invalidation matches on the resolved URL alone. `apiOptions` builds `queryKey: [url, options, {infinite}]`, so a single entry per URL reaches every filter, sort, cursor and expand variant the affected pages mount — which is what we want, since the embed cannot see which page is behind it. React Query compares element 0 by exact string equality, so this cannot leak into `/issues/<id>/autofix/` and feed back into the embed's own query.

Four endpoints:

| URL | Covers |
|---|---|
| `.../issues/` | every inbox section's infinite query |
| `.../issues-count/` | the my / my teams / all tab counts |
| `.../issues/{id}/pull-requests/` | the PR badge on the inbox row |
| `.../seer/autofix-overview/` | all three `useQuery` calls in `useAutofixOverview.ts` |

## Choices worth arguing with

**It refreshes on mount, not only on a transition.** I first guarded on a `processing → completed` transition so that reopening a chat history would stay quiet. A test proved that impossible: the first render has no data, so a cold mount always goes `undefined → completed` anyway. The guard was removed rather than left in place looking like it did something. Reopening a chat history now refreshes once per finished step it renders. React Query merges the concurrent invalidations, and the inbox already runs `staleTime: 0` with `refetchOnWindowFocus`, so the cost is small — but it is a real behaviour change on panel open.

**The effect watches section identity, not just status.** `findStepSection` resolves a `pr_iteration` embed to the pull_request section, falling back to code_changes while no PR exists. Both report `completed`, so a status-only dependency sat inert through the swap — precisely when the PR badge has news. This was caught in review of the first commit; the second commit fixes it and adds a test that fails without it.

**The breadth sweeps in bystanders.** The `/issues/` endpoint is shared with the feedback inbox, the dashboard issue widget, release issues and `groupList`. They refetch a list they were already showing. That is cheaper than working out which page is on screen, but it is a deliberate trade rather than a free one.

## Deliberately not done

The **legacy issue stream** is not refreshed. It reads through `GroupStore` and `IssueListCacheStore` rather than React Query, so cache invalidation cannot drive it — the precedent in `issuePreviewActions.tsx` pairs invalidation with `IssueListCacheStore.reset()`. The new inbox is covered; the old stream would need that separate treatment.

**`autofix-scm-info`** is not refreshed either. The overview fetches it through `fetchQuery` into component state behind a `requestedRunIdsRef` dedup guard, so invalidating its cache would not re-request it. It is also not a `useQuery` call.

## Feature flag

No new flag. This changes cache behaviour on the existing `autofixRef` embed, which is gated by `organizations:seer-agent-autofix`. To test: open the Seer chat panel over `/issues/inbox`, run an autofix step to completion, and watch the issue move buckets without a manual refresh.

No screenshots — the visible change is the absence of stale data, which does not photograph well. The two specs cover it instead.

https://claude.ai/code/session_01Xa2mhNZyeatSSoJHhbCJPJ
