### PR TITLE
ref(HC): Splits validation and proxy logic in IntegrationProxy, adds more granular metric tracking

### DIFF
--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -4,7 +4,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Generator, Mapping
 from enum import StrEnum
-from typing import Any, MutableMapping
+from typing import Any, MutableMapping, TypedDict
 from urllib.parse import urljoin
 
 from django.conf import settings
@@ -22,9 +22,12 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, internal_control_silo_endpoint
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
+from sentry.integrations.base import IntegrationInstallation
+from sentry.integrations.models import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
 from sentry.integrations.utils.metrics import IntegrationProxyEvent, IntegrationProxyEventType
 from sentry.metrics.base import Tags
+from sentry.shared_integrations.client.proxy import IntegrationProxyClient
 from sentry.shared_integrations.exceptions import (
     ApiForbiddenError,
     ApiHostError,
@@ -62,6 +65,7 @@ class IntegrationProxyFailureMetricType(StrEnum):
     INVALID_SENDER_HEADERS = "invalid_sender_headers"
     INVALID_SENDER_SIGNATURE = "invalid_sender_signature"
     INVALID_ORG_INTEGRATION = "invalid_org_integration"
+    INVALID_ORG_INTEGRATION_HEADERS = "invalid_org_integration_headers"
     INVALID_INTEGRATION = "invalid_integration"
     INVALID_CLIENT = "invalid_client"
     INVALID_MODE = "invalid_mode"
@@ -75,6 +79,36 @@ class IntegrationProxyFailureMetricType(StrEnum):
     FORBIDDEN_ERROR = "forbidden_error"
     UNKNOWN_ERROR = "unknown_error"
     FAILED_VALIDATION = "failed_validation"
+
+
+def _add_metric(
+    metric_name: str,
+    sample_rate: float | None = None,
+    tags: Tags | None = None,
+) -> None:
+    if sample_rate is None:
+        sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
+
+    metrics.incr(
+        f"{METRIC_PREFIX}.{metric_name}",
+        sample_rate=sample_rate,
+        tags=tags,
+    )
+
+
+def _add_failure_metric(
+    failure_type: IntegrationProxyFailureMetricType,
+    additional_tags: dict[str, str] | None = None,
+) -> None:
+    if additional_tags is None:
+        additional_tags = {}
+    tags = {"failure_type": failure_type.value, **additional_tags}
+
+    _add_metric(
+        metric_name="proxy_failure",
+        sample_rate=1.0,
+        tags=tags,
+    )
 
 
 class _PassthroughContentNegotiation(BaseContentNegotiation):
@@ -95,6 +129,229 @@ class _PassthroughContentNegotiation(BaseContentNegotiation):
         return (JSONRenderer(), JSONRenderer.media_type)
 
 
+class IntegrationProxyRequestValidationContext(TypedDict):
+    integration_id: int | None
+    organization_id: int | None
+
+
+class IntegrationProxyRequestValidationException(Exception):
+    failure_type: IntegrationProxyFailureMetricType
+    integration_context: IntegrationProxyRequestValidationContext
+
+    def __init__(
+        self,
+        failure_type: IntegrationProxyFailureMetricType,
+        integration_context: IntegrationProxyRequestValidationContext,
+    ):
+        super().__init__(f"Integration proxy request validation failed: {failure_type.value}")
+        self.failure_type = failure_type
+        self.integration_context = integration_context
+
+
+class IntegrationProxyRequestValidator:
+    """
+    Class that validates an integration proxy request, and unpacks the integration, organization integration,
+     and instantiates a new installation from the request.
+
+    Validation runs once, during construction. If any portion of the request
+    validation fails, an IntegrationProxyRequestValidationException is raised.
+    """
+
+    proxy_path: str
+    log_context: dict[str, Any]
+
+    # Populated by the validation steps below; each stays None if validation never got that far.
+    integration: Integration
+    organization_integration: OrganizationIntegration
+    integration_installation: IntegrationInstallation
+    client: IntegrationProxyClient
+
+    def __init__(self, request: HttpRequest):
+        self.request = request
+        # Removes leading slashes as it can result in incorrect urls being generated
+        self.proxy_path = trim_leading_slashes(request.headers.get(PROXY_PATH, ""))
+        self.log_context = {
+            "method": request.method,
+            "path": self.proxy_path,
+            "host": request.headers.get("Host"),
+        }
+
+        self._validate()
+
+        # A successful validation must have resolved every object the proxy needs.
+        assert self.organization_integration is not None, (
+            "Expected validated request to have an organization integration"
+        )
+        assert self.integration is not None, "Expected validated request to have an integration"
+        assert self.integration_installation is not None, (
+            "Expected validated request to have an integration installation"
+        )
+        assert self.client is not None, "Expected validated request to have a client"
+
+    def _validate(self):
+        """
+        Validates various components of the request to ensure the sender is both
+        trustworthy, and the request can be authenticated using the appropriate
+        integration credentials.
+
+        Post-validation, exposes the validated integration, org integration, and
+        install, along with a client that can be used to proxy the request.
+        """
+        self._validate_silo_mode()
+        self._validate_sender()
+        self._validate_and_set_organization_integration()
+        self._validate_and_set_integration_installation()
+        self._validate_and_set_client()
+
+    def _validate_silo_mode(self):
+        is_correct_silo = SiloMode.get_current_mode() == SiloMode.CONTROL
+        if not is_correct_silo:
+            self.log_context["silo_mode"] = SiloMode.get_current_mode().value
+            raise IntegrationProxyRequestValidationException(
+                failure_type=IntegrationProxyFailureMetricType.INVALID_MODE,
+                integration_context={
+                    "integration_id": None,
+                    "organization_id": None,
+                },
+            )
+
+    def _get_integration_context(self) -> IntegrationProxyRequestValidationContext:
+        integration = getattr(self, "integration", None)
+        organization_integration = getattr(self, "organization_integration", None)
+        return {
+            "integration_id": integration.id if integration else None,
+            "organization_id": organization_integration.organization_id
+            if organization_integration
+            else None,
+        }
+
+    def _validate_sender(self):
+        """
+        Returns True if the sender is deemed sufficiently trustworthy. A sender is considered trustworthy if they:
+            - Have a valid signature
+            - Can be mapped definitively to an integration and organization
+            - Have a valid subnet signature
+        """
+        request = self.request
+        signature = request.headers.get(PROXY_SIGNATURE_HEADER)
+        identifier = request.headers.get(PROXY_OI_HEADER)
+        base_url = request.headers.get(PROXY_BASE_URL_HEADER)
+        if signature is None or identifier is None or base_url is None:
+            raise IntegrationProxyRequestValidationException(
+                failure_type=IntegrationProxyFailureMetricType.INVALID_SENDER_HEADERS,
+                integration_context={
+                    **self._get_integration_context(),
+                },
+            )
+        is_valid = verify_subnet_signature(
+            base_url=base_url,
+            path=self.proxy_path,
+            identifier=identifier,
+            request_body=request.body,
+            provided_signature=signature,
+        )
+        if not is_valid:
+            raise IntegrationProxyRequestValidationException(
+                failure_type=IntegrationProxyFailureMetricType.INVALID_SENDER_SIGNATURE,
+                integration_context={
+                    "integration_id": None,
+                    "organization_id": None,
+                },
+            )
+
+    def _validate_and_set_organization_integration(self):
+        """
+        Extracts the organization integration id from the request headers and resolves it to an
+        active OrganizationIntegration, which is set on the validator.
+        """
+        request = self.request
+        org_integration_id_header = request.headers.get(PROXY_OI_HEADER)
+        if org_integration_id_header is None or not org_integration_id_header.isdecimal():
+            raise IntegrationProxyRequestValidationException(
+                failure_type=IntegrationProxyFailureMetricType.INVALID_ORG_INTEGRATION_HEADERS,
+                integration_context={
+                    **self._get_integration_context(),
+                },
+            )
+        org_integration_id = int(org_integration_id_header)
+
+        org_integration = (
+            OrganizationIntegration.objects.filter(
+                id=org_integration_id,
+                status=ObjectStatus.ACTIVE,
+            )
+            .select_related("integration")
+            .first()
+        )
+        if org_integration is None:
+            raise IntegrationProxyRequestValidationException(
+                failure_type=IntegrationProxyFailureMetricType.INVALID_ORG_INTEGRATION,
+                integration_context={
+                    **self._get_integration_context(),
+                },
+            )
+
+        self.organization_integration = org_integration
+
+    def _validate_and_set_integration_installation(self):
+        """
+        Checks that the resolved organization integration points at an active integration, then
+        instantiates that integration's installation. Both are set on the validator.
+        """
+        org_integration = self.organization_integration
+        if org_integration is None:
+            raise IntegrationProxyRequestValidationException(
+                failure_type=IntegrationProxyFailureMetricType.INVALID_ORG_INTEGRATION,
+                integration_context={
+                    **self._get_integration_context(),
+                },
+            )
+
+        integration = org_integration.integration
+        self.integration = integration
+        if not integration or integration.status is not ObjectStatus.ACTIVE:
+            logger.info("integration_proxy.invalid_integration", extra=self.log_context)
+            raise IntegrationProxyRequestValidationException(
+                failure_type=IntegrationProxyFailureMetricType.INVALID_INTEGRATION,
+                integration_context={
+                    **self._get_integration_context(),
+                },
+            )
+
+        self.integration_installation = integration.get_installation(
+            organization_id=org_integration.organization_id
+        )
+
+    def _validate_and_set_client(self):
+        """
+        Acquires the API client from the installation and sets it on the validator. Returns True only
+        if that client can actually proxy requests.
+        """
+        installation = self.integration_installation
+        if installation is None:
+            raise IntegrationProxyRequestValidationException(
+                failure_type=IntegrationProxyFailureMetricType.INVALID_CLIENT,
+                integration_context={
+                    **self._get_integration_context(),
+                },
+            )
+
+        # Some integrations use a keyring approach, so we need to pass in the keyid
+        keyid = self.request.headers.get(PROXY_KEYID_HEADER)
+        if keyid:
+            self.client = installation.get_keyring_client(keyid)
+        else:
+            self.client = installation.get_client()
+
+        if not isinstance(self.client, IntegrationProxyClient):
+            raise IntegrationProxyRequestValidationException(
+                failure_type=IntegrationProxyFailureMetricType.INVALID_CLIENT,
+                integration_context={
+                    **self._get_integration_context(),
+                },
+            )
+
+
 @internal_control_silo_endpoint
 class InternalIntegrationProxyEndpoint(Endpoint):
     content_negotiation_class = _PassthroughContentNegotiation
@@ -102,7 +359,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
     owner = ApiOwner.HYBRID_CLOUD
     authentication_classes = ()
     permission_classes = ()
-    log_extra: dict[str, str | int]
+    log_extra: dict[str, Any]
     enforce_rate_limit = False
     """
     This endpoint is used to proxy requests from cell silos to the third-party
@@ -123,142 +380,6 @@ class InternalIntegrationProxyEndpoint(Endpoint):
     @client.setter
     def client(self, client):
         self._client = client
-
-    def _add_metric(
-        self,
-        metric_name: str,
-        sample_rate: float | None = None,
-        tags: Tags | None = None,
-    ):
-        if sample_rate is None:
-            sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
-
-        metrics.incr(
-            f"{METRIC_PREFIX}.{metric_name}",
-            sample_rate=sample_rate,
-            tags=tags,
-        )
-
-    def _add_failure_metric(
-        self,
-        failure_type: IntegrationProxyFailureMetricType,
-        additional_tags: dict[str, str] | None = None,
-    ):
-        if additional_tags is None:
-            additional_tags = {}
-        tags = {"failure_type": failure_type, **additional_tags}
-
-        self._add_metric(
-            metric_name="proxy_failure",
-            sample_rate=1.0,
-            tags=tags,
-        )
-
-    def _validate_sender(self, request: HttpRequest) -> bool:
-        """
-        Returns True if the sender is deemed sufficiently trustworthy.
-        """
-        signature = request.headers.get(PROXY_SIGNATURE_HEADER)
-        identifier = request.headers.get(PROXY_OI_HEADER)
-        base_url = request.headers.get(PROXY_BASE_URL_HEADER)
-        if signature is None or identifier is None or base_url is None:
-            logger.info("integration_proxy.invalid_sender_headers", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_SENDER_HEADERS)
-            return False
-        is_valid = verify_subnet_signature(
-            base_url=base_url,
-            path=self.proxy_path,
-            identifier=identifier,
-            request_body=request.body,
-            provided_signature=signature,
-        )
-        if not is_valid:
-            logger.info("integration_proxy.invalid_sender_signature", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_SENDER_SIGNATURE)
-
-        return is_valid
-
-    def _validate_request(self, request: HttpRequest) -> bool:
-        """
-        Returns True if a client could be generated from the request
-        """
-        from sentry.shared_integrations.client.proxy import IntegrationProxyClient
-
-        # Get the organization integration
-        org_integration_id_header = request.headers.get(PROXY_OI_HEADER)
-        if org_integration_id_header is None or not org_integration_id_header.isdecimal():
-            logger.info("integration_proxy.missing_org_integration", extra=self.log_extra)
-            return False
-        org_integration_id = int(org_integration_id_header)
-        self.log_extra["org_integration_id"] = org_integration_id
-
-        self.org_integration = (
-            OrganizationIntegration.objects.filter(
-                id=org_integration_id,
-                status=ObjectStatus.ACTIVE,
-            )
-            .select_related("integration")
-            .first()
-        )
-        if self.org_integration is None:
-            logger.info("integration_proxy.invalid_org_integration", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_ORG_INTEGRATION)
-            return False
-        self.log_extra["integration_id"] = self.org_integration.integration_id
-
-        # Get the integration
-        self.integration = self.org_integration.integration
-        if not self.integration or self.integration.status is not ObjectStatus.ACTIVE:
-            logger.info("integration_proxy.invalid_integration", extra=self.log_extra)
-            if self.integration and self.integration.status is not ObjectStatus.ACTIVE:
-                self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_INTEGRATION)
-            return False
-
-        # Get the integration client
-        installation = self.integration.get_installation(
-            organization_id=self.org_integration.organization_id
-        )
-
-        # Get the client, some integrations use a keyring approach so
-        # we need to pass in the keyid
-        keyid = request.headers.get(PROXY_KEYID_HEADER)
-        if keyid:
-            self.client: IntegrationProxyClient = installation.get_keyring_client(keyid)
-        else:
-            self.client: IntegrationProxyClient = installation.get_client()
-        client_class = self.client.__class__
-
-        self.log_extra["client_type"] = client_class.__name__
-        if not issubclass(client_class, IntegrationProxyClient):
-            logger.info("integration_proxy.invalid_client", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_CLIENT)
-            return False
-
-        return True
-
-    def _should_operate(self, request: HttpRequest) -> bool:
-        """
-        Returns True if this endpoint should proxy the incoming integration request.
-        """
-        is_correct_silo = SiloMode.get_current_mode() == SiloMode.CONTROL
-        if not is_correct_silo:
-            self.log_extra["silo_mode"] = SiloMode.get_current_mode().value
-            logger.info("integration_proxy.incorrect_silo_mode", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_MODE)
-            return False
-
-        is_valid_sender = self._validate_sender(request=request)
-        if not is_valid_sender:
-            logger.info("integration_proxy.failure.invalid_sender", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_SENDER)
-            return False
-
-        is_valid_request = self._validate_request(request=request)
-        if not is_valid_request:
-            logger.info("integration_proxy.failure.invalid_request", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_REQUEST)
-            return False
-        return True
 
     @trace
     def _call_third_party_api(
@@ -309,21 +430,24 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         with IntegrationProxyEvent(
             interaction_type=IntegrationProxyEventType.SHOULD_PROXY
         ).capture() as lifecycle:
-            # Removes leading slashes as it can result in incorrect urls being generated
-            self.proxy_path = trim_leading_slashes(request.headers.get(PROXY_PATH, ""))
-            self.log_extra["method"] = request.method
-            self.log_extra["path"] = self.proxy_path
-            self.log_extra["host"] = request.headers.get("Host")
-
-            if not self._should_operate(request):
+            try:
+                validator = IntegrationProxyRequestValidator(request)
+            except IntegrationProxyRequestValidationException as e:
                 lifecycle.record_failure(
-                    failure_reason=IntegrationProxyFailureMetricType.FAILED_VALIDATION
+                    failure_reason=e.failure_type.value, extra={**e.integration_context}
+                )
+                _add_failure_metric(
+                    failure_type=e.failure_type,
                 )
                 return HttpResponseBadRequest()
 
-            self._add_metric(
-                metric_name=IntegrationProxySuccessMetricType.INITIALIZE, sample_rate=1.0
-            )
+            self.proxy_path = validator.proxy_path
+            # Share the validator's dict so keys added on either side are logged together.
+            self.log_extra = validator.log_context
+
+            self.client = validator.client
+
+            _add_metric(metric_name=IntegrationProxySuccessMetricType.INITIALIZE, sample_rate=1.0)
 
             base_url = request.headers.get(PROXY_BASE_URL_HEADER)
             base_url = base_url.rstrip("/")
@@ -335,21 +459,23 @@ class InternalIntegrationProxyEndpoint(Endpoint):
         with IntegrationProxyEvent(
             interaction_type=IntegrationProxyEventType.PROXY_REQUEST
         ).capture() as lifecycle:
-            if self.org_integration is not None:
+            org_integration = validator.organization_integration
+            if org_integration is not None:
                 lifecycle.add_extras(
                     {
-                        "integration_id": self.org_integration.integration_id,
-                        "organization_id": self.org_integration.organization_id,
+                        "integration_id": org_integration.integration_id,
+                        "organization_id": org_integration.organization_id,
                     }
                 )
-            if self.integration is not None:
-                lifecycle.add_extras({"provider": self.integration.provider})
+            integration = validator.integration
+            if integration is not None:
+                lifecycle.add_extras({"provider": integration.provider})
 
             response = self._call_third_party_api(
                 request=request, full_url=full_url, headers=headers
             )
 
-        self._add_metric(
+        _add_metric(
             metric_name=IntegrationProxySuccessMetricType.COMPLETE_RESPONSE_CODE,
             sample_rate=1.0,
             tags={"status": response.status_code},
@@ -365,34 +491,34 @@ class InternalIntegrationProxyEndpoint(Endpoint):
     ) -> DRFResponse:
         if isinstance(exc, IdentityNotValid):
             logger.warning("hybrid_cloud.integration_proxy.invalid_identity", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_IDENTITY)
+            _add_failure_metric(IntegrationProxyFailureMetricType.INVALID_IDENTITY)
             return self.respond(status=400)
         elif isinstance(exc, ApiHostError):
             logger.info(
                 "hybrid_cloud.integration_proxy.host_unreachable_error", extra=self.log_extra
             )
-            self._add_failure_metric(IntegrationProxyFailureMetricType.HOST_UNREACHABLE_ERROR)
+            _add_failure_metric(IntegrationProxyFailureMetricType.HOST_UNREACHABLE_ERROR)
             return self.respond(status=exc.code)
         elif isinstance(exc, ApiTimeoutError):
             logger.info("hybrid_cloud.integration_proxy.host_timeout_error", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.HOST_TIMEOUT_ERROR)
+            _add_failure_metric(IntegrationProxyFailureMetricType.HOST_TIMEOUT_ERROR)
             return self.respond(status=exc.code)
         elif isinstance(exc, ApiUnauthorized):
             logger.info("hybrid_cloud.integration_proxy.unauthorized_error", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.UNAUTHORIZED_ERROR)
+            _add_failure_metric(IntegrationProxyFailureMetricType.UNAUTHORIZED_ERROR)
             return self.respond(status=exc.code)
         elif isinstance(exc, ApiRateLimitedError):
             logger.info("hybrid_cloud.integration_proxy.rate_limited_error", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.RATE_LIMITED_ERROR)
+            _add_failure_metric(IntegrationProxyFailureMetricType.RATE_LIMITED_ERROR)
             return self.respond(status=exc.code)
         elif isinstance(exc, ApiForbiddenError):
             logger.info("hybrid_cloud.integration_proxy.forbidden_error", extra=self.log_extra)
-            self._add_failure_metric(IntegrationProxyFailureMetricType.FORBIDDEN_ERROR)
+            _add_failure_metric(IntegrationProxyFailureMetricType.FORBIDDEN_ERROR)
             return self.respond(status=exc.code)
 
         logger.warning(
             "hybrid_cloud.integration_proxy.unknown_error",
             extra={**self.log_extra, "exception_class": type(exc).__name__},
         )
-        self._add_failure_metric(IntegrationProxyFailureMetricType.UNKNOWN_ERROR)
+        _add_failure_metric(IntegrationProxyFailureMetricType.UNKNOWN_ERROR)
         return super().handle_exception_with_details(request, exc, handler_context, scope)

--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -81,36 +81,6 @@ class IntegrationProxyFailureMetricType(StrEnum):
     FAILED_VALIDATION = "failed_validation"
 
 
-def _add_metric(
-    metric_name: str,
-    sample_rate: float | None = None,
-    tags: Tags | None = None,
-) -> None:
-    if sample_rate is None:
-        sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
-
-    metrics.incr(
-        f"{METRIC_PREFIX}.{metric_name}",
-        sample_rate=sample_rate,
-        tags=tags,
-    )
-
-
-def _add_failure_metric(
-    failure_type: IntegrationProxyFailureMetricType,
-    additional_tags: dict[str, str] | None = None,
-) -> None:
-    if additional_tags is None:
-        additional_tags = {}
-    tags = {"failure_type": failure_type.value, **additional_tags}
-
-    _add_metric(
-        metric_name="proxy_failure",
-        sample_rate=1.0,
-        tags=tags,
-    )
-
-
 class _PassthroughContentNegotiation(BaseContentNegotiation):
     """
     DRF's initial() method calls perform_content_negotiation() before the handler runs. The default
@@ -373,6 +343,36 @@ class InternalIntegrationProxyEndpoint(Endpoint):
     def client(self, client):
         self._client = client
 
+    def _add_metric(
+        self,
+        metric_name: str,
+        sample_rate: float | None = None,
+        tags: Tags | None = None,
+    ) -> None:
+        if sample_rate is None:
+            sample_rate = settings.SENTRY_METRICS_SAMPLE_RATE
+
+        metrics.incr(
+            f"{METRIC_PREFIX}.{metric_name}",
+            sample_rate=sample_rate,
+            tags=tags,
+        )
+
+    def _add_failure_metric(
+        self,
+        failure_type: IntegrationProxyFailureMetricType,
+        additional_tags: dict[str, str] | None = None,
+    ) -> None:
+        if additional_tags is None:
+            additional_tags = {}
+        tags = {"failure_type": failure_type.value, **additional_tags}
+
+        self._add_metric(
+            metric_name="proxy_failure",
+            sample_rate=1.0,
+            tags=tags,
+        )
+
     @trace
     def _call_third_party_api(
         self, request: HttpRequest, full_url: str, headers: MutableMapping[str, str]
@@ -428,7 +428,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
                 lifecycle.record_failure(
                     failure_reason=e.failure_type.value, extra={**e.integration_context}
                 )
-                _add_failure_metric(
+                self._add_failure_metric(
                     failure_type=e.failure_type,
                 )
                 return HttpResponseBadRequest()
@@ -436,7 +436,9 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             self.proxy_path = validator.proxy_path
             self.client = validator.client
 
-            _add_metric(metric_name=IntegrationProxySuccessMetricType.INITIALIZE, sample_rate=1.0)
+            self._add_metric(
+                metric_name=IntegrationProxySuccessMetricType.INITIALIZE, sample_rate=1.0
+            )
 
             base_url = request.headers.get(PROXY_BASE_URL_HEADER)
             base_url = base_url.rstrip("/")
@@ -472,7 +474,7 @@ class InternalIntegrationProxyEndpoint(Endpoint):
                 request=request, full_url=full_url, headers=headers
             )
 
-        _add_metric(
+        self._add_metric(
             metric_name=IntegrationProxySuccessMetricType.COMPLETE_RESPONSE_CODE,
             sample_rate=1.0,
             tags={"status": response.status_code},
@@ -488,34 +490,34 @@ class InternalIntegrationProxyEndpoint(Endpoint):
     ) -> DRFResponse:
         if isinstance(exc, IdentityNotValid):
             logger.warning("hybrid_cloud.integration_proxy.invalid_identity", extra=self.log_extra)
-            _add_failure_metric(IntegrationProxyFailureMetricType.INVALID_IDENTITY)
+            self._add_failure_metric(IntegrationProxyFailureMetricType.INVALID_IDENTITY)
             return self.respond(status=400)
         elif isinstance(exc, ApiHostError):
             logger.info(
                 "hybrid_cloud.integration_proxy.host_unreachable_error", extra=self.log_extra
             )
-            _add_failure_metric(IntegrationProxyFailureMetricType.HOST_UNREACHABLE_ERROR)
+            self._add_failure_metric(IntegrationProxyFailureMetricType.HOST_UNREACHABLE_ERROR)
             return self.respond(status=exc.code)
         elif isinstance(exc, ApiTimeoutError):
             logger.info("hybrid_cloud.integration_proxy.host_timeout_error", extra=self.log_extra)
-            _add_failure_metric(IntegrationProxyFailureMetricType.HOST_TIMEOUT_ERROR)
+            self._add_failure_metric(IntegrationProxyFailureMetricType.HOST_TIMEOUT_ERROR)
             return self.respond(status=exc.code)
         elif isinstance(exc, ApiUnauthorized):
             logger.info("hybrid_cloud.integration_proxy.unauthorized_error", extra=self.log_extra)
-            _add_failure_metric(IntegrationProxyFailureMetricType.UNAUTHORIZED_ERROR)
+            self._add_failure_metric(IntegrationProxyFailureMetricType.UNAUTHORIZED_ERROR)
             return self.respond(status=exc.code)
         elif isinstance(exc, ApiRateLimitedError):
             logger.info("hybrid_cloud.integration_proxy.rate_limited_error", extra=self.log_extra)
-            _add_failure_metric(IntegrationProxyFailureMetricType.RATE_LIMITED_ERROR)
+            self._add_failure_metric(IntegrationProxyFailureMetricType.RATE_LIMITED_ERROR)
             return self.respond(status=exc.code)
         elif isinstance(exc, ApiForbiddenError):
             logger.info("hybrid_cloud.integration_proxy.forbidden_error", extra=self.log_extra)
-            _add_failure_metric(IntegrationProxyFailureMetricType.FORBIDDEN_ERROR)
+            self._add_failure_metric(IntegrationProxyFailureMetricType.FORBIDDEN_ERROR)
             return self.respond(status=exc.code)
 
         logger.warning(
             "hybrid_cloud.integration_proxy.unknown_error",
             extra={**self.log_extra, "exception_class": type(exc).__name__},
         )
-        _add_failure_metric(IntegrationProxyFailureMetricType.UNKNOWN_ERROR)
+        self._add_failure_metric(IntegrationProxyFailureMetricType.UNKNOWN_ERROR)
         return super().handle_exception_with_details(request, exc, handler_context, scope)

--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -158,7 +158,6 @@ class IntegrationProxyRequestValidator:
     """
 
     proxy_path: str
-    log_context: dict[str, Any]
 
     # Populated by the validation steps below; each stays None if validation never got that far.
     integration: Integration
@@ -170,11 +169,6 @@ class IntegrationProxyRequestValidator:
         self.request = request
         # Removes leading slashes as it can result in incorrect urls being generated
         self.proxy_path = trim_leading_slashes(request.headers.get(PROXY_PATH, ""))
-        self.log_context = {
-            "method": request.method,
-            "path": self.proxy_path,
-            "host": request.headers.get("Host"),
-        }
 
         self._validate()
 
@@ -206,7 +200,6 @@ class IntegrationProxyRequestValidator:
     def _validate_silo_mode(self):
         is_correct_silo = SiloMode.get_current_mode() == SiloMode.CONTROL
         if not is_correct_silo:
-            self.log_context["silo_mode"] = SiloMode.get_current_mode().value
             raise IntegrationProxyRequestValidationException(
                 failure_type=IntegrationProxyFailureMetricType.INVALID_MODE,
                 integration_context={
@@ -310,7 +303,6 @@ class IntegrationProxyRequestValidator:
         integration = org_integration.integration
         self.integration = integration
         if not integration or integration.status is not ObjectStatus.ACTIVE:
-            logger.info("integration_proxy.invalid_integration", extra=self.log_context)
             raise IntegrationProxyRequestValidationException(
                 failure_type=IntegrationProxyFailureMetricType.INVALID_INTEGRATION,
                 integration_context={
@@ -442,9 +434,6 @@ class InternalIntegrationProxyEndpoint(Endpoint):
                 return HttpResponseBadRequest()
 
             self.proxy_path = validator.proxy_path
-            # Share the validator's dict so keys added on either side are logged together.
-            self.log_extra = validator.log_context
-
             self.client = validator.client
 
             _add_metric(metric_name=IntegrationProxySuccessMetricType.INITIALIZE, sample_rate=1.0)
@@ -453,7 +442,15 @@ class InternalIntegrationProxyEndpoint(Endpoint):
             base_url = base_url.rstrip("/")
 
             full_url = urljoin(f"{base_url}/", self.proxy_path)
-            self.log_extra["full_url"] = full_url
+
+            self.log_extra = {
+                "full_url": full_url,
+                "method": request.method,
+                "path": self.proxy_path,
+                "host": request.headers.get("Host"),
+                "integration_id": validator.integration.id,
+                "organization_id": validator.organization_integration.organization_id,
+            }
             headers = clean_outbound_headers(request.headers)
 
         with IntegrationProxyEvent(

--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -70,7 +70,6 @@ class IntegrationProxyFailureMetricType(StrEnum):
     INVALID_CLIENT = "invalid_client"
     INVALID_MODE = "invalid_mode"
     INVALID_SENDER = "invalid_sender"
-    INVALID_REQUEST = "invalid_request"
     INVALID_IDENTITY = "invalid_identity"
     HOST_UNREACHABLE_ERROR = "host_unreachable_error"
     HOST_TIMEOUT_ERROR = "host_timeout_error"
@@ -78,7 +77,6 @@ class IntegrationProxyFailureMetricType(StrEnum):
     RATE_LIMITED_ERROR = "rate_limited_error"
     FORBIDDEN_ERROR = "forbidden_error"
     UNKNOWN_ERROR = "unknown_error"
-    FAILED_VALIDATION = "failed_validation"
 
 
 class _PassthroughContentNegotiation(BaseContentNegotiation):
@@ -190,7 +188,8 @@ class IntegrationProxyRequestValidator:
 
     def _validate_sender(self):
         """
-        Returns True if the sender is deemed sufficiently trustworthy. A sender is considered trustworthy if they:
+        Validates the sender of the request and raises an exception if the sender is not trustworthy.
+        A sender is considered trustworthy if they:
             - Have a valid signature
             - Can be mapped definitively to an integration and organization
             - Have a valid subnet signature
@@ -286,8 +285,8 @@ class IntegrationProxyRequestValidator:
 
     def _validate_and_set_client(self):
         """
-        Acquires the API client from the installation and sets it on the validator. Returns True only
-        if that client can actually proxy requests.
+        Acquires the API client from the installation and sets it on the validator.
+        Raises an exception if the client is not valid.
         """
         installation = self.integration_installation
         if installation is None:

--- a/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
+++ b/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Generator
-from typing import Any, TypedDict
+from typing import Any, TypedDict, Unpack
 from unittest.mock import MagicMock, Mock, patch
 
+import pytest
 from django.http.request import HttpHeaders
 from django.test import RequestFactory, override_settings
 from requests import Response
@@ -12,6 +13,8 @@ from sentry.auth.exceptions import IdentityNotValid
 from sentry.constants import ObjectStatus
 from sentry.integrations.api.endpoints.integration_proxy import (
     IntegrationProxyFailureMetricType,
+    IntegrationProxyRequestValidationException,
+    IntegrationProxyRequestValidator,
     IntegrationProxySuccessMetricType,
     InternalIntegrationProxyEndpoint,
 )
@@ -37,7 +40,7 @@ from sentry.silo.util import (
     encode_subnet_signature,
 )
 from sentry.testutils.asserts import assert_count_of_metric, assert_failure_metric
-from sentry.testutils.cases import APITestCase
+from sentry.testutils.cases import APITestCase, TestCase
 from sentry.testutils.silo import control_silo_test
 from sentry.utils import metrics
 
@@ -48,6 +51,30 @@ class SiloHttpHeaders(TypedDict, total=False):
     HTTP_X_SENTRY_SUBNET_BASE_URL: str
     HTTP_X_SENTRY_SUBNET_PATH: str
     HTTP_X_SENTRY_SUBNET_TIMEOUT: str
+    HTTP_X_SENTRY_SUBNET_KEYID: str
+
+
+def create_request_headers(
+    secret: str,
+    signature_path: str,
+    integration_id: int | None = None,
+    request_body=b"",
+    base_url="https://example.com/api",
+):
+    signature = encode_subnet_signature(
+        secret=secret,
+        base_url=base_url,
+        path=signature_path,
+        identifier=str(integration_id),
+        request_body=request_body,
+    )
+
+    return SiloHttpHeaders(
+        HTTP_X_SENTRY_SUBNET_BASE_URL=base_url,
+        HTTP_X_SENTRY_SUBNET_SIGNATURE=signature,
+        HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(integration_id),
+        HTTP_X_SENTRY_SUBNET_PATH=signature_path,
+    )
 
 
 def test_ensure_http_headers_match() -> None:
@@ -80,8 +107,6 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
     def setUp(self) -> None:
         self.factory = RequestFactory()
         self.proxy_path = "chat.postMessage"
-        self.endpoint_cls = InternalIntegrationProxyEndpoint()
-        self.endpoint_cls.proxy_path = self.proxy_path
         self.path = f"{PROXY_BASE_PATH}/"
         self.integration = self.create_integration(
             self.organization, external_id="example:1", provider="example"
@@ -90,8 +115,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
             integration_id=self.integration.id
         )
 
-        self.valid_header_kwargs = self.create_request_headers(
-            integration_id=self.org_integration.id, signature_path=self.proxy_path
+        self.valid_header_kwargs = create_request_headers(
+            self.secret, integration_id=self.org_integration.id, signature_path=self.proxy_path
         )
         self.valid_request = self.factory.get(self.path, **self.valid_header_kwargs)
 
@@ -133,39 +158,25 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         mock_metrics: MagicMock,
         tags: Tags | None = None,
     ):
-        metric_name = "proxy_failure"
-        kwargs: dict[str, Any] = {
-            "sample_rate": 1.0,
-            "tags": {"failure_type": failure_type, **(tags or {})},
-        }
-        self.assert_metric_count(
-            metric_name=metric_name,
-            count=count,
-            mock_metrics=mock_metrics,
-            kwargs_to_match=kwargs,
+        metric_name = "hybrid_cloud.integration_proxy.proxy_failure"
+        expected_tags = {"failure_type": failure_type, **(tags or {})}
+
+        # Filter on the failure_type tag, since a single validation pass can emit more than
+        # one proxy_failure metric (a specific reason plus the wrapping category).
+        matching_mock_calls = [
+            call
+            for call in mock_metrics.call_args_list
+            if call.args[0] == metric_name and call.kwargs.get("tags") == expected_tags
+        ]
+        logged_metrics = [
+            (call.args[0], call.kwargs.get("tags")) for call in mock_metrics.call_args_list
+        ]
+        assert len(matching_mock_calls) == count, (
+            f"Expected {count} {failure_type} metric(s), found {len(matching_mock_calls)} in {logged_metrics}"
         )
 
-    def create_request_headers(
-        self,
-        signature_path,
-        integration_id: int | None = None,
-        request_body=b"",
-        base_url="https://example.com/api",
-    ):
-        signature = encode_subnet_signature(
-            secret=self.secret,
-            base_url=base_url,
-            path=signature_path,
-            identifier=str(integration_id),
-            request_body=request_body,
-        )
-
-        return SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_BASE_URL=base_url,
-            HTTP_X_SENTRY_SUBNET_SIGNATURE=signature,
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(integration_id),
-            HTTP_X_SENTRY_SUBNET_PATH=signature_path,
-        )
+        for call in matching_mock_calls:
+            assert call.kwargs["sample_rate"] == 1.0
 
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
     @patch.object(ExampleIntegration, "get_client")
@@ -175,7 +186,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=self.org_integration.id,
         )
@@ -231,7 +243,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=self.org_integration.id,
         )
@@ -264,7 +277,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=self.org_integration.id,
         )
