### PR TITLE
default issue row graph to the selected time range

### DIFF
--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -239,15 +239,17 @@ function IssueListOverviewInner({
   const sort = decodeScalar(location.query.sort, defaultSort) as IssueSortOptions;
 
   const getGroupStatsPeriod = useCallback((): string => {
-    const currentPeriod = decodeScalar(
-      location.query?.groupStatsPeriod,
-      DEFAULT_GRAPH_STATS_PERIOD
-    );
+    const pagePeriod = selection.datetime.period;
+    const fallback =
+      pagePeriod && pagePeriod !== DEFAULT_GRAPH_STATS_PERIOD
+        ? 'auto'
+        : DEFAULT_GRAPH_STATS_PERIOD;
+    const currentPeriod = decodeScalar(location.query?.groupStatsPeriod, fallback);
 
     return DYNAMIC_COUNTS_STATS_PERIODS.has(currentPeriod)
       ? currentPeriod
-      : DEFAULT_GRAPH_STATS_PERIOD;
-  }, [location]);
+      : fallback;
+  }, [location, selection.datetime.period]);
 
   const getEndpointParams = useCallback((): EndpointParams => {
     const params: EndpointParams = {


### PR DESCRIPTION
The trend graph on the issues stream stays on 24h after you change the page time range, so you have to click the range label (e.g. 3d) to catch up. Default groupStatsPeriod to auto when the page filter is not 24h.

Fixes #115090
