### PR TITLE
feat(seer): render autofix embed detail through the live-run components

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -452,7 +452,7 @@
   },
   {
     "name": "autofix",
-    "description": "Render one step of a Seer Autofix run (root cause, solution, or code changes) as a collapsible block linking back to the issue. Emit this embed whenever the user signals intent to fix, solve, debug, or resolve a problem — e.g. \"fix this issue\", \"solve the problem\", \"find the root cause\", \"why is this happening\", \"how do I resolve this error\" — or asks for the status/result of an autofix run already in progress. `id` and `shortId` are the issue the run belongs to, exactly as the issue API returns them. `step` is the autofix step identifier exactly as the autofix API reports it — the UI renders the human-readable label, so do not send a display string. `result` is the full markdown write-up for that step. Prefer this embed over a plaintext explanation whenever an issue can be autofixed, and emit one embed per step rather than combining multiple steps into one.",
+    "description": "Render one step of a Seer Autofix run (root cause, solution, or code changes) as a collapsible block linking back to the issue. Emit this embed whenever the user signals intent to fix, solve, debug, or resolve a problem — e.g. \"fix this issue\", \"solve the problem\", \"find the root cause\", \"why is this happening\", \"how do I resolve this error\" — or asks for the status/result of an autofix run already in progress. `id` and `shortId` are the issue the run belongs to, exactly as the issue API returns them. `step` is the autofix step identifier exactly as the autofix API reports it — the UI renders the human-readable label, so do not send a display string. `result` is the markdown summary for that step. Send the step's detail in the structured fields rather than folding it into `result`, so it renders as the same sections a live run shows: `fiveWhys` and `reproductionSteps` for `root_cause`, `steps` for `solution`. Prefer this embed over a plaintext explanation whenever an issue can be autofixed, and emit one embed per step rather than combining multiple steps into one.",
     "level": ["block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
@@ -470,6 +470,37 @@
         },
         "shortId": {
           "type": "string"
+        },
+        "fiveWhys": {
+          "description": "root_cause only: the causal chain, most immediate cause first.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "reproductionSteps": {
+          "description": "root_cause only: ordered steps that reproduce the error.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "steps": {
+          "description": "solution only: the ordered steps needed to resolve the issue.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "title": {
+                "type": "string"
+              },
+              "description": {
+                "type": "string"
+              }
+            },
+            "required": ["title", "description"],
+            "additionalProperties": false
+          }
         }
       },
       "required": ["step", "result", "id", "shortId"],
@@ -481,8 +512,40 @@
         "data": {
           "id": "1234567890",
           "shortId": "EXMPL-123",
-          "result": "The root cause of the issue is that the code is not working correctly.",
+          "result": "`CartService.total()` reduces the line items without an initial accumulator, so an empty cart throws instead of totalling to zero.",
+          "fiveWhys": [
+            "`POST /checkout` returned a 500 for every request with an empty cart.",
+            "`CartService.total()` threw `TypeError: Reduce of empty array with no initial value`.",
+            "`items.reduce((sum, item) => sum + item.price)` was called without a second argument.",
+            "With no initial value `reduce` uses the first element as the seed, which an empty array does not have.",
+            "The empty cart path was never covered — every test seeded at least one line item."
+          ],
+          "reproductionSteps": [
+            "Sign in and add a single item to the cart.",
+            "Remove that item, leaving the cart empty.",
+            "Open `/checkout`, which calls `POST /api/checkout/quote`.",
+            "The request 500s and the page renders the generic error state."
+          ],
           "step": "root_cause"
+        }
+      },
+      {
+        "label": "Plan",
+        "data": {
+          "id": "1234567890",
+          "shortId": "EXMPL-123",
+          "result": "Seed the reduction with `0` so an empty cart totals to zero, and cover the path with a test.",
+          "steps": [
+            {
+              "title": "Pass an initial accumulator to `CartService.total()`",
+              "description": "Change `items.reduce((sum, item) => sum + item.price)` to pass `0` as the second argument."
+            },
+            {
+              "title": "Add a regression test for the empty cart",
+              "description": "Assert `total()` returns `0` for `[]` in `src/checkout/cartService.test.ts`."
+            }
+          ],
+          "step": "solution"
         }
       }
     ],

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -88,7 +88,7 @@ export function isRootCauseArtifact(
   );
 }
 
