### PR TITLE
feat(event formatter): render the event's extra data

### DIFF
--- a/src/sentry/issues/formatting/adapter.py
+++ b/src/sentry/issues/formatting/adapter.py
@@ -20,7 +20,7 @@ from sentry.issues.formatting.models import (
     Stacktrace,
     ThreadDetails,
     UserDetails,
-    contains_filtered,
+    drop_scrubbed,
 )
 from sentry.utils import json
 
@@ -188,14 +188,23 @@ def _extra(data: Mapping[str, Any]) -> list[tuple[str, str]]:
     """The response's ``context``: the ``extra`` data a customer's instrumentation attached.
 
     Distinct from ``contexts``, which is Sentry's own structured device/os/runtime data. Values
-    are arbitrary, so containers are serialized rather than str()'d, and scrubbed values are
-    dropped the way the breadcrumb and feedback paths drop theirs.
+    are arbitrary, so containers are serialized rather than str()'d.
+
+    ``context`` is typed as a mapping but arrives unvalidated, and the adapter runs before any
+    section: raising here would take down the whole render rather than this one block, which is
+    the same trap ``_contexts`` guards against.
     """
+    context = data.get("context")
+    if not isinstance(context, Mapping):
+        return []
+
     pairs: list[tuple[str, str]] = []
-    for key, value in (data.get("context") or {}).items():
-        if not key or value is None or contains_filtered(value):
+    for key, value in context.items():
+        # scrub per leaf rather than per entry, so one filtered key does not drop its siblings
+        cleaned = drop_scrubbed(value)
+        if not key or cleaned is None:
             continue
-        rendered = value if isinstance(value, str) else json.dumps(value)
+        rendered = cleaned if isinstance(cleaned, str) else json.dumps(cleaned)
         pairs.append((str(key), rendered))
     return pairs
 

--- a/src/sentry/issues/formatting/adapter.py
+++ b/src/sentry/issues/formatting/adapter.py
@@ -20,7 +20,9 @@ from sentry.issues.formatting.models import (
     Stacktrace,
     ThreadDetails,
     UserDetails,
+    contains_filtered,
 )
+from sentry.utils import json
 
 
 def _entries_by_type(data: Mapping[str, Any]) -> dict[str, Any]:
@@ -182,6 +184,22 @@ def _metric_alert(data: Mapping[str, Any]) -> list[tuple[str, str]]:
     return [(label, str(v)) for label, v in candidates if v is not None and str(v) != ""]
 
 
+def _extra(data: Mapping[str, Any]) -> list[tuple[str, str]]:
+    """The response's ``context``: the ``extra`` data a customer's instrumentation attached.
+
+    Distinct from ``contexts``, which is Sentry's own structured device/os/runtime data. Values
+    are arbitrary, so containers are serialized rather than str()'d, and scrubbed values are
+    dropped the way the breadcrumb and feedback paths drop theirs.
+    """
+    pairs: list[tuple[str, str]] = []
+    for key, value in (data.get("context") or {}).items():
+        if not key or value is None or contains_filtered(value):
+            continue
+        rendered = value if isinstance(value, str) else json.dumps(value)
+        pairs.append((str(key), rendered))
+    return pairs
+
+
 def event_response_to_model(data: Mapping[str, Any]) -> EventObject:
     entries = _entries_by_type(data)
     tags, transaction_name = _tags(data)
@@ -218,4 +236,5 @@ def event_response_to_model(data: Mapping[str, Any]) -> EventObject:
         spans=[EvidenceSpan.parse_obj(s) for s in entries.get("spans") or []],
         evidence=_evidence(data),
         metric_alert=_metric_alert(data),
+        extra=_extra(data),
     )

--- a/src/sentry/issues/formatting/models.py
+++ b/src/sentry/issues/formatting/models.py
@@ -40,6 +40,12 @@ def _drop_filtered(value: Any) -> Any:
     return kept_entries or _DROP
 
 
