### PR TITLE
feat(pr-iter): Record the trigger source on the iteration event

### DIFF
--- a/src/sentry/analytics/events/pr_iteration_events.py
+++ b/src/sentry/analytics/events/pr_iteration_events.py
@@ -19,6 +19,9 @@ class AiAutofixPrIterationFeedbackBatchCompletedEvent(analytics.Event):
     referrer: str | None
     iteration_index: int
 
+    # Why the drain that claimed this iteration ran, written at claim time.
+    trigger_source: str | None
+
     # Queue counts, written by the drain.
     feedback_count: int
     queued_count: int

--- a/src/sentry/seer/autofix/pr_iteration/emit.py
+++ b/src/sentry/seer/autofix/pr_iteration/emit.py
@@ -98,7 +98,11 @@ def open_pr_iteration_details(
 
 
 def trigger_pr_iteration_details(
-    *, log_ctx: PrIterationLogContext, run_id: int, organization_id: int
+    *,
+    log_ctx: PrIterationLogContext,
+    run_id: int,
+    organization_id: int,
+    trigger_source: str | None,
 ) -> int | None:
     """Claim the waiting iteration for the drain that is about to pop the queue.
 
@@ -112,7 +116,11 @@ def trigger_pr_iteration_details(
             return None
 
         iteration = _claim_untriggered(seer_run)
-        return None if iteration is None else iteration.id
+        if iteration is None:
+            return None
+
+        update_iteration(iteration, trigger_source=trigger_source)
+        return iteration.id
     except Exception:
         log_ctx.error("autofix.pr_iteration.details.trigger_failed")
         return None

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -476,7 +476,10 @@ def _drain_queued_autofix_feedback(
 
     # Claim before the pop, so feedback arriving mid-drain opens its own row.
     iteration_id = trigger_pr_iteration_details(
-        log_ctx=log_ctx, run_id=run_id, organization_id=organization_id
+        log_ctx=log_ctx,
+        run_id=run_id,
+        organization_id=organization_id,
+        trigger_source=trigger_source,
     )
 
     queued_items = pop_queued_autofix_feedback(run_id)

--- a/tests/sentry/seer/autofix/pr_iteration/test_emit.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_emit.py
@@ -74,9 +74,12 @@ class PrIterationDetailsTest(TestCase):
             group_id=self.group.id,
         )
 
-    def _trigger(self) -> int | None:
+    def _trigger(self, *, trigger_source: str | None = "feedback") -> int | None:
         iteration_id = trigger_pr_iteration_details(
-            log_ctx=self.log_ctx, run_id=RUN_ID, organization_id=self.organization.id
+            log_ctx=self.log_ctx,
+            run_id=RUN_ID,
+            organization_id=self.organization.id,
+            trigger_source=trigger_source,
         )
         if iteration_id is not None:
             record_pr_iteration_counts(
@@ -116,6 +119,7 @@ class PrIterationDetailsTest(TestCase):
 
         (row,) = self._open_rows()
         assert row.triggered
+        assert row.data["trigger_source"] == "feedback"
         assert row.data["referrer"] == "github_pr_comment"
         assert row.data["feedback_count"] == 2
         assert row.data["queued_count"] == 3
@@ -141,6 +145,7 @@ class PrIterationDetailsTest(TestCase):
                 run_id=RUN_ID,
                 referrer="github_pr_comment",
                 iteration_index=0,
+                trigger_source="feedback",
                 feedback_count=2,
                 queued_count=3,
                 dropped_count=1,


### PR DESCRIPTION
The analytics event for a finished PR iteration didn't say whether
push feedback or a deferred consume started it. The drain now writes
the trigger source onto the row at the same point it claims the
iteration, so the completed event carries it through.