-interface SolutionStep {
+export interface SolutionStep {
   description: string;
   title: string;
 }

--- a/static/app/components/seer/markdown/embeds/components/autofix.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/autofix.spec.tsx
@@ -1,9 +1,10 @@
 import {useInfiniteQuery} from '@tanstack/react-query';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {ExplorerAutofixState} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
 import {AutofixRef} from 'sentry/components/seer/markdown/embeds/components/autofix';
 import type {Group} from 'sentry/types/group';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
@@ -208,4 +209,79 @@ describe('AutofixRef embed', () => {
     ).toBeInTheDocument();
     await waitFor(() => expect(issuesMock).toHaveBeenCalledTimes(3));
   }, 20_000);
+});
+
+const ISSUE = {id: '6789012345', shortId: 'CHECKOUT-42'};
+
+function renderAutofixEmbed(data: Record<string, unknown>) {
+  const tag = `{% autofix %}${JSON.stringify({...ISSUE, ...data})}{% /autofix %}`;
+  return render(<SeerMarkdown raw={tag} />);
+}
+
+async function expand(name: string) {
+  await userEvent.click(screen.getByRole('button', {name: new RegExp(name)}));
+}
+
+describe('autofix embed', () => {
+  it('renders the root cause sections a live run shows', async () => {
+    renderAutofixEmbed({
+      step: 'root_cause',
+      result: '`CartService.total()` reduces line items without an initial accumulator.',
+      fiveWhys: [
+        '`POST /api/checkout/quote` returned a 500 for every empty cart.',
+        'The empty-cart path was never exercised by a test.',
+      ],
+      reproductionSteps: ['Empty the cart.', 'Open `/checkout`.'],
+    });
+
+    await expand('Root Cause');
+
+    expect(
+      screen.getByText(/reduces line items without an initial accumulator/)
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Why did this happen?')).toBeInTheDocument();
+    expect(screen.getByText(/returned a 500 for every empty cart/)).toBeInTheDocument();
+
+    expect(screen.getByText('Reproduction Steps')).toBeInTheDocument();
+    expect(screen.getByText('Empty the cart.')).toBeInTheDocument();
+  });
+
+  it('renders the plan steps', async () => {
+    renderAutofixEmbed({
+      step: 'solution',
+      result: 'Seed the reduction with `0`.',
+      steps: [
+        {
+          title: 'Pass an initial accumulator',
+          description: 'Pass `0` as the second argument to `reduce`.',
+        },
+      ],
+    });
+
+    await expand('Plan');
+
+    expect(screen.getByText('Steps to Resolve')).toBeInTheDocument();
+    expect(screen.getByText('Pass an initial accumulator')).toBeInTheDocument();
+    expect(
+      screen.getByText('Pass `0` as the second argument to `reduce`.')
+    ).toBeInTheDocument();
+  });
+
+  // Seer writes this embed itself, so the structured fields can be absent even
+  // on a step that normally carries them.
+  it('renders the summary alone when no structured detail is sent', async () => {
+    renderAutofixEmbed({
+      step: 'root_cause',
+      result: 'The cart total throws on an empty cart.',
+    });
+
+    await expand('Root Cause');
+
+    expect(
+      screen.getByText('The cart total throws on an empty cart.')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Why did this happen?')).not.toBeInTheDocument();
+    expect(screen.queryByText('Reproduction Steps')).not.toBeInTheDocument();
+  });
 });

--- a/static/app/components/seer/markdown/embeds/components/autofix.stories.tsx
+++ b/static/app/components/seer/markdown/embeds/components/autofix.stories.tsx
@@ -20,6 +20,7 @@ import {
   NEXT_STEP,
   STEP_LABELS,
 } from 'sentry/components/seer/markdown/embeds/components/autofix';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 import {IconArrow} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
 import type {Group} from 'sentry/types/group';
@@ -34,8 +35,21 @@ import type {
 
 const ISSUE = {id: '6789012345', shortId: 'CHECKOUT-42'};
 
-function autofix(step: AutofixExplorerStep, result: string): string {
-  return `{% autofix %}${JSON.stringify({...ISSUE, step, result})}{% /autofix %}`;
+/**
+ * Taken from the embed schema so these fixtures fail to compile rather than
+ * silently drop a field if the structured payload changes shape.
+ */
+type AutofixDetails = Pick<
+  EmbedOutput<'autofix'>,
+  'fiveWhys' | 'reproductionSteps' | 'steps'
+>;
+
+function autofix(
+  step: AutofixExplorerStep,
+  result: string,
+  details: AutofixDetails = {}
+): string {
+  return `{% autofix %}${JSON.stringify({...ISSUE, step, result, ...details})}{% /autofix %}`;
 }
 
 function autofixRefTag(
@@ -48,23 +62,69 @@ function autofixRefTag(
 
 const ROOT_CAUSE = autofix(
   'root_cause',
-  '`CartService.total()` calls `items.reduce((sum, item) => sum + item.price)` without an initial accumulator. When a customer empties their cart the array is empty, so `reduce` throws `TypeError: Reduce of empty array with no initial value` and the checkout request 500s.'
+  '`CartService.total()` reduces the line items without an initial accumulator, so an empty cart throws `TypeError: Reduce of empty array with no initial value` and `POST /api/checkout/quote` 500s.',
+  {
+    fiveWhys: [
+      '`POST /api/checkout/quote` returned a 500 for every request carrying an empty cart.',
+      '`CartService.total()` threw `TypeError: Reduce of empty array with no initial value`.',
+      '`items.reduce((sum, item) => sum + item.price)` is called without a second argument.',
+      'Without an initial value `reduce` seeds itself from the first element, which an empty array does not have.',
+      'The empty-cart path was never exercised — every fixture in `cartService.test.ts` seeds at least one line item.',
+    ],
+    reproductionSteps: [
+      'Sign in as any customer and add one item to the cart.',
+      'Remove that item, leaving the cart empty.',
+      'Navigate to `/checkout`, which calls `POST /api/checkout/quote` on mount.',
+      'The request 500s and the page falls back to the generic error state.',
+    ],
+  }
 );
 
 const SOLUTION = autofix(
   'solution',
-  'Seed the reduction with `0` so an empty cart totals to zero instead of throwing: `items.reduce((sum, item) => sum + item.price, 0)`.'
+  'Seed the reduction with `0` so an empty cart totals to zero instead of throwing.',
+  {
+    steps: [
+      {
+        title: 'Pass an initial accumulator to `CartService.total()`',
+        description:
+          'Change `items.reduce((sum, item) => sum + item.price)` to pass `0` as the second argument.',
+      },
+      {
+        title: 'Cover the empty cart in `cartService.test.ts`',
+        description: 'Assert `total()` returns `0` for an empty line-item array.',
+      },
+    ],
+  }
 );
 
 const CODE_CHANGES = autofix(
   'code_changes',
-  'Updated `src/checkout/cartService.ts` to pass the initial value and added a regression test covering the empty-cart path.'
+  '2 files changed in 1 repo — `src/checkout/cartService.ts` now passes the initial value, and `src/checkout/cartService.test.ts` covers the empty-cart path.'
 );
 
 // Autofix has no "plan" step — a plan is the write-up of the solution step.
 const PLANNED_SOLUTION = autofix(
   'solution',
-  'Guard `CartService.total()` with an initial accumulator of `0`, add a regression test covering the empty-cart path, then backfill a smoke test that renders the checkout page with zero items.'
+  'Guard `CartService.total()` against an empty cart, then close the coverage gap that let this ship.',
+  {
+    steps: [
+      {
+        title: 'Pass an initial accumulator to `CartService.total()`',
+        description:
+          'Change `items.reduce((sum, item) => sum + item.price)` to pass `0` as the second argument.',
+      },
+      {
+        title: 'Cover the empty cart in `cartService.test.ts`',
+        description: 'Assert `total()` returns `0` for an empty line-item array.',
+      },
+      {
+        title: 'Add a checkout smoke test with zero items',
+        description:
+          'Render `/checkout` with an empty cart and assert the quote renders `$0.00` instead of the error state.',
+      },
+    ],
+  }
 );
 
 function User({children}: {children: ReactNode}) {

--- a/static/app/components/seer/markdown/embeds/components/autofix.tsx
+++ b/static/app/components/seer/markdown/embeds/components/autofix.tsx
@@ -21,8 +21,7 @@ import {
   useExplorerAutofix,
   type AutofixExplorerStep,
   type AutofixSection,
-  type RootCauseArtifact,
-  type SolutionArtifact,
+  type SolutionStep,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
 import {useRefreshAutofixProgressQueries} from 'sentry/components/events/autofix/useRefreshAutofixProgressQueries';
 import {ArtifactDetails} from 'sentry/components/events/autofix/v3/artifactDetails';
@@ -36,7 +35,6 @@ import {IconOpen} from 'sentry/icons/iconOpen';
 import {IconPullRequest} from 'sentry/icons/iconPullRequest';
 import {t, tn} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
-import {MarkedText} from 'sentry/utils/marked/markedText';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {FileDiffViewer} from 'sentry/views/seerExplorer/components/fileDiffViewer';
 
@@ -92,14 +90,46 @@ interface AutofixContentProps extends Pick<Group, 'id' | 'shortId'> {
    */
   result: string;
   step: AutofixExplorerStep;
+  fiveWhys?: string[];
+  reproductionSteps?: string[];
+  steps?: SolutionStep[];
+}
+
+/**
+ * The structured fields are optional because Seer writes this embed itself
+ * rather than echoing back run state, so a step can arrive as the write-up
+ * alone. Missing detail collapses to the summary rather than an empty section.
+ */
+function AutofixStepBody({
+  fiveWhys,
+  reproductionSteps,
+  result,
+  step,
+  steps,
+}: Omit<AutofixContentProps, 'id' | 'shortId'>) {
+  if (step === 'root_cause') {
+    return (
+      <RootCauseBody
+        description={result}
+        fiveWhys={fiveWhys ?? []}
+        reproductionSteps={reproductionSteps}
+      />
+    );
+  }
+
+  if (step === 'solution') {
+    return <SolutionBody summary={result} steps={steps ?? []} />;
+  }
+
+  return <Markdown raw={result} />;
 }
 
 export const Autofix = defineSeerEmbed({
   name: 'autofix',
-  render({id, shortId, result, step}: AutofixContentProps) {
+  render({id, shortId, ...content}: AutofixContentProps) {
     return (
-      <AutofixDisclosure id={id} shortId={shortId} step={step}>
-        <MarkedText text={result} />
+      <AutofixDisclosure id={id} shortId={shortId} step={content.step}>
+        <AutofixStepBody {...content} />
       </AutofixDisclosure>
     );
   },
@@ -271,12 +301,23 @@ function AutofixRefBody({isLoading, section, step}: AutofixRefBodyProps) {
 
   const artifact = getAutofixArtifactFromSection(section);
 
-  if (step === 'root_cause' && isRootCauseArtifact(artifact)) {
-    return <RootCauseBody data={artifact.data} />;
+  if (step === 'root_cause' && isRootCauseArtifact(artifact) && artifact.data) {
+    return (
+      <RootCauseBody
+        description={artifact.data.one_line_description}
+        fiveWhys={artifact.data.five_whys}
+        reproductionSteps={artifact.data.reproduction_steps}
+      />
+    );
   }
 
-  if (step === 'solution' && isSolutionArtifact(artifact)) {
-    return <SolutionBody data={artifact.data} />;
+  if (step === 'solution' && isSolutionArtifact(artifact) && artifact.data) {
+    return (
+      <SolutionBody
+        summary={artifact.data.one_line_summary}
+        steps={artifact.data.steps}
+      />
+    );
   }
 
   if (isCodeChangesArtifact(artifact)) {
@@ -290,22 +331,20 @@ function AutofixRefBody({isLoading, section, step}: AutofixRefBodyProps) {
 }
 
 interface RootCauseBodyProps {
-  data: RootCauseArtifact | null;
+  description: string;
+  fiveWhys: string[];
+  reproductionSteps?: string[];
 }
 
-function RootCauseBody({data}: RootCauseBodyProps) {
-  if (!data) {
-    return <Markdown raw="" />;
-  }
-
+function RootCauseBody({description, fiveWhys, reproductionSteps}: RootCauseBodyProps) {
   return (
     <Stack gap="lg">
-      <Markdown raw={data.one_line_description} />
-      {data.five_whys.length > 0 && (
+      <Markdown raw={description} />
+      {fiveWhys.length > 0 && (
         <ArtifactDetails>
           <Text bold>{t('Why did this happen?')}</Text>
           <Container as="ul" margin="0">
-            {data.five_whys.map((why, index) => (
+            {fiveWhys.map((why, index) => (
               <li key={index}>
                 <Markdown raw={why} />
               </li>
@@ -313,11 +352,11 @@ function RootCauseBody({data}: RootCauseBodyProps) {
           </Container>
         </ArtifactDetails>
       )}
-      {data.reproduction_steps && data.reproduction_steps.length > 0 && (
+      {reproductionSteps && reproductionSteps.length > 0 && (
         <ArtifactDetails>
           <Text bold>{t('Reproduction Steps')}</Text>
           <Container as="ol" margin="0">
-            {data.reproduction_steps.map((step, index) => (
+            {reproductionSteps.map((step, index) => (
               <li key={index}>
                 <Markdown raw={step} />
               </li>
@@ -330,22 +369,19 @@ function RootCauseBody({data}: RootCauseBodyProps) {
 }
 
 interface SolutionBodyProps {
-  data: SolutionArtifact | null;
+  steps: SolutionStep[];
+  summary: string;
 }
 
-function SolutionBody({data}: SolutionBodyProps) {
-  if (!data) {
-    return <Markdown raw="" />;
-  }
-
+function SolutionBody({steps, summary}: SolutionBodyProps) {
   return (
     <Stack gap="lg">
-      <Markdown raw={data.one_line_summary} />
-      {data.steps.length > 0 && (
+      <Markdown raw={summary} />
+      {steps.length > 0 && (
         <ArtifactDetails>
           <Text bold>{t('Steps to Resolve')}</Text>
           <Container as="ol" margin="0">
-            {data.steps.map((step, index) => (
+            {steps.map((step, index) => (
               <li key={index}>
                 <Stack>
                   <Markdown raw={step.title} />

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -338,9 +338,12 @@ export const SEER_EMBED_SCHEMAS = {
       'belongs to, exactly as the issue API returns them. `step` is the ' +
       'autofix step identifier exactly as the autofix API reports it — the ' +
       'UI renders the human-readable label, so do not send a display ' +
-      'string. `result` is the full markdown write-up for that step. ' +
-      'Prefer this embed over a plaintext explanation whenever an issue ' +
-      'can be autofixed, and emit one embed per step rather than ' +
+      'string. `result` is the markdown summary for that step. Send the ' +
+      "step's detail in the structured fields rather than folding it into " +
+      '`result`, so it renders as the same sections a live run shows: ' +
+      '`fiveWhys` and `reproductionSteps` for `root_cause`, `steps` for ' +
+      '`solution`. Prefer this embed over a plaintext explanation whenever ' +
+      'an issue can be autofixed, and emit one embed per step rather than ' +
       'combining multiple steps into one.',
     level: ['block'],
     schema: z.object({
@@ -348,6 +351,18 @@ export const SEER_EMBED_SCHEMAS = {
       result: z.string(),
       id: z.string(),
       shortId: z.string(),
+      fiveWhys: z
+        .array(z.string())
+        .optional()
+        .describe('root_cause only: the causal chain, most immediate cause first.'),
+      reproductionSteps: z
+        .array(z.string())
+        .optional()
+        .describe('root_cause only: ordered steps that reproduce the error.'),
+      steps: z
+        .array(z.object({title: z.string(), description: z.string()}))
+        .optional()
+        .describe('solution only: the ordered steps needed to resolve the issue.'),
     }),
     examples: [
       {
@@ -356,8 +371,44 @@ export const SEER_EMBED_SCHEMAS = {
           id: '1234567890',
           shortId: 'EXMPL-123',
           result:
-            'The root cause of the issue is that the code is not working correctly.',
+            '`CartService.total()` reduces the line items without an initial ' +
+            'accumulator, so an empty cart throws instead of totalling to zero.',
+          fiveWhys: [
+            '`POST /checkout` returned a 500 for every request with an empty cart.',
+            '`CartService.total()` threw `TypeError: Reduce of empty array with no initial value`.',
+            '`items.reduce((sum, item) => sum + item.price)` was called without a second argument.',
+            'With no initial value `reduce` uses the first element as the seed, which an empty array does not have.',
+            'The empty cart path was never covered — every test seeded at least one line item.',
+          ],
+          reproductionSteps: [
+            'Sign in and add a single item to the cart.',
+            'Remove that item, leaving the cart empty.',
+            'Open `/checkout`, which calls `POST /api/checkout/quote`.',
+            'The request 500s and the page renders the generic error state.',
+          ],
           step: 'root_cause' as const,
+        },
+      },
+      {
+        label: 'Plan',
+        data: {
+          id: '1234567890',
+          shortId: 'EXMPL-123',
+          result:
+            'Seed the reduction with `0` so an empty cart totals to zero, and cover the path with a test.',
+          steps: [
+            {
+              title: 'Pass an initial accumulator to `CartService.total()`',
+              description:
+                'Change `items.reduce((sum, item) => sum + item.price)` to pass `0` as the second argument.',
+            },
+            {
+              title: 'Add a regression test for the empty cart',
+              description:
+                'Assert `total()` returns `0` for `[]` in `src/checkout/cartService.test.ts`.',
+            },
+          ],
+          step: 'solution' as const,
         },
       },
     ],


### PR DESCRIPTION
Seer has two ways to put an Autofix step into a chat, and until now they looked
nothing alike. `{% autofixRef %}` reads the live run state and lays a root cause
out as titled sections — "Why did this happen?", "Reproduction Steps".
`{% autofix %}` handed the whole step to `MarkedText` as one markdown blob, so
the same root cause arrived as an undifferentiated wall of prose. Which one you
got depended on whether Seer happened to have a `runId` in hand, which is not
something a reader should be able to notice.

Both embeds now render through the same `RootCauseBody` and `SolutionBody`
components, so either path shows the same sections in the same shape.

To make that possible the `autofix` payload gained three optional fields —
`fiveWhys`, `reproductionSteps`, and `steps` — mirroring the artifact shapes the
Autofix API already returns, and the schema description now tells Seer to put
detail there instead of folding it into `result`. The step bodies were changed
to take plain values rather than the `Artifact<T>` wrapper; that is the bit that
lets an embed with no artifact feed the same component.

## Feature flag

Everything here sits behind **`organizations:seer-agent-autofix`**, which gates
both the `autofix` and `autofixRef` embeds. Enable it to see either in a Seer
chat, or open the `Autofix` storybook entry, which is not flagged.

## Approaches not taken

**Making `{% autofix %}` fetch the run too.** That would collapse the two embeds
into one and delete the difference entirely. It also deletes the reason the
static embed exists: it is what Seer emits when it is writing a step up itself
and has no run to poll. Fetching would turn every mention of a past root cause
into a network round trip.

**A `z.discriminatedUnion` on `step`,** so each step carries exactly its own
fields and nothing else. Tighter, and it is what the data actually looks like.
Rejected because this schema is compiled to JSON Schema by
`pnpm gen:embed-widgets` and handed to the model — flat optional fields produce
a much simpler contract for it to follow than a four-branch union, and the
per-field `.describe()` text ("root_cause only: …") carries the same
information.

**Replacing `result` with the structured fields.** Cleanest end state, but it
invalidates every payload Seer emits today. Keeping `result` as the summary
means old payloads still render; they just collapse to the summary instead of
showing empty sections.

## Reviewer notes

`src/sentry/seer/agent/embed_widgets.generated.json` is regenerated output from
`pnpm gen:embed-widgets`, committed in the same PR because CI checks its
freshness with a plain `git diff`. It is what sentry sends the model, so the new
fields reach Seer without a change in the seer repo — worth a second opinion
from someone closer to that side.

One behavior change is not in the stated scope, so flagging it: `AutofixRefBody`
now falls through to the step's error text when a *completed* section carries a
null artifact, where it previously rendered a blank. A completed step with no
data is a real failure and I think saying so beats showing nothing, but it is a
judgment call and easy to revert.

No screenshots attached — the storybook needs a backend the worktree does not
have set up, and it hangs on the bootstrap screen. To see the difference
yourself, run `pnpm dev-ui` and open the `Autofix` entry: the "Fix it end to
end" story now shows the sections, where before it was a paragraph per step.
Happy to add captures if that would help review.

Start the review at `autofix.tsx`. `autofix.spec.tsx` is new and covers the
three cases that matter: sections render from structured fields, plan steps
render, and a payload with no structured detail degrades to the summary without
emitting empty section headers.
