### PR TITLE
feat(seer): Show PR iteration feedback status as a tag

### DIFF
--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -211,7 +211,6 @@ export interface ExplorerAutofixState {
     id: string;
     input_type: 'file_change_approval' | 'ask_user_question';
   } | null;
-  // The outcome of each PR iteration, keyed by the iteration index as a string.
   pr_iteration_outcomes?: Record<string, string>;
   pr_iteration_paused?: boolean;
   queued_feedback?: RawFeedback[];

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -211,6 +211,8 @@ export interface ExplorerAutofixState {
     id: string;
     input_type: 'file_change_approval' | 'ask_user_question';
   } | null;
+  // The outcome of each PR iteration, keyed by the iteration index as a string.
+  pr_iteration_outcomes?: Record<string, string>;
   pr_iteration_paused?: boolean;
   queued_feedback?: RawFeedback[];
   repo_pr_states?: Record<string, RepoPRState>;

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1637,7 +1637,7 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.getByText('first pass')).toBeInTheDocument();
-      expect(screen.getByText('Seer cannot fix this failure')).toBeInTheDocument();
+      expect(screen.getByText('No changes')).toBeInTheDocument();
     });
 
     it('does not tag block feedback whose iteration made changes', () => {
@@ -1656,10 +1656,8 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.getByText('first pass')).toBeInTheDocument();
-      expect(screen.queryByText('Seer cannot fix this failure')).not.toBeInTheDocument();
-      expect(
-        screen.queryByText('Seer is working on this failure')
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('No changes')).not.toBeInTheDocument();
+      expect(screen.queryByText('Processing')).not.toBeInTheDocument();
     });
 
     it('does not tag block feedback that carries no iteration outcome', () => {
@@ -1678,10 +1676,8 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.getByText('first pass')).toBeInTheDocument();
-      expect(screen.queryByText('Seer cannot fix this failure')).not.toBeInTheDocument();
-      expect(
-        screen.queryByText('Seer is working on this failure')
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('No changes')).not.toBeInTheDocument();
+      expect(screen.queryByText('Processing')).not.toBeInTheDocument();
     });
 
     it('tags the current iteration feedback as in progress while processing', () => {
@@ -1701,8 +1697,8 @@ describe('ArtifactCard', () => {
 
       // The run status beats the stored outcome of the previous attempt.
       expect(screen.getByText('fix the CI failure')).toBeInTheDocument();
-      expect(screen.getByText('Seer is working on this failure')).toBeInTheDocument();
-      expect(screen.queryByText('Seer cannot fix this failure')).not.toBeInTheDocument();
+      expect(screen.getByText('Processing')).toBeInTheDocument();
+      expect(screen.queryByText('No changes')).not.toBeInTheDocument();
     });
 
     it('marks queued feedback with a queued label and no timestamp', () => {
@@ -1730,9 +1726,7 @@ describe('ArtifactCard', () => {
 
       expect(screen.getByText('Make the button blue')).toBeInTheDocument();
       expect(screen.getByText('Queued')).toBeInTheDocument();
-      expect(
-        screen.queryByText('Seer is working on this failure')
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Processing')).not.toBeInTheDocument();
     });
 
     it('disables reset once PRs exist when only automated CI iteration is enabled', () => {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1621,7 +1621,7 @@ describe('ArtifactCard', () => {
       expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
     });
 
-    it('tags block feedback whose iteration made no changes', () => {
+    it('tags block feedback whose iteration made no changes', async () => {
       render(
         <CodeChangesCard
           groupId="1"
@@ -1638,6 +1638,12 @@ describe('ArtifactCard', () => {
 
       expect(screen.getByText('first pass')).toBeInTheDocument();
       expect(screen.getByText('No changes')).toBeInTheDocument();
+
+      // The tooltip scopes the outcome to the iteration, not the single comment.
+      await userEvent.hover(screen.getByText('No changes'));
+      expect(
+        await screen.findByText('Seer made no code changes for this round of feedback.')
+      ).toBeInTheDocument();
     });
 
     it('does not tag block feedback whose iteration made changes', () => {
@@ -1680,7 +1686,7 @@ describe('ArtifactCard', () => {
       expect(screen.queryByText('Processing')).not.toBeInTheDocument();
     });
 
-    it('tags the current iteration feedback as in progress while processing', () => {
+    it('tags the current iteration feedback as in progress while processing', async () => {
       render(
         <CodeChangesCard
           groupId="1"
@@ -1699,6 +1705,11 @@ describe('ArtifactCard', () => {
       expect(screen.getByText('fix the CI failure')).toBeInTheDocument();
       expect(screen.getByText('Processing')).toBeInTheDocument();
       expect(screen.queryByText('No changes')).not.toBeInTheDocument();
+
+      await userEvent.hover(screen.getByText('Processing'));
+      expect(
+        await screen.findByText('Seer is working on this round of feedback.')
+      ).toBeInTheDocument();
     });
 
     it('marks queued feedback with a queued label and no timestamp', () => {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -1639,10 +1639,9 @@ describe('ArtifactCard', () => {
       expect(screen.getByText('first pass')).toBeInTheDocument();
       expect(screen.getByText('No changes')).toBeInTheDocument();
 
-      // The tooltip scopes the outcome to the iteration, not the single comment.
       await userEvent.hover(screen.getByText('No changes'));
       expect(
-        await screen.findByText('Seer made no code changes for this round of feedback.')
+        await screen.findByText('Seer made no code changes for this feedback.')
       ).toBeInTheDocument();
     });
 
@@ -1708,7 +1707,7 @@ describe('ArtifactCard', () => {
 
       await userEvent.hover(screen.getByText('Processing'));
       expect(
-        await screen.findByText('Seer is working on this round of feedback.')
+        await screen.findByText('Seer is working on this feedback.')
       ).toBeInTheDocument();
     });
 

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -55,7 +55,8 @@ function makeAssistantBlock(content: string | null): AutofixSection['blocks'][nu
 
 function makePrIterationBlock(
   iterationIndex: number,
-  feedback: {text: string; timestamp?: string; user?: any}
+  feedback: {text: string; timestamp?: string; user?: any},
+  iterationOutcome?: string
 ): AutofixSection['blocks'][number] {
   return {
     id: `block-pr-${iterationIndex}`,
@@ -66,6 +67,7 @@ function makePrIterationBlock(
       metadata: {
         step: 'pr_iteration',
         iteration_index: String(iterationIndex),
+        ...(iterationOutcome ? {iteration_outcome: iterationOutcome} : {}),
         feedback: JSON.stringify({
           text: feedback.text,
           timestamp: feedback.timestamp,
@@ -1619,7 +1621,48 @@ describe('ArtifactCard', () => {
       expect(screen.queryByText('Implementing changes…')).not.toBeInTheDocument();
     });
 
-    it('marks block feedback as processed when the section is not processing', () => {
+    it('tags block feedback whose iteration made no changes', () => {
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={mockAutofix}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [makePrIterationBlock(0, {text: 'first pass'}, 'no_changes')]
+          )}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('first pass')).toBeInTheDocument();
+      expect(screen.getByText('Seer cannot fix this failure')).toBeInTheDocument();
+    });
+
+    it('does not tag block feedback whose iteration made changes', () => {
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={mockAutofix}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [makePrIterationBlock(0, {text: 'first pass'}, 'changes_made')]
+          )}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('first pass')).toBeInTheDocument();
+      expect(screen.queryByText('Seer cannot fix this failure')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Seer is working on this failure')
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not tag block feedback that carries no iteration outcome', () => {
       render(
         <CodeChangesCard
           groupId="1"
@@ -1635,10 +1678,13 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.getByText('first pass')).toBeInTheDocument();
-      expect(screen.getByTestId('feedback-processed')).toBeInTheDocument();
+      expect(screen.queryByText('Seer cannot fix this failure')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Seer is working on this failure')
+      ).not.toBeInTheDocument();
     });
 
-    it('marks the current iteration feedback as in progress while processing', () => {
+    it('tags the current iteration feedback as in progress while processing', () => {
       render(
         <CodeChangesCard
           groupId="1"
@@ -1647,17 +1693,16 @@ describe('ArtifactCard', () => {
             'code_changes',
             'processing',
             [],
-            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
+            [makePrIterationBlock(0, {text: 'fix the CI failure'}, 'no_changes')]
           )}
         />,
         {organization: prIterationOrganization}
       );
 
-      // While processing, the row shows a spinner (there is also the card body
-      // "Iterating on PR…" loader, hence getAllByTestId) and no processed check.
+      // The run status beats the stored outcome of the previous attempt.
       expect(screen.getByText('fix the CI failure')).toBeInTheDocument();
-      expect(screen.getAllByTestId('loading-indicator').length).toBeGreaterThan(0);
-      expect(screen.queryByTestId('feedback-processed')).not.toBeInTheDocument();
+      expect(screen.getByText('Seer is working on this failure')).toBeInTheDocument();
+      expect(screen.queryByText('Seer cannot fix this failure')).not.toBeInTheDocument();
     });
 
     it('marks queued feedback with a queued label and no timestamp', () => {
@@ -1685,7 +1730,9 @@ describe('ArtifactCard', () => {
 
       expect(screen.getByText('Make the button blue')).toBeInTheDocument();
       expect(screen.getByText('Queued')).toBeInTheDocument();
-      expect(screen.queryByTestId('feedback-processed')).not.toBeInTheDocument();
+      expect(
+        screen.queryByText('Seer is working on this failure')
+      ).not.toBeInTheDocument();
     });
 
     it('disables reset once PRs exist when only automated CI iteration is enabled', () => {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -55,8 +55,7 @@ function makeAssistantBlock(content: string | null): AutofixSection['blocks'][nu
 
 function makePrIterationBlock(
   iterationIndex: number,
-  feedback: {text: string; timestamp?: string; user?: any},
-  iterationOutcome?: string
+  feedback: {text: string; timestamp?: string; user?: any}
 ): AutofixSection['blocks'][number] {
   return {
     id: `block-pr-${iterationIndex}`,
@@ -67,7 +66,6 @@ function makePrIterationBlock(
       metadata: {
         step: 'pr_iteration',
         iteration_index: String(iterationIndex),
-        ...(iterationOutcome ? {iteration_outcome: iterationOutcome} : {}),
         feedback: JSON.stringify({
           text: feedback.text,
           timestamp: feedback.timestamp,
@@ -136,6 +134,17 @@ const mockAutofixWithRunState: ReturnType<typeof useExplorerAutofix> = {
     updated_at: '2026-01-01T00:00:00Z',
   },
 };
+
+// The backend derives each iteration's outcome and returns it on the response,
+// keyed by the iteration index.
+function makeAutofixWithOutcomes(
+  outcomes: Record<string, string>
+): ReturnType<typeof useExplorerAutofix> {
+  return {
+    ...mockAutofixWithRunState,
+    runState: {...mockAutofixWithRunState.runState!, pr_iteration_outcomes: outcomes},
+  };
+}
 
 function makeRootCauseArtifact(data: RootCauseArtifact | null) {
   return {
@@ -1625,12 +1634,12 @@ describe('ArtifactCard', () => {
       render(
         <CodeChangesCard
           groupId="1"
-          autofix={mockAutofix}
+          autofix={makeAutofixWithOutcomes({'0': 'no_changes'})}
           section={makeSection(
             'code_changes',
             'completed',
             [[makePatch('org/repo', 'src/app.py')]],
-            [makePrIterationBlock(0, {text: 'first pass'}, 'no_changes')]
+            [makePrIterationBlock(0, {text: 'first pass'})]
           )}
         />,
         {organization: prIterationOrganization}
@@ -1645,16 +1654,36 @@ describe('ArtifactCard', () => {
       ).toBeInTheDocument();
     });
 
-    it('does not tag block feedback whose iteration made changes', () => {
+    it('does not tag block feedback whose iteration pushed changes', () => {
       render(
         <CodeChangesCard
           groupId="1"
-          autofix={mockAutofix}
+          autofix={makeAutofixWithOutcomes({'0': 'changes_pushed'})}
           section={makeSection(
             'code_changes',
             'completed',
             [[makePatch('org/repo', 'src/app.py')]],
-            [makePrIterationBlock(0, {text: 'first pass'}, 'changes_made')]
+            [makePrIterationBlock(0, {text: 'first pass'})]
+          )}
+        />,
+        {organization: prIterationOrganization}
+      );
+
+      expect(screen.getByText('first pass')).toBeInTheDocument();
+      expect(screen.queryByText('No changes')).not.toBeInTheDocument();
+      expect(screen.queryByText('Processing')).not.toBeInTheDocument();
+    });
+
+    it('does not tag block feedback whose iteration failed to push', () => {
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={makeAutofixWithOutcomes({'0': 'push_failed'})}
+          section={makeSection(
+            'code_changes',
+            'completed',
+            [[makePatch('org/repo', 'src/app.py')]],
+            [makePrIterationBlock(0, {text: 'first pass'})]
           )}
         />,
         {organization: prIterationOrganization}
@@ -1689,18 +1718,18 @@ describe('ArtifactCard', () => {
       render(
         <CodeChangesCard
           groupId="1"
-          autofix={mockAutofix}
+          autofix={makeAutofixWithOutcomes({'0': 'no_changes'})}
           section={makeSection(
             'code_changes',
             'processing',
             [],
-            [makePrIterationBlock(0, {text: 'fix the CI failure'}, 'no_changes')]
+            [makePrIterationBlock(0, {text: 'fix the CI failure'})]
           )}
         />,
         {organization: prIterationOrganization}
       );
 
-      // The run status beats the stored outcome of the previous attempt.
+      // The run status beats the outcome reported for the previous attempt.
       expect(screen.getByText('fix the CI failure')).toBeInTheDocument();
       expect(screen.getByText('Processing')).toBeInTheDocument();
       expect(screen.queryByText('No changes')).not.toBeInTheDocument();

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -478,19 +478,17 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
 
 // `changes_made` gets no tag, because the pushed commit already shows on the PR.
 // `queued` gets no tag, because the timestamp cell reads "Queued".
-// The outcome covers the whole iteration — which can fold in a review's worth of
-// comments — not the one comment the tag sits beside, so the tooltip says so.
 function FeedbackStatusTag({status}: {status: FeedbackStatus | undefined}) {
   switch (status) {
     case 'in_progress':
       return (
-        <Tooltip title={t('Seer is working on this round of feedback.')}>
+        <Tooltip title={t('Seer is working on this feedback.')}>
           <Tag variant="promotion">{t('Processing')}</Tag>
         </Tooltip>
       );
     case 'no_changes':
       return (
-        <Tooltip title={t('Seer made no code changes for this round of feedback.')}>
+        <Tooltip title={t('Seer made no code changes for this feedback.')}>
           <Tag variant="warning">{t('No changes')}</Tag>
         </Tooltip>
       );

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -481,9 +481,9 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
 function FeedbackStatusTag({status}: {status: FeedbackStatus | undefined}) {
   switch (status) {
     case 'in_progress':
-      return <Tag variant="promotion">{t('Seer is working on this failure')}</Tag>;
+      return <Tag variant="promotion">{t('Processing')}</Tag>;
     case 'no_changes':
-      return <Tag variant="warning">{t('Seer cannot fix this failure')}</Tag>;
+      return <Tag variant="warning">{t('No changes')}</Tag>;
     default:
       return null;
   }

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -478,12 +478,22 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
 
 // `changes_made` gets no tag, because the pushed commit already shows on the PR.
 // `queued` gets no tag, because the timestamp cell reads "Queued".
+// The outcome covers the whole iteration — which can fold in a review's worth of
+// comments — not the one comment the tag sits beside, so the tooltip says so.
 function FeedbackStatusTag({status}: {status: FeedbackStatus | undefined}) {
   switch (status) {
     case 'in_progress':
-      return <Tag variant="promotion">{t('Processing')}</Tag>;
+      return (
+        <Tooltip title={t('Seer is working on this round of feedback.')}>
+          <Tag variant="promotion">{t('Processing')}</Tag>
+        </Tooltip>
+      );
     case 'no_changes':
-      return <Tag variant="warning">{t('No changes')}</Tag>;
+      return (
+        <Tooltip title={t('Seer made no code changes for this round of feedback.')}>
+          <Tag variant="warning">{t('No changes')}</Tag>
+        </Tooltip>
+      );
     default:
       return null;
   }

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -34,12 +34,19 @@ const SOURCE_BADGE_SIZE = 14;
  * - `queued`: submitted while a run was processing, not yet picked up.
  * - `in_progress`: it's driving the iteration currently being processed.
  * - `no_changes`: the iteration it drove ended without a code change.
- * - `changes_made`: the iteration it drove pushed a code change.
+ * - `changes_pushed`: the iteration it drove pushed a code change.
+ * - `push_failed`: the iteration it drove made changes that never got pushed.
  *
- * The first two come from the run status and the block position. The last two
- * come from `iteration_outcome`, which seer writes onto the block.
+ * The first two come from the run status and the block position. The rest come
+ * from `pr_iteration_outcomes` on the autofix response, which the backend
+ * derives from the run state.
  */
-type FeedbackStatus = 'queued' | 'in_progress' | 'no_changes' | 'changes_made';
+type FeedbackStatus =
+  | 'queued'
+  | 'in_progress'
+  | 'no_changes'
+  | 'changes_pushed'
+  | 'push_failed';
 
 interface ParsedBaseFeedback {
   text: string;
@@ -101,7 +108,7 @@ type ParsedFeedback =
 // A parsed feedback enriched with the iteration context the caller supplies.
 type IterationFeedback = ParsedFeedback & {
   iterationIndex: number;
-  // Absent on iterations that ran before seer wrote an outcome.
+  // Absent when the response carries no outcome for the iteration.
   status?: FeedbackStatus;
 };
 
@@ -170,13 +177,13 @@ function parseFeedback(raw: string): ParsedFeedback[] {
   return items.map(parseFeedbackItem).filter(defined);
 }
 
-// Seer writes the outcome of a finished iteration onto the block that opens it.
-// Iterations that ran before seer wrote it carry no value, and no other value is
-// expected, so anything else reads as no outcome.
+// The response types the outcomes as plain strings, so narrow them here. A
+// backend older than this field, or newer than these names, reads as no outcome.
 function parseIterationOutcome(value: string | undefined): FeedbackStatus | undefined {
   switch (value) {
     case 'no_changes':
-    case 'changes_made':
+    case 'changes_pushed':
+    case 'push_failed':
       return value;
     default:
       return undefined;
@@ -191,9 +198,9 @@ function parseIterationOutcome(value: string | undefined): FeedbackStatus | unde
  * by `getOrderedAutofixSections`, so here we only surface the feedback text.
  * Feedback on a block at/after the current step marker drives the iteration
  * still running (when the section is processing); everything earlier takes the
- * outcome seer stored on the block. Feedback submitted mid-run that hasn't been
- * folded into a block yet is appended as `queued`. The list is returned
- * newest-first.
+ * outcome the backend derived for that iteration index. Feedback submitted
+ * mid-run that hasn't been folded into a block yet is appended as `queued`. The
+ * list is returned newest-first.
  */
 export function usePrIterationFeedback(
   section: AutofixSection,
@@ -204,6 +211,8 @@ export function usePrIterationFeedback(
     () => section.blocks.findLastIndex(block => defined(block.message.metadata?.step)),
     [section.blocks]
   );
+
+  const outcomes = autofix.runState?.pr_iteration_outcomes;
 
   const blockFeedback = useMemo<IterationFeedback[]>(() => {
     if (!enabled) {
@@ -226,7 +235,7 @@ export function usePrIterationFeedback(
       const status =
         section.status === 'processing' && blockIndex >= currentStepStart
           ? 'in_progress'
-          : parseIterationOutcome(metadata?.iteration_outcome);
+          : parseIterationOutcome(outcomes?.[String(iterationIndex)]);
 
       return parseFeedback(value).map(parsed => ({
         ...parsed,
@@ -234,7 +243,7 @@ export function usePrIterationFeedback(
         status,
       }));
     });
-  }, [section.blocks, section.status, currentStepStart, enabled]);
+  }, [section.blocks, section.status, currentStepStart, outcomes, enabled]);
 
   const latestIterationIndex = useMemo(
     () =>
@@ -476,8 +485,10 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
   );
 }
 
-// `changes_made` gets no tag, because the pushed commit already shows on the PR.
-// `queued` gets no tag, because the timestamp cell reads "Queued".
+// `changes_pushed` gets no tag, because the pushed commit already shows on the
+// PR. `queued` gets no tag, because the timestamp cell reads "Queued".
+// `push_failed` gets no tag either: what to tell the user about a failed push is
+// still an open product decision.
 function FeedbackStatusTag({status}: {status: FeedbackStatus | undefined}) {
   switch (status) {
     case 'in_progress':

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -17,10 +17,7 @@ import {
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {TimeSince} from 'sentry/components/timeSince';
-import {IconCircle} from 'sentry/icons/iconCircle';
-import {IconCircleCheckmark} from 'sentry/icons/iconCircleCheckmark';
 import {IconGithub} from 'sentry/icons/iconGithub';
 import {IconOpen} from 'sentry/icons/iconOpen';
 import {IconSeer} from 'sentry/icons/iconSeer';
@@ -34,11 +31,15 @@ const AVATAR_SIZE = 24;
 const SOURCE_BADGE_SIZE = 14;
 
 /**
- * - `processed`: the iteration it drove has finished and its changes are pushed.
- * - `in_progress`: it's driving the iteration currently being processed.
  * - `queued`: submitted while a run was processing, not yet picked up.
+ * - `in_progress`: it's driving the iteration currently being processed.
+ * - `no_changes`: the iteration it drove ended without a code change.
+ * - `changes_made`: the iteration it drove pushed a code change.
+ *
+ * The first two come from the run status and the block position. The last two
+ * come from `iteration_outcome`, which seer writes onto the block.
  */
-type FeedbackStatus = 'processed' | 'in_progress' | 'queued';
+type FeedbackStatus = 'queued' | 'in_progress' | 'no_changes' | 'changes_made';
 
 interface ParsedBaseFeedback {
   text: string;
@@ -100,7 +101,8 @@ type ParsedFeedback =
 // A parsed feedback enriched with the iteration context the caller supplies.
 type IterationFeedback = ParsedFeedback & {
   iterationIndex: number;
-  status: FeedbackStatus;
+  // Absent on iterations that ran before seer wrote an outcome.
+  status?: FeedbackStatus;
 };
 
 // Bot comments arrive as HTML-flavored markdown; keep only the visible prose.
@@ -168,6 +170,19 @@ function parseFeedback(raw: string): ParsedFeedback[] {
   return items.map(parseFeedbackItem).filter(defined);
 }
 
+// Seer writes the outcome of a finished iteration onto the block that opens it.
+// Iterations that ran before seer wrote it carry no value, and no other value is
+// expected, so anything else reads as no outcome.
+function parseIterationOutcome(value: string | undefined): FeedbackStatus | undefined {
+  switch (value) {
+    case 'no_changes':
+    case 'changes_made':
+      return value;
+    default:
+      return undefined;
+  }
+}
+
 /**
  * Collects the PR-iteration feedback to render in the Feedback section.
  *
@@ -175,9 +190,10 @@ function parseFeedback(raw: string): ParsedFeedback[] {
  * the cumulative diff is already merged into the section's code-change artifact
  * by `getOrderedAutofixSections`, so here we only surface the feedback text.
  * Feedback on a block at/after the current step marker drives the iteration
- * still running (when the section is processing); everything earlier is pushed.
- * Feedback submitted mid-run that hasn't been folded into a block yet is
- * appended as `queued`. The list is returned newest-first.
+ * still running (when the section is processing); everything earlier takes the
+ * outcome seer stored on the block. Feedback submitted mid-run that hasn't been
+ * folded into a block yet is appended as `queued`. The list is returned
+ * newest-first.
  */
 export function usePrIterationFeedback(
   section: AutofixSection,
@@ -207,10 +223,10 @@ export function usePrIterationFeedback(
         return [];
       }
 
-      const status: FeedbackStatus =
+      const status =
         section.status === 'processing' && blockIndex >= currentStepStart
           ? 'in_progress'
-          : 'processed';
+          : parseIterationOutcome(metadata?.iteration_outcome);
 
       return parseFeedback(value).map(parsed => ({
         ...parsed,
@@ -417,7 +433,7 @@ const ReviewChildRow = styled('div')`
 `;
 
 // Each source type owns an `Avatar` and a `Comment` cell. `FeedbackItem` renders
-// the shared grid shell (avatar · comment · timestamp · status) and dispatches
+// the shared grid shell (avatar · comment · timestamp) and dispatches
 // the two varying cells through this table — the single place that switches on
 // `sourceType`. Adding a source means adding one entry plus its cell components.
 type FeedbackCell = React.ComponentType<{item: IterationFeedback}>;
@@ -440,25 +456,37 @@ const SOURCE: Record<
 function FeedbackItem({item}: {item: IterationFeedback}) {
   const {Avatar, Comment} = SOURCE[item.sourceType];
 
-  // Four columns: author avatar, comment, timestamp, status icon. `align="start"`
-  // keeps the avatar top-aligned against multiline comments; each non-avatar cell
-  // is at least one avatar tall (`minHeight`) so its content centers with the
-  // avatar on a single line, and grows top-aligned once the comment wraps.
+  // Three columns: author avatar, comment, timestamp. `align="start"` keeps the
+  // avatar top-aligned against multiline comments; each non-avatar cell is at
+  // least one avatar tall (`minHeight`) so its content centers with the avatar
+  // on a single line, and grows top-aligned once the comment wraps.
   return (
-    <Grid columns="auto 1fr auto auto" gap="md" align="start">
+    <Grid columns="auto 1fr auto" gap="md" align="start">
       <Avatar item={item} />
       <Cell>
-        <Comment item={item} />
+        <Flex align="center" gap="sm" wrap="wrap" minWidth="0">
+          <FeedbackStatusTag status={item.status} />
+          <Comment item={item} />
+        </Flex>
       </Cell>
       <Cell>
         <FeedbackTimestamp item={item} />
       </Cell>
-      {/* Status icon sits at the far right, after the timestamp. */}
-      <Cell>
-        <FeedbackStatusIcon status={item.status} />
-      </Cell>
     </Grid>
   );
+}
+
+// `changes_made` gets no tag, because the pushed commit already shows on the PR.
+// `queued` gets no tag, because the timestamp cell reads "Queued".
+function FeedbackStatusTag({status}: {status: FeedbackStatus | undefined}) {
+  switch (status) {
+    case 'in_progress':
+      return <Tag variant="promotion">{t('Seer is working on this failure')}</Tag>;
+    case 'no_changes':
+      return <Tag variant="warning">{t('Seer cannot fix this failure')}</Tag>;
+    default:
+      return null;
+  }
 }
 
 // A non-avatar grid cell: at least one avatar tall so its content centers with
@@ -770,37 +798,6 @@ function PrimaryIconAvatar({Icon, tooltip}: {Icon: typeof IconSeer; tooltip: str
       </AvatarFrame>
     </Tooltip>
   );
-}
-
-// Source-agnostic: the same three status glyphs regardless of where the
-// iteration came from.
-function FeedbackStatusIcon({status}: {status: FeedbackStatus}) {
-  switch (status) {
-    case 'processed':
-      return (
-        <Tooltip title={t('Changes from this feedback have been pushed')} skipWrapper>
-          <Flex align="center" justify="center">
-            <IconCircleCheckmark variant="accent" data-test-id="feedback-processed" />
-          </Flex>
-        </Tooltip>
-      );
-    case 'in_progress':
-      return (
-        <Tooltip title={t('This feedback is being processed')} skipWrapper>
-          <LoadingIndicator size={16} style={{margin: 0}} />
-        </Tooltip>
-      );
-    case 'queued':
-      return (
-        <Tooltip title={t('Queued, not yet picked up')} skipWrapper>
-          <Flex align="center" justify="center">
-            <IconCircle variant="muted" />
-          </Flex>
-        </Tooltip>
-      );
-    default:
-      return null;
-  }
 }
 
 // The inline external-link arrow sits with the last line of the comment. A small

--- a/static/app/components/events/autofix/v3/feedbackList.tsx
+++ b/static/app/components/events/autofix/v3/feedbackList.tsx
@@ -36,10 +36,6 @@ const SOURCE_BADGE_SIZE = 14;
  * - `no_changes`: the iteration it drove ended without a code change.
  * - `changes_pushed`: the iteration it drove pushed a code change.
  * - `push_failed`: the iteration it drove made changes that never got pushed.
- *
- * The first two come from the run status and the block position. The rest come
- * from `pr_iteration_outcomes` on the autofix response, which the backend
- * derives from the run state.
  */
 type FeedbackStatus =
   | 'queued'
@@ -108,7 +104,6 @@ type ParsedFeedback =
 // A parsed feedback enriched with the iteration context the caller supplies.
 type IterationFeedback = ParsedFeedback & {
   iterationIndex: number;
-  // Absent when the response carries no outcome for the iteration.
   status?: FeedbackStatus;
 };
 
@@ -177,8 +172,6 @@ function parseFeedback(raw: string): ParsedFeedback[] {
   return items.map(parseFeedbackItem).filter(defined);
 }
 
-// The response types the outcomes as plain strings, so narrow them here. A
-// backend older than this field, or newer than these names, reads as no outcome.
 function parseIterationOutcome(value: string | undefined): FeedbackStatus | undefined {
   switch (value) {
     case 'no_changes':
@@ -485,10 +478,6 @@ function FeedbackItem({item}: {item: IterationFeedback}) {
   );
 }
 
-// `changes_pushed` gets no tag, because the pushed commit already shows on the
-// PR. `queued` gets no tag, because the timestamp cell reads "Queued".
-// `push_failed` gets no tag either: what to tell the user about a failed push is
-// still an open product decision.
 function FeedbackStatusTag({status}: {status: FeedbackStatus | undefined}) {
   switch (status) {
     case 'in_progress':


### PR DESCRIPTION
<img width="1106" height="435" alt="image" src="https://github.com/user-attachments/assets/37c0d302-687b-4e9e-bf8e-d6ffebb95f27" />

now shows the user much more clearly when we are processing the feedback, and when there were no changes.