### PR TITLE
fix(seer-infra-telemetry): Fix Datadog org URL in Datadog integration installation flow

### DIFF
--- a/static/app/components/pipeline/integrationDatadog/index.spec.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.spec.tsx
@@ -19,21 +19,46 @@ describe('DatadogCredentialsStep', () => {
     expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
   });
 
-  it('points key help links at the selected site settings pages', async () => {
+  it('links key help to the docs until a site is selected', () => {
     render(<DatadogCredentialsStep {...makeStepProps({stepData: {}})} />);
 
+    const docsUrl = 'https://docs.datadoghq.com/account_management/api-app-keys/';
+    expect(screen.getByRole('link', {name: /API Keys/})).toHaveAttribute('href', docsUrl);
+    expect(screen.getByRole('link', {name: /Application Keys/})).toHaveAttribute(
+      'href',
+      docsUrl
+    );
+  });
+
+  it('prefixes app. only for primary sites, not regional ones', async () => {
+    render(<DatadogCredentialsStep {...makeStepProps({stepData: {}})} />);
+
+    // Regional sites already carry their region as a subdomain, so no app. prefix.
     await selectEvent.select(
       screen.getByRole('textbox', {name: 'Datadog Site'}),
       'us3.datadoghq.com (US3)'
     );
-
     expect(screen.getByRole('link', {name: /API Keys/})).toHaveAttribute(
       'href',
-      'https://app.us3.datadoghq.com/organization-settings/api-keys'
+      'https://us3.datadoghq.com/organization-settings/api-keys'
     );
     expect(screen.getByRole('link', {name: /Application Keys/})).toHaveAttribute(
       'href',
-      'https://app.us3.datadoghq.com/organization-settings/application-keys'
+      'https://us3.datadoghq.com/organization-settings/application-keys'
+    );
+
+    // Primary sites take the app. prefix.
+    await selectEvent.select(
+      screen.getByRole('textbox', {name: 'Datadog Site'}),
+      'datadoghq.com (US1)'
+    );
+    expect(screen.getByRole('link', {name: /API Keys/})).toHaveAttribute(
+      'href',
+      'https://app.datadoghq.com/organization-settings/api-keys'
+    );
+    expect(screen.getByRole('link', {name: /Application Keys/})).toHaveAttribute(
+      'href',
+      'https://app.datadoghq.com/organization-settings/application-keys'
     );
   });
 

--- a/static/app/components/pipeline/integrationDatadog/index.tsx
+++ b/static/app/components/pipeline/integrationDatadog/index.tsx
@@ -16,11 +16,19 @@ import type {IntegrationWithConfig} from 'sentry/types/integrations';
 import {requestErrorToFieldErrors} from 'sentry/utils/requestError/requestErrorToFieldErrors';
 import {DATADOG_SITES, DATADOG_SITE_VALUES} from 'sentry/utils/seer/datadogSites';
 
+const DATADOG_API_KEYS_DOCS_URL =
+  'https://docs.datadoghq.com/account_management/api-app-keys/';
+
+// Deep-links to the settings page for the selected site, falling back to the docs
+// when no (or an unrecognized) site is selected rather than guessing a host.
 function datadogOrgSettingsUrl(
   site: string,
   page: 'api-keys' | 'application-keys'
 ): string {
-  return `https://app.${site}/organization-settings/${page}`;
+  const appHost = DATADOG_SITES.find(s => s.value === site)?.appHost;
+  return appHost
+    ? `https://${appHost}/organization-settings/${page}`
+    : DATADOG_API_KEYS_DOCS_URL;
 }
 
 const credentialsSchema = z.object({
@@ -81,10 +89,6 @@ function DatadogCredentialsStep({
         </form.AppField>
         <form.Subscribe selector={state => state.values.site}>
           {site => {
-            const keysHref = (page: 'api-keys' | 'application-keys') =>
-              site
-                ? datadogOrgSettingsUrl(site, page)
-                : 'https://docs.datadoghq.com/account_management/api-app-keys/';
             return (
               <Stack gap="lg">
                 <form.AppField name="apiKey">
@@ -93,7 +97,13 @@ function DatadogCredentialsStep({
                       label={t('API Key')}
                       hintText={tct(
                         'Identifies your Datadog organization. Create one under [link:Organization Settings › API Keys].',
-                        {link: <ExternalLink href={keysHref('api-keys')} />}
+                        {
+                          link: (
+                            <ExternalLink
+                              href={datadogOrgSettingsUrl(site, 'api-keys')}
+                            />
+                          ),
+                        }
                       )}
                       required
                     >
@@ -111,7 +121,13 @@ function DatadogCredentialsStep({
                       label={t('Application Key')}
                       hintText={tct(
                         'Authorizes requests on top of the API key. Create one under [link:Organization Settings › Application Keys].',
-                        {link: <ExternalLink href={keysHref('application-keys')} />}
+                        {
+                          link: (
+                            <ExternalLink
+                              href={datadogOrgSettingsUrl(site, 'application-keys')}
+                            />
+                          ),
+                        }
                       )}
                       required
                     >

--- a/static/app/utils/seer/datadogSites.ts
+++ b/static/app/utils/seer/datadogSites.ts
@@ -1,13 +1,36 @@
 // Keep in sync with DATADOG_VALID_SITES in src/sentry/integrations/datadog/client.py.
+// appHost is the web app hostname: primary sites live at app.<site>, while regional
+// sites already carry their region as a subdomain. See
+// https://docs.datadoghq.com/getting_started/site/.
 export const DATADOG_SITES = [
-  {value: 'datadoghq.com', label: 'datadoghq.com (US1)'},
-  {value: 'us3.datadoghq.com', label: 'us3.datadoghq.com (US3)'},
-  {value: 'us5.datadoghq.com', label: 'us5.datadoghq.com (US5)'},
-  {value: 'datadoghq.eu', label: 'datadoghq.eu (EU)'},
-  {value: 'ap1.datadoghq.com', label: 'ap1.datadoghq.com (AP1)'},
-  {value: 'ap2.datadoghq.com', label: 'ap2.datadoghq.com (AP2)'},
-  {value: 'ddog-gov.com', label: 'ddog-gov.com (US1-FED)'},
-  {value: 'us2.ddog-gov.com', label: 'us2.ddog-gov.com (US2-FED)'},
+  {value: 'datadoghq.com', label: 'datadoghq.com (US1)', appHost: 'app.datadoghq.com'},
+  {
+    value: 'us3.datadoghq.com',
+    label: 'us3.datadoghq.com (US3)',
+    appHost: 'us3.datadoghq.com',
+  },
+  {
+    value: 'us5.datadoghq.com',
+    label: 'us5.datadoghq.com (US5)',
+    appHost: 'us5.datadoghq.com',
+  },
+  {value: 'datadoghq.eu', label: 'datadoghq.eu (EU)', appHost: 'app.datadoghq.eu'},
+  {
+    value: 'ap1.datadoghq.com',
+    label: 'ap1.datadoghq.com (AP1)',
+    appHost: 'ap1.datadoghq.com',
+  },
+  {
+    value: 'ap2.datadoghq.com',
+    label: 'ap2.datadoghq.com (AP2)',
+    appHost: 'ap2.datadoghq.com',
+  },
+  {value: 'ddog-gov.com', label: 'ddog-gov.com (US1-FED)', appHost: 'app.ddog-gov.com'},
+  {
+    value: 'us2.ddog-gov.com',
+    label: 'us2.ddog-gov.com (US2-FED)',
+    appHost: 'us2.ddog-gov.com',
+  },
 ];
 
 export const DATADOG_SITE_VALUES = DATADOG_SITES.map(site => site.value) as [


### PR DESCRIPTION
Per https://docs.datadoghq.com/getting_started/site/, only Datadog's primary sites live at `app.<site>` while regional sites (us3, us5, ap1, ap2, us2) already carry their region as a subdomain. The install flow's API/app-key links now derive each site's app host instead of blindly prepending `app.`, and fall back to the docs page for an unknown or unselected site.