### PR TITLE
fix(ui): Remove conflicting bubble transform styles

### DIFF
--- a/static/app/components/brandPageLayout/interactiveIllustration.tsx
+++ b/static/app/components/brandPageLayout/interactiveIllustration.tsx
@@ -311,7 +311,7 @@ function InteractiveIllustrationContent({
       >
         <MaskDefinitions aria-hidden="true">
           <defs>
-            <BubblePaths id={bubblePathsId} ref={bubblePaths} />
+            <g id={bubblePathsId} ref={bubblePaths} />
             <mask
               id={bubbleRevealMaskId}
               x="0"
@@ -649,14 +649,6 @@ const MaskDefinitions = styled('svg')`
   width: 100%;
   height: 100%;
   pointer-events: none;
-`;
-
-const BubblePaths = styled('g')`
-  path {
-    transform-box: fill-box;
-    transform-origin: center;
-    will-change: transform, opacity;
-  }
 `;
 
 const BubbleMaskLayer = styled('div')<{$maskId: string}>`


### PR DESCRIPTION
Removes CSS transform geometry from the dynamically animated SVG paths now that their transforms are expressed as explicit SVG matrices. This prevents Chromium from applying a second transform origin while preserving the corrected Firefox behavior.