### PR TITLE
fix(autofix): Expand small code changes by default

### DIFF
--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -2,7 +2,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
+import {CodingAgentProvider, DiffLineType} from 'sentry/components/events/autofix/types';
 import type {
   AutofixArtifact,
   AutofixSection,
@@ -22,7 +22,9 @@ import type {
 } from 'sentry/views/seerExplorer/types';
 
 jest.mock('sentry/views/seerExplorer/components/fileDiffViewer', () => ({
-  FileDiffViewer: () => <div data-testid="file-diff-viewer" />,
+  FileDiffViewer: ({defaultExpanded}: {defaultExpanded?: boolean}) => (
+    <div data-expanded={defaultExpanded} data-test-id="file-diff-viewer" />
+  ),
 }));
 
 const prIterationOrganization = OrganizationFixture({
@@ -440,6 +442,55 @@ describe('ArtifactCard', () => {
       );
 
       expect(screen.getByText('3 files changed in 2 repos')).toBeInTheDocument();
+    });
+
+    it('expands small multi-file changes by default', () => {
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={mockAutofix}
+          section={makeSection('code_changes', 'completed', [
+            [makePatch('org/repo', 'src/app.py'), makePatch('org/repo', 'src/utils.py')],
+          ])}
+        />
+      );
+
+      const diffViewers = screen.getAllByTestId('file-diff-viewer');
+      expect(diffViewers[0]).toHaveAttribute('data-expanded', 'true');
+      expect(diffViewers[1]).toHaveAttribute('data-expanded', 'true');
+    });
+
+    it('collapses large changes by default', () => {
+      const patch = makePatch('org/repo', 'src/app.py');
+      patch.patch.hunks = [
+        {
+          lines: Array.from({length: 51}, (_, index) => ({
+            diff_line_no: index,
+            line_type: DiffLineType.CONTEXT,
+            source_line_no: index,
+            target_line_no: index,
+            value: `line ${index}`,
+          })),
+          section_header: '',
+          source_length: 51,
+          source_start: 1,
+          target_length: 51,
+          target_start: 1,
+        },
+      ];
+
+      render(
+        <CodeChangesCard
+          groupId="1"
+          autofix={mockAutofix}
+          section={makeSection('code_changes', 'completed', [[patch]])}
+        />
+      );
+
+      expect(screen.getByTestId('file-diff-viewer')).toHaveAttribute(
+        'data-expanded',
+        'false'
+      );
     });
 
     it('renders repository name labels', () => {

--- a/static/app/components/events/autofix/v3/autofixCards.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixCards.spec.tsx
@@ -464,7 +464,7 @@ describe('ArtifactCard', () => {
       const patch = makePatch('org/repo', 'src/app.py');
       patch.patch.hunks = [
         {
-          lines: Array.from({length: 51}, (_, index) => ({
+          lines: Array.from({length: 31}, (_, index) => ({
             diff_line_no: index,
             line_type: DiffLineType.CONTEXT,
             source_line_no: index,
@@ -472,9 +472,9 @@ describe('ArtifactCard', () => {
             value: `line ${index}`,
           })),
           section_header: '',
-          source_length: 51,
+          source_length: 31,
           source_start: 1,
-          target_length: 51,
+          target_length: 31,
           target_start: 1,
         },
       ];

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -43,6 +43,8 @@ interface CodeChangesCardProps {
   section: AutofixSection;
 }
 
+const MAX_AUTO_EXPANDED_DIFF_LINES = 50;
+
 function getFinalExplanation(section: AutofixSection): string | null {
   for (let i = section.blocks.length - 1; i >= 0; i--) {
     const block = section.blocks[i];
@@ -143,6 +145,20 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
   }, [location, navigate, shouldShowReset]);
 
   const patchesByRepo = useMemo(() => collectPatches(artifact ?? []), [artifact]);
+
+  const shouldExpandDiffs = useMemo(() => {
+    let lineCount = 0;
+
+    for (const patches of patchesByRepo.values()) {
+      for (const patch of patches) {
+        for (const hunk of patch.patch.hunks) {
+          lineCount += hunk.lines.length;
+        }
+      }
+    }
+
+    return lineCount <= MAX_AUTO_EXPANDED_DIFF_LINES;
+  }, [patchesByRepo]);
 
   const explanation = useMemo(() => getFinalExplanation(section), [section]);
 
@@ -247,7 +263,7 @@ export function CodeChangesCard({autofix, groupId, section}: CodeChangesCardProp
                 patch={patch.patch}
                 showBorder
                 collapsible
-                defaultExpanded={artifact !== null && artifact.length <= 1}
+                defaultExpanded={shouldExpandDiffs}
               />
             ))}
           </ArtifactDetails>

--- a/static/app/components/events/autofix/v3/codeChangesCard.tsx
+++ b/static/app/components/events/autofix/v3/codeChangesCard.tsx
@@ -43,7 +43,7 @@ interface CodeChangesCardProps {
   section: AutofixSection;
 }
 
-const MAX_AUTO_EXPANDED_DIFF_LINES = 50;
+const MAX_AUTO_EXPANDED_DIFF_LINES = 30;
 
 function getFinalExplanation(section: AutofixSection): string | null {
   for (let i = section.blocks.length - 1; i >= 0; i--) {


### PR DESCRIPTION
Autofix Code Changes now expands all displayed file diffs when their combined rendered diff is 30 lines or fewer. Larger changes remain collapsed, replacing the previous file-count rule that collapsed even compact multi-file fixes and expanded every single-file fix regardless of size.

The size calculation uses the cleaned, de-duplicated patches that are actually rendered. Coverage verifies both small multi-file expansion and large single-file collapse.
