### PR TITLE
ref(hybridcloud): Derive total_outbox_count from category depths

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
+++ b/src/sentry/hybridcloud/tasks/deliver_from_outbox.py
@@ -153,16 +153,21 @@ def schedule_outbox_model(
     if options.get("hybridcloud.outbox.deep_shard_logging.enabled"):
         _log_deep_shards(outbox_model, deepest_shards, metrics_tags)
 
-    outbox_count = outbox_model.get_total_outbox_count()
+    # The per-category depths cover every row, so their sum is the total count
+    # and saves a second full scan of the table.
+    if options.get("hybridcloud.outbox.category_depth_metric.enabled"):
+        category_depths = outbox_model.get_category_depths()
+        _record_category_depths(silo_mode, outbox_model, category_depths)
+        outbox_count = sum(category_depths.values())
+    else:
+        outbox_count = outbox_model.get_total_outbox_count()
+
     metrics.gauge(
         "deliver_from_outbox.total_outbox_count",
         value=outbox_count,
         tags=metrics_tags,
         sample_rate=1.0,
     )
-
-    if options.get("hybridcloud.outbox.category_depth_metric.enabled"):
-        _record_category_depths(silo_mode, outbox_model)
     return scheduled_count
 
 
@@ -190,8 +195,9 @@ def _log_deep_shards(
         )
 
 
-def _record_category_depths(silo_mode: SiloMode, outbox_model: type[OutboxBase]) -> None:
-    category_depths = outbox_model.get_category_depths()
+def _record_category_depths(
+    silo_mode: SiloMode, outbox_model: type[OutboxBase], category_depths: Mapping[int, int]
+) -> None:
     for category, depth in category_depths.items():
         metrics.gauge(
             "deliver_from_outbox.category_shard_depth",

--- a/tests/sentry/hybridcloud/models/test_outbox.py
+++ b/tests/sentry/hybridcloud/models/test_outbox.py
@@ -888,3 +888,46 @@ class OutboxAggregationTest(TestCase):
             warning_call.args and warning_call.args[0] == "deliver_from_outbox.deep_shard"
             for warning_call in mock_logger.warning.mock_calls
         )
+
+    @patch("sentry.hybridcloud.tasks.deliver_from_outbox.metrics")
+    def test_total_outbox_count_derived_from_category_depths(self, mock_metrics: Mock) -> None:
+        with patch.object(
+            ControlOutbox, "get_total_outbox_count", wraps=ControlOutbox.get_total_outbox_count
+        ) as mock_count:
+            schedule_outbox_model(
+                silo_mode=SiloMode.CONTROL,
+                outbox_model=ControlOutbox,
+                drain_task=Mock(),
+            )
+
+        mock_count.assert_not_called()
+        total_calls = [
+            gauge_call
+            for gauge_call in mock_metrics.gauge.mock_calls
+            if gauge_call.args and gauge_call.args[0] == "deliver_from_outbox.total_outbox_count"
+        ]
+        assert len(total_calls) == 1
+        assert total_calls[0].kwargs["value"] == 7 + 4 + 1
+
+    @override_options({"hybridcloud.outbox.category_depth_metric.enabled": False})
+    @patch("sentry.hybridcloud.tasks.deliver_from_outbox.metrics")
+    def test_total_outbox_count_falls_back_when_category_metric_disabled(
+        self, mock_metrics: Mock
+    ) -> None:
+        with patch.object(
+            ControlOutbox, "get_total_outbox_count", wraps=ControlOutbox.get_total_outbox_count
+        ) as mock_count:
+            schedule_outbox_model(
+                silo_mode=SiloMode.CONTROL,
+                outbox_model=ControlOutbox,
+                drain_task=Mock(),
+            )
+
+        mock_count.assert_called_once()
+        total_calls = [
+            gauge_call
+            for gauge_call in mock_metrics.gauge.mock_calls
+            if gauge_call.args and gauge_call.args[0] == "deliver_from_outbox.total_outbox_count"
+        ]
+        assert len(total_calls) == 1
+        assert total_calls[0].kwargs["value"] == 7 + 4 + 1


### PR DESCRIPTION
## What

Stacked on #123466. When the `category_shard_depth` gauge is enabled, the `total_outbox_count` gauge now uses `sum(get_category_depths().values())` instead of a separate `get_total_outbox_count()` query. When the category metric is disabled via `hybridcloud.outbox.category_depth_metric.enabled`, it falls back to the plain `COUNT(*)` as before.

`_record_category_depths` takes the precomputed depths as a parameter rather than querying itself.

## Why

`get_category_depths()` groups every row in the table by category, so its sum is exactly the total count. Running both was two full scans of the outbox table per scheduler tick for the same information; this drops one with no change to the emitted values.

Part of CTRL-2.