### PR TITLE
fix(rules): attribute ticket creation to the ambient action context

### DIFF
--- a/src/sentry/rules/actions/integrations/create_ticket/utils.py
+++ b/src/sentry/rules/actions/integrations/create_ticket/utils.py
@@ -16,8 +16,8 @@ from sentry.integrations.project_management.metrics import (
 )
 from sentry.integrations.services.integration.model import RpcIntegration
 from sentry.integrations.services.integration.service import integration_service
-from sentry.issues.action_log.publish import publish_action
-from sentry.issues.action_log.types import SYSTEM_ACTOR, ActionSource, CreateExternalIssueAction
+from sentry.issues.action_log.publish import publish_action_from_context
+from sentry.issues.action_log.types import CreateExternalIssueAction
 from sentry.models.activity import Activity
 from sentry.models.grouplink import GroupLink
 from sentry.notifications.utils.links import create_link_to_workflow
@@ -87,16 +87,13 @@ def create_link(
             "new": True,
         },
     )
-    # This runs from a rule/workflow firing, so there is no request user to attribute.
-    publish_action(
+    publish_action_from_context(
         CreateExternalIssueAction(
             provider=integration.provider,
             external_issue_key=external_issue.key,
         ),
-        source=ActionSource.SYSTEM,
         group_id=event.group.id,
         project=event.group.project,
-        actor=SYSTEM_ACTOR,
     )
 
 

--- a/tests/sentry/integrations/github/test_ticket_action.py
+++ b/tests/sentry/integrations/github/test_ticket_action.py
@@ -9,7 +9,8 @@ from sentry.integrations.github import client
 from sentry.integrations.github.actions.create_ticket import GitHubCreateTicketAction
 from sentry.integrations.github.integration import GitHubIntegration
 from sentry.integrations.models.external_issue import ExternalIssue
-from sentry.issues.action_log.types import SYSTEM_ACTOR, ActionSource, CreateExternalIssueAction
+from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource, action_context_scope
+from sentry.issues.action_log.types import CreateExternalIssueAction
 from sentry.models.activity import Activity
 from sentry.models.repository import Repository
 from sentry.models.rule import Rule
@@ -151,7 +152,10 @@ class GitHubTicketRulesTestCase(RuleTestCase, BaseAPITestCase):
         event = self.get_group_event()
 
         # Trigger its `after`
-        with capture_action_log() as action_log:
+        with (
+            action_context_scope(ActionSource.SYSTEM),
+            capture_action_log() as action_log,
+        ):
             self.trigger(event, rule_object)
 
         action_log.assert_logged(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_test_fire_action.py
@@ -7,7 +7,7 @@ from sentry.integrations.pagerduty.client import PagerDutyClient
 from sentry.integrations.pagerduty.utils import PagerDutyServiceDict, add_service
 from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.issues.action_log import ActionSource, GroupActionActor
-from sentry.issues.action_log.types import CreateIssueAction
+from sentry.issues.action_log.types import CreateExternalIssueAction, CreateIssueAction
 from sentry.models.project import Project
 from sentry.notifications.notification_action.group_type_notification_registry import (
     IssueAlertRegistryHandler,
@@ -212,13 +212,19 @@ class TestFireActionsEndpointTest(APITestCase, BaseWorkflowTest):
             }
         ]
 
+        actor = GroupActionActor.user(self.user.id)
         with capture_action_log() as log:
             self.get_success_response(self.organization.slug, actions=action_data)
 
         log.assert_logged(
             CreateIssueAction,
             source=ActionSource.WEB,
-            actor=GroupActionActor.user(self.user.id),
+            actor=actor,
+        )
+        log.assert_logged(
+            CreateExternalIssueAction,
+            source=ActionSource.WEB,
+            actor=actor,
         )
 
     def test_no_projects_available(self) -> None:


### PR DESCRIPTION
Use action context here instead of explicitly setting system / actor. The issue here is that when users fire actions, we attribute the event to the user / web, but the actual action context here assumes that they are triggered from a rule / workflow. We can use action context to clean up this edge case


Refs SENTRY-5RK2