### PR TITLE
feat(explore): add a Share button to send time-locked URL

### DIFF
--- a/static/app/components/pageFilters/actions.tsx
+++ b/static/app/components/pageFilters/actions.tsx
@@ -32,8 +32,8 @@ import type {Organization} from 'sentry/types/organization';
 import type {Environment, MinimalProject, Project} from 'sentry/types/project';
 import {getUtcDateString} from 'sentry/utils/dates';
 import {defined} from 'sentry/utils/defined';
-import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
-import {DAY as DAY_IN_MS, HOUR as HOUR_IN_MS} from 'sentry/utils/formatters';
+import {getAbsoluteRangeFromPeriod} from 'sentry/utils/duration/getAbsoluteRangeFromPeriod';
+import {DAY as DAY_IN_MS} from 'sentry/utils/formatters';
 import {isActiveSuperuser} from 'sentry/utils/isActiveSuperuser';
 import {navigateIfQueryChanged} from 'sentry/utils/navigateIfQueryChanged';
 import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
@@ -353,10 +353,12 @@ export function initializeUrlState({
     const now = Date.now();
     let {start, end} = pageFilters.datetime;
 
-    if (pageFilters.datetime.period) {
-      const periodInHours = parsePeriodToHours(pageFilters.datetime.period);
-      start = new Date(now - periodInHours * HOUR_IN_MS);
-      end = new Date(now);
+    const range = pageFilters.datetime.period
+      ? getAbsoluteRangeFromPeriod(pageFilters.datetime.period, now)
+      : null;
+    if (range) {
+      start = range.start;
+      end = range.end;
     }
 
     if (start && end) {

--- a/static/app/utils/analytics/exploreAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/exploreAnalyticsEvents.tsx
@@ -11,6 +11,11 @@ export type ExploreAnalyticsEventParameters = {
   'explore.floating_trigger.zoom_in': {
     organization: Organization;
   };
+  'explore.share_link_copied': {
+    frozen_relative_period: boolean;
+    organization: Organization;
+    traceItemDataset: TraceItemDataset;
+  };
   'explore.table_exported': {
     export_type: 'browser_sync' | 'export_download';
     organization: Organization;
@@ -37,5 +42,6 @@ export const exploreAnalyticsEventMap: Record<ExploreAnalyticsEventKey, string |
   'explore.floating_trigger.compare_attribute_breakdowns':
     'Explore: Floating Trigger Compare Attribute Breakdowns',
   'explore.floating_trigger.zoom_in': 'Explore: Floating Trigger Zoom In',
+  'explore.share_link_copied': 'Explore: Share Link Copied',
   'explore.table_exported': 'Explore: Table Exported',
 };

--- a/static/app/utils/duration/getAbsoluteRangeFromPeriod.spec.tsx
+++ b/static/app/utils/duration/getAbsoluteRangeFromPeriod.spec.tsx
@@ -1,0 +1,16 @@
+import {getAbsoluteRangeFromPeriod} from 'sentry/utils/duration/getAbsoluteRangeFromPeriod';
+
+describe('getAbsoluteRangeFromPeriod', () => {
+  const now = new Date('2026-09-03T12:00:00.000Z').getTime();
+
+  it('returns a range ending now when given a valid period', () => {
+    expect(getAbsoluteRangeFromPeriod('7d', now)).toEqual({
+      start: new Date('2026-08-27T12:00:00.000Z'),
+      end: new Date('2026-09-03T12:00:00.000Z'),
+    });
+  });
+
+  it('returns null when the period cannot be parsed', () => {
+    expect(getAbsoluteRangeFromPeriod('yesterday', now)).toBeNull();
+  });
+});

--- a/static/app/utils/duration/getAbsoluteRangeFromPeriod.tsx
+++ b/static/app/utils/duration/getAbsoluteRangeFromPeriod.tsx
@@ -1,0 +1,13 @@
+import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
+import {HOUR} from 'sentry/utils/formatters';
+
+export function getAbsoluteRangeFromPeriod(
+  period: string,
+  now: number = Date.now()
+): {end: Date; start: Date} | null {
+  const hours = parsePeriodToHours(period);
+  if (hours <= 0) {
+    return null;
+  }
+  return {start: new Date(now - hours * HOUR), end: new Date(now)};
+}

--- a/static/app/utils/url/getPageUrlWithParams.spec.tsx
+++ b/static/app/utils/url/getPageUrlWithParams.spec.tsx
@@ -1,0 +1,20 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {getPageUrlWithParams} from 'sentry/utils/url/getPageUrlWithParams';
+
+describe('getPageUrlWithParams', () => {
+  it('returns an absolute URL with the edited params when given a location', () => {
+    const url = getPageUrlWithParams(
+      LocationFixture({
+        pathname: '/organizations/org-slug/explore/logs/',
+        search: '?a=1&b=2',
+      }),
+      params => {
+        params.delete('a');
+        params.set('c', '3');
+      }
+    );
+
+    expect(url).toBe('http://localhost/organizations/org-slug/explore/logs/?b=2&c=3');
+  });
+});

--- a/static/app/utils/url/getPageUrlWithParams.tsx
+++ b/static/app/utils/url/getPageUrlWithParams.tsx
@@ -1,0 +1,12 @@
+import type {Location} from 'history';
+
+export function getPageUrlWithParams(
+  location: Location,
+  edit: (params: URLSearchParams) => void
+): string {
+  const url = new URL(location.pathname, window.location.origin);
+  const params = new URLSearchParams(location.search);
+  edit(params);
+  url.search = params.toString();
+  return url.toString();
+}

--- a/static/app/views/discover/table/discoverExportModalButton.spec.tsx
+++ b/static/app/views/discover/table/discoverExportModalButton.spec.tsx
@@ -7,6 +7,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import type {TableData} from 'sentry/utils/discover/discoverQuery';
@@ -69,10 +70,12 @@ describe('DiscoverExportModalButton', () => {
     renderButton();
 
     await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Export Data'})).toBeEnabled()
+      expect(screen.getByRole('button', {name: 'Export'})).toBeEnabled()
     );
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(downloadAsCsv).toHaveBeenCalledTimes(1);
@@ -88,7 +91,7 @@ describe('DiscoverExportModalButton', () => {
     renderButton({disabled: true});
 
     await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Export Data'})).toBeDisabled()
+      expect(screen.getByRole('button', {name: 'Export'})).toBeDisabled()
     );
   });
 
@@ -108,11 +111,13 @@ describe('DiscoverExportModalButton', () => {
     renderButton();
 
     await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Export Data'})).toBeEnabled()
+      expect(screen.getByRole('button', {name: 'Export'})).toBeEnabled()
     );
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(downloadAsCsv).toHaveBeenCalledTimes(1);
@@ -124,10 +129,10 @@ describe('DiscoverExportModalButton', () => {
     mockEstimatedRowCount(5000);
     renderButton();
 
-    expect(screen.getByRole('button', {name: 'Export Data'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Export'})).toBeDisabled();
 
     await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Export Data'})).toBeEnabled()
+      expect(screen.getByRole('button', {name: 'Export'})).toBeEnabled()
     );
   });
 
@@ -156,13 +161,15 @@ describe('DiscoverExportModalButton', () => {
 
     await waitFor(() => expect(countMock).toHaveBeenCalled());
     await waitFor(() =>
-      expect(screen.getByRole('button', {name: 'Export Data'})).toBeEnabled()
+      expect(screen.getByRole('button', {name: 'Export'})).toBeEnabled()
     );
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Number of rows'}));
     await userEvent.click(await screen.findByRole('option', {name: /\(All\)$/}));
-    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(dataExportMock).toHaveBeenCalledWith(

--- a/static/app/views/explore/components/exploreShareButton.spec.tsx
+++ b/static/app/views/explore/components/exploreShareButton.spec.tsx
@@ -54,6 +54,22 @@ describe('getExploreShareLink', () => {
     );
   });
 
+  it('strips page-scoped date params when the URL carries them', () => {
+    const link = getExploreShareLink({
+      datetime: relative,
+      location: LocationFixture({
+        pathname,
+        search:
+          '?pageStatsPeriod=7d&pageStart=2026-08-01T00%3A00%3A00&pageUtc=true&project=1',
+      }),
+      now,
+    });
+
+    expect(link.url).toBe(
+      'http://localhost/organizations/org-slug/explore/logs/?project=1&start=2026-08-27T12%3A00%3A00&end=2026-09-03T12%3A00%3A00'
+    );
+  });
+
   it('keeps the URL unchanged when the selection is already absolute', () => {
     const search =
       '?start=2026-08-01T00%3A00%3A00&end=2026-08-02T00%3A00%3A00&utc=true&project=1';

--- a/static/app/views/explore/components/exploreShareButton.spec.tsx
+++ b/static/app/views/explore/components/exploreShareButton.spec.tsx
@@ -6,72 +6,84 @@ import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {
   ExploreShareButton,
-  getExploreShareUrl,
+  getExploreShareLink,
 } from 'sentry/views/explore/components/exploreShareButton';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
 jest.mock('sentry/utils/analytics');
 
-describe('getExploreShareUrl', () => {
-  const now = new Date('2026-09-03T12:00:00.000Z');
+describe('getExploreShareLink', () => {
+  const now = new Date('2026-09-03T12:00:00.000Z').getTime();
+  const pathname = '/organizations/org-slug/explore/logs/';
+  const relative = {period: '7d', start: null, end: null, utc: null};
 
   it('replaces a relative period with absolute start and end when the selection is relative', () => {
-    const url = getExploreShareUrl({
-      datetime: {period: '7d', start: null, end: null, utc: null},
-      location: LocationFixture({
-        pathname: '/organizations/org-slug/explore/logs/',
-        search: '?statsPeriod=7d&project=1',
-      }),
+    const link = getExploreShareLink({
+      datetime: relative,
+      location: LocationFixture({pathname, search: '?statsPeriod=7d&project=1'}),
       now,
     });
 
-    expect(url).toBe(
-      'http://localhost/organizations/org-slug/explore/logs/?project=1&start=2026-08-27T12%3A00%3A00&end=2026-09-03T12%3A00%3A00'
-    );
+    expect(link).toEqual({
+      frozenRelativePeriod: true,
+      url: 'http://localhost/organizations/org-slug/explore/logs/?project=1&start=2026-08-27T12%3A00%3A00&end=2026-09-03T12%3A00%3A00',
+    });
   });
 
   it('adds absolute start and end when the URL has no period', () => {
-    const url = getExploreShareUrl({
-      datetime: {period: '1h', start: null, end: null, utc: null},
-      location: LocationFixture({
-        pathname: '/organizations/org-slug/explore/logs/',
-        search: '?project=1',
-      }),
+    const link = getExploreShareLink({
+      datetime: {...relative, period: '1h'},
+      location: LocationFixture({pathname, search: '?project=1'}),
       now,
     });
 
-    expect(url).toBe(
+    expect(link.url).toBe(
       'http://localhost/organizations/org-slug/explore/logs/?project=1&start=2026-09-03T11%3A00%3A00&end=2026-09-03T12%3A00%3A00'
     );
   });
 
+  it('strips the legacy period param when the URL uses it', () => {
+    const link = getExploreShareLink({
+      datetime: relative,
+      location: LocationFixture({pathname, search: '?period=7d&utc=true'}),
+      now,
+    });
+
+    expect(link.url).toBe(
+      'http://localhost/organizations/org-slug/explore/logs/?utc=true&start=2026-08-27T12%3A00%3A00&end=2026-09-03T12%3A00%3A00'
+    );
+  });
+
   it('keeps the URL unchanged when the selection is already absolute', () => {
-    const url = getExploreShareUrl({
+    const search =
+      '?start=2026-08-01T00%3A00%3A00&end=2026-08-02T00%3A00%3A00&utc=true&project=1';
+    const link = getExploreShareLink({
       datetime: {
         period: null,
         start: '2026-08-01T00:00:00.000',
         end: '2026-08-02T00:00:00.000',
         utc: true,
       },
-      location: LocationFixture({
-        pathname: '/organizations/org-slug/explore/logs/',
-        search:
-          '?start=2026-08-01T00%3A00%3A00&end=2026-08-02T00%3A00%3A00&utc=true&project=1',
-      }),
+      location: LocationFixture({pathname, search}),
       now,
     });
 
-    expect(url).toBe(
-      'http://localhost/organizations/org-slug/explore/logs/?start=2026-08-01T00%3A00%3A00&end=2026-08-02T00%3A00%3A00&utc=true&project=1'
-    );
+    expect(link).toEqual({
+      frozenRelativePeriod: false,
+      url: `http://localhost${pathname}${search}`,
+    });
   });
 });
 
 describe('ExploreShareButton', () => {
+  const initialRouterConfig = {
+    location: {
+      pathname: '/organizations/org-slug/explore/logs/',
+      query: {statsPeriod: '7d', project: '1'},
+    },
+  };
+
   beforeEach(() => {
-    Object.assign(navigator, {
-      clipboard: {writeText: jest.fn().mockResolvedValue('')},
-    });
     PageFiltersStore.init();
     PageFiltersStore.onInitializeUrlState({
       projects: [1],
@@ -81,13 +93,11 @@ describe('ExploreShareButton', () => {
   });
 
   it('copies a link with a frozen time range when clicked', async () => {
+    Object.assign(navigator, {
+      clipboard: {writeText: jest.fn().mockResolvedValue('')},
+    });
     render(<ExploreShareButton traceItemDataset={TraceItemDataset.LOGS} />, {
-      initialRouterConfig: {
-        location: {
-          pathname: '/organizations/org-slug/explore/logs/',
-          query: {statsPeriod: '7d', project: '1'},
-        },
-      },
+      initialRouterConfig,
     });
 
     await userEvent.click(screen.getByRole('button', {name: 'Share'}));
@@ -106,5 +116,21 @@ describe('ExploreShareButton', () => {
         frozen_relative_period: true,
       })
     );
+  });
+
+  it('does not track analytics when the clipboard write fails', async () => {
+    Object.assign(navigator, {
+      clipboard: {writeText: jest.fn().mockRejectedValue(new Error('denied'))},
+    });
+    render(<ExploreShareButton traceItemDataset={TraceItemDataset.LOGS} />, {
+      initialRouterConfig,
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Share'}));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalled();
+    });
+    expect(trackAnalytics).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/explore/components/exploreShareButton.spec.tsx
+++ b/static/app/views/explore/components/exploreShareButton.spec.tsx
@@ -1,0 +1,110 @@
+import {LocationFixture} from 'sentry-fixture/locationFixture';
+
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {
+  ExploreShareButton,
+  getExploreShareUrl,
+} from 'sentry/views/explore/components/exploreShareButton';
+import {TraceItemDataset} from 'sentry/views/explore/types';
+
+jest.mock('sentry/utils/analytics');
+
+describe('getExploreShareUrl', () => {
+  const now = new Date('2026-09-03T12:00:00.000Z');
+
+  it('replaces a relative period with absolute start and end when the selection is relative', () => {
+    const url = getExploreShareUrl({
+      datetime: {period: '7d', start: null, end: null, utc: null},
+      location: LocationFixture({
+        pathname: '/organizations/org-slug/explore/logs/',
+        search: '?statsPeriod=7d&project=1',
+      }),
+      now,
+    });
+
+    expect(url).toBe(
+      'http://localhost/organizations/org-slug/explore/logs/?project=1&start=2026-08-27T12%3A00%3A00&end=2026-09-03T12%3A00%3A00'
+    );
+  });
+
+  it('adds absolute start and end when the URL has no period', () => {
+    const url = getExploreShareUrl({
+      datetime: {period: '1h', start: null, end: null, utc: null},
+      location: LocationFixture({
+        pathname: '/organizations/org-slug/explore/logs/',
+        search: '?project=1',
+      }),
+      now,
+    });
+
+    expect(url).toBe(
+      'http://localhost/organizations/org-slug/explore/logs/?project=1&start=2026-09-03T11%3A00%3A00&end=2026-09-03T12%3A00%3A00'
+    );
+  });
+
+  it('keeps the URL unchanged when the selection is already absolute', () => {
+    const url = getExploreShareUrl({
+      datetime: {
+        period: null,
+        start: '2026-08-01T00:00:00.000',
+        end: '2026-08-02T00:00:00.000',
+        utc: true,
+      },
+      location: LocationFixture({
+        pathname: '/organizations/org-slug/explore/logs/',
+        search:
+          '?start=2026-08-01T00%3A00%3A00&end=2026-08-02T00%3A00%3A00&utc=true&project=1',
+      }),
+      now,
+    });
+
+    expect(url).toBe(
+      'http://localhost/organizations/org-slug/explore/logs/?start=2026-08-01T00%3A00%3A00&end=2026-08-02T00%3A00%3A00&utc=true&project=1'
+    );
+  });
+});
+
+describe('ExploreShareButton', () => {
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {writeText: jest.fn().mockResolvedValue('')},
+    });
+    PageFiltersStore.init();
+    PageFiltersStore.onInitializeUrlState({
+      projects: [1],
+      environments: [],
+      datetime: {period: '7d', start: null, end: null, utc: null},
+    });
+  });
+
+  it('copies a link with a frozen time range when clicked', async () => {
+    render(<ExploreShareButton traceItemDataset={TraceItemDataset.LOGS} />, {
+      initialRouterConfig: {
+        location: {
+          pathname: '/organizations/org-slug/explore/logs/',
+          query: {statsPeriod: '7d', project: '1'},
+        },
+      },
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Share'}));
+
+    await waitFor(() => {
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+        expect.stringMatching(
+          /^http:\/\/localhost\/organizations\/org-slug\/explore\/logs\/\?project=1&start=[^&]+&end=[^&]+$/
+        )
+      );
+    });
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'explore.share_link_copied',
+      expect.objectContaining({
+        traceItemDataset: TraceItemDataset.LOGS,
+        frozen_relative_period: true,
+      })
+    );
+  });
+});

--- a/static/app/views/explore/components/exploreShareButton.tsx
+++ b/static/app/views/explore/components/exploreShareButton.tsx
@@ -2,7 +2,10 @@ import type {Location} from 'history';
 
 import {Button} from '@sentry/scraps/button';
 
-import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/components/pageFilters/constants';
+import {
+  ALL_DATE_TIME_QUERY_KEYS,
+  URL_PARAM,
+} from 'sentry/components/pageFilters/constants';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconUpload} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -35,7 +38,7 @@ export function getExploreShareLink({
     if (!range) {
       return;
     }
-    for (const key of DATE_TIME_KEYS) {
+    for (const key of ALL_DATE_TIME_QUERY_KEYS) {
       if (key !== URL_PARAM.UTC) {
         params.delete(key);
       }

--- a/static/app/views/explore/components/exploreShareButton.tsx
+++ b/static/app/views/explore/components/exploreShareButton.tsx
@@ -1,57 +1,57 @@
 import type {Location} from 'history';
-import moment from 'moment-timezone';
 
-import {Button, type ButtonProps} from '@sentry/scraps/button';
+import {Button} from '@sentry/scraps/button';
 
-import {URL_PARAM} from 'sentry/components/pageFilters/constants';
+import {DATE_TIME_KEYS, URL_PARAM} from 'sentry/components/pageFilters/constants';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {IconUpload} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {PageFilterDatetime} from 'sentry/types/core';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getUtcDateString} from 'sentry/utils/dates';
-import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
+import {getAbsoluteRangeFromPeriod} from 'sentry/utils/duration/getAbsoluteRangeFromPeriod';
+import {getPageUrlWithParams} from 'sentry/utils/url/getPageUrlWithParams';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import type {TraceItemDataset} from 'sentry/views/explore/types';
 
-export function getExploreShareUrl({
+export function getExploreShareLink({
   datetime,
   location,
-  now = new Date(),
+  now = Date.now(),
 }: {
   datetime: PageFilterDatetime;
   location: Location;
-  now?: Date;
-}): string {
-  const url = new URL(location.pathname, window.location.origin);
-  const params = new URLSearchParams(location.search);
-
+  now?: number;
+}): {frozenRelativePeriod: boolean; url: string} {
   const hasAbsoluteRange = Boolean(datetime.start && datetime.end);
-  const periodHours = datetime.period ? parsePeriodToHours(datetime.period) : -1;
+  const range =
+    !hasAbsoluteRange && datetime.period
+      ? getAbsoluteRangeFromPeriod(datetime.period, now)
+      : null;
 
-  if (!hasAbsoluteRange && periodHours > 0) {
-    const end = moment(now);
-    const start = end.clone().subtract(periodHours, 'hours');
-    params.delete(URL_PARAM.PERIOD);
-    params.set(URL_PARAM.START, getUtcDateString(start));
-    params.set(URL_PARAM.END, getUtcDateString(end));
-  }
+  const url = getPageUrlWithParams(location, params => {
+    if (!range) {
+      return;
+    }
+    for (const key of DATE_TIME_KEYS) {
+      if (key !== URL_PARAM.UTC) {
+        params.delete(key);
+      }
+    }
+    params.set(URL_PARAM.START, getUtcDateString(range.start));
+    params.set(URL_PARAM.END, getUtcDateString(range.end));
+  });
 
-  url.search = params.toString();
-  return url.toString();
+  return {url, frozenRelativePeriod: range !== null};
 }
 
 type ExploreShareButtonProps = {
   traceItemDataset: TraceItemDataset;
-  size?: ButtonProps['size'];
 };
 
-export function ExploreShareButton({
-  traceItemDataset,
-  size = 'xs',
-}: ExploreShareButtonProps) {
+export function ExploreShareButton({traceItemDataset}: ExploreShareButtonProps) {
   const organization = useOrganization();
   const location = useLocation();
   const {selection} = usePageFilters();
@@ -59,23 +59,29 @@ export function ExploreShareButton({
 
   return (
     <Button
-      size={size}
+      size="xs"
       variant="secondary"
       icon={<IconUpload />}
       onClick={() => {
-        copy(getExploreShareUrl({datetime: selection.datetime, location}), {
+        const {url, frozenRelativePeriod} = getExploreShareLink({
+          datetime: selection.datetime,
+          location,
+        });
+        copy(url, {
           successMessage: t('Link copied to clipboard'),
           errorMessage: t('Failed to copy link'),
-        }).then(() => {
-          trackAnalytics('explore.share_link_copied', {
-            organization,
-            traceItemDataset,
-            frozen_relative_period: !selection.datetime.start && !selection.datetime.end,
-          });
+        }).then(copied => {
+          if (copied) {
+            trackAnalytics('explore.share_link_copied', {
+              organization,
+              traceItemDataset,
+              frozen_relative_period: frozenRelativePeriod,
+            });
+          }
         });
       }}
       tooltipProps={{
-        title: t('Copy a link to this view with the time range frozen.'),
+        title: t('Copy a link to this view with the current time range.'),
       }}
     >
       {t('Share')}

--- a/static/app/views/explore/components/exploreShareButton.tsx
+++ b/static/app/views/explore/components/exploreShareButton.tsx
@@ -1,0 +1,84 @@
+import type {Location} from 'history';
+import moment from 'moment-timezone';
+
+import {Button, type ButtonProps} from '@sentry/scraps/button';
+
+import {URL_PARAM} from 'sentry/components/pageFilters/constants';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {IconUpload} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {PageFilterDatetime} from 'sentry/types/core';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {getUtcDateString} from 'sentry/utils/dates';
+import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
+import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
+import {useLocation} from 'sentry/utils/useLocation';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {TraceItemDataset} from 'sentry/views/explore/types';
+
+export function getExploreShareUrl({
+  datetime,
+  location,
+  now = new Date(),
+}: {
+  datetime: PageFilterDatetime;
+  location: Location;
+  now?: Date;
+}): string {
+  const url = new URL(location.pathname, window.location.origin);
+  const params = new URLSearchParams(location.search);
+
+  const hasAbsoluteRange = Boolean(datetime.start && datetime.end);
+  const periodHours = datetime.period ? parsePeriodToHours(datetime.period) : -1;
+
+  if (!hasAbsoluteRange && periodHours > 0) {
+    const end = moment(now);
+    const start = end.clone().subtract(periodHours, 'hours');
+    params.delete(URL_PARAM.PERIOD);
+    params.set(URL_PARAM.START, getUtcDateString(start));
+    params.set(URL_PARAM.END, getUtcDateString(end));
+  }
+
+  url.search = params.toString();
+  return url.toString();
+}
+
+type ExploreShareButtonProps = {
+  traceItemDataset: TraceItemDataset;
+  size?: ButtonProps['size'];
+};
+
+export function ExploreShareButton({
+  traceItemDataset,
+  size = 'xs',
+}: ExploreShareButtonProps) {
+  const organization = useOrganization();
+  const location = useLocation();
+  const {selection} = usePageFilters();
+  const {copy} = useCopyToClipboard();
+
+  return (
+    <Button
+      size={size}
+      variant="secondary"
+      icon={<IconUpload />}
+      onClick={() => {
+        copy(getExploreShareUrl({datetime: selection.datetime, location}), {
+          successMessage: t('Link copied to clipboard'),
+          errorMessage: t('Failed to copy link'),
+        }).then(() => {
+          trackAnalytics('explore.share_link_copied', {
+            organization,
+            traceItemDataset,
+            frozen_relative_period: !selection.datetime.start && !selection.datetime.end,
+          });
+        });
+      }}
+      tooltipProps={{
+        title: t('Copy a link to this view with the time range frozen.'),
+      }}
+    >
+      {t('Share')}
+    </Button>
+  );
+}

--- a/static/app/views/explore/components/exports/exploreExportModalButton.spec.tsx
+++ b/static/app/views/explore/components/exports/exploreExportModalButton.spec.tsx
@@ -65,7 +65,7 @@ describe('ExploreExportModalButton', () => {
   it('opens the modal and fires onOpen when clicked', async () => {
     const {onOpen} = renderButton();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(onOpen).toHaveBeenCalled();
@@ -74,7 +74,7 @@ describe('ExploreExportModalButton', () => {
   it('fires onClose with escape_key when closed via Escape', async () => {
     const {onClose} = renderButton();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
 
     await userEvent.keyboard('{Escape}');
@@ -87,7 +87,7 @@ describe('ExploreExportModalButton', () => {
   it('fires onClose once with cancel_button when the Cancel button is clicked', async () => {
     const {onClose} = renderButton();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Cancel'}));
 
     await waitFor(() => {
@@ -99,7 +99,7 @@ describe('ExploreExportModalButton', () => {
   it('disables the button with a tooltip when data is empty', async () => {
     renderButton({isDataEmpty: true});
 
-    const button = screen.getByRole('button', {name: 'Export Data'});
+    const button = screen.getByRole('button', {name: 'Export'});
     expect(button).toBeDisabled();
     await userEvent.hover(button);
     expect(await screen.findByText('No data to export')).toBeInTheDocument();

--- a/static/app/views/explore/components/exports/exploreExportModalButton.tsx
+++ b/static/app/views/explore/components/exports/exploreExportModalButton.tsx
@@ -77,7 +77,7 @@ export function ExploreExportModalButton({
           : t('Configure export options before starting your export.'),
       }}
     >
-      {t('Export Data')}
+      {t('Export')}
     </Button>
   );
 }

--- a/static/app/views/explore/errors/body.tsx
+++ b/static/app/views/explore/errors/body.tsx
@@ -4,7 +4,6 @@ import {Flex} from '@sentry/scraps/layout';
 import {IconDownload, IconSettings} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
-import {ExploreShareButton} from 'sentry/views/explore/components/exploreShareButton';
 import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
 import {
   ExploreContentSection,
@@ -13,7 +12,6 @@ import {
 import {ErrorsCharts} from 'sentry/views/explore/errors/charts';
 import {ErrorsToolbar} from 'sentry/views/explore/errors/toolbar';
 import {ChevronButton} from 'sentry/views/explore/spans/spansTab';
-import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface ErrorsControlSectionProps {
   controlSectionExpanded: boolean;
@@ -59,7 +57,6 @@ export function ErrorsContentSection({
           {controlSectionExpanded ? null : t('Advanced')}
         </ChevronButton>
         <Flex gap="xs">
-          <ExploreShareButton traceItemDataset={TraceItemDataset.ERRORS} />
           <Button size="xs" aria-label={t('Export data')} icon={<IconDownload />}>
             {t('Export')}
           </Button>

--- a/static/app/views/explore/errors/body.tsx
+++ b/static/app/views/explore/errors/body.tsx
@@ -4,6 +4,7 @@ import {Flex} from '@sentry/scraps/layout';
 import {IconDownload, IconSettings} from 'sentry/icons';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {t} from 'sentry/locale';
+import {ExploreShareButton} from 'sentry/views/explore/components/exploreShareButton';
 import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
 import {
   ExploreContentSection,
@@ -12,6 +13,7 @@ import {
 import {ErrorsCharts} from 'sentry/views/explore/errors/charts';
 import {ErrorsToolbar} from 'sentry/views/explore/errors/toolbar';
 import {ChevronButton} from 'sentry/views/explore/spans/spansTab';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 
 interface ErrorsControlSectionProps {
   controlSectionExpanded: boolean;
@@ -57,6 +59,7 @@ export function ErrorsContentSection({
           {controlSectionExpanded ? null : t('Advanced')}
         </ChevronButton>
         <Flex gap="xs">
+          <ExploreShareButton traceItemDataset={TraceItemDataset.ERRORS} />
           <Button size="xs" aria-label={t('Export data')} icon={<IconDownload />}>
             {t('Export')}
           </Button>

--- a/static/app/views/explore/logs/exports/logsAggregateExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsAggregateExportModalButton.spec.tsx
@@ -5,6 +5,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
@@ -102,8 +103,10 @@ describe('LogsAggregateExportModalButton', () => {
     });
 
     renderButton();
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(mockDownloadFromHref).toHaveBeenCalled();
@@ -119,8 +122,10 @@ describe('LogsAggregateExportModalButton', () => {
     });
 
     renderButton(nextPageLink);
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(exportRequest).toHaveBeenCalledWith(
@@ -142,8 +147,10 @@ describe('LogsAggregateExportModalButton', () => {
     });
 
     renderButton(lastPageLinks);
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(exportRequest).toHaveBeenCalled();

--- a/static/app/views/explore/logs/exports/logsDirectExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsDirectExportModalButton.spec.tsx
@@ -7,6 +7,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
@@ -101,8 +102,10 @@ describe('LogsDirectExportModalButton', () => {
     );
     renderGlobalModal();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(exportRequest).toHaveBeenCalledWith(
@@ -140,8 +143,10 @@ describe('LogsDirectExportModalButton', () => {
     );
     renderGlobalModal();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(exportRequest).toHaveBeenCalled();

--- a/static/app/views/explore/logs/exports/logsExportModalButton.spec.tsx
+++ b/static/app/views/explore/logs/exports/logsExportModalButton.spec.tsx
@@ -61,7 +61,7 @@ describe('LogsExportModalButton', () => {
       {organization}
     );
     renderGlobalModal();
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
   }
 

--- a/static/app/views/explore/logs/logsTab.tsx
+++ b/static/app/views/explore/logs/logsTab.tsx
@@ -28,6 +28,7 @@ import {parsePeriodToHours} from 'sentry/utils/duration/parsePeriodToHours';
 import {HOUR} from 'sentry/utils/formatters';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {ExploreShareButton} from 'sentry/views/explore/components/exploreShareButton';
 import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
 import {
   ExploreBodyContent,
@@ -496,20 +497,23 @@ function LogsTabContentInner({datePageFilterProps}: LogsTabProps) {
                   {sidebarOpen ? null : t('Advanced')}
                 </LogsSidebarCollapseButton>
               </Container>
-              {mode === Mode.AGGREGATE ? (
-                <LogsAggregateExportModalButton
-                  isLoading={aggregatesTableResult.isPending}
-                  tableData={aggregatesTableResult.data?.data ?? []}
-                  error={aggregatesTableResult.error}
-                  pageLinks={aggregatesTableResult.pageLinks}
-                />
-              ) : (
-                <LogsDirectExportModalButton
-                  isLoading={tableData.isPending}
-                  tableData={tableData.data}
-                  error={tableData.error}
-                />
-              )}
+              <Flex gap="xs">
+                <ExploreShareButton traceItemDataset={TraceItemDataset.LOGS} />
+                {mode === Mode.AGGREGATE ? (
+                  <LogsAggregateExportModalButton
+                    isLoading={aggregatesTableResult.isPending}
+                    tableData={aggregatesTableResult.data?.data ?? []}
+                    error={aggregatesTableResult.error}
+                    pageLinks={aggregatesTableResult.pageLinks}
+                  />
+                ) : (
+                  <LogsDirectExportModalButton
+                    isLoading={tableData.isPending}
+                    tableData={tableData.data}
+                    error={tableData.error}
+                  />
+                )}
+              </Flex>
             </OverChartButtonGroup>
             <QuotaExceededAlert referrer="logs-explore" traceItemDataset="logs" />
             <LogsDownSamplingAlert

--- a/static/app/views/explore/logs/tables/logsTableRow.tsx
+++ b/static/app/views/explore/logs/tables/logsTableRow.tsx
@@ -34,6 +34,7 @@ import {normalizeTimestampToSeconds} from 'sentry/utils/dates';
 import {defined} from 'sentry/utils/defined';
 import type {EventsMetaType} from 'sentry/utils/discover/eventView';
 import {FieldValueType} from 'sentry/utils/fields';
+import {getPageUrlWithParams} from 'sentry/utils/url/getPageUrlWithParams';
 import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';
 import {useLocation} from 'sentry/utils/useLocation';
@@ -717,27 +718,28 @@ export const LogRowContent = memo(function LogRowContentImpl({
                           break;
                         case Actions.COPY_LINK: {
                           const logId = String(dataRow[OurLogKnownFieldKey.ID]);
-                          const url = new URL(window.location.origin + location.pathname);
-                          const params = new URLSearchParams(location.search);
                           // In frozen/embedded views (e.g. trace details) the row set is
                           // bounded, so link to the row and let it highlight + expand in
                           // context. On the standalone logs page the row may not be loaded,
                           // so filter to it instead.
-                          if (isFrozen) {
-                            params.set(LOGS_ROW_ID_KEY, logId);
-                          } else {
-                            params.set(LOGS_QUERY_KEY, `id:${logId}`);
-                            params.delete(LOGS_ROW_ID_KEY);
-                          }
-                          url.search = params.toString();
-                          copy(url.toString(), {
+                          const url = getPageUrlWithParams(location, params => {
+                            if (isFrozen) {
+                              params.set(LOGS_ROW_ID_KEY, logId);
+                            } else {
+                              params.set(LOGS_QUERY_KEY, `id:${logId}`);
+                              params.delete(LOGS_ROW_ID_KEY);
+                            }
+                          });
+                          copy(url, {
                             successMessage: t('Copied!'),
                             errorMessage: t('Failed to copy'),
-                          }).then(() => {
-                            trackAnalytics('logs.table.row_link_copied', {
-                              log_id: logId,
-                              organization,
-                            });
+                          }).then(copied => {
+                            if (copied) {
+                              trackAnalytics('logs.table.row_link_copied', {
+                                log_id: logId,
+                                organization,
+                              });
+                            }
                           });
                           break;
                         }

--- a/static/app/views/explore/metrics/exports/metricsAggregateExportModalButton.spec.tsx
+++ b/static/app/views/explore/metrics/exports/metricsAggregateExportModalButton.spec.tsx
@@ -8,6 +8,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -118,8 +119,10 @@ describe('MetricsAggregateExportModalButton', () => {
     });
 
     renderButton();
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(mockDownloadFromHref).toHaveBeenCalled();
@@ -135,8 +138,10 @@ describe('MetricsAggregateExportModalButton', () => {
     });
 
     renderButton({pageLinks: nextPageLink});
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(exportRequest).toHaveBeenCalledWith(
@@ -161,12 +166,12 @@ describe('MetricsAggregateExportModalButton', () => {
   it('disables the button when the table has no rows', () => {
     renderButton({rows: []});
 
-    expect(screen.getByRole('button', {name: 'Export Data'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Export'})).toBeDisabled();
   });
 
   it('disables the button when the table errored', () => {
     renderButton({isError: true});
 
-    expect(screen.getByRole('button', {name: 'Export Data'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Export'})).toBeDisabled();
   });
 });

--- a/static/app/views/explore/metrics/exports/metricsSamplesExportModalButton.spec.tsx
+++ b/static/app/views/explore/metrics/exports/metricsSamplesExportModalButton.spec.tsx
@@ -8,6 +8,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -100,8 +101,10 @@ describe('MetricsSamplesExportModalButton', () => {
     });
 
     renderButton();
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(exportRequest).toHaveBeenCalled();
@@ -198,12 +201,12 @@ describe('MetricsSamplesExportModalButton', () => {
   it('disables the button when the table has no rows', () => {
     renderButton({rows: []});
 
-    expect(screen.getByRole('button', {name: 'Export Data'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Export'})).toBeDisabled();
   });
 
   it('disables the button when the table errored', () => {
     renderButton({isError: true});
 
-    expect(screen.getByRole('button', {name: 'Export Data'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Export'})).toBeDisabled();
   });
 });

--- a/static/app/views/explore/metrics/metricPanel/index.tsx
+++ b/static/app/views/explore/metrics/metricPanel/index.tsx
@@ -3,7 +3,7 @@ import type {DraggableAttributes} from '@dnd-kit/core';
 import type {SyntheticListenerMap} from '@dnd-kit/core/dist/hooks/utilities';
 
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {Text} from '@sentry/scraps/text';
 
@@ -20,6 +20,7 @@ import {
 import {useDimensions} from 'sentry/utils/useDimensions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {calculateHeatMapBucketDimensions} from 'sentry/views/dashboards/widgets/heatMapWidget/utils/calculateHeatMapBucketDimensions';
+import {ExploreShareButton} from 'sentry/views/explore/components/exploreShareButton';
 import {EXPLORE_FIVE_MIN_STALE_TIME} from 'sentry/views/explore/constants';
 import {useMetricsPanelAnalytics} from 'sentry/views/explore/hooks/useAnalytics';
 import {useMetricOptions} from 'sentry/views/explore/hooks/useMetricOptions';
@@ -65,6 +66,7 @@ import {
   isVisualizeEquation,
   isVisualizeFunction,
 } from 'sentry/views/explore/queryParams/visualize';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {ChartType} from 'sentry/views/insights/common/components/chart';
 
 const RESULT_LIMIT = 50;
@@ -345,23 +347,28 @@ export function MetricPanel({
                         traceMetric={traceMetric}
                         isMetricOptionsEmpty={isMetricOptionsEmpty}
                         additionalActions={
-                          mode === Mode.AGGREGATE ? (
-                            <MetricsAggregateExportModalButton
-                              isError={metricAggregatesTableResult.result.isError}
-                              isLoading={metricAggregatesTableResult.result.isPending}
-                              pageLinks={metricAggregatesTableResult.result.pageLinks}
-                              tableData={metricAggregatesTableResult.result.data ?? []}
-                              traceMetric={traceMetric}
+                          <Flex gap="xs">
+                            <ExploreShareButton
+                              traceItemDataset={TraceItemDataset.TRACEMETRICS}
                             />
-                          ) : (
-                            <MetricsSamplesExportModalButton
-                              fields={fields}
-                              isError={Boolean(metricSamplesTableResult.isError)}
-                              isLoading={Boolean(metricSamplesTableResult.isPending)}
-                              tableData={metricSamplesTableResult.result.data ?? []}
-                              traceMetric={traceMetric}
-                            />
-                          )
+                            {mode === Mode.AGGREGATE ? (
+                              <MetricsAggregateExportModalButton
+                                isError={metricAggregatesTableResult.result.isError}
+                                isLoading={metricAggregatesTableResult.result.isPending}
+                                pageLinks={metricAggregatesTableResult.result.pageLinks}
+                                tableData={metricAggregatesTableResult.result.data ?? []}
+                                traceMetric={traceMetric}
+                              />
+                            ) : (
+                              <MetricsSamplesExportModalButton
+                                fields={fields}
+                                isError={Boolean(metricSamplesTableResult.isError)}
+                                isLoading={Boolean(metricSamplesTableResult.isPending)}
+                                tableData={metricSamplesTableResult.result.data ?? []}
+                                traceMetric={traceMetric}
+                              />
+                            )}
+                          </Flex>
                         }
                       />
                     </Container>

--- a/static/app/views/explore/spans/spansTab.tsx
+++ b/static/app/views/explore/spans/spansTab.tsx
@@ -28,6 +28,7 @@ import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useChartInterval} from 'sentry/utils/useChartInterval';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {ChartSelectionProvider} from 'sentry/views/explore/components/attributeBreakdowns/chartSelectionContext';
+import {ExploreShareButton} from 'sentry/views/explore/components/exploreShareButton';
 import {OverChartButtonGroup} from 'sentry/views/explore/components/overChartButtonGroup';
 import {
   ExploreBodyContent,
@@ -69,6 +70,7 @@ import {ExploreSpansTour, ExploreSpansTourContext} from 'sentry/views/explore/sp
 import {TracesExportModalButton} from 'sentry/views/explore/spans/tracesExportModalButton';
 import {ExploreTables} from 'sentry/views/explore/tables';
 import {ExploreToolbar} from 'sentry/views/explore/toolbar';
+import {TraceItemDataset} from 'sentry/views/explore/types';
 import {useRawCounts} from 'sentry/views/explore/useRawCounts';
 import {Onboarding} from 'sentry/views/performance/onboarding';
 import {useLLMContext} from 'sentry/views/seerExplorer/contexts/llmContext';
@@ -324,6 +326,7 @@ function SpanTabContentSectionInner({
           {controlSectionExpanded ? null : t('Advanced')}
         </ChevronButton>
         <Flex gap="xs">
+          <ExploreShareButton traceItemDataset={TraceItemDataset.SPANS} />
           <TracesExportModalButton
             aggregatesTableResult={aggregatesTableResult}
             spansTableResult={spansTableResult}

--- a/static/app/views/explore/spans/tracesExportModalButton.spec.tsx
+++ b/static/app/views/explore/spans/tracesExportModalButton.spec.tsx
@@ -10,6 +10,7 @@ import {
   screen,
   userEvent,
   waitFor,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import type {ResponseMeta} from 'sentry/types/api';
@@ -114,7 +115,7 @@ describe('TracesExportModalButton', () => {
   it('does not render the All Columns switch when the modal is opened', async () => {
     renderButton();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
 
     expect(await screen.findByRole('dialog')).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Traces Export'})).toBeInTheDocument();
@@ -145,7 +146,7 @@ describe('TracesExportModalButton', () => {
       }
     );
 
-    expect(screen.getByRole('button', {name: 'Export Data'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Export'})).toBeDisabled();
   });
 
   it('does not surface the aggregates table state in the tooltip on a non-exportable tab', async () => {
@@ -170,7 +171,7 @@ describe('TracesExportModalButton', () => {
       }
     );
 
-    const button = screen.getByRole('button', {name: 'Export Data'});
+    const button = screen.getByRole('button', {name: 'Export'});
     expect(button).toBeDisabled();
 
     await userEvent.hover(button);
@@ -215,8 +216,10 @@ describe('TracesExportModalButton', () => {
     );
     renderGlobalModal();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(dataExportMock).toHaveBeenCalledWith(
@@ -261,8 +264,10 @@ describe('TracesExportModalButton', () => {
     );
     renderGlobalModal();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(downloadAsCsv).toHaveBeenCalledTimes(1);
@@ -278,8 +283,10 @@ describe('TracesExportModalButton', () => {
       totalCount: 2,
     });
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
-    await userEvent.click(await screen.findByRole('button', {name: 'Export'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(await screen.findByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(downloadAsCsv).toHaveBeenCalledTimes(1);
@@ -296,10 +303,12 @@ describe('TracesExportModalButton', () => {
 
     renderButton();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Number of rows'}));
     await userEvent.click(await screen.findByRole('option', {name: /\(All\)$/}));
-    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(dataExportMock).toHaveBeenCalled();
@@ -327,10 +336,12 @@ describe('TracesExportModalButton', () => {
 
     renderButton({totalCount: null});
 
-    await userEvent.click(screen.getByRole('button', {name: 'Export Data'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
     await userEvent.click(await screen.findByRole('button', {name: 'Number of rows'}));
     await userEvent.click(await screen.findByRole('option', {name: '10,000'}));
-    await userEvent.click(screen.getByRole('button', {name: 'Export'}));
+    await userEvent.click(
+      within(screen.getByRole('dialog')).getByRole('button', {name: 'Export'})
+    );
 
     await waitFor(() => {
       expect(dataExportMock).toHaveBeenCalledWith(


### PR DESCRIPTION
This PR adds a _Share_ button to the left of the export button on the Logs, Traces, and Metrics tabs. Clicking it copies the current view to the clipboard with any relative period replaced by absolute `start`/`end` values, so the recipient sees the same chart regardless of open time.

<table>
<thead><tr><th></th><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>Logs</td><td><img src="https://github.com/user-attachments/assets/42e60449-a55a-4f15-9b7b-d67b2f90ad23" alt="Logs before"></td><td><img src="https://github.com/user-attachments/assets/8a4175fc-7aae-48ab-9e5c-cb975f0551b3" alt="Logs after"></td></tr>
<tr><td>Traces</td><td><img src="https://github.com/user-attachments/assets/e0baa82d-4f08-411d-8a62-96ead8bc9557" alt="Traces before"></td><td><img src="https://github.com/user-attachments/assets/61e0f8f3-6493-486e-b389-d87cd6a0cdff" alt="Traces after"></td></tr>
<tr><td>Metrics</td><td><img src="https://github.com/user-attachments/assets/9edb7d66-7295-4288-a856-32102f26bc7c" alt="Metrics before"></td><td><img src="https://github.com/user-attachments/assets/45306af9-d8b7-486b-8a70-63346ec144a9" alt="Metrics after"></td></tr>
</tbody>
</table>

Design: [Figma](https://www.figma.com/design/zwH7VEk2Ff18WfFoT9J66s/%F0%9F%94%8D-Explore?node-id=2578-4897)

Closes LOGS-942.