### PR TITLE
fix(onboarding): Key the MS Teams channel picker by name

### DIFF
--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -248,9 +248,9 @@ describe('ScmMessagingChannelPicker', () => {
     });
 
     it('preserves stored MS Teams identifiers when the channel list is empty', async () => {
-      // msteams selects by id but validates by name, so overwriting channelName
-      // with the id (the fallback when the list can't resolve the selection)
-      // breaks revalidation. An empty /channels/ must not corrupt the saved name.
+      // The seed carries both identifiers, so an empty /channels/ must not
+      // replace the saved channelId with the name (the fallback when the list
+      // can't resolve the selection).
       mockChannels('30', []);
       const {onConfigured} = renderPicker({
         eligibleIntegrations: [msteamsIntegration],

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -702,8 +702,8 @@ describe('ScmMessaging', () => {
   });
 
   it('Continue targets an MS Teams channel by its name', async () => {
-    // The picker keys Teams channels by id, but the backend resolves a Teams
-    // channel by name only, so the workflow must carry the name.
+    // The backend resolves a Teams channel by name only, so the workflow must
+    // carry the name.
     const msteamsSetup: ScmMessagingSetup = {
       mode: 'selected',
       providerKey: 'msteams',

--- a/static/app/views/projectInstall/createProject.spec.tsx
+++ b/static/app/views/projectInstall/createProject.spec.tsx
@@ -834,8 +834,8 @@ describe('CreateProject', () => {
   });
 
   it('targets an MS Teams channel picked from the list by its name', async () => {
-    // The picker keys Teams channels by id, but the backend resolves a Teams
-    // channel by name only, so the workflow must carry the name.
+    // The backend resolves a Teams channel by name only, so the workflow must
+    // carry the name.
     const {organization, messagingIntegration} = mockMessagingProjectCreation({
       provider: {key: 'msteams', name: 'MS Teams'},
       channels: [
@@ -856,7 +856,7 @@ describe('CreateProject', () => {
 
     render(<CreateProject />, {organization});
 
-    await createProjectWithChannel('General (19:abc@thread.tacv2)');
+    await createProjectWithChannel('General');
 
     await waitFor(() => {
       expect(ruleCreationMockRequest).toHaveBeenCalled();

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.spec.tsx
@@ -93,8 +93,8 @@ describe('getChannelTarget', () => {
     [
       'msteams',
       {
-        label: 'General (19:abc@thread.tacv2)',
-        value: '19:abc@thread.tacv2',
+        label: 'General',
+        value: 'General',
         channelId: '19:abc@thread.tacv2',
         channelName: 'General',
       },
@@ -697,21 +697,5 @@ describe('buildNotificationSelection', () => {
         channel: {label: '#eng', value: '#eng'},
       })
     ).toEqual({provider: 'slack', integrationId: '5', channel: '#eng'});
-  });
-
-  it('stores the action target rather than the picker key', () => {
-    const integration = OrganizationIntegrationsFixture({id: '5'});
-    expect(
-      buildNotificationSelection({
-        provider: 'msteams',
-        integration,
-        channel: {
-          label: 'General (19:abc@thread.tacv2)',
-          value: '19:abc@thread.tacv2',
-          channelId: '19:abc@thread.tacv2',
-          channelName: 'General',
-        },
-      })
-    ).toEqual({provider: 'msteams', integrationId: '5', channel: 'General'});
   });
 });

--- a/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
+++ b/static/app/views/projectInstall/issueAlertNotificationOptions.tsx
@@ -43,10 +43,10 @@ interface MessagingProviderDetail {
 }
 
 /**
- * Providers disagree on what identifies a channel. MS Teams is the only row
- * that is not uniform: the picker keys it by id, since two Teams channels can
- * share a name, but the backend resolves a Teams channel by name only
- * (`find_channel_id`), so it is validated and targeted by name.
+ * Providers disagree on what identifies a channel. Slack and MS Teams resolve
+ * a channel by name (`find_channel_id` matches Teams channels by name only),
+ * Discord by id. Each picker is keyed by the field its backend resolves, so a
+ * picked channel and its action target are the same value.
  */
 export const providerDetails = {
   slack: {
@@ -86,8 +86,8 @@ export const providerDetails = {
   msteams: {
     name: t('MS Teams'),
     action: IssueAlertActionType.MS_TEAMS,
-    placeholder: t('channel name'),
-    channelSelectedBy: 'channelId',
+    placeholder: t('channel, e.g. General'),
+    channelSelectedBy: 'channelName',
     channelValidatedBy: 'channelName',
     channelTargetedBy: 'channelName',
     makeSentence: ({providerName, integrationName, target}: any) =>

--- a/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
+++ b/static/app/views/projectInstall/messagingIntegrationAlertRule.spec.tsx
@@ -355,41 +355,6 @@ describe('MessagingIntegrationAlertRule', () => {
     );
     expect(mockSetIntegration).toHaveBeenCalledWith(slackIntegrations[1]);
   });
-
-  it('keys Microsoft Teams channels by id and keeps the name for the action', async () => {
-    MockApiClient.addMockResponse({
-      url: `/organizations/${organization.slug}/integrations/${msteamsIntegrations[0]!.id}/channels/`,
-      body: {
-        nextCursor: null,
-        results: [
-          {id: '1', name: 'general', display: '#general', type: 'text'},
-          {id: '2', name: 'alerts', display: '#alerts', type: 'text'},
-        ],
-      },
-    });
-    render(
-      <MessagingIntegrationAlertRule
-        {...{
-          ...notificationProps,
-          channel: undefined,
-          integration: msteamsIntegrations[0],
-          provider: 'msteams',
-        }}
-      />
-    );
-    expect(screen.getByText('channel name')).toBeInTheDocument();
-    await selectEvent.openMenu(getChannelSelect());
-    expect(await screen.findByText('#general (1)')).toBeInTheDocument();
-    expect(screen.getByText('#alerts (2)')).toBeInTheDocument();
-    await selectEvent.select(getChannelSelect(), /#alerts/);
-    expect(mockSetChannel).toHaveBeenCalledWith({
-      label: '#alerts (2)',
-      value: '2',
-      new: false,
-      channelId: '2',
-      channelName: '#alerts',
-    });
-  });
 });
 
 describe('useMessagingIntegrationAlertRule change analytics', () => {

--- a/static/app/views/projectInstall/useMessagingChannel.ts
+++ b/static/app/views/projectInstall/useMessagingChannel.ts
@@ -77,7 +77,7 @@ export type UseMessagingChannelResult = {
  *   - /channels/ query (skipped without provider + integration; staleTime
  *     Infinity unless refetchOnWindowFocus is set)
  *   - /channel-validate/ for manually entered channels
- *   - channelOptions shaping (Slack keyed by display name; Discord and MS Teams
+ *   - channelOptions shaping (Slack and MS Teams keyed by display name; Discord
  *     keyed by id with `display (id)` labels, since the name alone cannot
  *     disambiguate same-named channels)
  *   - Label-upgrade effect: restores raw-id labels to human-readable once the


### PR DESCRIPTION
The MS Teams channel picker now keys its options by channel name, like Slack, so each option shows the channel name alone rather than `General (19:...@thread.tacv2)` once #123621 returns Teams channels. The placeholder follows the Slack pattern with an example, "channel, e.g. General".

The picker had kept the id key so that two same-named Teams channels stayed distinguishable in the list. The backend resolves a Teams channel by name only and the action target is the name, so picking either entry sent the same channel, and the id in the label promised a distinction the action could not deliver.

`channelTargetedBy` stays in `providerDetails`. Every provider now keys the picker by the field it targets, so the picked value and the action target coincide, but the declaration keeps the per-provider contract in one place and the SCM destination still stores both identifiers.

Covers the create project page and the onboarding messaging step, which share `useMessagingChannel`. Slack and Discord are unchanged.

Fixes VDY-202
