### PR TITLE
ref(issues): Derive issue category choices from shared types

### DIFF
--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -131,6 +131,29 @@ export const VALID_ISSUE_CATEGORIES = [
   IssueCategory.CONFIGURATION,
 ];
 
+/**
+ * Numeric values used by issue category workflow conditions.
+ * These must match GroupCategory in src/sentry/issues/grouptype.py.
+ */
+export const ISSUE_CATEGORY_TO_GROUP_CATEGORY: Record<IssueCategory, number> = {
+  [IssueCategory.ERROR]: 1,
+  [IssueCategory.PERFORMANCE]: 2,
+  [IssueCategory.CRON]: 4,
+  [IssueCategory.REPLAY]: 5,
+  [IssueCategory.FEEDBACK]: 6,
+  [IssueCategory.UPTIME]: 7,
+  [IssueCategory.METRIC_ALERT]: 8,
+  [IssueCategory.OUTAGE]: 10,
+  [IssueCategory.METRIC]: 11,
+  [IssueCategory.DB_QUERY]: 12,
+  [IssueCategory.HTTP_CLIENT]: 13,
+  [IssueCategory.FRONTEND]: 14,
+  [IssueCategory.MOBILE]: 15,
+  [IssueCategory.AI_DETECTED]: 16,
+  [IssueCategory.PREPROD]: 17,
+  [IssueCategory.CONFIGURATION]: 19,
+};
+
 export const ISSUE_CATEGORY_TO_DESCRIPTION: Record<IssueCategory, string> = {
   [IssueCategory.ERROR]: t('Runtime errors or exceptions.'),
   [IssueCategory.OUTAGE]: t('Uptime or cron monitoring issues.'),

--- a/static/app/types/group.tsx
+++ b/static/app/types/group.tsx
@@ -135,23 +135,42 @@ export const VALID_ISSUE_CATEGORIES = [
  * Numeric values used by issue category workflow conditions.
  * These must match GroupCategory in src/sentry/issues/grouptype.py.
  */
-export const ISSUE_CATEGORY_TO_GROUP_CATEGORY: Record<IssueCategory, number> = {
-  [IssueCategory.ERROR]: 1,
-  [IssueCategory.PERFORMANCE]: 2,
-  [IssueCategory.CRON]: 4,
-  [IssueCategory.REPLAY]: 5,
-  [IssueCategory.FEEDBACK]: 6,
-  [IssueCategory.UPTIME]: 7,
-  [IssueCategory.METRIC_ALERT]: 8,
-  [IssueCategory.OUTAGE]: 10,
-  [IssueCategory.METRIC]: 11,
-  [IssueCategory.DB_QUERY]: 12,
-  [IssueCategory.HTTP_CLIENT]: 13,
-  [IssueCategory.FRONTEND]: 14,
-  [IssueCategory.MOBILE]: 15,
-  [IssueCategory.AI_DETECTED]: 16,
-  [IssueCategory.PREPROD]: 17,
-  [IssueCategory.CONFIGURATION]: 19,
+export enum GroupCategory {
+  ERROR = 1,
+  PERFORMANCE = 2,
+  CRON = 4,
+  REPLAY = 5,
+  FEEDBACK = 6,
+  UPTIME = 7,
+  METRIC_ALERT = 8,
+  OUTAGE = 10,
+  METRIC = 11,
+  DB_QUERY = 12,
+  HTTP_CLIENT = 13,
+  FRONTEND = 14,
+  MOBILE = 15,
+  AI_DETECTED = 16,
+  PREPROD = 17,
+  CONFIGURATION = 19,
+}
+
+export const ISSUE_CATEGORY_TO_GROUP_CATEGORY: Record<IssueCategory, GroupCategory> = {
+  [IssueCategory.ERROR]: GroupCategory.ERROR,
+  [IssueCategory.PERFORMANCE]: GroupCategory.PERFORMANCE,
+  [IssueCategory.CRON]: GroupCategory.CRON,
+  [IssueCategory.REPLAY]: GroupCategory.REPLAY,
+  [IssueCategory.FEEDBACK]: GroupCategory.FEEDBACK,
+  [IssueCategory.UPTIME]: GroupCategory.UPTIME,
+  [IssueCategory.METRIC_ALERT]: GroupCategory.METRIC_ALERT,
+  [IssueCategory.OUTAGE]: GroupCategory.OUTAGE,
+  [IssueCategory.METRIC]: GroupCategory.METRIC,
+  [IssueCategory.DB_QUERY]: GroupCategory.DB_QUERY,
+  [IssueCategory.HTTP_CLIENT]: GroupCategory.HTTP_CLIENT,
+  [IssueCategory.FRONTEND]: GroupCategory.FRONTEND,
+  [IssueCategory.MOBILE]: GroupCategory.MOBILE,
+  [IssueCategory.AI_DETECTED]: GroupCategory.AI_DETECTED,
+  [IssueCategory.PREPROD]: GroupCategory.PREPROD,
+  [IssueCategory.CONFIGURATION]: GroupCategory.CONFIGURATION,
 };
 
 export const ISSUE_CATEGORY_TO_DESCRIPTION: Record<IssueCategory, string> = {

--- a/static/app/views/automations/components/actionFilters/issueCategory.tsx
+++ b/static/app/views/automations/components/actionFilters/issueCategory.tsx
@@ -2,32 +2,19 @@ import type {SelectValue} from '@sentry/scraps/select';
 
 import {AutomationBuilderSelect} from 'sentry/components/workflowEngine/form/automationBuilderSelect';
 import {t, tct} from 'sentry/locale';
+import {
+  ISSUE_CATEGORY_TO_GROUP_CATEGORY,
+  VALID_ISSUE_CATEGORIES,
+} from 'sentry/types/group';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
 import type {ValidateDataConditionProps} from 'sentry/views/automations/components/automationFormData';
 import {useDataConditionNodeContext} from 'sentry/views/automations/components/dataConditionNodes';
 
-enum GroupCategory {
-  ERROR = 1,
-  FEEDBACK = 6,
-  OUTAGE = 10,
-  METRIC = 11,
-  DB_QUERY = 12,
-  HTTP_CLIENT = 13,
-  FRONTEND = 14,
-  MOBILE = 15,
-}
-
-const GROUP_CATEGORY_CHOICES = [
-  {value: GroupCategory.ERROR, label: 'error'},
-  {value: GroupCategory.FEEDBACK, label: 'feedback'},
-  {value: GroupCategory.OUTAGE, label: 'outage'},
-  {value: GroupCategory.METRIC, label: 'metric'},
-  {value: GroupCategory.DB_QUERY, label: 'db_query'},
-  {value: GroupCategory.HTTP_CLIENT, label: 'http_client'},
-  {value: GroupCategory.FRONTEND, label: 'frontend'},
-  {value: GroupCategory.MOBILE, label: 'mobile'},
-];
+const GROUP_CATEGORY_CHOICES = VALID_ISSUE_CATEGORIES.map(issueCategory => ({
+  value: ISSUE_CATEGORY_TO_GROUP_CATEGORY[issueCategory],
+  label: issueCategory,
+}));
 
 const INCLUDE_CHOICES = [
   {value: true, label: t('equal to')},
@@ -81,7 +68,7 @@ function CategoryField() {
       aria-label={t('Issue category')}
       value={condition.comparison.value}
       options={GROUP_CATEGORY_CHOICES}
-      onChange={(option: SelectValue<GroupCategory>) => {
+      onChange={(option: SelectValue<number>) => {
         onUpdate({comparison: {...condition.comparison, value: option.value}});
         removeError(condition.id);
       }}

--- a/static/app/views/automations/components/actionFilters/issueCategory.tsx
+++ b/static/app/views/automations/components/actionFilters/issueCategory.tsx
@@ -5,6 +5,7 @@ import {t, tct} from 'sentry/locale';
 import {
   ISSUE_CATEGORY_TO_GROUP_CATEGORY,
   VALID_ISSUE_CATEGORIES,
+  type GroupCategory,
 } from 'sentry/types/group';
 import type {DataCondition} from 'sentry/types/workflowEngine/dataConditions';
 import {useAutomationBuilderErrorContext} from 'sentry/views/automations/components/automationBuilderErrorContext';
@@ -68,7 +69,7 @@ function CategoryField() {
       aria-label={t('Issue category')}
       value={condition.comparison.value}
       options={GROUP_CATEGORY_CHOICES}
-      onChange={(option: SelectValue<number>) => {
+      onChange={(option: SelectValue<GroupCategory>) => {
         onUpdate({comparison: {...condition.comparison, value: option.value}});
         removeError(condition.id);
       }}

--- a/static/app/views/automations/components/dataConditionNodeList.spec.tsx
+++ b/static/app/views/automations/components/dataConditionNodeList.spec.tsx
@@ -344,10 +344,21 @@ describe('DataConditionNodeList', () => {
       });
 
       await userEvent.click(await screen.findByLabelText('Issue category'));
+      expect(
+        screen.getByRole('menuitemradio', {name: 'configuration'})
+      ).toBeInTheDocument();
+      expect(screen.getByRole('menuitemradio', {name: 'preprod'})).toBeInTheDocument();
       await userEvent.click(screen.getByRole('menuitemradio', {name: 'metric'}));
 
       expect(mockUpdateCondition).toHaveBeenLastCalledWith('issue-category', {
         comparison: {value: 11, include: false},
+      });
+
+      await userEvent.click(await screen.findByLabelText('Issue category'));
+      await userEvent.click(screen.getByRole('menuitemradio', {name: 'configuration'}));
+
+      expect(mockUpdateCondition).toHaveBeenLastCalledWith('issue-category', {
+        comparison: {value: 19, include: false},
       });
     });
 


### PR DESCRIPTION
Resolves https://linear.app/getsentry/issue/ISWF-810/issuecategorytsx-dupes-indextypeconfig-code.

Automation issue-category filters now derive their options from the shared valid-category list and numeric mapping instead of maintaining a parallel enum & choice list.

Adds `preprod` & `configuration`.