### PR TITLE
fix(integrations): Preserve ticket rule selections

### DIFF
--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -393,6 +393,8 @@ export function BackendJsonSubmitForm({
                         );
                         const customQueryOptions = customAsyncQueryOptions?.[field.name];
                         const defaultAsyncQueryOptions = ((debouncedInput: string) => {
+                          const shouldUseStaticOptions =
+                            !field.prefetch && !debouncedInput;
                           return queryOptions({
                             queryKey: [
                               'backend-json-async-select',
@@ -401,7 +403,7 @@ export function BackendJsonSubmitForm({
                               debouncedInput,
                               dynamicQueryValues,
                               prefetchReady,
-                              !field.prefetch && !debouncedInput ? staticOptions : null,
+                              shouldUseStaticOptions ? staticOptions : null,
                               JSON.stringify(onAsyncOptionsFetchedRef),
                             ],
                             queryFn: async (): Promise<
@@ -410,7 +412,7 @@ export function BackendJsonSubmitForm({
                               if (field.prefetch && !prefetchReady) {
                                 return staticOptions;
                               }
-                              if (!debouncedInput && !field.prefetch) {
+                              if (shouldUseStaticOptions) {
                                 return staticOptions;
                               }
                               const response = await API_CLIENT.requestPromise(

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -401,6 +401,7 @@ export function BackendJsonSubmitForm({
                               debouncedInput,
                               dynamicQueryValues,
                               prefetchReady,
+                              field.prefetch ? null : staticOptions,
                               JSON.stringify(onAsyncOptionsFetchedRef),
                             ],
                             queryFn: async (): Promise<

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -401,7 +401,7 @@ export function BackendJsonSubmitForm({
                               debouncedInput,
                               dynamicQueryValues,
                               prefetchReady,
-                              field.prefetch ? null : staticOptions,
+                              !field.prefetch && !debouncedInput ? staticOptions : null,
                               JSON.stringify(onAsyncOptionsFetchedRef),
                             ],
                             queryFn: async (): Promise<

--- a/static/app/components/externalIssues/ticketRuleModal.spec.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.spec.tsx
@@ -160,6 +160,103 @@ describe('ProjectAlerts -> TicketRuleModal', () => {
       await submitSuccess();
     });
 
+    it('preserves a searched option after reloading the form fields', async () => {
+      const searchUrl = '/extensions/example/search';
+
+      MockApiClient.addMockResponse({
+        url: searchUrl,
+        method: 'GET',
+        body: [],
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/1/',
+        match: [MockApiClient.matchQuery({action: 'create', ignored: ['Sprint']})],
+        method: 'GET',
+        body: {
+          createIssueConfig: [
+            {
+              name: 'project',
+              label: 'Project',
+              choices: [['project-1', 'Initial Project']],
+              default: 'project-1',
+              type: 'select',
+              updatesForm: true,
+              required: true,
+              url: searchUrl,
+            },
+          ],
+        },
+      });
+      MockApiClient.addMockResponse({
+        url: searchUrl,
+        match: [
+          MockApiClient.matchQuery({
+            field: 'project',
+            query: 'Selected',
+          }),
+        ],
+        method: 'GET',
+        body: [{label: 'Selected Project', value: 'project-99'}],
+      });
+      const dynamicQuery = MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/1/',
+        match: [
+          MockApiClient.matchQuery({
+            action: 'create',
+            project: 'project-99',
+          }),
+        ],
+        method: 'GET',
+        body: {
+          createIssueConfig: [
+            {
+              name: 'project',
+              label: 'Project',
+              choices: [['project-1', 'Initial Project']],
+              default: 'project-99',
+              type: 'select',
+              updatesForm: true,
+              required: true,
+              url: searchUrl,
+            },
+            {
+              name: 'details',
+              label: 'Details',
+              type: 'text',
+              default: 'Default details for selected project',
+            },
+          ],
+        },
+      });
+
+      render(
+        <TicketRuleModal
+          Body={ModalBody}
+          Header={makeClosableHeader(closeModal)}
+          Footer={ModalFooter}
+          CloseButton={makeCloseButton(closeModal)}
+          closeModal={closeModal}
+          link=""
+          ticketType=""
+          instance={{integration: '1'}}
+          onSubmitAction={onSubmitAction}
+        />,
+        {organization}
+      );
+
+      await screen.findByRole('button', {name: 'Apply Changes'});
+      const projectField = screen.getByRole('textbox', {name: 'Project'});
+      await userEvent.click(projectField);
+      await userEvent.type(projectField, 'Selected');
+      await userEvent.click(await screen.findByText('Selected Project'));
+
+      await waitFor(() => expect(dynamicQuery).toHaveBeenCalled());
+      expect(await screen.findByText('Selected Project')).toBeInTheDocument();
+      expect(screen.getByRole('textbox', {name: 'Details'})).toHaveValue(
+        'Default details for selected project'
+      );
+    });
+
     it('should ignore error checking when default is empty array', async () => {
       const dynamicQuery = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/1/',

--- a/static/app/components/externalIssues/ticketRuleModal.spec.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.spec.tsx
@@ -160,7 +160,7 @@ describe('ProjectAlerts -> TicketRuleModal', () => {
       await submitSuccess();
     });
 
-    it('preserves a searched option after reloading the form fields', async () => {
+    it('preserves options after reloading and searching again', async () => {
       const searchUrl = '/extensions/example/search';
       onSubmitAction.mockClear();
 
@@ -198,6 +198,17 @@ describe('ProjectAlerts -> TicketRuleModal', () => {
         ],
         method: 'GET',
         body: [{label: 'Selected Project', value: 'project-99'}],
+      });
+      const laterSearchQuery = MockApiClient.addMockResponse({
+        url: searchUrl,
+        match: [
+          MockApiClient.matchQuery({
+            field: 'project',
+            query: 'Other',
+          }),
+        ],
+        method: 'GET',
+        body: [{label: 'Other Project', value: 'project-100'}],
       });
       const dynamicQuery = MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/1/',
@@ -258,6 +269,21 @@ describe('ProjectAlerts -> TicketRuleModal', () => {
       );
 
       const detailsField = screen.getByRole('textbox', {name: 'Details'});
+      const reloadedProjectField = screen.getByRole('textbox', {name: 'Project'});
+      await userEvent.click(reloadedProjectField);
+      await userEvent.type(reloadedProjectField, 'Other');
+      expect(await screen.findByText('Other Project')).toBeInTheDocument();
+      expect(laterSearchQuery).toHaveBeenCalledTimes(1);
+      await userEvent.clear(reloadedProjectField);
+      expect(
+        await screen.findByRole('menuitemradio', {name: 'Initial Project'})
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('menuitemradio', {name: 'Selected Project'})
+      ).toBeInTheDocument();
+      await userEvent.click(detailsField);
+      expect(screen.getByText('Selected Project')).toBeInTheDocument();
+
       await userEvent.clear(detailsField);
       await userEvent.type(detailsField, 'Updated details');
       await userEvent.click(screen.getByRole('button', {name: 'Apply Changes'}));

--- a/static/app/components/externalIssues/ticketRuleModal.spec.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.spec.tsx
@@ -162,6 +162,7 @@ describe('ProjectAlerts -> TicketRuleModal', () => {
 
     it('preserves a searched option after reloading the form fields', async () => {
       const searchUrl = '/extensions/example/search';
+      onSubmitAction.mockClear();
 
       MockApiClient.addMockResponse({
         url: searchUrl,
@@ -187,7 +188,7 @@ describe('ProjectAlerts -> TicketRuleModal', () => {
           ],
         },
       });
-      MockApiClient.addMockResponse({
+      const searchQuery = MockApiClient.addMockResponse({
         url: searchUrl,
         match: [
           MockApiClient.matchQuery({
@@ -255,6 +256,22 @@ describe('ProjectAlerts -> TicketRuleModal', () => {
       expect(screen.getByRole('textbox', {name: 'Details'})).toHaveValue(
         'Default details for selected project'
       );
+
+      const detailsField = screen.getByRole('textbox', {name: 'Details'});
+      await userEvent.clear(detailsField);
+      await userEvent.type(detailsField, 'Updated details');
+      await userEvent.click(screen.getByRole('button', {name: 'Apply Changes'}));
+
+      expect(onSubmitAction).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: 'Updated details',
+          dynamic_form_fields: expect.arrayContaining([
+            expect.objectContaining({name: 'details'}),
+          ]),
+        }),
+        expect.any(Object)
+      );
+      expect(searchQuery).toHaveBeenCalledTimes(1);
     });
 
     it('should ignore error checking when default is empty array', async () => {

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -297,7 +297,18 @@ export function TicketRuleModal({
    */
   const cleanFields = useMemo((): JsonFormAdapterFieldConfig[] => {
     const savedChoicesMap = getSavedChoicesMap(instance);
-    const configFields = integrationDetails?.[getConfigName(action)] || [];
+    const configFields = (integrationDetails?.[getConfigName(action)] || []).map(
+      field => {
+        const cachedChoices = asyncOptionsCache[field.name];
+        // A dynamic reload can omit the searched selection from its limited choices.
+        // Keep the fetched options so the remounted select can still render its label.
+        return (field.type === 'select' || field.type === 'choice') &&
+          field.url &&
+          cachedChoices
+          ? {...field, choices: cachedChoices}
+          : field;
+      }
+    );
 
     const cleanedFields = configFields
       // Don't overwrite the default values for title and description.
@@ -314,7 +325,7 @@ export function TicketRuleModal({
         });
       });
     return [...STATIC_TICKET_FIELDS, ...cleanedFields];
-  }, [instance, integrationDetails, showInstanceValues]);
+  }, [instance, integrationDetails, showInstanceValues, asyncOptionsCache]);
 
   const formErrors = useMemo(() => {
     const errors: Record<string, React.ReactNode> = {};

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -39,6 +39,14 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 
 const IGNORED_FIELDS = ['Sprint'];
 
+function mergeChoices(
+  ...choiceGroups: Array<readonly JsonFormAdapterChoice[]>
+): JsonFormAdapterChoice[] {
+  return [
+    ...new Map(choiceGroups.flat().map(choice => [String(choice[0]), choice])).values(),
+  ];
+}
+
 interface TicketRuleModalProps extends ModalRenderProps {
   instance: TicketActionData;
   link: string | null;
@@ -97,11 +105,14 @@ export function TicketRuleModal({
   >({});
   const handleAsyncOptionsFetched = useCallback(
     (fieldName: string, options: Array<SelectValue<JsonFormAdapterChoiceValue>>) => {
+      const fetchedChoices = options.map((option): JsonFormAdapterChoice => {
+        const label =
+          typeof option.label === 'string' ? option.label : String(option.value);
+        return [option.value, label];
+      });
       setAsyncOptionsCache(prev => ({
         ...prev,
-        [fieldName]: options.map(
-          o => [o.value, typeof o.label === 'string' ? o.label : String(o.value)] as const
-        ),
+        [fieldName]: mergeChoices(prev[fieldName] ?? [], fetchedChoices),
       }));
     },
     []
@@ -285,14 +296,16 @@ export function TicketRuleModal({
     const configFields = (integrationDetails?.[getConfigName(action)] || []).map(
       field => {
         const cachedChoices = asyncOptionsCache[field.name];
-        // A dynamic reload can omit the searched selection from its limited choices.
-        // Keep the fetched options so the remounted select can still render its label.
+        // Keep backend and prior search options so later searches cannot hide the selection.
         if (
           (field.type === 'select' || field.type === 'choice') &&
           field.url &&
           cachedChoices
         ) {
-          return {...field, choices: cachedChoices};
+          return {
+            ...field,
+            choices: mergeChoices(field.choices ?? [], cachedChoices),
+          };
         }
         return field;
       }

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -302,11 +302,14 @@ export function TicketRuleModal({
         const cachedChoices = asyncOptionsCache[field.name];
         // A dynamic reload can omit the searched selection from its limited choices.
         // Keep the fetched options so the remounted select can still render its label.
-        return (field.type === 'select' || field.type === 'choice') &&
+        if (
+          (field.type === 'select' || field.type === 'choice') &&
           field.url &&
           cachedChoices
-          ? {...field, choices: cachedChoices}
-          : field;
+        ) {
+          return {...field, choices: cachedChoices};
+        }
+        return field;
       }
     );
 

--- a/static/app/components/externalIssues/ticketRuleModal.tsx
+++ b/static/app/components/externalIssues/ticketRuleModal.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useState} from 'react';
+import {Fragment, useCallback, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
 import {useQueryClient} from '@tanstack/react-query';
@@ -33,7 +33,6 @@ import type {IntegrationIssueConfig} from 'sentry/types/integrations';
 import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {defined} from 'sentry/utils/defined';
 import {setApiQueryData, useApiQuery} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -89,13 +88,6 @@ export function TicketRuleModal({
   // override any inputs with these instance values.
   const [showInstanceValues, setShowInstanceValues] = useState(true);
 
-  const [hasUpdatedCache, setHasUpdatedCache] = useState(false);
-  const [issueConfigFieldsCache, setIssueConfigFieldsCache] = useState<
-    JsonFormAdapterFieldConfig[]
-  >(() => {
-    return Object.values(instance?.dynamic_form_fields || {});
-  });
-
   const [isDynamicallyRefetching, setIsDynamicallyRefetching] = useState(false);
 
   // Track async select options fetched via search so they can be persisted
@@ -150,17 +142,10 @@ export function TicketRuleModal({
     {staleTime: Infinity, retry: false, refetchOnMount: 'always'}
   );
 
-  // After the first fetch, update this config cache state
-  useEffect(() => {
-    if (isPending || !defined(integrationDetails) || hasUpdatedCache) {
-      return;
-    }
-    const newConfigCache = integrationDetails[getConfigName(action)];
-    if (newConfigCache) {
-      setIssueConfigFieldsCache(newConfigCache);
-      setHasUpdatedCache(true);
-    }
-  }, [isPending, integrationDetails, action, hasUpdatedCache]);
+  // Dynamic reloads can change the schema, so always submit the latest field config.
+  const issueConfigFields =
+    integrationDetails?.[getConfigName(action)] ??
+    Object.values(instance?.dynamic_form_fields || {});
 
   const {dynamicFieldValues, setDynamicFieldValue} = useDynamicFields({
     action,
@@ -168,10 +153,10 @@ export function TicketRuleModal({
   });
 
   const validAndSavableFieldNames = useMemo(() => {
-    return issueConfigFieldsCache
+    return issueConfigFields
       .filter(field => Object.hasOwn(field, 'name'))
       .map(field => field.name);
-  }, [issueConfigFieldsCache]);
+  }, [issueConfigFields]);
 
   /**
    * XXX: This function seems illegal but it's necessary.
@@ -235,7 +220,7 @@ export function TicketRuleModal({
       if (instance && Object.hasOwn(instance, 'integration')) {
         formData.integration = instance.integration;
       }
-      formData.dynamic_form_fields = issueConfigFieldsCache;
+      formData.dynamic_form_fields = issueConfigFields;
       for (const [key, value] of Object.entries(data)) {
         if (validAndSavableFieldNames.includes(key)) {
           formData[key] = value;
@@ -243,7 +228,7 @@ export function TicketRuleModal({
       }
       return formData;
     },
-    [validAndSavableFieldNames, issueConfigFieldsCache, instance]
+    [validAndSavableFieldNames, issueConfigFields, instance]
   );
 
   const handleSubmit = useCallback(


### PR DESCRIPTION
Searching for a project outside the initial option page could leave the project field blank after dynamic ticket fields reloaded.

Keeps the searched choices available through the form remount so the selected label remains visible.

fixes JAVASCRIPT-3BRZ