### PR TITLE
fix(api): Correct Explore saved query contracts

### DIFF
--- a/src/sentry/api/serializers/models/exploresavedquery.py
+++ b/src/sentry/api/serializers/models/exploresavedquery.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
-from typing import TypedDict
+from datetime import datetime
+from typing import Literal, TypedDict
 
 from sentry.api.serializers import Serializer, register
 from sentry.constants import ALL_ACCESS_PROJECTS
@@ -13,6 +14,11 @@ from sentry.users.api.serializers.user import UserSerializerResponse
 from sentry.users.services.user.service import user_service
 from sentry.utils.dates import outside_retention_with_modified_start, parse_timestamp
 
+ExploreSavedQueryDatasetType = Literal[
+    "spans", "logs", "segment_spans", "metrics", "replays", "ai_conversations"
+]
+ExploreSavedQueryMode = Literal["samples", "aggregate"]
+
 
 class MetricResponseTypeOptional(TypedDict, total=False):
     unit: str | None
@@ -20,27 +26,57 @@ class MetricResponseTypeOptional(TypedDict, total=False):
 
 class MetricResponseType(MetricResponseTypeOptional):
     name: str
-    type: str
+    type: Literal["counter", "gauge", "distribution"]
+
+
+class VisualizeResponseTypeOptional(TypedDict, total=False):
+    chartType: int
+
+
+class VisualizeResponseType(VisualizeResponseTypeOptional):
+    yAxes: list[str]
+
+
+class AggregateFieldResponseType(TypedDict, total=False):
+    chartType: int
+    yAxes: list[str]
+    groupBy: str
+
+
+class QueryResponseTypeOptional(TypedDict, total=False):
+    fields: list[str] | None
+    orderby: str | None
+    groupby: list[str] | None
+    query: str | None
+    visualize: list[VisualizeResponseType] | None
+    aggregateField: list[AggregateFieldResponseType] | None
+    aggregateOrderby: str | None
+    metric: MetricResponseType | None
+    caseInsensitive: bool
+
+
+class QueryResponseType(QueryResponseTypeOptional):
+    mode: ExploreSavedQueryMode
 
 
 class CrossEventResponseTypeOptional(TypedDict, total=False):
-    metric: MetricResponseType
+    metric: MetricResponseType | None
 
 
 class CrossEventResponseType(CrossEventResponseTypeOptional):
     query: str
-    type: str
+    type: Literal["spans", "logs", "metrics"]
 
 
 class ExploreSavedQueryResponseOptional(TypedDict, total=False):
     environment: list[str]
-    query: str
+    query: list[QueryResponseType]
     range: str
     start: str
     end: str
     interval: str
-    mode: str
     crossEvents: list[CrossEventResponseType]
+    agent: list[str]
 
 
 class ExploreSavedQueryChangedReasonType(TypedDict):
@@ -53,12 +89,12 @@ class ExploreSavedQueryResponse(ExploreSavedQueryResponseOptional):
     id: str
     name: str
     projects: list[int]
-    dataset: str
+    dataset: ExploreSavedQueryDatasetType
     expired: bool
-    dateAdded: str
-    dateUpdated: str
-    lastVisited: str
-    createdBy: UserSerializerResponse
+    dateAdded: datetime
+    dateUpdated: datetime
+    lastVisited: datetime | None
+    createdBy: UserSerializerResponse | None
     starred: bool
     position: int | None
     isPrebuilt: bool