@@ -296,7 +310,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=self.org_integration.id,
             base_url="https://foobar.example.com/api",
@@ -358,7 +373,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         mock_record_event: MagicMock,
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=None,
         )
@@ -384,7 +400,7 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         assert proxy_response.get(PROXY_SIGNATURE_HEADER) is None
 
         self.assert_failure_metric_count(
-            failure_type=IntegrationProxyFailureMetricType.INVALID_REQUEST,
+            failure_type=IntegrationProxyFailureMetricType.INVALID_ORG_INTEGRATION_HEADERS,
             count=1,
             mock_metrics=mock_metrics,
         )
@@ -394,90 +410,61 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         assert_count_of_metric(mock_record_event, EventLifecycleOutcome.STARTED, 1)
         assert_count_of_metric(mock_record_event, EventLifecycleOutcome.FAILURE, 1)
 
-    @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test__validate_sender(self) -> None:
-        # Missing header data
-        header_kwargs = SiloHttpHeaders()
-        request = self.factory.get(self.path, **header_kwargs)
-        assert not self.endpoint_cls._validate_sender(request)
-
-        # Bad header data
-        header_kwargs = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_SIGNATURE="data",
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION="present",
-        )
-        request = self.factory.get(self.path, **header_kwargs)
-        assert not self.endpoint_cls._validate_sender(request)
-
-        # Success
-        assert self.endpoint_cls._validate_sender(self.valid_request)
-
-    @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test__validate_request(self) -> None:
-        request = self.factory.get(self.path)
-        assert not self.endpoint_cls._validate_request(request)
-
-    @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test__validate_header_data(self) -> None:
-        self.org_integration.update(status=ObjectStatus.DISABLED)
-        header_kwargs = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
-        )
-        request = self.factory.get(self.path, **header_kwargs)
-        assert not self.endpoint_cls._validate_request(request)
-
-    @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test__validate_organization_integration(self) -> None:
-        header_kwargs = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION="None",
-        )
-        request = self.factory.get(self.path, **header_kwargs)
-        assert not self.endpoint_cls._validate_request(request)
-
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @patch.object(OrganizationIntegration, "integration", None)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
     @patch.object(metrics, "incr")
