### PR TITLE
fix(msteams): Read name and type from the Teams channel list response

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_integration_channels.py
+++ b/src/sentry/integrations/api/endpoints/organization_integration_channels.py
@@ -152,8 +152,7 @@ def _msteams_list_channels(
     """
     List Microsoft Teams channels for a given team.
 
-    The Teams API returns all channels at once.
-    Only standard and private channels are included.
+    The Teams API returns all channels at once, each as `id`, `name` and `type`.
     """
 
     client = MsTeamsClient(integration)
@@ -194,18 +193,20 @@ def _msteams_list_channels(
             continue
 
         ch_id = item.get("id")
-        display_name = item.get("displayName")
-        if not ch_id or not display_name:
+        if not ch_id:
             continue
 
-        ch_type = str(item.get("membershipType") or "standard")
+        # A channel without a name is General, which is also how
+        # `find_channel_id` resolves the name "General" back to it.
+        name = str(item.get("name") or "General")
+        ch_type = str(item.get("type") or "standard")
 
         results.append(
             {
                 "id": str(ch_id),
-                "name": str(display_name),
-                "display": str(display_name),
-                "type": ch_type,  # "standard" or "private"
+                "name": name,
+                "display": name,
+                "type": ch_type,  # "standard", "private" or "shared"
             }
         )
 

--- a/tests/sentry/integrations/api/endpoints/test_organization_integration_channels.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integration_channels.py
@@ -130,31 +130,36 @@ class OrganizationIntegrationChannelsMsTeamsTest(OrganizationIntegrationChannels
 
     @patch("sentry.integrations.msteams.client.MsTeamsClient.get")
     def test_msteams_channels_list(self, mock_get):
-        mock_channels = {
+        # The Bot Framework returns `id`, `name` and `type` per channel. The
+        # General channel has no name, and its id is the team id.
+        mock_get.return_value = {
             "conversations": [
-                {"id": "19:channel1@thread.tacv2", "displayName": "Development"},
-                {"id": "19:channel2@thread.tacv2", "displayName": "General"},
-                {
-                    "id": "19:channel3@thread.tacv2",
-                    "displayName": "Testing",
-                    "membershipType": "private",
-                },
+                {"id": "19:team-id@thread.tacv2"},
+                {"id": "19:channel1@thread.tacv2", "name": "Development"},
+                {"id": "19:channel3@thread.tacv2", "name": "Testing", "type": "private"},
             ]
         }
-        mock_get.return_value = mock_channels
         response = self.get_success_response(self.organization.slug, self.integration.id)
-        results = response.data["results"]
-        expected = []
-        for ch in mock_channels["conversations"]:
-            expected.append(
-                {
-                    "id": ch["id"],
-                    "name": ch["displayName"],
-                    "display": ch["displayName"],
-                    "type": ch.get("membershipType", "standard"),
-                }
-            )
-        assert results == expected
+        assert response.data["results"] == [
+            {
+                "id": "19:team-id@thread.tacv2",
+                "name": "General",
+                "display": "General",
+                "type": "standard",
+            },
+            {
+                "id": "19:channel1@thread.tacv2",
+                "name": "Development",
+                "display": "Development",
+                "type": "standard",
+            },
+            {
+                "id": "19:channel3@thread.tacv2",
+                "name": "Testing",
+                "display": "Testing",
+                "type": "private",
+            },
+        ]
         mock_get.assert_called_once()
 
 


### PR DESCRIPTION
The integration channels endpoint returned an empty list for every Microsoft Teams team, so the channel picker in onboarding and on the create project page showed "No options" and only a typed channel name worked. `_msteams_list_channels` read `displayName` and `membershipType` from each conversation, but the Bot Framework returns `id`, `name` and `type`, so every item was skipped. It has done so since the endpoint was added in #101321.

A channel without a name is listed as General. The Bot Framework leaves the General channel's name null so Teams can localize it, and `find_channel_id`, which resolves the name an alert action carries, already treats a nameless channel as General, so the listed name round-trips to the same channel. The test fixture now uses the real response shape, including a nameless General entry.

Backend only. Stacked on #123602 so the Teams path can be checked end to end in one stack, but it has no dependency on the frontend PRs and could land on master by itself. With both merged, a channel picked from the list creates the workflow.

Fixes VDY-201
