### PR TITLE
fix(integrations): Use GraphQL for GitHub assignees

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -175,7 +175,6 @@ class GitHubApiRequestType(StrEnum):
     CREATE_ISSUE_REACTION = "create_issue_reaction"
     DELETE_ISSUE_REACTION = "delete_issue_reaction"
     GET_ARCHIVE_LINK = "get_archive_link"
-    GET_ASSIGNEES = "get_assignees"
     GET_BLAME_FOR_FILES = "get_blame_for_files"
     GET_CHECK_RUN = "get_check_run"
     GET_CHECK_RUNS = "get_check_runs"
@@ -816,16 +815,6 @@ class GitHubBaseClient(
             "/search/repositories",
             params={"q": query},
             api_request_type=GitHubApiRequestType.SEARCH_REPOSITORIES,
-        )
-
-    def get_assignees(self, repo: str, page_number_limit: int | None = None) -> Sequence[Any]:
-        """
-        https://docs.github.com/en/rest/issues/assignees#list-assignees
-        """
-        return self._get_with_pagination(
-            f"/repos/{repo}/assignees",
-            page_number_limit=page_number_limit,
-            api_request_type=GitHubApiRequestType.GET_ASSIGNEES,
         )
 
     def search_issue_assignees(self, repo: str, query: str) -> list[Any]:

--- a/src/sentry/integrations/github/issues.py
+++ b/src/sentry/integrations/github/issues.py
@@ -194,7 +194,7 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             labels: Sequence[tuple[str, str]] = []
         else:
             default_repo, repo_choices = self.get_repository_choices(group, params, PAGE_LIMIT)
-            assignees = self.get_allowed_assignees(default_repo, PAGE_LIMIT) if default_repo else []
+            assignees = self.get_allowed_assignees(default_repo) if default_repo else []
             labels = []
             if default_repo:
                 owner, repo = default_repo.split("/")
@@ -379,28 +379,15 @@ class GitHubIssuesSpec(SourceCodeIssueIntegration):
             "repo": repo,
         }
 
-    def get_allowed_assignees(
-        self, repo: str, page_number_limit: int | None = None
-    ) -> Sequence[tuple[str, str]]:
-        client = self.get_client()
-        try:
-            response = client.get_assignees(repo, page_number_limit=page_number_limit)
-        except Exception as e:
-            self.raise_error(e)
-
-        users = tuple(self._format_assignee(user) for user in response)
-
-        return (("", "Unassigned"),) + users
-
-    def search_allowed_assignees(self, repo: str, query: str) -> Sequence[tuple[str, str]]:
+    def get_allowed_assignees(self, repo: str, query: str = "") -> Sequence[tuple[str, str]]:
         client = self.get_client()
         try:
             response = client.search_issue_assignees(repo, query)
         except Exception as e:
             self.raise_error(e)
 
