### PR TITLE
fix(api): Capture more script user agents in client_kind

### DIFF
--- a/src/sentry/api/client_kind.py
+++ b/src/sentry/api/client_kind.py
@@ -50,12 +50,28 @@ _SDK_USER_AGENT = re.compile(r"^sentry[.-][a-z0-9_.-]+/", re.IGNORECASE)
 # Generic HTTP clients: someone's automation, not a Sentry-authored client. A
 # coding agent hitting the API directly lands here too -- nothing in the request
 # separates it from any other script, so we don't pretend to detect `agent`.
-_SCRIPT_USER_AGENT = re.compile(
-    r"^(?:"
-    r"curl|wget|python-requests|python-urllib|urllib3|httpx|aiohttp|requests"
-    r"|node-fetch|axios|got|undici|okhttp|go-http-client|java|libwww-perl"
-    r"|postmanruntime|insomnia|ruby|php|guzzlehttp|httparty|faraday|reqwest"
+#
+# Split by how safe a name is to look for mid-string. A user agent is a sequence of
+# `product/version (comment)` tokens and real clients bury the telling one behind a
+# prefix -- `python-httpx/0.28.1`, `Python/3.10 aiohttp/3.13.5`,
+# `Symfony HttpClient (Curl)`, `Apache-HttpClient/5.5.2 (Java/21.0.10)`. Requiring
+# every name to lead the string (as this once did) read all of those as UNKNOWN.
+_SCRIPT_USER_AGENT_ANYWHERE = re.compile(
+    r"(?:"
+    r"curl|wget|urllib3|httpx|aiohttp|node-fetch|axios|undici|okhttp"
+    r"|go-http-client|apache-httpclient|libwww-perl|postmanruntime|insomnia"
+    r"|guzzlehttp|httparty|faraday|reqwest|scrapy|deno|powershell"
+    r"|google-apps-script"
     r")\b",
+    re.IGNORECASE,
+)
+
+# Names too generic to look for mid-string: `java` is a substring of every
+# JavaScript runtime's user agent, and `got`/`requests` are ordinary English words
+# that appear in comment tokens. These only count when the caller leads with them.
+# `python` covers `python-requests`, `python-urllib` and `python-httpx` alike.
+_SCRIPT_USER_AGENT_PREFIX = re.compile(
+    r"^(?:node|java|ruby|php|python|requests|got)\b",
     re.IGNORECASE,
 )
 
@@ -131,7 +147,9 @@ def get_client_kind(request: Request, organization: Organization) -> ClientKind 
         return ClientKind.CLI
     if _SDK_USER_AGENT.match(user_agent):
         return ClientKind.SDK
-    if _SCRIPT_USER_AGENT.match(user_agent):
+    if _SCRIPT_USER_AGENT_PREFIX.match(user_agent) or _SCRIPT_USER_AGENT_ANYWHERE.search(
+        user_agent
+    ):
         return ClientKind.SCRIPT
 
     return ClientKind.UNKNOWN
@@ -144,6 +162,14 @@ def set_client_kind_attributes(request: Request, organization: Organization) -> 
     ``OrganizationEventsEndpointBase.convert_args`` so every events endpoint
     reports the same set of attributes without hand-wiring them per handler.
     """
+    # `sentry.api.client.ApiClient` dispatches endpoints in-process with a synthetic
+    # request that carries no user agent, cookies or token, so it classifies as
+    # UNKNOWN. These attributes are isolation-scoped, so recording that would overwrite
+    # the enclosing transaction's own classification -- or invent one for a Celery task
+    # that never served an API request. The outer caller is the one worth attributing.
+    if getattr(request, "__from_api_client__", False):
+        return
+
     client_kind = get_client_kind(request, organization)
     if client_kind is None:
         return

--- a/src/sentry/api/client_kind.py
+++ b/src/sentry/api/client_kind.py
@@ -24,8 +24,12 @@ from sentry.middleware import is_frontend_request
 from sentry.models.organization import Organization
 from sentry.seer.agent_token import is_agent_auth
 from sentry.utils.http import SEER_REFERRER_HEADER, get_mcp_client_family, is_mcp_request
+from sentry.utils.sdk import get_transaction_name_from_request
+from sentry.utils.tracing import set_span_data, start_span
 
 FEATURE_FLAG = "organizations:api-client-kind-check"
+
+ATTRIBUTION_SPAN_OP = "api.attribution"
 
 
 class ClientKind(StrEnum):
@@ -156,12 +160,21 @@ def get_client_kind(request: Request, organization: Organization) -> ClientKind 
 
 
 def set_client_kind_attributes(request: Request, organization: Organization) -> None:
-    """Tag the current transaction with who called the endpoint.
+    """Record who called the endpoint, on a span and on the enclosing transaction.
 
     A no-op when the org has not opted into ``client_kind``. Wired into
     ``OrganizationEventsEndpointBase.convert_args`` so every events endpoint
     reports the same set of attributes without hand-wiring them per handler.
     """
+    client_kind = get_client_kind(request, organization)
+    if client_kind is None:
+        return
+
+    client_host = get_client_host(request)
+    user_agent = get_user_agent(request)
+
+    _record_attribution_span(request, client_kind, client_host, user_agent)
+
     # `sentry.api.client.ApiClient` dispatches endpoints in-process with a synthetic
     # request that carries no user agent, cookies or token, so it classifies as
     # UNKNOWN. These attributes are isolation-scoped, so recording that would overwrite
@@ -170,23 +183,39 @@ def set_client_kind_attributes(request: Request, organization: Organization) -> 
     if getattr(request, "__from_api_client__", False):
         return
 
-    client_kind = get_client_kind(request, organization)
-    if client_kind is None:
-        return
-
     # `_test` suffix while this is a POC, to keep it out of the way of a
     # real `client_kind` attribute later.
     sentry_sdk.set_tag("client_kind_test", client_kind.value)
     sentry_sdk.set_attribute("client_kind_test", client_kind.value)
 
-    client_host = get_client_host(request)
     if client_host is not None:
         sentry_sdk.set_tag("client_host_test", client_host)
         sentry_sdk.set_attribute("client_host_test", client_host)
 
-    user_agent = get_user_agent(request)
     if user_agent is not None:
         sentry_sdk.set_attribute(ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, user_agent)
+
+
+def _record_attribution_span(
+    request: Request,
+    client_kind: ClientKind,
+    client_host: str | None,
+    user_agent: str | None,
+) -> None:
+    """Emit a span pairing the route served with the caller that asked for it.
+
+    Scoped to the dispatch, unlike the isolation-scoped attributes above, so an
+    endpoint reached in-process through `sentry.api.client.ApiClient` reports the
+    route it served rather than its caller's.
+    """
+    route = get_transaction_name_from_request(request)
+    with start_span(op=ATTRIBUTION_SPAN_OP, name=route) as span:
+        set_span_data(span, ATTRIBUTE_NAMES.HTTP_ROUTE, route)
+        set_span_data(span, "client_kind_test", client_kind.value)
+        if client_host is not None:
+            set_span_data(span, "client_host_test", client_host)
+        if user_agent is not None:
+            set_span_data(span, ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, user_agent)
 
 
 def get_user_agent(request: Request) -> str | None:

--- a/src/sentry/api/client_kind.py
+++ b/src/sentry/api/client_kind.py
@@ -175,14 +175,6 @@ def set_client_kind_attributes(request: Request, organization: Organization) -> 
 
     _record_attribution_span(request, client_kind, client_host, user_agent)
 
-    # `sentry.api.client.ApiClient` dispatches endpoints in-process with a synthetic
-    # request that carries no user agent, cookies or token, so it classifies as
-    # UNKNOWN. These attributes are isolation-scoped, so recording that would overwrite
-    # the enclosing transaction's own classification -- or invent one for a Celery task
-    # that never served an API request. The outer caller is the one worth attributing.
-    if getattr(request, "__from_api_client__", False):
-        return
-
     # `_test` suffix while this is a POC, to keep it out of the way of a
     # real `client_kind` attribute later.
     sentry_sdk.set_tag("client_kind_test", client_kind.value)

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -41,6 +41,16 @@ def make_request(
     return request
 
 
+def mark_from_api_client(request: Request) -> None:
+    """Stamp the marker `sentry.api.client.ApiClient` puts on its synthetic requests.
+
+    Set on the underlying Django request, as `ApiClient` does; the DRF request
+    delegates the lookup, which is what the guard in `client_kind` relies on.
+    """
+    django_request: Any = request._request
+    django_request.__from_api_client__ = True
+
+
 def session_user(*, is_sentry_app: bool = False) -> SimpleNamespace:
     return SimpleNamespace(is_authenticated=True, is_sentry_app=is_sentry_app)
 
@@ -125,6 +135,39 @@ class GetClientKindTest(TestCase):
                 request = make_request(auth=api_token(), user_agent=user_agent)
                 assert self.classify(request) == expected
 
+    def test_tool_name_is_found_after_a_prefix(self) -> None:
+        # Real clients bury the telling token behind a prefix or inside a comment.
+        # Requiring it to lead the string read every one of these as UNKNOWN.
+        cases = [
+            "node",
+            "python-httpx/0.28.1",
+            "Python/3.10 aiohttp/3.13.5",
+            "Apache-HttpClient/5.5.2 (Java/21.0.10)",
+            "Symfony HttpClient (Curl)",
+            "Deno/2.1.4 (variant; SupabaseEdgeRuntime/1.74.4)",
+            "Mozilla/5.0 (compatible; Google-Apps-Script; beanserver; +https://script.google.com)",
+            "Mozilla/5.0 (Windows NT; Windows NT 10.0; en-GB) WindowsPowerShell/5.1.20348",
+        ]
+        for user_agent in cases:
+            with self.subTest(user_agent=user_agent):
+                request = make_request(auth=api_token(), user_agent=user_agent)
+                assert self.classify(request) == ClientKind.SCRIPT
+
+    def test_browsers_are_not_mistaken_for_scripts(self) -> None:
+        # The cost of matching mid-string is false positives, so the generic names
+        # (`java` inside `JavaScript`, `got`, `requests`) stay anchored to the front.
+        cases = [
+            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 "
+            "(KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36",
+            "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) "
+            "AppleWebKit/605.1.15 Version/17.0 Mobile/15E148 Safari/604.1",
+            "JavaScript/1.0",
+        ]
+        for user_agent in cases:
+            with self.subTest(user_agent=user_agent):
+                request = make_request(auth=api_token(), user_agent=user_agent)
+                assert self.classify(request) == ClientKind.UNKNOWN
+
     def test_frontend_requires_a_session_cookie(self) -> None:
         # Shares `is_frontend_request` with the `ui_request` tag on `view.response`.
         request = make_request(user=session_user(), cookies=False)
@@ -206,3 +249,17 @@ class SetClientKindAttributesTest(TestCase):
             set_client_kind_attributes(request, self.organization)
         for call in sdk.set_attribute.call_args_list:
             assert call.args[0] != ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL
+
+    def test_skips_requests_from_the_internal_api_client(self) -> None:
+        # `ApiClient` dispatches in-process with a synthetic request carrying no user
+        # agent, cookies or token. Recording its UNKNOWN would clobber the enclosing
+        # transaction's own attribution, since these attributes are isolation-scoped.
+        request = make_request(auth=api_token(), user_agent="curl/8.7.1")
+        mark_from_api_client(request)
+        with (
+            self.feature(FEATURE_FLAG),
+            mock.patch("sentry.api.client_kind.sentry_sdk") as sdk,
+        ):
+            set_client_kind_attributes(request, self.organization)
+        sdk.set_tag.assert_not_called()
+        sdk.set_attribute.assert_not_called()

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -309,10 +309,10 @@ class SetClientKindAttributesTest(TestCase):
         for call in sdk.set_attribute.call_args_list:
             assert call.args[0] != ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL
 
-    def test_skips_transaction_attributes_from_the_internal_api_client(self) -> None:
-        # `ApiClient` dispatches in-process with a synthetic request carrying no user
-        # agent, cookies or token. Recording its UNKNOWN would clobber the enclosing
-        # transaction's own attribution, since these attributes are isolation-scoped.
+    def test_records_for_the_internal_api_client_too(self) -> None:
+        # These attributes are isolation-scoped, so a nested `ApiClient` dispatch writes
+        # onto its caller's transaction. That is what lets an entrypoint declare a kind
+        # its nested dispatches cannot derive for themselves.
         request = make_request(auth=api_token(), user_agent="curl/8.7.1")
         mark_from_api_client(request)
         with (
@@ -321,8 +321,7 @@ class SetClientKindAttributesTest(TestCase):
             mock.patch("sentry.api.client_kind.start_span"),
         ):
             set_client_kind_attributes(request, self.organization)
-        sdk.set_tag.assert_not_called()
-        sdk.set_attribute.assert_not_called()
+        assert sdk.set_tag.call_args_list == [mock.call("client_kind_test", "script")]
 
 
 class AttributionSpanTest(TestCase):

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -5,9 +5,11 @@ from unittest import mock
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.api.client_kind import (
+    ATTRIBUTION_SPAN_OP,
     FEATURE_FLAG,
     ClientKind,
     get_client_host,
@@ -20,6 +22,10 @@ from sentry.auth.system import SystemToken
 from sentry.seer.agent_token import AGENT_TOKEN_KIND
 from sentry.seer.endpoints.seer_rpc import SeerRpcSignatureAuthentication
 from sentry.testutils.cases import TestCase
+from sentry.utils.sdk import get_transaction_name_from_request
+
+EVENTS_PATH = "/api/0/organizations/my-org/events/"
+EVENTS_ROUTE = "/api/0/organizations/{organization_id_or_slug}/events/"
 
 
 def make_request(
@@ -29,8 +35,9 @@ def make_request(
     user_agent: str | None = None,
     headers: dict[str, str] | None = None,
     cookies: bool = True,
+    path: str = EVENTS_PATH,
 ) -> Request:
-    request = Request(RequestFactory().get("/", headers=headers or {}))
+    request = Request(RequestFactory().get(path, headers=headers or {}))
     if user_agent is not None:
         request.META["HTTP_USER_AGENT"] = user_agent
     if cookies:
@@ -255,10 +262,12 @@ class SetClientKindAttributesTest(TestCase):
         with (
             self.feature({FEATURE_FLAG: False}),
             mock.patch("sentry.api.client_kind.sentry_sdk") as sdk,
+            mock.patch("sentry.api.client_kind.start_span") as start_span,
         ):
             set_client_kind_attributes(request, self.organization)
         sdk.set_tag.assert_not_called()
         sdk.set_attribute.assert_not_called()
+        start_span.assert_not_called()
 
     def test_records_kind_and_user_agent(self) -> None:
         request = make_request(auth=api_token(), user_agent="curl/8.7.1")
@@ -300,7 +309,7 @@ class SetClientKindAttributesTest(TestCase):
         for call in sdk.set_attribute.call_args_list:
             assert call.args[0] != ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL
 
-    def test_skips_requests_from_the_internal_api_client(self) -> None:
+    def test_skips_transaction_attributes_from_the_internal_api_client(self) -> None:
         # `ApiClient` dispatches in-process with a synthetic request carrying no user
         # agent, cookies or token. Recording its UNKNOWN would clobber the enclosing
         # transaction's own attribution, since these attributes are isolation-scoped.
@@ -309,7 +318,77 @@ class SetClientKindAttributesTest(TestCase):
         with (
             self.feature(FEATURE_FLAG),
             mock.patch("sentry.api.client_kind.sentry_sdk") as sdk,
+            mock.patch("sentry.api.client_kind.start_span"),
         ):
             set_client_kind_attributes(request, self.organization)
         sdk.set_tag.assert_not_called()
         sdk.set_attribute.assert_not_called()
+
+
+class AttributionSpanTest(TestCase):
+    def record(self, request: Request) -> tuple[Any, list[tuple[str, Any]]]:
+        with (
+            self.feature(FEATURE_FLAG),
+            mock.patch("sentry.api.client_kind.start_span") as start_span,
+            mock.patch("sentry.api.client_kind.set_span_data") as set_span_data,
+        ):
+            set_client_kind_attributes(request, self.organization)
+        span = start_span.return_value.__enter__.return_value
+        return start_span, [
+            call.args[1:] for call in set_span_data.call_args_list if call.args[0] is span
+        ]
+
+    def test_pairs_the_route_with_the_caller(self) -> None:
+        start_span, attributes = self.record(
+            make_request(auth=api_token(), user_agent="curl/8.7.1")
+        )
+        assert start_span.call_args == mock.call(op=ATTRIBUTION_SPAN_OP, name=EVENTS_ROUTE)
+        assert attributes == [
+            (ATTRIBUTE_NAMES.HTTP_ROUTE, EVENTS_ROUTE),
+            ("client_kind_test", "script"),
+            (ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, "curl/8.7.1"),
+        ]
+
+    def test_records_the_route_for_an_internal_api_client_dispatch(self) -> None:
+        request = make_request(auth=api_token(), user_agent="curl/8.7.1")
+        mark_from_api_client(request)
+        start_span, attributes = self.record(request)
+        assert start_span.call_args == mock.call(op=ATTRIBUTION_SPAN_OP, name=EVENTS_ROUTE)
+        assert (ATTRIBUTE_NAMES.HTTP_ROUTE, EVENTS_ROUTE) in attributes
+
+    def test_carries_the_mcp_client_host(self) -> None:
+        _, attributes = self.record(
+            make_request(
+                auth=api_token(),
+                user_agent="sentry-mcp/1.0",
+                headers={
+                    "X-Sentry-MCP-Version": "1.0",
+                    "X-Sentry-MCP-Client-Family": "Claude-Code",
+                },
+            )
+        )
+        assert ("client_host_test", "claude-code") in attributes
+
+    def test_omits_user_agent_when_absent(self) -> None:
+        _, attributes = self.record(make_request(auth=api_token()))
+        assert [key for key, _ in attributes] == [
+            ATTRIBUTE_NAMES.HTTP_ROUTE,
+            "client_kind_test",
+        ]
+
+
+class SpanRouteTest(TestCase):
+    """Pin the route resolution `_record_attribution_span` names its span with."""
+
+    def test_parameterizes_the_url(self) -> None:
+        assert get_transaction_name_from_request(make_request()) == EVENTS_ROUTE
+
+    def test_an_internal_dispatch_resolves_to_the_same_route(self) -> None:
+        mock_request = APIRequestFactory().get(EVENTS_PATH, {})
+        request = Request(mock_request)
+        request.user = AnonymousUser()
+        assert get_transaction_name_from_request(request) == EVENTS_ROUTE
+
+    def test_an_unmatched_path_collapses_onto_a_catch_all(self) -> None:
+        request = make_request(path="/api/0/definitely/not/a/route/")
+        assert get_transaction_name_from_request(request) == "/api/0/"

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -18,6 +18,7 @@ from sentry.api.client_kind import (
 from sentry.auth.services.auth import AuthenticatedToken
 from sentry.auth.system import SystemToken
 from sentry.seer.agent_token import AGENT_TOKEN_KIND
+from sentry.seer.endpoints.seer_rpc import SeerRpcSignatureAuthentication
 from sentry.testutils.cases import TestCase
 
 
@@ -49,6 +50,16 @@ def mark_from_api_client(request: Request) -> None:
     """
     django_request: Any = request._request
     django_request.__from_api_client__ = True
+
+
+def mark_authenticated_by(request: Request, authenticator: object) -> None:
+    """Record the authenticator DRF would have selected.
+
+    `successful_authenticator` is a read-only property over `_authenticator`, so
+    tests that exercise credential-based branches have to set the backing attribute.
+    """
+    drf_request: Any = request
+    drf_request._authenticator = authenticator
 
 
 def session_user(*, is_sentry_app: bool = False) -> SimpleNamespace:
@@ -134,6 +145,45 @@ class GetClientKindTest(TestCase):
             with self.subTest(user_agent=user_agent):
                 request = make_request(auth=api_token(), user_agent=user_agent)
                 assert self.classify(request) == expected
+
+    def test_seer_signals_outrank_seers_own_script_like_user_agent(self) -> None:
+        # Seer calls Sentry with `python-httpx`, which the script rules match. Every
+        # Seer branch is checked before the user-agent rules, so widening those must
+        # not reclassify Seer as SCRIPT -- the bucket is only reached on a fall-through.
+        user_agent = "python-httpx/0.28.1"
+        assert self.classify(make_request(auth=api_token(), user_agent=user_agent)) == (
+            ClientKind.SCRIPT
+        )
+
+        rpc_signature = make_request(auth=api_token(), user_agent=user_agent)
+        mark_authenticated_by(rpc_signature, SeerRpcSignatureAuthentication())
+        cases = [
+            (
+                "seer referrer",
+                make_request(
+                    auth=api_token(),
+                    user_agent=user_agent,
+                    headers={"X-Seer-Referrer": "explorer"},
+                ),
+            ),
+            (
+                "viewer context",
+                make_request(
+                    auth=api_token(), user_agent=user_agent, headers={"X-Viewer-Context": "a.b.c"}
+                ),
+            ),
+            (
+                "agent token",
+                make_request(
+                    auth=AuthenticatedToken(kind=AGENT_TOKEN_KIND, user_id=1, organization_id=1),
+                    user_agent=user_agent,
+                ),
+            ),
+            ("rpc signature", rpc_signature),
+        ]
+        for signal, request in cases:
+            with self.subTest(signal=signal):
+                assert self.classify(request) == ClientKind.SEER
 
     def test_tool_name_is_found_after_a_prefix(self) -> None:
         # Real clients bury the telling token behind a prefix or inside a comment.


### PR DESCRIPTION
Follow-up to #123578 and #123587. With `user_agent.original` recorded, the `unknown` bucket is now inspectable — two of its causes turn out to be bugs rather than genuinely unattributable callers.

### The script pattern only matched at the start of the user agent

`_SCRIPT_USER_AGENT` was anchored with `^`, so a tool only counted when it led the string. Real clients bury it behind a prefix or inside a comment token, and all of these read as `UNKNOWN`:

| User agent | Why it missed |
|---|---|
| `python-httpx/0.28.1` | `httpx` was listed, but the `python-` prefix defeated `^` |
| `Python/3.10 aiohttp/3.13.5` | `aiohttp` listed, not at the start |
| `Apache-HttpClient/5.5.2 (Java/21.0.10)` | `java` listed, not at the start |
| `Symfony HttpClient (Curl)` | `curl` listed, not at the start |
| `node` | `node-fetch` was listed, bare `node` was not |
| `Deno/…`, `…WindowsPowerShell/…`, `Google-Apps-Script` | absent entirely |

Names that are distinctive enough to match mid-string now do. The generic ones stay anchored to the front, because `java` is a substring of every JavaScript runtime's user agent and `got`/`requests` are ordinary words that show up in comment tokens — there's a test pinning that browsers don't get swept into `script`. `python` replaces the two `python-*` entries and covers `python-httpx` too.

This accounts for roughly a fifth of the `unknown` bucket.

### Internal API-client calls now record too

`sentry.api.client.ApiClient` dispatches endpoints in-process with a synthetic request built by `APIRequestFactory` — no user agent, no cookies, no token — so it classifies as `UNKNOWN`. An earlier revision of this PR skipped those dispatches outright, via the `__from_api_client__` marker `ApiClient` already sets, to stop that `UNKNOWN` landing on the enclosing transaction.

That guard is gone: it also blocks #123785, which declares the caller at the RPC entrypoint through a contextvar and relies on the nested dispatch to write it. With nothing writing, a declared kind never lands.

Dropping it overwrites nothing. `set_client_kind_attributes` only runs on `OrganizationEventsEndpointBase`, and no events endpoint reaches another one through `ApiClient` — the nested callers are notification handlers (`incidents/charts.py` → events-stats) and the Slack unfurls, whose transactions carry no classification to begin with. Those gain an `unknown` until something declares for them, the same way #123785 declares for Seer.

### The endpoint that ran wasn't recorded anywhere for those calls

Skipping the internal dispatch fixes the leak but leaves a hole: because a transaction only names the outermost request, an endpoint reached through `ApiClient` — how Seer's RPC handlers call the public API — is filed under `/api/0/internal/seer-rpc/{method_name}/` rather than the route it served, so RPC callers can't be filtered alongside direct HTTP ones. `set_client_kind_attributes` now also emits an `api.attribution` span carrying `http.route` next to the caller, scoped to the dispatch rather than the transaction. Filter on `http.route` and group by `client_kind_test` and both paths land in one result. The route comes from `get_transaction_name_from_request`, which resolves the path rather than reading the scope, so the synthetic request and the equivalent HTTP call produce the same string — both shapes are tested.

Those spans still say `client_kind: unknown` until #123785 lands and supplies the caller's identity.

No behavior change for callers that already classified correctly — `frontend`, `mcp`, `seer`, `integration`, `cli` and `sdk` are all checked before these rules and are covered by existing tests.


