### PR TITLE
fix(auth): Keep 2FA authorizing state during redirect

### DIFF
--- a/static/app/views/authV2/authLogin/components/secondFactorAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/secondFactorAuth.spec.tsx
@@ -72,7 +72,7 @@ describe('SecondFactorAuth', () => {
     expect(challengeRequest).toHaveBeenCalledTimes(1);
   });
 
-  it('completes a WebAuthn challenge without additional UI', async () => {
+  it('keeps showing authorization progress while completing a WebAuthn challenge', async () => {
     const user = UserFixture();
     const onComplete = jest.fn();
     const webAuthnResponse = {
@@ -135,6 +135,7 @@ describe('SecondFactorAuth', () => {
     await waitFor(() =>
       expect(onComplete).toHaveBeenCalledWith({nextUri: '/organizations/', user})
     );
+    expect(screen.getByText('Authorizing...')).toBeInTheDocument();
   });
 
   it('requests a fresh WebAuthn challenge after submission fails', async () => {
@@ -307,7 +308,7 @@ describe('SecondFactorAuth', () => {
     expect(onBack).toHaveBeenCalledTimes(1);
   });
 
-  it('disables navigation while authentication is pending', async () => {
+  it('disables navigation while authentication is processing', async () => {
     const response = Promise.withResolvers<{
       nextUri: string;
       user: ReturnType<typeof UserFixture>;
@@ -335,6 +336,7 @@ describe('SecondFactorAuth', () => {
     expect(screen.getByRole('button', {name: 'Use recovery code'})).toBeDisabled();
     response.resolve({nextUri: '/organizations/', user: UserFixture()});
     await waitFor(() => expect(onComplete).toHaveBeenCalledTimes(1));
+    expect(screen.getByRole('button', {name: 'Back to Login'})).toBeDisabled();
   });
 
   it('disables authentication controls while cancellation is pending', async () => {

--- a/static/app/views/authV2/authLogin/components/secondFactorAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/secondFactorAuth.tsx
@@ -78,7 +78,7 @@ export function SecondFactorAuth({
     : sortedMethods[0]?.id;
   const auth = useSecondFactorAuth();
   const cancellation = useCancelSecondFactorAuth();
-  const isProcessing = auth.isPending || cancellation.isPending;
+  const isProcessing = auth.isPending || Boolean(auth.result) || cancellation.isPending;
   const authenticate = (credentials: SecondFactorCredentials) => {
     cancellation.reset();
     auth.authenticate(credentials);
@@ -164,7 +164,7 @@ export function SecondFactorAuth({
             size="xs"
             icon={<IconArrow direction="left" />}
             busy={cancellation.isPending}
-            disabled={auth.isPending}
+            disabled={isProcessing}
             onClick={() => cancellation.cancel(undefined, {onSuccess: onBack})}
           >
             {t('Back to Login')}


### PR DESCRIPTION
After WebAuthn verification succeeds, the mutation leaves its pending state before the browser redirect completes, briefly restoring the waiting prompt.

Treat a successful result as processing until the page unloads, keeping `Authorizing...` visible and controls disabled throughout navigation. Includes regression coverage for the completion handoff.