### PR TITLE
build(deps): bump sentry-protos to 0.64.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.2.8",
-  "sentry-protos>=0.64.5",
+  "sentry-protos>=0.64.6",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.28",
   "sentry-scm==1.5.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2385,7 +2385,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.2.0" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.2.8" },
-    { name = "sentry-protos", specifier = ">=0.64.5" },
+    { name = "sentry-protos", specifier = ">=0.64.6" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.28" },
     { name = "sentry-scm", specifier = "==1.5.0" },
@@ -2565,7 +2565,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.64.5"
+version = "0.64.6"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2573,7 +2573,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.64.5-py3-none-any.whl", hash = "sha256:648d9f44fd652f08270bd86ebe71d756ff8479f6ee022507fa4471ed547620ed" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.64.6-py3-none-any.whl", hash = "sha256:41c6387e5e0c747b74bf38e65b267193f3a5472132df879a18d8403d9a61806b" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps `sentry-protos` from 0.64.5 to 0.64.6 and refreshes the uv lockfile so Sentry can consume the latest generated protocol definitions.
