### PR TITLE
fix(auth): Synchronize branded sign-in loading

### DIFF
--- a/static/app/components/brandPageLayout/index.spec.tsx
+++ b/static/app/components/brandPageLayout/index.spec.tsx
@@ -1,4 +1,6 @@
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {useEffect} from 'react';
+
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {BrandPageLayout} from 'sentry/components/brandPageLayout';
 
@@ -11,5 +13,33 @@ describe('BrandPageLayout', () => {
     );
 
     expect(screen.getByText('Close').closest('[style]')).toHaveStyle({gridColumn: '3'});
+  });
+
+  it('holds artwork effects while its activity is hidden', async () => {
+    const onArtworkActive = jest.fn();
+
+    function Artwork() {
+      useEffect(() => {
+        onArtworkActive();
+      }, []);
+
+      return null;
+    }
+
+    const {rerender} = render(
+      <BrandPageLayout artwork={<Artwork />} isArtworkActive={false}>
+        Content
+      </BrandPageLayout>
+    );
+
+    expect(onArtworkActive).not.toHaveBeenCalled();
+
+    rerender(
+      <BrandPageLayout artwork={<Artwork />} isArtworkActive>
+        Content
+      </BrandPageLayout>
+    );
+
+    await waitFor(() => expect(onArtworkActive).toHaveBeenCalledTimes(1));
   });
 });

--- a/static/app/components/brandPageLayout/index.tsx
+++ b/static/app/components/brandPageLayout/index.tsx
@@ -1,3 +1,5 @@
+import {Activity} from 'react';
+
 import artworkBackground from 'sentry-images/brandPageLayout/background.avif';
 import artworkImage from 'sentry-images/brandPageLayout/full-art.avif';
 import artworkOutline from 'sentry-images/brandPageLayout/outline.webp';
