### PR TITLE
fix(webvitals): Fix web vital samples not loading in detail slideout panel

### DIFF
--- a/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
+++ b/static/app/views/insights/browser/webVitals/components/pageOverviewWebVitalsDetailPanel.tsx
@@ -60,18 +60,47 @@ const PAGELOADS_COLUMN_ORDER: GridColumnOrder[] = [
   {key: 'score', width: COL_WIDTH_UNDEFINED, name: t('Score')},
 ];
 
-const SPANS_SAMPLES_COLUMN_ORDER: GridColumnOrder[] = [
-  {key: 'id', width: COL_WIDTH_UNDEFINED, name: t('Trace')},
-  {
-    key: SpanFields.SPAN_DESCRIPTION,
+const SPANS_SAMPLES_SUBJECT_COLUMNS: Partial<Record<WebVitals, GridColumnOrder>> = {
+  lcp: {
+    key: SpanFields.BROWSER_WEB_VITAL_LCP_ELEMENT,
     width: COL_WIDTH_UNDEFINED,
-    name: t('Description'),
+    name: t('LCP Element'),
   },
-  {key: 'profile.id', width: COL_WIDTH_UNDEFINED, name: t('Profile')},
-  {key: 'replayId', width: COL_WIDTH_UNDEFINED, name: t('Replay')},
-  {key: 'webVital', width: COL_WIDTH_UNDEFINED, name: t('Web Vital')},
-  {key: 'score', width: COL_WIDTH_UNDEFINED, name: t('Score')},
-];
+  cls: {
+    key: SpanFields.BROWSER_WEB_VITAL_CLS_SOURCE_1,
+    width: COL_WIDTH_UNDEFINED,
+    name: t('CLS Source'),
+  },
+  inp: {
+    key: SpanFields.NAME,
+    width: COL_WIDTH_UNDEFINED,
+    name: t('Interaction Target'),
+  },
+};
+
+const DEFAULT_SPANS_SAMPLES_SUBJECT_COLUMN: GridColumnOrder = {
+  key: SpanFields.NAME,
+  width: COL_WIDTH_UNDEFINED,
+  name: t('Name'),
+};
+
+function getSpansSamplesSubjectColumn(webVital: WebVitals | null): GridColumnOrder {
+  return (
+    (webVital && SPANS_SAMPLES_SUBJECT_COLUMNS[webVital]) ??
+    DEFAULT_SPANS_SAMPLES_SUBJECT_COLUMN
+  );
+}
+
+function getSpansSamplesColumnOrder(webVital: WebVitals | null): GridColumnOrder[] {
+  return [
+    {key: 'id', width: COL_WIDTH_UNDEFINED, name: t('Trace')},
+    getSpansSamplesSubjectColumn(webVital),
+    {key: 'profile.id', width: COL_WIDTH_UNDEFINED, name: t('Profile')},
+    {key: 'replayId', width: COL_WIDTH_UNDEFINED, name: t('Replay')},
+    {key: 'webVital', width: COL_WIDTH_UNDEFINED, name: t('Web Vital')},
+    {key: 'score', width: COL_WIDTH_UNDEFINED, name: t('Score')},
+  ];
+}
 
 const NO_VALUE = ' \u2014 ';
 
@@ -156,6 +185,8 @@ export function PageOverviewWebVitalsDetailPanel({
     spansTableData.filter(row => row['profile.id']).map(row => row['profile.id'])
   );
 
+  const spansSamplesColumnOrder = getSpansSamplesColumnOrder(webVital);
+
   const renderHeadCell = (col: Column) => {
     if (col.key === 'transaction') {
       return <NoOverflow>{col.name}</NoOverflow>;
@@ -170,17 +201,6 @@ export function PageOverviewWebVitalsDetailPanel({
       return <AlignCenter>{col.name}</AlignCenter>;
     }
 
-    if (col.key === SpanFields.SPAN_DESCRIPTION) {
-      if (webVital === 'lcp') {
-        return <span>{t('LCP Element')}</span>;
-      }
-      if (webVital === 'cls') {
-        return <span>{t('CLS Source')}</span>;
-      }
-      if (webVital === 'inp') {
-        return <span>{t('Interaction Target')}</span>;
-      }
-    }
     return <NoOverflow>{col.name}</NoOverflow>;
   };
 
@@ -268,18 +288,15 @@ export function PageOverviewWebVitalsDetailPanel({
       );
     }
 
-    if (key === SpanFields.SPAN_DESCRIPTION) {
-      const description =
-        webVital === 'lcp' && row[SpanFields.SPAN_OP] === 'pageload'
-          ? row[SpanFields.BROWSER_WEB_VITAL_LCP_ELEMENT]
-          : webVital === 'cls' && row[SpanFields.SPAN_OP] === 'pageload'
-            ? row[SpanFields.BROWSER_WEB_VITAL_CLS_SOURCE_1]
-            : row[key];
-
-      if (description) {
+    if (
+      key === SpanFields.NAME ||
+      key === SpanFields.BROWSER_WEB_VITAL_LCP_ELEMENT ||
+      key === SpanFields.BROWSER_WEB_VITAL_CLS_SOURCE_1
+    ) {
+      if (row[key]) {
         return (
           <NoOverflow>
-            <Tooltip title={description}>{description}</Tooltip>
+            <Tooltip title={row[key]}>{row[key]}</Tooltip>
           </NoOverflow>
         );
       }
@@ -351,7 +368,7 @@ export function PageOverviewWebVitalsDetailPanel({
               data={spansTableData}
               isLoading={isSpansLoading}
               columnOrder={
-                isSpansWebVital ? SPANS_SAMPLES_COLUMN_ORDER : PAGELOADS_COLUMN_ORDER
+                isSpansWebVital ? spansSamplesColumnOrder : PAGELOADS_COLUMN_ORDER
               }
               grid={{
                 getColumnSort: column => ({

--- a/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/useSpanSamplesWebVitalsQuery.tsx
@@ -53,10 +53,7 @@ export function useSpanSamplesWebVitalsQuery({
     sortableFields: filteredSortableFields,
   });
 
-  const mutableSearch = MutableSearch.fromQueryObject({
-    has: 'message',
-    [`!${SpanFields.SPAN_DESCRIPTION}`]: '<unknown>',
-  });
+  const mutableSearch = new MutableSearch('');
   if (transaction !== undefined) {
     mutableSearch.addFilterValue(SpanFields.TRANSACTION, transaction);
   }
@@ -110,7 +107,7 @@ export function useSpanSamplesWebVitalsQuery({
         SpanFields.USER_ID,
         SpanFields.USER_IP,
         SpanFields.PROJECT,
-        SpanFields.SPAN_DESCRIPTION,
+        SpanFields.NAME,
         SpanFields.TIMESTAMP,
         SpanFields.SPAN_SELF_TIME,
         SpanFields.TRANSACTION,

--- a/static/app/views/insights/browser/webVitals/types.tsx
+++ b/static/app/views/insights/browser/webVitals/types.tsx
@@ -53,7 +53,7 @@ type SpanSampleRow = {
   'profile.id': string;
   project: string;
   replayId: string;
-  [SpanFields.SPAN_DESCRIPTION]: string;
+  [SpanFields.NAME]: string;
   [SpanFields.SPAN_SELF_TIME]: number;
   [SpanFields.TIMESTAMP]: string;
   [SpanFields.TRACE]: string;


### PR DESCRIPTION
standalone web vitals no longer uses span.description. Update to use
correct attributes for lcp element, cls source, and inp target