-    @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test__invalid_integration(self, mock_metrics):
-        self.org_integration.update(status=ObjectStatus.ACTIVE)
-        self.integration.update(status=ObjectStatus.DISABLED)
-        header_kwargs = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
+    def test_proxy_request_with_unresolvable_integration(
+        self,
+        mock_metrics: MagicMock,
+        mock_client: MagicMock,
+        mock_get_client: MagicMock,
+        mock_record_event: MagicMock,
+    ) -> None:
+        """
+        The organization integration's foreign key is non-null in the database, but guard against
+        it resolving to nothing anyway rather than blowing up on a missing installation.
+        """
+        signature_path = f"/{self.proxy_path}"
+        headers = create_request_headers(
+            self.secret,
+            signature_path=signature_path,
+            integration_id=self.org_integration.id,
         )
-        request = self.factory.get(self.path, **header_kwargs)
-        assert not self.endpoint_cls._validate_request(request)
+
+        mock_client.base_url = "https://example.com/api"
+        mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
+        mock_client.request = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        proxy_response = self.client.get(self.path, **headers)
+
+        assert proxy_response.status_code == 400
+        assert mock_client.request.call_count == 0
+        assert proxy_response.get(PROXY_SIGNATURE_HEADER) is None
+
         self.assert_failure_metric_count(
             failure_type=IntegrationProxyFailureMetricType.INVALID_INTEGRATION,
             count=1,
             mock_metrics=mock_metrics,
         )
