### PR TITLE
ref(conversations): Keep message stats type private

### DIFF
--- a/static/app/views/explore/conversations/utils/conversationMessages.ts
+++ b/static/app/views/explore/conversations/utils/conversationMessages.ts
@@ -384,7 +384,7 @@ export function parseUserContent(node: AITraceSpanNode): string | null {
   return userMessage.content;
 }
 
-export interface InputMessageStats {
+interface InputMessageStats {
   totalMessageCount: number;
   userMessageCount: number;
 }


### PR DESCRIPTION
InputMessageStats was exported even though it only describes the return value of a helper in the same conversation message module and has no external consumers.