### PR TITLE
test(snapshots): Verify workflow_run upload

### DIFF
--- a/static/app/components/core/badge/badge.snapshots.tsx
+++ b/static/app/components/core/badge/badge.snapshots.tsx
@@ -33,5 +33,17 @@ describe('Badge', () => {
       ),
       variant => ({tags: {variant: String(variant), area: 'core'}})
     );
+
+    it.snapshot(
+      'snapshot upload workflow test',
+      () => (
+        <ThemeProvider theme={themes[themeName]}>
+          <div style={{padding: 8}}>
+            <Badge variant="highlight">Snapshot upload workflow test</Badge>
+          </div>
+        </ThemeProvider>
+      ),
+      {tags: {area: 'core', purpose: 'workflow-test'}}
+    );
   });
 });


### PR DESCRIPTION
The Badge snapshot suite adds a dedicated light and dark visual case solely to exercise the split snapshot build/upload workflow merged in #118943. This does not change production behavior.
