### PR TITLE
fix(loader): Reuse initial loader during app bootstrap

### DIFF
--- a/static/app/components/initialLoadingIndicator.spec.tsx
+++ b/static/app/components/initialLoadingIndicator.spec.tsx
@@ -1,0 +1,84 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {InitialLoadingIndicator} from 'sentry/components/initialLoadingIndicator';
+import {ROOT_ELEMENT} from 'sentry/constants';
+
+describe('InitialLoadingIndicator', () => {
+  let root: HTMLElement;
+  let originalGetAnimationsDescriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    originalGetAnimationsDescriptor = Object.getOwnPropertyDescriptor(
+      Element.prototype,
+      'getAnimations'
+    );
+    root = document.createElement('div');
+    root.id = ROOT_ELEMENT;
+    document.body.appendChild(root);
+  });
+
+  afterEach(() => {
+    if (originalGetAnimationsDescriptor) {
+      Object.defineProperty(
+        Element.prototype,
+        'getAnimations',
+        originalGetAnimationsDescriptor
+      );
+    } else {
+      Reflect.deleteProperty(Element.prototype, 'getAnimations');
+    }
+    root.remove();
+  });
+
+  it('reuses the server-rendered loader', () => {
+    root.innerHTML = `
+      <main>Current application content</main>
+      <div class="splash-loader" style="display: none">Inactive loader</div>
+      <div class="splash-loader">
+        <div data-test-id="server-loader">Loading Sentry</div>
+      </div>
+    `;
+
+    render(<InitialLoadingIndicator fallback={<div>Fallback loader</div>} />);
+    root.replaceChildren();
+
+    const loader = screen.getByTestId('server-loader');
+    expect(loader).toHaveTextContent('Loading Sentry');
+    expect(loader.closest('.splash-loader')).toBeInTheDocument();
+    expect(screen.queryByText('Inactive loader')).not.toBeInTheDocument();
+    expect(screen.queryByText('Current application content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Fallback loader')).not.toBeInTheDocument();
+  });
+
+  it('continues animations from the server-rendered loader timeline', () => {
+    root.innerHTML = '<div class="splash-loader">Loading Sentry</div>';
+    const sourceAnimation = {
+      currentTime: 750,
+      playbackRate: 1,
+      startTime: 100,
+    } as Animation;
+    const clonedAnimation = {
+      currentTime: 0,
+      playbackRate: 0,
+      startTime: 900,
+    } as Animation;
+
+    Object.defineProperty(Element.prototype, 'getAnimations', {
+      configurable: true,
+      value: jest.fn(function (this: Element) {
+        return root.contains(this) ? [sourceAnimation] : [clonedAnimation];
+      }),
+    });
+
+    render(<InitialLoadingIndicator />);
+
+    expect(clonedAnimation.playbackRate).toBe(1);
+    expect(clonedAnimation.startTime).toBe(100);
+  });
+
+  it('renders its fallback when the initial loader is no longer present', () => {
+    render(<InitialLoadingIndicator fallback={<div>Fallback loader</div>} />);
+
+    expect(screen.getByText('Fallback loader')).toBeInTheDocument();
+  });
+});