--- a/src/sentry/apidocs/examples/explore_saved_query_examples.py
+++ b/src/sentry/apidocs/examples/explore_saved_query_examples.py
@@ -7,20 +7,29 @@ EXPLORE_SAVED_QUERY_OBJ = {
     "dateAdded": "2024-07-25T19:35:38.422859Z",
     "dateUpdated": "2024-07-25T19:35:38.422874Z",
     "environment": [],
-    "query": "span.op:pageload",
-    "fields": [
-        "span.op",
-        "project",
-        "count(span.duration)",
-        "avg(span.duration)",
-        "p75(span.duration)",
-        "p95(span.duration)",
+    "query": [
+        {
+            "query": "span.op:pageload",
+            "fields": [
+                "span.op",
+                "project",
+                "count(span.duration)",
+                "avg(span.duration)",
+                "p75(span.duration)",
+                "p95(span.duration)",
+            ],
+            "orderby": "-count(span.duration)",
+            "mode": "samples",
+        }
     ],
     "range": "24h",
-    "orderby": "-count(span.duration)",
-    "mode": "samples",
     "dataset": "spans",
     "expired": False,
+    "lastVisited": None,
+    "starred": False,
+    "position": None,
+    "isPrebuilt": False,
+    "changedReason": None,
     "createdBy": {
         "id": "1",
         "name": "Admin",
@@ -55,16 +64,22 @@ SAVED_QUERIES = [
         "dateAdded": "2024-07-25T19:35:38.422859Z",
         "dateUpdated": "2024-07-25T19:35:38.422874Z",
         "environment": [],
-        "query": "span.op:pageload",
-        "fields": [
-            "span.op",
-            "timestamp",
+        "query": [
+            {
+                "query": "span.op:pageload",
+                "fields": ["span.op", "timestamp"],
+                "orderby": "-timestamp",
+                "mode": "samples",
+            }
         ],
         "range": "24h",
-        "orderby": "-timestamp",
-        "mode": "samples",
         "dataset": "spans",
         "expired": False,
+        "lastVisited": None,
+        "starred": False,
+        "position": None,
+        "isPrebuilt": False,
+        "changedReason": None,
         "createdBy": {
             "id": "1",
             "name": "Admin",
@@ -97,17 +112,22 @@ SAVED_QUERIES = [
         "dateAdded": "2024-07-25T19:35:38.422859Z",
         "dateUpdated": "2024-07-25T19:35:38.422874Z",
         "environment": [],
-        "query": "span.op:cache.get",
-        "fields": [
-            "span.op",
-            "span.duration",
-            "timestamp",
+        "query": [
+            {
+                "query": "span.op:cache.get",
+                "fields": ["span.op", "span.duration", "timestamp"],
+                "orderby": "-timestamp",
+                "mode": "samples",
+            }
         ],
         "range": "24h",
-        "orderby": "-timestamp",
-        "mode": "samples",
         "dataset": "spans",
         "expired": False,
+        "lastVisited": None,
+        "starred": False,
+        "position": None,
+        "isPrebuilt": False,
+        "changedReason": None,
         "createdBy": {
             "id": "1",
             "name": "Admin",

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -27,6 +27,7 @@ from sentry.apidocs.parameters import (
     GlobalParams,
     VisibilityParams,
 )
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.explore.endpoints.bases import (
     ExploreSavedQueryPermission,
@@ -314,8 +315,8 @@ def sync_prebuilt_queries_starred(organization, user_id):
 @cell_silo_endpoint
 class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.PRIVATE,
-        "POST": ApiPublishStatus.PRIVATE,
+        "GET": ApiPublishStatus.PUBLIC,
+        "POST": ApiPublishStatus.PUBLIC,
     }
     owner = ApiOwner.EXPLORE
     permission_classes = (ExploreSavedQueryPermission,)
@@ -511,7 +512,9 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
         return self.paginate(
             request=request,
             paginator=GenericOffsetPaginator(data_fn=data_fn),
-            on_results=lambda x: serialize(x, request.user),
+            on_results=lambda x: serialize(
+                x, request.user, serializer=ExploreSavedQueryModelSerializer()
+            ),
             default_per_page=25,
         )
 
@@ -527,7 +530,9 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
         },
         examples=ExploreExamples.EXPLORE_SAVED_QUERY_POST_RESPONSE,
     )
-    def post(self, request: Request, organization) -> Response:
+    def post(
+        self, request: Request, organization: Organization
+    ) -> Response[ExploreSavedQueryResponse] | Response[ValidationErrorResponse]:
         """
         Create a new trace explorersaved query for the given organization.
         """
@@ -550,7 +555,7 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
         )
 
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         data = serializer.validated_data
 
@@ -572,4 +577,4 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
         except Exception as err:
             sentry_sdk.capture_exception(err)
 
-        return Response(serialize(model), status=201)
+        return Response(serialize(model, serializer=ExploreSavedQueryModelSerializer()), status=201)

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -315,8 +315,8 @@ def sync_prebuilt_queries_starred(organization, user_id):
 @cell_silo_endpoint
 class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
     publish_status = {
-        "GET": ApiPublishStatus.PUBLIC,
-        "POST": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "POST": ApiPublishStatus.EXPERIMENTAL,
     }
     owner = ApiOwner.EXPLORE
     permission_classes = (ExploreSavedQueryPermission,)

--- a/src/sentry/explore/endpoints/explore_saved_query_detail.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_detail.py
@@ -53,9 +53,9 @@ class ExploreSavedQueryBase(OrganizationEndpoint):
 @cell_silo_endpoint
 class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
     publish_status = {
-        "DELETE": ApiPublishStatus.PUBLIC,
-        "GET": ApiPublishStatus.PUBLIC,
-        "PUT": ApiPublishStatus.PUBLIC,
+        "DELETE": ApiPublishStatus.EXPERIMENTAL,
+        "GET": ApiPublishStatus.EXPERIMENTAL,
+        "PUT": ApiPublishStatus.EXPERIMENTAL,
     }
 
     def has_feature(self, organization, request):

--- a/src/sentry/explore/endpoints/explore_saved_query_detail.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_detail.py
@@ -12,7 +12,10 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import NoProjects, OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.serializers import serialize
-from sentry.api.serializers.models.exploresavedquery import ExploreSavedQueryModelSerializer
+from sentry.api.serializers.models.exploresavedquery import (
+    ExploreSavedQueryModelSerializer,
+    ExploreSavedQueryResponse,
+)
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
     RESPONSE_FORBIDDEN,
@@ -21,6 +24,7 @@ from sentry.apidocs.constants import (
 )
 from sentry.apidocs.examples.explore_saved_query_examples import ExploreExamples
 from sentry.apidocs.parameters import ExploreSavedQueryParams, GlobalParams
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.explore.endpoints.bases import ExploreSavedQueryPermission
 from sentry.explore.endpoints.serializers import ExploreSavedQuerySerializer
 from sentry.explore.models import ExploreSavedQuery, ExploreSavedQueryLastVisited
@@ -49,9 +53,9 @@ class ExploreSavedQueryBase(OrganizationEndpoint):
 @cell_silo_endpoint
 class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
     publish_status = {
-        "DELETE": ApiPublishStatus.PRIVATE,
-        "GET": ApiPublishStatus.PRIVATE,
-        "PUT": ApiPublishStatus.PRIVATE,
+        "DELETE": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC,
+        "PUT": ApiPublishStatus.PUBLIC,
     }
 
     def has_feature(self, organization, request):
@@ -73,7 +77,9 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
         },
         examples=ExploreExamples.EXPLORE_SAVED_QUERY_GET_RESPONSE,
     )
-    def get(self, request: Request, organization, query) -> Response:
+    def get(
+        self, request: Request, organization: Organization, query: ExploreSavedQuery
+    ) -> Response[ExploreSavedQueryResponse]:
         """
         Retrieve a saved query.
         """
@@ -82,7 +88,10 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
 
         self.check_object_permissions(request, query)
 
-        return Response(serialize(query, request.user), status=200)
+        return Response(
+            serialize(query, request.user, serializer=ExploreSavedQueryModelSerializer()),
+            status=200,
+        )
 
     @extend_schema(
         operation_id="Edit an Organization's Explore Saved Query",
@@ -96,7 +105,9 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
         },
         examples=ExploreExamples.EXPLORE_SAVED_QUERY_GET_RESPONSE,
     )
-    def put(self, request: Request, organization: Organization, query) -> Response:
+    def put(
+        self, request: Request, organization: Organization, query: ExploreSavedQuery
+    ) -> Response[ExploreSavedQueryResponse] | Response[ValidationErrorResponse]:
         """
         Modify a saved query.
         """
@@ -120,7 +131,7 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
             context={"params": params, "organization": organization, "user": request.user},
         )
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         data = serializer.validated_data
 
@@ -134,7 +145,7 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
 
         query.set_projects(data["project_ids"])
 
-        return Response(serialize(query), status=200)
+        return Response(serialize(query, serializer=ExploreSavedQueryModelSerializer()), status=200)
 
     @extend_schema(
         operation_id="Delete an Organization's Explore Saved Query",
@@ -145,7 +156,9 @@ class ExploreSavedQueryDetailEndpoint(ExploreSavedQueryBase):
             404: RESPONSE_NOT_FOUND,
         },
     )
-    def delete(self, request: Request, organization, query) -> Response:
+    def delete(
+        self, request: Request, organization: Organization, query: ExploreSavedQuery
+    ) -> Response[None]:
         """
         Delete a saved query.
         """

--- a/src/sentry/explore/endpoints/serializers.py
+++ b/src/sentry/explore/endpoints/serializers.py
@@ -228,7 +228,12 @@ class ExploreSavedQuerySerializer(serializers.Serializer):
         allow_null=True,
         help_text="Agent names to filter conversations by.",
     )
-    query = ListField(child=QuerySerializer(), required=True, min_length=1)
+    query = ListField(
+        child=QuerySerializer(),
+        required=True,
+        min_length=1,
+        help_text="The Explore query definitions to save.",
+    )
 
     def validate_projects(self, projects):
         from sentry.api.validators import validate_project_ids


### PR DESCRIPTION
Keep the Explore saved query list, create, retrieve, update, and delete endpoints experimental while giving them concrete request and response contracts for generated internal API consumers.

The response contract previously described `query` as a flat string even though the API has returned a list of nested query definitions since multi-query support shipped. This models the nested queries, visualizations, aggregate fields, metrics, and cross-event fields; corrects enum, date, and nullability types; includes the agent filter; and updates the examples to match actual responses.

Existing feature gates and organization/project access checks are unchanged. These endpoints remain outside the public API contract and its stability guarantees.
