### PR TITLE
perf(integrations): Batch the `canAdd` lookup when serializing integration providers

### DIFF
--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -263,6 +263,38 @@ class IntegrationProviderResponse(TypedDict):
 
 
 class IntegrationProviderSerializer(Serializer[IntegrationProviderResponse]):
+    def get_attrs(
+        self,
+        item_list: Sequence[IntegrationProvider],
+        user: User | RpcUser | AnonymousUser,
+        **kwargs: Any,
+    ) -> MutableMapping[IntegrationProvider, MutableMapping[str, Any]]:
+        organization = kwargs["organization"]
+
+        # Only providers that disallow a second installation need to know whether one
+        # already exists, so restrict the lookup to those keys (and skip it entirely
+        # when there are none).
+        keys = [
+            provider.key
+            for provider in item_list
+            if provider.can_add and not provider.allow_multiple
+        ]
+        installed_provider_keys: set[str] = set()
+        if keys:
+            installed_provider_keys = {
+                integration.provider
+                for integration in integration_service.get_integrations(
+                    organization_id=organization.id,
+                    providers=keys,
+                    status=ObjectStatus.ACTIVE,
+                )
+            }
+
+        return {
+            provider: {"has_existing_integration": provider.key in installed_provider_keys}
+            for provider in item_list
+        }
+
     def serialize(
         self,
         obj: IntegrationProvider,
@@ -270,19 +302,12 @@ class IntegrationProviderSerializer(Serializer[IntegrationProviderResponse]):
         user: User | RpcUser | AnonymousUser,
         **kwargs: Any,
     ) -> IntegrationProviderResponse:
-        organization = kwargs.pop("organization")
         metadata: Any = obj.metadata
         metadata = metadata and metadata.asdict() or None
 
         can_add = obj.can_add
-        if can_add and not obj.allow_multiple:
-            existing = integration_service.get_integrations(
-                organization_id=organization.id,
-                providers=[obj.key],
-                status=ObjectStatus.ACTIVE,
-            )
-            if existing:
-                can_add = False
+        if can_add and not obj.allow_multiple and attrs["has_existing_integration"]:
+            can_add = False
 
         return {
             "key": obj.key,

--- a/tests/sentry/api/endpoints/test_organization_config_integrations.py
+++ b/tests/sentry/api/endpoints/test_organization_config_integrations.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from sentry.constants import ObjectStatus
 from sentry.testutils.cases import APITestCase
 
@@ -91,3 +93,39 @@ class OrganizationConfigIntegrationsTest(APITestCase):
         )
         assert len(response.data["providers"]) == 1
         assert response.data["providers"][0]["canAdd"] is True
+
+    def test_can_add_resolved_correctly_across_the_full_provider_list(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="claude_code",
+            external_id="claude-ext-1",
+        )
+        self.create_integration(
+            organization=self.organization,
+            provider="example",
+            external_id="example-ext-1",
+        )
+
+        response = self.get_success_response(self.organization.slug)
+
+        can_add_by_key = {p["key"]: p["canAdd"] for p in response.data["providers"]}
+        # Installed, allow_multiple=False: a second installation is blocked.
+        assert can_add_by_key["claude_code"] is False
+        # Not installed, allow_multiple=False: still available.
+        assert can_add_by_key["cursor"] is True
+        # Installed, allow_multiple=True: unaffected by the existing installation.
+        assert can_add_by_key["example"] is True
+
+    def test_provider_list_batches_the_integration_lookup(self) -> None:
+        with patch(
+            "sentry.integrations.api.serializers.models.integration"
+            ".integration_service.get_integrations",
+            return_value=[],
+        ) as mock_get_integrations:
+            response = self.get_success_response(self.organization.slug)
+
+        # More than one provider is serialized, so a per-provider lookup would fan out.
+        assert len(response.data["providers"]) > 1
+        assert mock_get_integrations.call_count == 1
+        # The single call covers every allow_multiple=False provider at once.
+        assert len(mock_get_integrations.call_args.kwargs["providers"]) > 1


### PR DESCRIPTION
Resolves https://linear.app/getsentry/issue/ISWF-3424/batch-the-per-provider-get-integrations-calls-in.

`IntegrationProviderSerializer.serialize()` ran one `integration_service.get_integrations()` call per provider. `serialize()` executes once per object, so the lookup fanned out.

This PR moves the lookup into `get_attrs()` to calculate this parameter for all providers for the organization at once, eliminating cross-silo round trips.