### PR TITLE
fix(issue-details): Allow dupe-name repos, still query by unique (name,SHA)

### DIFF
--- a/src/sentry/api/helpers/group_index/validators/in_commit.py
+++ b/src/sentry/api/helpers/group_index/validators/in_commit.py
@@ -19,13 +19,6 @@ class InCommitValidator(serializers.Serializer[InCommitResult]):
         required=True, help_text="The name of the repository (as it appears in Sentry)."
     )
 
-    def validate_repository(self, value: str) -> Repository:
-        project = self.context["project"]
-        try:
-            return Repository.objects.get(organization_id=project.organization_id, name=value)
-        except Repository.DoesNotExist:
-            raise serializers.ValidationError("Unable to find the given repository.")
-
     def validate(self, attrs: dict[str, Any]) -> Commit:
         attrs = super().validate(attrs)
         repository = attrs.get("repository")
@@ -36,8 +29,24 @@ class InCommitValidator(serializers.Serializer[InCommitResult]):
             )
         if not commit:
             raise serializers.ValidationError({"commit": ["Unable to find the given commit."]})
+
+        project = self.context["project"]
+        repositories = Repository.objects.filter(
+            organization_id=project.organization_id, name=repository
+        )
+        if not repositories.exists():
+            raise serializers.ValidationError(
+                {"repository": ["Unable to find the given repository."]}
+            )
+
         try:
-            commit = Commit.objects.get(repository_id=repository.id, key=commit)
+            return Commit.objects.get(
+                repository_id__in=repositories.values("id"),
+                key=commit,
+            )
         except Commit.DoesNotExist:
             raise serializers.ValidationError({"commit": ["Unable to find the given commit."]})
-        return commit
+        except Commit.MultipleObjectsReturned:
+            raise serializers.ValidationError(
+                {"commit": ["Multiple repositories contain the given commit."]}
+            )

--- a/tests/sentry/api/helpers/test_in_commit_validator.py
+++ b/tests/sentry/api/helpers/test_in_commit_validator.py
@@ -1,0 +1,21 @@
+from sentry.api.helpers.group_index.validators.in_commit import InCommitValidator
+from sentry.testutils.cases import TestCase
+
+
+class InCommitValidatorTest(TestCase):
+    def test_duplicate_repository_name_is_disambiguated_by_commit(self) -> None:
+        repo = self.create_repo(project=self.project, name=self.project.name)
+        commit = self.create_commit(project=self.project, repo=repo)
+        self.create_repo(
+            project=self.project,
+            name=repo.name,
+            provider="integrations:github",
+            external_id="duplicate-repository",
+        )
+        validator = InCommitValidator(
+            data={"commit": commit.key, "repository": repo.name},
+            context={"project": self.project},
+        )
+
+        assert validator.is_valid(), validator.errors
+        assert validator.validated_data == commit

--- a/tests/snuba/api/endpoints/test_project_group_index.py
+++ b/tests/snuba/api/endpoints/test_project_group_index.py
@@ -897,6 +897,36 @@ class GroupUpdateTest(APITestCase, SnubaTestCase):
         activity = Activity.objects.get(group=group, type=ActivityType.SET_RESOLVED_IN_COMMIT.value)
         assert activity.data["commit"] == commit.id
 
+    def test_set_resolved_in_explicit_commit_with_duplicate_repository_name(self) -> None:
+        repo = self.create_repo(project=self.project, name=self.project.name)
+        commit = self.create_commit(project=self.project, repo=repo)
+        self.create_repo(
+            project=self.project,
+            name=repo.name,
+            provider="integrations:github",
+            external_id="duplicate-repository",
+        )
+        group = self.create_group(status=GroupStatus.UNRESOLVED)
+
+        self.login_as(user=self.user)
+
+        url = f"{self.path}?id={group.id}"
+        response = self.client.put(
+            url,
+            data={
+                "status": "resolved",
+                "statusDetails": {"inCommit": {"commit": commit.key, "repository": repo.name}},
+            },
+            format="json",
+        )
+
+        assert response.status_code == 200
+        assert response.data["status"] == "resolved"
+        assert response.data["statusDetails"]["inCommit"]["id"] == commit.key
+
+        link = GroupLink.objects.get(group_id=group.id)
+        assert link.linked_id == commit.id
+
     def test_set_resolved_in_explicit_commit_released(self) -> None:
         release = self.create_release(project=self.project)
         repo = self.create_repo(project=self.project, name=self.project.name)


### PR DESCRIPTION
`Repository.objects.get()` in `validate_repository` was failing when there were 2 repos with the same name (`seer` in Sentry I guess??), even though that's a valid state. Instead, lookup all repos with the given name, then find the commit from those. (There may still be duplicate commits, which IS an error.)

This was breaking for me when I tried to resolve-in-commit for https://sentry.sentry.io/issues/7574858783/?project=6178942&referrer=inbox