--- a/static/app/components/initialLoadingIndicator.tsx
+++ b/static/app/components/initialLoadingIndicator.tsx
@@ -1,0 +1,94 @@
+import {useLayoutEffect, useRef, useState} from 'react';
+
+import {ROOT_ELEMENT} from 'sentry/constants';
+
+const INITIAL_LOADER_SELECTOR = '.splash-loader';
+
+interface InitialLoaderSnapshot {
+  animationStates: Array<{
+    currentTime: number | null;
+    playbackRate: number;
+    startTime: number | null;
+  }>;
+  html: string;
+}
+
+function getNumericTime(time: CSSNumberish | null): number | null {
+  return typeof time === 'number' ? time : null;
+}
+
+interface InitialLoadingIndicatorProps {
+  fallback?: React.ReactNode;
+}
+
+/**
+ * Snapshots the splash loader rendered by Django before React's first commit
+ * replaces the contents of its root. Each rendered copy keeps the splash
+ * class, allowing bootstrap loading boundaries to hand off the same trusted
+ * markup without copying arbitrary application content. Dev-ui includes both
+ * seasonal loader variants, so only its visible variant is eligible. Once the
+ * splash loader leaves the root, later lazy loads use their normal fallback.
+ * Animation timing is captured with the markup so each handoff can continue
+ * on the original document timeline.
+ */
+export function InitialLoadingIndicator({fallback = null}: InitialLoadingIndicatorProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [initialLoaderSnapshot] = useState<InitialLoaderSnapshot | null>(() => {
+    const root = document.getElementById(ROOT_ELEMENT);
+    const initialLoader = Array.from(
+      root?.querySelectorAll<HTMLElement>(INITIAL_LOADER_SELECTOR) ?? []
+    ).find(loader => loader.style.display !== 'none');
+
+    if (!initialLoader) {
+      return null;
+    }
+
+    return {
+      animationStates: (initialLoader.getAnimations?.({subtree: true}) ?? []).map(
+        animation => ({
+          currentTime: getNumericTime(animation.currentTime),
+          playbackRate: animation.playbackRate,
+          startTime: getNumericTime(animation.startTime),
+        })
+      ),
+      html: initialLoader.outerHTML,
+    };
+  });
+
+  useLayoutEffect(() => {
+    const initialLoader = containerRef.current?.querySelector<HTMLElement>(
+      INITIAL_LOADER_SELECTOR
+    );
+    const animations = initialLoader?.getAnimations?.({subtree: true}) ?? [];
+
+    animations.forEach((animation, index) => {
+      const state = initialLoaderSnapshot?.animationStates[index];
+      if (!state) {
+        return;
+      }
+
+      try {
+        animation.playbackRate = state.playbackRate;
+
+        if (state.startTime !== null) {
+          animation.startTime = state.startTime;
+        } else if (state.currentTime !== null) {
+          animation.currentTime = state.currentTime;
+        }
+      } catch {
+        // State transfer is best-effort; the cloned CSS animation keeps running.
+      }
+    });
+  }, [initialLoaderSnapshot]);
+
+  if (!initialLoaderSnapshot) {
+    return fallback;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      dangerouslySetInnerHTML={{__html: initialLoaderSnapshot.html}}
+    />
+  );
+}

--- a/static/app/components/lazyLoad.spec.tsx
+++ b/static/app/components/lazyLoad.spec.tsx
@@ -3,6 +3,7 @@ import {lazy} from 'react';
 import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {LazyLoad} from 'sentry/components/lazyLoad';