-
-    @patch.object(metrics, "incr")
-    @patch.object(Integration, "get_installation")
-    @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test_invalid_client(self, mock_get_installation, mock_metrics):
-        header_kwargs = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
+        self.assert_metric_count(
+            metric_name=IntegrationProxySuccessMetricType.INITIALIZE,
+            count=0,
+            mock_metrics=mock_metrics,
         )
-        self.integration.update(status=ObjectStatus.ACTIVE)
-        mock_get_installation().get_client = MagicMock(return_value=ApiClient())
-        request = self.factory.get(self.path, **header_kwargs)
-        assert not self.endpoint_cls._validate_request(request)
-        self.assert_failure_metric_count(
-            failure_type=IntegrationProxyFailureMetricType.INVALID_CLIENT,
-            count=1,
+        self.assert_metric_count(
+            metric_name=IntegrationProxySuccessMetricType.COMPLETE_RESPONSE_CODE,
+            count=0,
             mock_metrics=mock_metrics,
         )
 
-    @patch.object(Integration, "get_installation")
-    @override_settings(SENTRY_SUBNET_SECRET=secret, SILO_MODE=SiloMode.CONTROL)
-    def test_successful_response(self, mock_get_installation):
-        header_kwargs = SiloHttpHeaders(
-            HTTP_X_SENTRY_SUBNET_ORGANIZATION_INTEGRATION=str(self.org_integration.id),
-        )
-        mock_get_installation().get_client = MagicMock(
-            return_value=IntegrationProxyClient(org_integration_id=self.org_integration.id)
-        )
-        request = self.factory.get(self.path, **header_kwargs)
-        assert self.endpoint_cls._validate_request(request)
+        # SLO assertions
+        # SHOULD_PROXY (failure)
+        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.STARTED, 1)
+        assert_count_of_metric(mock_record_event, EventLifecycleOutcome.FAILURE, 1)
 
     def raise_exception(self, exc_type: type[Exception], *args, **kwargs):
         raise exc_type(*args)