-        user_choices = tuple(self._format_assignee(user) for user in response)
-        return user_choices if query else (("", "Unassigned"),) + user_choices
+        users = tuple(self._format_assignee(user) for user in response)
+        return users if query else (("", "Unassigned"),) + users
 
     def get_repo_labels(
         self, owner: str, repo: str, page_number_limit: int | None = None

--- a/src/sentry/integrations/github/search.py
+++ b/src/sentry/integrations/github/search.py
@@ -113,16 +113,13 @@ class GithubSharedSearchEndpoint(SourceCodeSearchEndpoint):
 
         assert isinstance(installation, self.installation_class)
         try:
-            if not query:
-                # TODO: Use GraphQL for preloads after validating these queries across supported
+            if field == "assignee":
+                choices = installation.get_allowed_assignees(repo, query)
+            elif not query:
+                # TODO: Use GraphQL for label preloads after validating the query across supported
                 # GHES versions.
-                if field == "assignee":
-                    choices = installation.get_allowed_assignees(repo, PAGE_LIMIT)
-                else:
-                    owner, repo_name = repo.split("/", 1)
-                    choices = installation.get_repo_labels(owner, repo_name, PAGE_LIMIT)
-            elif field == "assignee":
-                choices = installation.search_allowed_assignees(repo, query)
+                owner, repo_name = repo.split("/", 1)
+                choices = installation.get_repo_labels(owner, repo_name, PAGE_LIMIT)
             else:
                 choices = installation.search_repo_labels(repo, query)
         except (IntegrationError, InvalidIdentity) as error:

--- a/tests/sentry/integrations/github/test_issues.py
+++ b/tests/sentry/integrations/github/test_issues.py
@@ -1,7 +1,7 @@
 import datetime
 from collections.abc import Mapping, Sequence
 from functools import cached_property
-from typing import cast
+from typing import Any, cast
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
@@ -32,6 +32,10 @@ from sentry.testutils.silo import all_silo_test, assume_test_silo_mode
 from sentry.testutils.skips import requires_snuba
 
 pytestmark = [requires_snuba]
+
+
+def assignee_response(login: str, name: str | None = None) -> dict[str, Any]:
+    return {"data": {"repository": {"results": {"nodes": [{"login": login, "name": name}]}}}}
 
 
 @all_silo_test
@@ -73,9 +77,9 @@ class GitHubIssueBasicAllSiloTest(TestCase):
             },
         )
         responses.add(
-            responses.GET,
-            "https://api.github.com/repos/getsentry/sentry/assignees",
-            json=[{"login": "leeandher"}],
+            responses.POST,
+            "https://api.github.com/graphql",
+            json=assignee_response("leeandher", "Lee Ander"),
         )
 
         responses.add(
@@ -96,6 +100,10 @@ class GitHubIssueBasicAllSiloTest(TestCase):
         assert assignee_field["name"] == "assignee"
         assert assignee_field["type"] == "select"
         assert assignee_field["label"] == "Assignee"
+        assert assignee_field["choices"] == (
+            ("", "Unassigned"),
+            ("leeandher", "Lee Ander (@leeandher)"),
+        )
         assert label_field["name"] == "labels"
         assert label_field["type"] == "select"
         assert label_field["label"] == "Labels"
@@ -172,30 +180,6 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             assert request.headers[PROXY_OI_HEADER] == str(self.install.org_integration.id)
             assert request.headers[PROXY_BASE_URL_HEADER] == "https://api.github.com"
             assert PROXY_SIGNATURE_HEADER in request.headers
-
-    @responses.activate
-    def test_get_allowed_assignees(self) -> None:
-        responses.add(
-            responses.GET,
-            "https://api.github.com/repos/getsentry/sentry/assignees",
-            json=[{"login": "MeredithAnya", "name": "Meredith Anya"}],
-        )
-
-        assert self.install.get_allowed_assignees(self.repo) == (
-            ("", "Unassigned"),
-            ("MeredithAnya", "Meredith Anya (@MeredithAnya)"),
-        )
-
-        if self.should_call_api_without_proxying():
-            assert len(responses.calls) == 2
-
-            request = responses.calls[0].request
-            assert request.headers["Authorization"] == "Bearer jwt_token_1"
-
-            request = responses.calls[1].request
-            assert request.headers["Authorization"] == "Bearer token_1"
-        else:
-            self._check_proxying()
 
     @responses.activate
     def test_get_repo_labels(self) -> None:
@@ -647,9 +631,9 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         )
 
         responses.add(
-            responses.GET,
-            "https://api.github.com/repos/getsentry/sentry/assignees",
-            json=[{"login": "MeredithAnya"}],
+            responses.POST,
+            "https://api.github.com/graphql",
+            json=assignee_response("MeredithAnya"),
         )
         responses.add(
             responses.GET,
@@ -673,9 +657,9 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
         assert create_config[0]["choices"] == [("getsentry/sentry", "sentry")]
 
         responses.add(
-            responses.GET,
-            "https://api.github.com/repos/getsentry/hello/assignees",
-            json=[{"login": "MeredithAnya"}],
+            responses.POST,
+            "https://api.github.com/graphql",
+            json=assignee_response("MeredithAnya"),
         )
         responses.add(
             responses.GET,
@@ -801,9 +785,9 @@ class GitHubIssueBasicTest(TestCase, PerformanceIssueTestCase, IntegratedApiTest
             },
         )
         responses.add(
-            responses.GET,
-            "https://api.github.com/repos/getsentry/sentry/assignees",
-            json=[{"login": "MeredithAnya"}],
+            responses.POST,
+            "https://api.github.com/graphql",
+            json=assignee_response("MeredithAnya"),
         )
         responses.add(
             responses.GET,

--- a/tests/sentry/integrations/github/test_search.py
+++ b/tests/sentry/integrations/github/test_search.py
@@ -192,30 +192,23 @@ class GithubSearchTest(APITestCase):
         assert resp.data == {"detail": "Rate limit exceeded"}
 
     @responses.activate
-    def test_prefetches_assignee_results(self) -> None:
+    def test_assignee_results(self) -> None:
         responses.add(
-            responses.GET,
-            self.base_url + "/repos/test/example/assignees",
-            json=[
-                {"login": "octocat", "name": "The Octocat"},
-                {"login": "github-actions[bot]", "name": None},
-            ],
+            responses.POST,
+            self.graphql_url,
+            json={
+                "data": {
+                    "repository": {
+                        "results": {
+                            "nodes": [
+                                {"login": "octocat", "name": "The Octocat"},
+                                {"login": "github-actions[bot]", "name": None},
+                            ]
+                        }
+                    }
+                }
+            },
         )
-
-        resp = self.client.get(
-            self.url,
-            data={"field": "assignee", "query": "", "repo": "test/example"},
-        )
-
-        assert resp.status_code == 200
-        assert resp.data == [
-            {"value": "", "label": "Unassigned"},
-            {"value": "octocat", "label": "The Octocat (@octocat)"},
-            {"value": "github-actions[bot]", "label": "github-actions[bot]"},
-        ]
-
-    @responses.activate
-    def test_searches_assignees(self) -> None:
         responses.add(
             responses.POST,
             self.graphql_url,
@@ -228,16 +221,37 @@ class GithubSearchTest(APITestCase):
             },
         )
 
-        resp = self.client.get(
+        prefetch_response = self.client.get(
+            self.url,
+            data={"field": "assignee", "query": "", "repo": "test/example"},
+        )
+
+        assert prefetch_response.status_code == 200
+        assert prefetch_response.data == [
+            {"value": "", "label": "Unassigned"},
+            {"value": "octocat", "label": "The Octocat (@octocat)"},
+            {"value": "github-actions[bot]", "label": "github-actions[bot]"},
+        ]
+        prefetch_body = orjson.loads(responses.calls[0].request.body)
+        assert "assignableUsers" in prefetch_body["query"]
+        assert prefetch_body["variables"] == {
+            "owner": "test",
+            "name": "example",
+            "search": "",
+        }
+
+        search_response = self.client.get(
             self.url,
             data={"field": "assignee", "query": "TARGET", "repo": "test/example"},
         )
 
-        assert resp.status_code == 200
-        assert resp.data == [{"value": "target-user", "label": "Target User (@target-user)"}]
-        request_body = orjson.loads(responses.calls[0].request.body)
-        assert "assignableUsers" in request_body["query"]
-        assert request_body["variables"] == {
+        assert search_response.status_code == 200
+        assert search_response.data == [
+            {"value": "target-user", "label": "Target User (@target-user)"}
+        ]
+        search_body = orjson.loads(responses.calls[1].request.body)
+        assert "assignableUsers" in search_body["query"]
+        assert search_body["variables"] == {
             "owner": "test",
             "name": "example",
             "search": "TARGET",

--- a/tests/sentry/integrations/github_enterprise/test_issues.py
+++ b/tests/sentry/integrations/github_enterprise/test_issues.py
@@ -50,38 +50,6 @@ class GitHubEnterpriseIssueBasicTest(TestCase, IntegratedApiTestCase):
 
     @responses.activate
     @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
-    def test_get_allowed_assignees(self, mock_get_jwt: MagicMock) -> None:
-        responses.add(
-            responses.POST,
-            f"https://{self._IP_ADDRESS}/api/v3/app/installations/installation_id/access_tokens",
-            json={"token": "token_1", "expires_at": "2018-10-11T22:14:10Z"},
-        )
-
-        responses.add(
-            responses.GET,
-            f"https://{self._IP_ADDRESS}/api/v3/repos/getsentry/sentry/assignees",
-            json=[{"login": "MeredithAnya"}],
-        )
-
-        repo = "getsentry/sentry"
-        assert self.install.get_allowed_assignees(repo) == (
-            ("", "Unassigned"),
-            ("MeredithAnya", "MeredithAnya"),
-        )
-
-        if self.should_call_api_without_proxying():
-            assert len(responses.calls) == 2
-
-            request = responses.calls[0].request
-            assert request.headers["Authorization"] == "Bearer jwt_token_1"
-
-            request = responses.calls[1].request
-            assert request.headers["Authorization"] == "Bearer token_1"
-        else:
-            self._check_proxying()
-
-    @responses.activate
-    @patch("sentry.integrations.github_enterprise.client.get_jwt", return_value="jwt_token_1")
     def test_get_repo_labels(self, mock_get_jwt: MagicMock) -> None:
         responses.add(
             responses.POST,


### PR DESCRIPTION
#123455 intentionally kept empty-query assignee preloads on REST and only used GraphQL for typed searches because assignableUsers had not been validated across our supported GitHub Enterprise versions.

This switches it entirely to graphql because it looks like its working.

Follow-up to #123455.