+import {ROOT_ELEMENT} from 'sentry/constants';
 
 type TestProps = {
   testProp?: boolean;
@@ -19,12 +20,33 @@ function BarComponent() {
 type ResolvedComponent = {default: React.ComponentType<TestProps>};
 
 describe('LazyLoad', () => {
+  let initialLoaderRoot: HTMLElement | null = null;
+
   beforeEach(() => {
     jest.useFakeTimers();
   });
   afterEach(() => {
+    initialLoaderRoot?.remove();
+    initialLoaderRoot = null;
     jest.restoreAllMocks();
     jest.useRealTimers();
+  });
+
+  it('reuses the initial server loader when it is present', () => {
+    initialLoaderRoot = document.createElement('div');
+    initialLoaderRoot.id = ROOT_ELEMENT;
+    initialLoaderRoot.innerHTML = `
+      <div class="splash-loader">
+        <div data-test-id="server-loader">Loading Sentry</div>
+      </div>
+    `;
+    document.body.appendChild(initialLoaderRoot);
+
+    const importTest = new Promise<ResolvedComponent>(() => {});
+    render(<LazyLoad LazyComponent={lazy(() => importTest)} />);
+    initialLoaderRoot.replaceChildren();
+
+    expect(screen.getByTestId('server-loader')).toHaveTextContent('Loading Sentry');
   });
 
   it('renders with a loading indicator when promise is not resolved yet', async () => {

--- a/static/app/components/lazyLoad.tsx
+++ b/static/app/components/lazyLoad.tsx
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/react';
 
 import {Container, Flex} from '@sentry/scraps/layout';
 
+import {InitialLoadingIndicator} from 'sentry/components/initialLoadingIndicator';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {t} from 'sentry/locale';
@@ -62,11 +63,17 @@ export function LazyLoad<C extends React.LazyExoticComponent<any>>({
       <Suspense
         fallback={
           loadingFallback ?? (
-            <Flex flex="1" align="center" column="1 / -1">
-              <DeferredLoader fallback={<LoadingIndicator style={{display: 'none'}} />}>
-                <LoadingIndicator />
-              </DeferredLoader>
-            </Flex>
+            <InitialLoadingIndicator
+              fallback={
+                <Flex flex="1" align="center" column="1 / -1">
+                  <DeferredLoader
+                    fallback={<LoadingIndicator style={{display: 'none'}} />}
+                  >
+                    <LoadingIndicator />
+                  </DeferredLoader>
+                </Flex>
+              }
+            />
           )
         }
       >

--- a/static/app/views/organizationContainer.tsx
+++ b/static/app/views/organizationContainer.tsx
@@ -4,8 +4,10 @@ import {useProfiler} from '@sentry/react';
 import {Alert} from '@sentry/scraps/alert';
 import {Container} from '@sentry/scraps/layout';
 
+import {InitialLoadingIndicator} from 'sentry/components/initialLoadingIndicator';
 import {LoadingError} from 'sentry/components/loadingError';
-import {ORGANIZATION_FETCH_ERROR_TYPES, ROOT_ELEMENT} from 'sentry/constants';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ORGANIZATION_FETCH_ERROR_TYPES} from 'sentry/constants';
 import {t} from 'sentry/locale';
 import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
@@ -16,21 +18,7 @@ function OrganizationLoadingIndicator() {
     hasRenderSpan: true,
   });
 
-  /**
-   * This is the initial loader React will render as the app bootstraps.
-   * Rather than rendering a loader component, we can reuse the existing DOM
-   * provided by the server-rendered Django view!
-   *
-   * This ensures there are no layout shifts as the app initially boots up
-   * because the DOM is exactly the same and React doesn't have to reconcile
-   * the fallback state.
-   */
-  const root = document.getElementById(ROOT_ELEMENT);
-  // There is no scenario in which this component is rendering,
-  // but the root element where the app is mounted doesn't exist
-  const ssrLoader = root!.innerHTML;
-
-  return <div dangerouslySetInnerHTML={{__html: ssrLoader}} />;
+  return <InitialLoadingIndicator fallback={<LoadingIndicator />} />;
 }
 
 interface Props {


### PR DESCRIPTION
Initial route lazy loading can replace the server-rendered loader with a different React fallback during bootstrap. The organization loading boundary also copied the entire application root to preserve that loader.

Use the existing `splash-loader` class to capture only the visible initial loader through a shared `InitialLoadingIndicator`. The default lazy fallback and organization loading boundary reuse that loader while it is present and retain their normal React fallback for later in-app loads. Selecting the visible class instance also supports dev-ui's seasonal loader variants without additional HTML markers.

Capture the Web Animations timing state before React replaces the server-rendered loader, then apply its original document-timeline start time to each cloned animation in a layout effect. This keeps the loader at the same point in its animation across the handoff without waiting for another frame.

Tests: `static/app/components/initialLoadingIndicator.spec.tsx` and `static/app/components/lazyLoad.spec.tsx`.