@@ -490,8 +477,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
-            signature_path=signature_path, integration_id=self.org_integration.id
+        headers = create_request_headers(
+            self.secret, signature_path=signature_path, integration_id=self.org_integration.id
         )
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
@@ -530,8 +517,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
-            signature_path=signature_path, integration_id=self.org_integration.id
+        headers = create_request_headers(
+            self.secret, signature_path=signature_path, integration_id=self.org_integration.id
         )
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
@@ -573,8 +560,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
-            signature_path=signature_path, integration_id=self.org_integration.id
+        headers = create_request_headers(
+            self.secret, signature_path=signature_path, integration_id=self.org_integration.id
         )
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
@@ -615,8 +602,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
-            signature_path=signature_path, integration_id=self.org_integration.id
+        headers = create_request_headers(
+            self.secret, signature_path=signature_path, integration_id=self.org_integration.id
         )
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
@@ -657,8 +644,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
-            signature_path=signature_path, integration_id=self.org_integration.id
+        headers = create_request_headers(
+            self.secret, signature_path=signature_path, integration_id=self.org_integration.id
         )
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
@@ -699,8 +686,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
-            signature_path=signature_path, integration_id=self.org_integration.id
+        headers = create_request_headers(
+            self.secret, signature_path=signature_path, integration_id=self.org_integration.id
         )
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
@@ -744,8 +731,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         mock_record_event: MagicMock,
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
-            signature_path=signature_path, integration_id=self.org_integration.id
+        headers = create_request_headers(
+            self.secret, signature_path=signature_path, integration_id=self.org_integration.id
         )
         mock_client.base_url = "https://example.com/api"
         mock_client.authorize_request = MagicMock(side_effect=lambda req: req)
