### PR TITLE
ref(hybrid-cloud): clean up deletion watermarks so we don't refresh every cycle

### DIFF
--- a/src/sentry/deletions/tasks/hybrid_cloud.py
+++ b/src/sentry/deletions/tasks/hybrid_cloud.py
@@ -42,7 +42,6 @@ from sentry.utils import metrics
 
 TOMBSTONE_WATERMARK = "tombstone"
 ROW_WATERMARK = "row"
-WATERMARK_PREFIXES = (TOMBSTONE_WATERMARK, ROW_WATERMARK)
 
 
 @dataclass
@@ -126,12 +125,6 @@ def set_watermark(
     prefix: str, field: HybridCloudForeignKey[Any, Any], value: int, prev_transaction_id: str
 ) -> None:
     _write_watermark(prefix, field, value, sha1(prev_transaction_id.encode("utf8")).hexdigest())
-
-
-def refresh_watermarks(field: HybridCloudForeignKey[Any, Any]) -> None:
-    for prefix in WATERMARK_PREFIXES:
-        low_bound, transaction_id = get_watermark(prefix, field)
-        _write_watermark(prefix, field, low_bound, transaction_id)
 
 
 def _chunk_watermark_batch(
@@ -284,8 +277,6 @@ def _process_hybrid_cloud_foreign_key_cascade(
 
         tombstone_cls = TombstoneBase.class_for_silo_mode(silo_mode)
         assert tombstone_cls, "A tombstone class is required"
-
-        refresh_watermarks(field)
 
         # We rely on the return value of _process_tombstone_reconciliation
         # to short circuit the second half of this `or` so that the terminal batch

--- a/src/sentry/deletions/tasks/hybrid_cloud.py
+++ b/src/sentry/deletions/tasks/hybrid_cloud.py
@@ -42,6 +42,7 @@ from sentry.utils import metrics
 
 TOMBSTONE_WATERMARK = "tombstone"
 ROW_WATERMARK = "row"
+WATERMARK_PREFIXES = (TOMBSTONE_WATERMARK, ROW_WATERMARK)
 
 
 @dataclass
@@ -68,6 +69,17 @@ def _watermark_model(
     return CellDeletionWatermark
 
 
+def _report_low_bound(prefix: str, field: HybridCloudForeignKey[Any, Any], value: int) -> None:
+    metrics.gauge(
+        "deletion.hybrid_cloud.low_bound",
+        value,
+        tags=dict(
+            field_name=f"{field.model._meta.db_table}.{field.name}",
+            watermark=prefix,
+        ),
+    )
+
+
 def _write_watermark(
     prefix: str, field: HybridCloudForeignKey[Any, Any], value: int, transaction_id: str
 ) -> None:
@@ -77,14 +89,7 @@ def _write_watermark(
         field_name=field.name,
         defaults={"low_bound": value, "transaction_id": transaction_id},
     )
-    metrics.gauge(
-        "deletion.hybrid_cloud.low_bound",
-        value,
-        tags=dict(
-            field_name=f"{field.model._meta.db_table}.{field.name}",
-            watermark=prefix,
-        ),
-    )
+    _report_low_bound(prefix, field, value)
 
 
 def _watermark_row_lookup(prefix: str, field: HybridCloudForeignKey[Any, Any]) -> dict[str, str]:
@@ -125,6 +130,12 @@ def set_watermark(
     prefix: str, field: HybridCloudForeignKey[Any, Any], value: int, prev_transaction_id: str
 ) -> None:
     _write_watermark(prefix, field, value, sha1(prev_transaction_id.encode("utf8")).hexdigest())
+
+
+def report_watermarks(field: HybridCloudForeignKey[Any, Any]) -> None:
+    for prefix in WATERMARK_PREFIXES:
+        low_bound, _ = get_watermark(prefix, field)
+        _report_low_bound(prefix, field, low_bound)
 
 
 def _chunk_watermark_batch(
@@ -277,6 +288,8 @@ def _process_hybrid_cloud_foreign_key_cascade(
 
         tombstone_cls = TombstoneBase.class_for_silo_mode(silo_mode)
         assert tombstone_cls, "A tombstone class is required"
+
+        report_watermarks(field)
 
         # We rely on the return value of _process_tombstone_reconciliation
         # to short circuit the second half of this `or` so that the terminal batch

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -21,7 +21,6 @@ from sentry.deletions.models.watermark import CellDeletionWatermark, ControlDele
 from sentry.deletions.tasks.hybrid_cloud import (
     ROW_WATERMARK,
     TOMBSTONE_WATERMARK,
-    WATERMARK_PREFIXES,
     WatermarkBatch,
     _process_hybrid_cloud_foreign_key_cascade,
     _read_postgres_watermark,
@@ -135,8 +134,8 @@ def record_watermark_writes(
     field: HybridCloudForeignKey[int, int],
 ) -> Generator[set[str]]:
     """
-    Collect the watermark prefixes written for one field. A rewrite stores the
-    value it already holds, so the row itself cannot show that it happened.
+    Collect the watermark prefixes written for one field. A write can store the
+    value the row already holds, so the row itself cannot show that it happened.
     """
     written: set[str] = set()
     manager = _watermark_model(field).objects
@@ -172,53 +171,22 @@ def test_no_work_is_no_op(
 
 
 @django_db_all
-def test_no_work_rewrites_both_watermarks(
+def test_no_work_writes_no_watermark(
     task_runner: Callable[[], ContextManager[None]],
     project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
 ) -> None:
+    """
+    A caught up field writes its watermark rows only when it has work. The
+    every cycle rewrite existed to fill the Postgres tables during the
+    Redis to Postgres migration and is gone now.
+    """
     reset_watermarks()
-
-    before = {
-        prefix: get_watermark(prefix, project_bookmark_user_id_field)
-        for prefix in WATERMARK_PREFIXES
-    }
 
     with record_watermark_writes(project_bookmark_user_id_field) as written:
         with task_runner():
             schedule_hybrid_cloud_foreign_key_jobs()
 
-    assert written == set(WATERMARK_PREFIXES)
-
-    for prefix, watermark in before.items():
-        assert get_watermark(prefix, project_bookmark_user_id_field) == watermark
-
-
-@django_db_all
-def test_catch_up_rewrites_both_watermarks(
-    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
-) -> None:
-    """
-    The `or` in _process_hybrid_cloud_foreign_key_cascade skips the second
-    reconciliation while the first one still has work. Both watermarks must be
-    written on such a cycle.
-    """
-    reset_watermarks()
-
-    with record_watermark_writes(project_bookmark_user_id_field) as written:
-        with patch(
-            "sentry.deletions.tasks.hybrid_cloud._process_tombstone_reconciliation",
-            return_value=True,
-        ) as reconciliation:
-            _process_hybrid_cloud_foreign_key_cascade(
-                app_name=ProjectBookmark._meta.app_label,
-                model_name=ProjectBookmark.__name__,
-                field_name=project_bookmark_user_id_field.name,
-                process_task=Mock(),
-                silo_mode=SiloMode.CELL,
-            )
-
-    assert reconciliation.call_count == 1
-    assert written == set(WATERMARK_PREFIXES)
+    assert written == set()
 
 
 @django_db_all
@@ -308,25 +276,6 @@ def test_write_failure_reaches_the_caller(
     row = _cell_watermark_rows(project_bookmark_user_id_field).get(prefix=TOMBSTONE_WATERMARK)
     assert row.low_bound == 5
     assert get_watermark(TOMBSTONE_WATERMARK, project_bookmark_user_id_field)[0] == 5
-
-
-@django_db_all
-def test_one_cycle_fills_both_watermark_rows(
-    task_runner: Callable[[], ContextManager[None]],
-    project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
-) -> None:
-    reset_watermarks()
-    _cell_watermark_rows(project_bookmark_user_id_field).delete()
-
-    with task_runner():
-        schedule_hybrid_cloud_foreign_key_jobs()
-
-    rows = {row.prefix: row for row in _cell_watermark_rows(project_bookmark_user_id_field)}
-    assert set(rows) == set(WATERMARK_PREFIXES)
-    for prefix, row in rows.items():
-        assert (row.low_bound, row.transaction_id) == get_watermark(
-            prefix, project_bookmark_user_id_field
-        )
 
 
 @django_db_all

--- a/tests/sentry/deletions/tasks/test_hybrid_cloud.py
+++ b/tests/sentry/deletions/tasks/test_hybrid_cloud.py
@@ -18,9 +18,11 @@ from sentry.db.models.fields.hybrid_cloud_foreign_key import HybridCloudForeignK
 from sentry.db.models.manager.base import BaseManager
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.deletions.models.watermark import CellDeletionWatermark, ControlDeletionWatermark
+from sentry.deletions.tasks import hybrid_cloud
 from sentry.deletions.tasks.hybrid_cloud import (
     ROW_WATERMARK,
     TOMBSTONE_WATERMARK,
+    WATERMARK_PREFIXES,
     WatermarkBatch,
     _process_hybrid_cloud_foreign_key_cascade,
     _read_postgres_watermark,
@@ -153,6 +155,29 @@ def record_watermark_writes(
         yield written
 
 
+@contextmanager
+def record_low_bound_reports(
+    field: HybridCloudForeignKey[int, int],
+) -> Generator[set[str]]:
+    """
+    Collect the watermark prefixes that reported their position for one field.
+    Reporting does not touch the row, so the row cannot show that it happened.
+    """
+    reported: set[str] = set()
+    real_report = hybrid_cloud._report_low_bound
+
+    def record(prefix: str, reported_field: Any, value: int) -> None:
+        if (
+            reported_field.model._meta.db_table == field.model._meta.db_table
+            and reported_field.name == field.name
+        ):
+            reported.add(prefix)
+        return real_report(prefix, reported_field, value)
+
+    with patch.object(hybrid_cloud, "_report_low_bound", record):
+        yield reported
+
+
 @django_db_all
 def test_no_work_is_no_op(
     task_runner: Callable[[], ContextManager[None]],
@@ -171,22 +196,25 @@ def test_no_work_is_no_op(
 
 
 @django_db_all
-def test_no_work_writes_no_watermark(
+def test_no_work_reports_both_watermarks_without_writing(
     task_runner: Callable[[], ContextManager[None]],
     project_bookmark_user_id_field: HybridCloudForeignKey[int, int],
 ) -> None:
     """
-    A caught up field writes its watermark rows only when it has work. The
-    every cycle rewrite existed to fill the Postgres tables during the
-    Redis to Postgres migration and is gone now.
+    A caught up field writes its watermark rows only when it has work, but it
+    still reports where both watermarks sit. The every cycle rewrite existed to
+    fill the Postgres tables during the Redis to Postgres migration and is gone
+    now, so the report is what keeps the position visible.
     """
     reset_watermarks()
 
     with record_watermark_writes(project_bookmark_user_id_field) as written:
-        with task_runner():
-            schedule_hybrid_cloud_foreign_key_jobs()
+        with record_low_bound_reports(project_bookmark_user_id_field) as reported:
+            with task_runner():
+                schedule_hybrid_cloud_foreign_key_jobs()
 
     assert written == set()
+    assert reported == set(WATERMARK_PREFIXES)
 
 
 @django_db_all


### PR DESCRIPTION
Before we migrated these keys to Postgres, we were only writing them when work was actually being done. In order to unlock the dual-write, we refreshed the keys every cycle. Now that the migration is done, we don't need to refresh that frequently, so this just moves it back to the cadence it was before.