+def drop_scrubbed(value: Any) -> Any | None:
+    """``_drop_filtered`` for callers outside this module: ``None`` when nothing survives."""
+    cleaned = _drop_filtered(value)
+    return None if cleaned is _DROP else cleaned
+
+
 class Frame(BaseModel):
     # accept the serialized camelCase keys (absPath, lineNo, ...) via aliases,
     # while still allowing snake_case construction in-code

--- a/src/sentry/issues/formatting/models.py
+++ b/src/sentry/issues/formatting/models.py
@@ -165,4 +165,6 @@ class EventObject(BaseModel):
     evidence: list[tuple[str, str]] = []
     # the alert definition behind a metric issue, as ordered label/value pairs
     metric_alert: list[tuple[str, str]] = []
+    # the response's ``context``: data the customer's own instrumentation attached
+    extra: list[tuple[str, str]] = []
     culprit: str | None = None

--- a/src/sentry/issues/formatting/sections.py
+++ b/src/sentry/issues/formatting/sections.py
@@ -310,6 +310,17 @@ def evidence_section(model: EventObject, limits: Limits) -> Section | None:
     )
 
 
+def extra_section(model: EventObject, limits: Limits) -> Section | None:
+    # the response's ``context``: whatever the customer's instrumentation attached
+    if not model.extra:
+        return None
+    items = tuple(Field(key, value) for key, value in model.extra)
+    return Section(
+        title="Extra Data",
+        groups=(Group(items=items, max_chars=limits.max_contexts_chars),),
+    )
+
+
 def contexts_section(model: EventObject, limits: Limits) -> Section | None:
     groups: list[Group] = []
     for name, data in model.contexts.items():
@@ -344,13 +355,15 @@ EVENT_SECTIONS_WITH_USER: list[SectionFn] = [
     request_section,
     tags_section,
     user_section,
+    extra_section,
     contexts_section,
 ]
 
-# sections that render a user identifier: ``user_section``'s email/IP/username/ID, and the device
+# sections that render a user identifier: ``user_section``'s email/IP/username/ID, the device
 # and session ids that ride along in contexts (device_unique_identifier, replay.replay_id, and
-# whatever a custom context defines -- there is no safe key list for an open-ended mapping).
-_USER_IDENTIFYING_SECTIONS = frozenset({user_section, contexts_section})
+# whatever a custom context defines -- there is no safe key list for an open-ended mapping),
+# and ``extra_section``, which is the same open-ended shape but filled by the customer.
+_USER_IDENTIFYING_SECTIONS = frozenset({user_section, contexts_section, extra_section})
 
 # the default. Rendered output is bound for an LLM, so user identifiers are opt-in -- a caller
 # that doesn't think about it can't leak them into a prompt.

--- a/tests/sentry/issues/formatting/test_adapter.py
+++ b/tests/sentry/issues/formatting/test_adapter.py
@@ -503,3 +503,18 @@ def test_extra_is_held_back_from_the_default_sections() -> None:
     event = _event_with_extra(shardId=7)
     assert "Extra Data" not in format_issue(event)
     assert "Extra Data" in format_issue(event, sections=EVENT_SECTIONS_WITH_USER)
+
+
+def test_extra_scrubs_per_leaf_not_per_entry() -> None:
+    # one filtered key must not take its siblings with it
+    model = event_response_to_model(_event_with_extra(cfg={"token": "[Filtered]", "region": "us"}))
+    assert model.extra == [("cfg", '{"region":"us"}')]
+
+
+def test_extra_survives_a_malformed_context() -> None:
+    # the adapter runs before any section, so raising here would render the whole event as ""
+    for bad in ("a string", ["a", "list"], 7):
+        data: dict[str, Any] = {"title": "ValueError: x", "context": bad}
+        out = format_issue(data, sections=EVENT_SECTIONS_WITH_USER)
+        assert "ValueError: x" in out, f"context={bad!r} sank the render"
+        assert "Extra Data" not in out

--- a/tests/sentry/issues/formatting/test_adapter.py
+++ b/tests/sentry/issues/formatting/test_adapter.py
@@ -469,3 +469,37 @@ def test_metric_alert_renders_in_the_output() -> None:
     assert "## Metric Alert Details" in out
     assert "**Aggregate:** p95(span.duration)" in out
     assert "**Threshold:** above 500" in out