@@ -790,7 +777,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=self.org_integration.id,
         )
@@ -830,7 +818,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=self.org_integration.id,
         )
@@ -867,7 +856,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=self.org_integration.id,
         )
@@ -904,7 +894,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         from requests.exceptions import ChunkedEncodingError
 
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=self.org_integration.id,
         )
@@ -942,7 +933,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         self, mock_metrics: MagicMock, mock_client: MagicMock, mock_get_client: MagicMock
     ) -> None:
         signature_path = f"/{self.proxy_path}"
-        headers = self.create_request_headers(
+        headers = create_request_headers(
+            self.secret,
             signature_path=signature_path,
             integration_id=self.org_integration.id,
         )
@@ -968,3 +960,195 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
 
         assert proxy_response.status_code == 200
         assert b"".join(proxy_response.streaming_content) == b""
+
+
+@control_silo_test
+class IntegrationProxyRequestValidatorTest(TestCase):
+    secret = SENTRY_SUBNET_SECRET
+
+    def setUp(self) -> None:
+        self.factory = RequestFactory()
+        self.proxy_path = "chat.postMessage"
+        self.path = f"{PROXY_BASE_PATH}/"
+        self.integration = self.create_integration(
+            self.organization, external_id="example:1", provider="example"
+        )
+        self.org_integration = OrganizationIntegration.objects.get(
+            integration_id=self.integration.id
+        )
+
+    def build_request(self, **extra_headers: Unpack[SiloHttpHeaders]):
+        """
+        Build a request with a valid subnet signature over the default proxy path, letting
+        individual tests override single headers to exercise each validation failure.
+        """
+        header_kwargs = create_request_headers(
+            self.secret, signature_path=self.proxy_path, integration_id=self.org_integration.id
+        )
+        header_kwargs.update(extra_headers)
+        return self.factory.get(self.path, **header_kwargs)
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    @patch.object(metrics, "incr")
+    def test_valid_request(self, mock_metrics: MagicMock, mock_get_client: MagicMock) -> None:
+        proxy_client = IntegrationProxyClient(org_integration_id=self.org_integration.id)
+        mock_get_client.return_value = proxy_client
+
+        validator = IntegrationProxyRequestValidator(self.build_request())
+
+        assert validator.integration == self.integration
+        assert validator.organization_integration == self.org_integration
+        assert isinstance(validator.integration_installation, ExampleIntegration)
+        assert validator.client is proxy_client
+
+        assert validator.proxy_path == self.proxy_path
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(ExampleIntegration, "get_client")
+    def test_strips_leading_slashes_from_proxy_path(self, mock_get_client: MagicMock) -> None:
+        mock_get_client.return_value = IntegrationProxyClient(
+            org_integration_id=self.org_integration.id
+        )
+        request = self.build_request(HTTP_X_SENTRY_SUBNET_PATH=f"/{self.proxy_path}")
+        validator = IntegrationProxyRequestValidator(request)
+
+        assert validator.proxy_path == self.proxy_path
+        # The signature is verified against the trimmed path, so it still checks out.
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CELL)
+    @patch.object(metrics, "incr")
+    def test_incorrect_silo_mode(self, mock_metrics: MagicMock) -> None:
+        with pytest.raises(
+            IntegrationProxyRequestValidationException,
+            match=IntegrationProxyFailureMetricType.INVALID_MODE.value,
+        ) as cm:
+            IntegrationProxyRequestValidator(self.build_request())
+
+        assert cm.value.failure_type == IntegrationProxyFailureMetricType.INVALID_MODE
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(metrics, "incr")
+    def test_missing_sender_headers(self, mock_metrics: MagicMock) -> None:
+        request = self.factory.get(self.path, **SiloHttpHeaders())
+        with pytest.raises(
+            IntegrationProxyRequestValidationException,
+            match=IntegrationProxyFailureMetricType.INVALID_SENDER_HEADERS.value,
+        ) as cm:
+            IntegrationProxyRequestValidator(request)
+
+        assert cm.value.failure_type == IntegrationProxyFailureMetricType.INVALID_SENDER_HEADERS
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(metrics, "incr")
+    def test_non_decimal_org_integration_header(self, mock_metrics: MagicMock) -> None:
+        header_kwargs = create_request_headers(
+            self.secret, signature_path=self.proxy_path, integration_id=None
+        )
+        with pytest.raises(
+            IntegrationProxyRequestValidationException,
+            match=IntegrationProxyFailureMetricType.INVALID_ORG_INTEGRATION_HEADERS.value,
+        ) as cm:
+            IntegrationProxyRequestValidator(self.factory.get(self.path, **header_kwargs))
+
+        assert (
+            cm.value.failure_type
+            == IntegrationProxyFailureMetricType.INVALID_ORG_INTEGRATION_HEADERS
+        )
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(metrics, "incr")
+    def test_inactive_org_integration(self, mock_metrics: MagicMock) -> None:
+        self.org_integration.update(status=ObjectStatus.DISABLED)
+        with pytest.raises(
+            IntegrationProxyRequestValidationException,
+            match=IntegrationProxyFailureMetricType.INVALID_ORG_INTEGRATION.value,
+        ) as cm:
+            IntegrationProxyRequestValidator(self.build_request())
+
+        assert cm.value.failure_type == IntegrationProxyFailureMetricType.INVALID_ORG_INTEGRATION
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(metrics, "incr")
+    def test_inactive_integration(self, mock_metrics: MagicMock) -> None:
+        self.integration.update(status=ObjectStatus.DISABLED)
+        with pytest.raises(
+            IntegrationProxyRequestValidationException,
+            match=IntegrationProxyFailureMetricType.INVALID_INTEGRATION.value,
+        ) as cm:
+            IntegrationProxyRequestValidator(self.build_request())
+
+        assert cm.value.failure_type == IntegrationProxyFailureMetricType.INVALID_INTEGRATION
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(OrganizationIntegration, "integration", None)
+    @patch.object(metrics, "incr")
+    def test_unresolvable_integration(self, mock_metrics: MagicMock) -> None:
+        with pytest.raises(
+            IntegrationProxyRequestValidationException,
+            match=IntegrationProxyFailureMetricType.INVALID_INTEGRATION.value,
+        ) as cm:
+            IntegrationProxyRequestValidator(self.build_request())
+
+        assert cm.value.failure_type == IntegrationProxyFailureMetricType.INVALID_INTEGRATION
+        assert cm.value.integration_context["integration_id"] is None
+        assert cm.value.integration_context["organization_id"] == self.organization.id
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(Integration, "get_installation")
+    @patch.object(metrics, "incr")
+    def test_non_proxy_client(
+        self, mock_metrics: MagicMock, mock_get_installation: MagicMock
+    ) -> None:
+        mock_get_installation().get_client = MagicMock(return_value=ApiClient())
+        with pytest.raises(
+            IntegrationProxyRequestValidationException,
+            match=IntegrationProxyFailureMetricType.INVALID_CLIENT.value,
+        ) as cm:
+            IntegrationProxyRequestValidator(self.build_request())
+
+        assert cm.value.failure_type == IntegrationProxyFailureMetricType.INVALID_CLIENT
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(Integration, "get_installation")
+    def test_uses_keyring_client_when_keyid_present(self, mock_get_installation: MagicMock) -> None:
+        keyring_client = IntegrationProxyClient(org_integration_id=self.org_integration.id)
+        mock_installation = mock_get_installation.return_value
+        mock_installation.get_keyring_client = MagicMock(return_value=keyring_client)
+        mock_installation.get_client = MagicMock(return_value=ApiClient())
+
+        request = self.build_request(HTTP_X_SENTRY_SUBNET_KEYID="12345")
+        validator = IntegrationProxyRequestValidator(request)
+
+        mock_installation.get_keyring_client.assert_called_once_with("12345")
+        assert mock_installation.get_client.call_count == 0
+        assert validator.client is keyring_client
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    @patch.object(Integration, "get_installation")
+    def test_validates_once_during_construction(self, mock_get_installation: MagicMock) -> None:
+        mock_get_installation.return_value.get_client = MagicMock(
+            return_value=IntegrationProxyClient(org_integration_id=self.org_integration.id)
+        )
+        validator = IntegrationProxyRequestValidator(self.build_request())
+
+        # Validation already ran in the constructor; the getters just read what it resolved.
+        assert validator.integration == self.integration
+        assert validator.organization_integration == self.org_integration
+        assert validator.client is not None
+
+        assert mock_get_installation.call_count == 1
+
+    @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
+    def test_exception_integration_context_empty_when_invalid_request_is_made(self) -> None:
+        request = self.build_request(HTTP_X_SENTRY_SUBNET_SIGNATURE="not-the-real-signature")
+        with pytest.raises(
+            IntegrationProxyRequestValidationException,
+            match=IntegrationProxyFailureMetricType.INVALID_SENDER_SIGNATURE.value,
+        ) as cm:
+            IntegrationProxyRequestValidator(request)
+
+        assert cm.value.failure_type == IntegrationProxyFailureMetricType.INVALID_SENDER_SIGNATURE
+
+        assert cm.value.integration_context["integration_id"] is None
+        assert cm.value.integration_context["organization_id"] is None


### PR DESCRIPTION
Refactors the IntegrationProxyEndpoint to separate request validation from the actual proxy request being made. Rather than conflate the two, I've decided to flatten the validation step and raise exceptions, allowing the SLO context decorators we added in the past to perform the majority of metric and logging handling.

This also allows validation logic to be tested in isolation with higher granularity, where before, integration style tests were required to validate the various proxy failure scenarios.