### PR TITLE
stop bolding slack alert titles inside links

### DIFF
--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -61,5 +61,5 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
             blocks.append(self.get_image_block(self.chart_url, alt="Metric Alert Chart"))
 
         color = LEVEL_TO_COLOR.get(INCIDENT_COLOR_MAPPING.get(data["status"], ""))
-        fallback_text = f"<{data['title_link']}|*{escape_slack_text(data['title'])}*>"
+        fallback_text = f"<{data['title_link']}|{escape_slack_text(data['title'])}>"
         return self._build_blocks(*blocks, fallback_text=fallback_text, color=color)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -456,7 +456,7 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         title = build_attachment_title(event_or_group)
         title_emojis = self.get_title_emoji(has_action)
 
-        title_text = f"{title_emojis} <{title_link}|*{escape_slack_text(title)}*>"
+        title_text = f"{title_emojis} <{title_link}|{escape_slack_text(title)}>"
         return self.get_markdown_block(title_text)
 
     def get_title_emoji(self, has_action: bool) -> str:

--- a/src/sentry/integrations/slack/message_builder/notifications/base.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/base.py
@@ -39,9 +39,9 @@ class SlackNotificationsMessageBuilder(BlockSlackMessageBuilder):
         first_block_text = ""
         if title_link:
             if title:
-                first_block_text += f"<{title_link}|*{escape_slack_text(title)}*>  \n"
+                first_block_text += f"<{title_link}|{escape_slack_text(title)}>  \n"
             else:
-                first_block_text += f"<{title_link}|*{escape_slack_text(title_link)}*>  \n"
+                first_block_text += f"<{title_link}|{escape_slack_text(title_link)}>  \n"
         elif title:  # ie. "ZeroDivisionError",
             first_block_text += f"*{escape_slack_text(title)}*  \n"
 

--- a/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
+++ b/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
@@ -84,7 +84,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         assert NotificationMessage.objects.all().count() == 1
@@ -129,7 +129,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         assert (
@@ -216,7 +216,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         # Test action should not create a notification message
@@ -257,7 +257,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|Hello world>"
         )
 
         assert NotificationMessage.objects.all().count() == 1
@@ -298,7 +298,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         assert NotificationMessage.objects.all().count() == 1
@@ -355,7 +355,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         assert NotificationMessage.objects.all().count() == 2

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -102,7 +102,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
 
         assert (

--- a/tests/sentry/integrations/slack/notifications/test_escalating.py
+++ b/tests/sentry/integrations/slack/notifications/test_escalating.py
@@ -40,7 +40,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
         )
         assert (
             blocks[2]["elements"][0]["text"]
@@ -70,7 +70,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|*{event.group.title}*>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|{event.group.title}>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
         )
         assert (
             blocks[2]["elements"][0]["text"]
@@ -103,7 +103,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{group_event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{group_event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|{TEST_ISSUE_OCCURRENCE.issue_title}>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
         )
         assert (
             blocks[2]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -87,7 +87,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -321,7 +321,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -355,7 +355,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment=production&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment=production&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -491,7 +491,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         # Verify suggested assignees are in the context block and footer is last
         context_blocks = [b for b in blocks if b.get("type") == "context"]
@@ -727,7 +727,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[5]["elements"][0]["text"]
@@ -952,7 +952,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[4]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -42,7 +42,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         comment = notification.activity.data["text"]
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n{comment}"
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>  \n{comment}"
         )
         assert (
             blocks[2]["elements"][0]["text"]
@@ -70,7 +70,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         comment = notification.activity.data["text"]
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|*N+1 Query*>  \n{comment}"
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|N+1 Query>  \n{comment}"
         )
         assert (
             blocks[2]["elements"][0]["text"]
@@ -105,7 +105,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>  \n{comment}"
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|{TEST_ISSUE_OCCURRENCE.issue_title}>  \n{comment}"
         )
         assert (
             blocks[2]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -38,7 +38,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
@@ -61,7 +61,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
@@ -79,7 +79,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
 
     def test_regression_with_event_id_and_release_block(self) -> None:
@@ -94,7 +94,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
 
     @mock.patch(

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -45,7 +45,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert blocks[0]["text"]["text"] == fallback_text
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <{issue_link}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            == f":red_circle: <{issue_link}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_pull_request.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_pull_request.py
@@ -48,7 +48,7 @@ class SlackResolvedInPullRequestNotificationTest(
 
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_pull_request_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_pull_request_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -42,7 +42,7 @@ class SlackResolvedInReleaseNotificationTest(
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
 
         assert (

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -40,7 +40,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -85,7 +85,7 @@ def build_test_message_blocks(
         else:
             title_link += f"&alert_rule_id={rule.id}&alert_type=issue"
 
-    title_text = f":red_circle: <{title_link}|*{formatted_title}*>"
+    title_text = f":red_circle: <{title_link}|{formatted_title}>"
 
     if rule:
         if legacy_rule_id:

--- a/tests/sentry/integrations/slack/webhooks/events/__init__.py
+++ b/tests/sentry/integrations/slack/webhooks/events/__init__.py
@@ -45,7 +45,7 @@ def build_test_block(link):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f"<{link}/1|*wow an issue very cool*> \n",
+                    "text": f"<{link}/1|wow an issue very cool> \n",
                 },
                 "block_id": orjson.dumps({"issue": 1}).decode(),
             }


### PR DESCRIPTION
Slack Android treats <url|*bold text*> as plain text instead of a link. Drop the nested bold on alert titles so they stay clickable, same as desktop.

Fixes #109694