+
+
+def _event_with_extra(**context: Any) -> dict[str, Any]:
+    return {"title": "ValueError: x", "context": context}
+
+
+def test_extra_maps_the_response_context() -> None:
+    model = event_response_to_model(
+        _event_with_extra(shardId=7, note="retry after backoff", flags=["a", "b"])
+    )
+    # containers are serialized rather than str()'d, so the value stays machine readable
+    assert model.extra == [
+        ("shardId", "7"),
+        ("note", "retry after backoff"),
+        ("flags", '["a","b"]'),
+    ]
+
+
+def test_extra_drops_scrubbed_and_empty_values() -> None:
+    model = event_response_to_model(_event_with_extra(secret="[Filtered]", missing=None, kept=1))
+    assert model.extra == [("kept", "1")]
+
+
+def test_extra_absent_when_there_is_no_context() -> None:
+    assert event_response_to_model({"title": "t"}).extra == []
+    assert event_response_to_model({"title": "t", "context": {}}).extra == []
+
+
+def test_extra_is_held_back_from_the_default_sections() -> None:
+    # the same open-ended shape as contexts, but filled by the customer's own instrumentation,
+    # so it is opt-in rather than in the list a caller gets without thinking about it
+    event = _event_with_extra(shardId=7)
+    assert "Extra Data" not in format_issue(event)
+    assert "Extra Data" in format_issue(event, sections=EVENT_SECTIONS_WITH_USER)

--- a/tests/sentry/issues/formatting/test_sections.py
+++ b/tests/sentry/issues/formatting/test_sections.py
@@ -33,6 +33,7 @@ from sentry.issues.formatting.sections import (
     detection_context_section,
     evidence_section,
     exceptions_section,
+    extra_section,
     format_issue,
     message_section,
     request_section,
@@ -498,7 +499,9 @@ def test_user_identifiers_are_opt_in() -> None:
     assert user_section in EVENT_SECTIONS_WITH_USER
     # opting in changes nothing else about the render order
     assert [s.__name__ for s in EVENT_SECTIONS] == [
-        s.__name__ for s in EVENT_SECTIONS_WITH_USER if s not in (user_section, contexts_section)
+        s.__name__
+        for s in EVENT_SECTIONS_WITH_USER
+        if s not in (user_section, contexts_section, extra_section)
     ]
 
     data = {"title": "t", "user": {"email": "someone@example.com", "ipAddress": "203.0.113.7"}}
@@ -655,3 +658,14 @@ def test_evidence_truncation_never_splits_markup() -> None:
             dataclasses.replace(LIMITS_DEFAULT, max_evidence_chars=cap),
         )
         ElementTree.fromstring(out)  # raises if a tag was split
+
+
+def test_extra_data_is_opt_in() -> None:
+    # ``context`` is the same open-ended shape as contexts, but filled by the customer's own
+    # instrumentation, so it follows the same rule rather than riding along in the default list
+    assert extra_section not in EVENT_SECTIONS
+    assert extra_section in EVENT_SECTIONS_WITH_USER
+
+    data = {"title": "t", "context": {"customerRef": "cus_9871", "shardId": 7}}
+    assert "cus_9871" not in format_issue(data)
+    assert "cus_9871" in format_issue(data, sections=EVENT_SECTIONS_WITH_USER)


### PR DESCRIPTION
The response's ``context`` was not mapped at all, so the "Extra Data" the MCP
renders (whatever a customer's own instrumentation attached) came out as
nothing. Distinct from ``contexts``, which is Sentry's own structured
device/os/runtime data and already had a section.

Held back from the default section list, alongside user_section and
contexts_section. It is the same open-ended mapping with no safe key list, and
the customer fills this one, so it is opt-in rather than something a caller
gets into an LLM prompt without deciding to. The REST consumers use
EVENT_SECTIONS_WITH_USER and still get it; Seer's default does not.

Container values are serialized rather than str()'d so they stay machine
readable, and scrubbed values are dropped the way the breadcrumb and feedback
paths drop theirs.

