### PR TITLE
fix(auth): Use consistent sign-in copy in organization card

### DIFF
--- a/static/app/views/authV2/authLogin/components/organizationAuth.spec.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationAuth.spec.tsx
@@ -29,7 +29,7 @@ describe('OrganizationAuth', () => {
     render(<OrganizationAuth authOrganization={authOrganization} onClear={onClear} />);
 
     expect(screen.getByText('Acme')).toBeInTheDocument();
-    expect(screen.getByText('Members log in with SAML')).toBeInTheDocument();
+    expect(screen.getByText('Members sign in with SAML')).toBeInTheDocument();
     const ssoButton = screen.getByRole('button', {name: 'SSO'});
     const ssoForm = ssoButton.closest('form')!;
     expect(ssoButton).toBeInTheDocument();

--- a/static/app/views/authV2/authLogin/components/organizationAuth.tsx
+++ b/static/app/views/authV2/authLogin/components/organizationAuth.tsx
@@ -43,7 +43,7 @@ export function OrganizationAuth({
         name: organization.name,
       } as const);
   const description = provider
-    ? tct('Members log in with [icon] [provider]', {
+    ? tct('Members sign in with [icon] [provider]', {
         icon: <InlineIdentityIcon providerId={provider.key} />,
         provider: provider.name,
       })

--- a/tests/acceptance/test_auth_react.py
+++ b/tests/acceptance/test_auth_react.py
@@ -81,7 +81,7 @@ class ReactAuthTest(AcceptanceTestCase):
     def select_organization_sso(self, organization_slug: str) -> None:
         self.locate_organization_sso(organization_slug)
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members sign in with Dummy')]"
         )
 
     def leave_organization_sso(self) -> None:
@@ -285,7 +285,7 @@ class ReactAuthTest(AcceptanceTestCase):
 
         self.locate_organization_sso(self.organization.slug)
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members sign in with Dummy')]"
         )
         assert self.browser.element_exists('[aria-label="Email"]')
         assert self.browser.element_exists('[aria-label="Password"]')
@@ -311,7 +311,7 @@ class ReactAuthTest(AcceptanceTestCase):
             f"return window.location.pathname === '/auth/login/{organization.slug}/'"
         )
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members sign in with Dummy')]"
         )
 
     def test_password_login_uses_organization_without_sso(self) -> None:
@@ -354,7 +354,7 @@ class ReactAuthTest(AcceptanceTestCase):
             f"return window.location.pathname === '/auth/login/{sso_organization.slug}/'"
         )
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members sign in with Dummy')]"
         )
 
         # SSO authentication returns to the protected organization destination.
@@ -386,7 +386,7 @@ class ReactAuthTest(AcceptanceTestCase):
         # The current session cannot access the selected organization until SSO completes, so
         # the login page keeps the organization in focus and offers no alternative auth method.
         self.browser.wait_until(
-            xpath="//*[contains(normalize-space(.), 'Members log in with Dummy')]"
+            xpath="//*[contains(normalize-space(.), 'Members sign in with Dummy')]"
         )
         assert not self.browser.element_exists('[aria-label="Email"]')
         assert not self.browser.element_exists('[aria-label="Password"]')


### PR DESCRIPTION
The organization authentication card uses “log in” for SSO providers and “sign in” for email and password, while the surrounding page also uses “sign in.”

Use “sign in” for the SSO provider description so both card states use consistent terminology.