@@ -15,6 +17,7 @@ interface BrandPageLayoutProps {
   children: React.ReactNode;
   artwork?: React.ReactNode;
   background?: React.ReactNode;
+  isArtworkActive?: boolean;
 }
 
 /**
@@ -32,6 +35,7 @@ function BrandPageLayoutRoot({
   ),
   background = <BrandPageBackground />,
   children,
+  isArtworkActive = true,
 }: BrandPageLayoutProps) {
   return (
     <BrandPageLayoutSlot.Provider>
@@ -62,7 +66,9 @@ function BrandPageLayoutRoot({
             overflow="visible"
             pointerEvents="none"
           >
-            {artwork}
+            <Activity mode={isArtworkActive ? 'visible' : 'hidden'} name="Brand artwork">
+              {artwork}
+            </Activity>
           </Container>
         </Container>
 

--- a/static/app/views/authV2/authLogin/index.spec.tsx
+++ b/static/app/views/authV2/authLogin/index.spec.tsx
@@ -1,3 +1,4 @@
+import {Fragment} from 'react';
 import Cookies from 'js-cookie';
 import {UserFixture} from 'sentry-fixture/user';
 
@@ -8,6 +9,7 @@ import {BrandPageLayout} from 'sentry/components/brandPageLayout';
 import type {AuthConfig} from 'sentry/types/auth';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
+import {BrandedAuthLoadingProvider} from 'sentry/views/authV2/useBrandedAuthLoading';
 
 import AuthLogin from './index';
 
@@ -44,6 +46,19 @@ describe('AuthLogin', () => {
     });
   }
 
+  function renderWithLoadingState() {
+    return render(
+      <BrandedAuthLoadingProvider>
+        {isLoading => (
+          <Fragment>
+            <div>{isLoading ? 'Loading authentication' : 'Authentication ready'}</div>
+            <AuthLogin />
+          </Fragment>
+        )}
+      </BrandedAuthLoadingProvider>
+    );
+  }
+
   it('does not render the sign-in flow while auth config is loading', async () => {
     const authConfig = Promise.withResolvers<AuthConfig>();
     MockApiClient.addMockResponse({
@@ -51,8 +66,9 @@ describe('AuthLogin', () => {
       body: () => authConfig.promise,
     });
 
-    render(<AuthLogin />);
+    renderWithLoadingState();
 
+    expect(screen.getByText('Loading authentication')).toBeInTheDocument();
     expect(
       screen.queryByRole('heading', {name: 'Sign in to Sentry'})
     ).not.toBeInTheDocument();
@@ -76,6 +92,7 @@ describe('AuthLogin', () => {
     expect(
       await screen.findByRole('heading', {name: 'Sign in to Sentry'})
     ).toBeInTheDocument();
+    expect(screen.getByText('Authentication ready')).toBeInTheDocument();
     expect(trackAnalytics).toHaveBeenCalledWith(
       'auth.login.rendered',
       {
@@ -94,7 +111,7 @@ describe('AuthLogin', () => {
       body: {detail: 'Config unavailable'},
     });
 
-    render(<AuthLogin />);
+    renderWithLoadingState();
 
     expect(
       await screen.findByText('Unable to load the login page. Try again.')
@@ -112,7 +129,7 @@ describe('AuthLogin', () => {
       body: {nextUri: '/organizations/acme/issues/'},
     });
 
-    render(<AuthLogin />);
+    renderWithLoadingState();
 
     await waitFor(() =>
       expect(testableWindowLocation.assign).toHaveBeenCalledWith(
@@ -122,6 +139,7 @@ describe('AuthLogin', () => {
     expect(
       screen.queryByRole('heading', {name: 'Sign in to Sentry'})
     ).not.toBeInTheDocument();
+    expect(screen.getByText('Loading authentication')).toBeInTheDocument();
   });
 
   it('focuses organization SSO when the authenticated user still requires it', async () => {

--- a/static/app/views/authV2/authLogin/index.tsx
+++ b/static/app/views/authV2/authLogin/index.tsx
@@ -22,6 +22,7 @@ import {AuthV2CookieState, useEnableAuthV2} from 'sentry/utils/useEnableAuthV2';
 import {useLocation} from 'sentry/utils/useLocation';
 import {useNavigate} from 'sentry/utils/useNavigate';
 import {useParams} from 'sentry/utils/useParams';
+import {useBrandedAuthLoading} from 'sentry/views/authV2/useBrandedAuthLoading';
 
 import {EmailAuth} from './components/emailAuth';
 import {OrganizationSwitcher} from './components/organizationSwitcher';
@@ -165,6 +166,7 @@ export default function AuthLogin() {
     (orgSlug && isAuthOrganizationPending) ||
     (nextUri && !focusedOrgAuth && !hasAuthOrganizationError)
   );
+  useBrandedAuthLoading(!isLoginRenderable);
 
   useEffect(() => {
     if (!isLoginRenderable) {

--- a/static/app/views/authV2/brandedAuthLayout.tsx
+++ b/static/app/views/authV2/brandedAuthLayout.tsx
@@ -1,19 +1,52 @@
+import {Fragment} from 'react';
 import {Outlet, useLocation} from 'react-router-dom';
 import {AnimatePresence} from 'framer-motion';
 
+import {Container, Flex} from '@sentry/scraps/layout';
+
 import {BrandPageLayout} from 'sentry/components/brandPageLayout';
+import {InitialLoadingIndicator} from 'sentry/components/initialLoadingIndicator';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+
+import {BrandedAuthLoadingProvider} from './useBrandedAuthLoading';
 
 export default function BrandedAuthLayout() {
   const location = useLocation();
   const pageKey = location.pathname.split('/').slice(0, 3).join('/');
 
   return (
-    <BrandPageLayout>
-      <BrandPageLayout.Content>
-        <AnimatePresence initial={false} mode="wait">
-          <Outlet key={pageKey} />
-        </AnimatePresence>
-      </BrandPageLayout.Content>
-    </BrandPageLayout>
+    <BrandedAuthLoadingProvider>
+      {isLoading => (
+        <Fragment>
+          <Container
+            visibility={isLoading ? 'hidden' : 'visible'}
+            pointerEvents={isLoading ? 'none' : 'auto'}
+            aria-hidden={isLoading}
+          >
+            <BrandPageLayout isArtworkActive={!isLoading}>
+              <BrandPageLayout.Content>
+                <AnimatePresence initial={false} mode="wait">
+                  <Outlet key={pageKey} />
+                </AnimatePresence>
+              </BrandPageLayout.Content>
+            </BrandPageLayout>
+          </Container>
+
+          {isLoading && (
+            <Flex
+              position="fixed"
+              inset="0"
+              align="center"
+              justify="center"
+              background="primary"
+            >
+              <InitialLoadingIndicator
+                fallback={<LoadingIndicator style={{margin: 0}} />}
+              />
+            </Flex>
+          )}
+        </Fragment>
+      )}
+    </BrandedAuthLoadingProvider>
   );
 }

--- a/static/app/views/authV2/useBrandedAuthLoading.spec.tsx
+++ b/static/app/views/authV2/useBrandedAuthLoading.spec.tsx
@@ -1,0 +1,46 @@
+import {Fragment, useState} from 'react';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {
+  BrandedAuthLoadingProvider,
+  useBrandedAuthLoading,
+} from 'sentry/views/authV2/useBrandedAuthLoading';
+
+function LoadingReporter({isLoading}: {isLoading: boolean}) {
+  useBrandedAuthLoading(isLoading);
+
+  return null;
+}
+
+function TestPage() {
+  const [isLoading, setIsLoading] = useState(true);
+  const [isMounted, setIsMounted] = useState(true);
+
+  return (
+    <BrandedAuthLoadingProvider>
+      {isPageLoading => (
+        <Fragment>
+          <div>{isPageLoading ? 'Loading authentication' : 'Authentication ready'}</div>
+          {isMounted && <LoadingReporter isLoading={isLoading} />}
+          <button onClick={() => setIsLoading(false)}>Finish loading</button>
+          <button onClick={() => setIsMounted(false)}>Unmount page</button>
+        </Fragment>
+      )}
+    </BrandedAuthLoadingProvider>
+  );
+}
+
+describe('useBrandedAuthLoading', () => {
+  it('reports loading state and restores it when the page unmounts', async () => {
+    render(<TestPage />);
+
+    expect(screen.getByText('Loading authentication')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Finish loading'}));
+    expect(screen.getByText('Authentication ready')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Unmount page'}));
+    expect(screen.getByText('Loading authentication')).toBeInTheDocument();
+  });
+});

--- a/static/app/views/authV2/useBrandedAuthLoading.tsx
+++ b/static/app/views/authV2/useBrandedAuthLoading.tsx
@@ -1,0 +1,27 @@
+import {createContext, useContext, useLayoutEffect, useState} from 'react';
+
+const BrandedAuthLoadingContext = createContext<(isLoading: boolean) => void>(() => {});
+
+interface BrandedAuthLoadingProviderProps {
+  children: (isLoading: boolean) => React.ReactNode;
+}
+
+export function BrandedAuthLoadingProvider({children}: BrandedAuthLoadingProviderProps) {
+  const [isLoading, setIsLoading] = useState(true);
+
+  return (
+    <BrandedAuthLoadingContext value={setIsLoading}>
+      {children(isLoading)}
+    </BrandedAuthLoadingContext>
+  );
+}
+
+export function useBrandedAuthLoading(isLoading: boolean) {
+  const setIsLoading = useContext(BrandedAuthLoadingContext);
+
+  useLayoutEffect(() => {
+    setIsLoading(isLoading);
+
+    return () => setIsLoading(true);
+  }, [isLoading, setIsLoading]);
+}


### PR DESCRIPTION
Keep branded authentication hidden until its configuration settles, then reveal the form, background, and newly activated artwork together.