### PR TITLE
docs(api): Add AI conversation details response example

### DIFF
--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
@@ -22,6 +22,7 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
+from sentry.apidocs.examples.ai_conversation_examples import AIConversationExamples
 from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, OrganizationParams
 from sentry.apidocs.response_types import DetailResponse
 from sentry.apidocs.utils import inline_sentry_response_serializer
@@ -151,6 +152,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
             403: RESPONSE_FORBIDDEN,
             404: RESPONSE_NOT_FOUND,
         },
+        examples=AIConversationExamples.RETRIEVE_AI_CONVERSATION,
     )
     def get(
         self, request: Request, organization: Organization, conversation_id: str

--- a/src/sentry/apidocs/examples/ai_conversation_examples.py
+++ b/src/sentry/apidocs/examples/ai_conversation_examples.py
@@ -2,13 +2,54 @@ from drf_spectacular.utils import OpenApiExample
 
 
 class AIConversationExamples:
+    RETRIEVE_AI_CONVERSATION = [
+        OpenApiExample(
+            "Return an AI conversation",
+            value={
+                "conversationId": "01JQZ4W8X7J2Q9B4R5M6N7P8T9",
+                "title": "Check San Francisco weather",
+                "spans": [
+                    {
+                        "span_id": "a1b2c3d4e5f67890",
+                        "trace": "4c79f60c11214eb38604f4ae0781bfb2",
+                        "parent_span": None,
+                        "precise.start_ts": 1743465600.0,
+                        "precise.finish_ts": 1743465601.25,
+                        "project": "weather-assistant",
+                        "project.id": 1,
+                        "span.op": "gen_ai.chat",
+                        "span.status": "ok",
+                        "span.description": "chat gpt-4o-mini",
+                        "span.duration": 1250.0,
+                        "transaction": "weather-agent",
+                        "is_transaction": False,
+                        "gen_ai.conversation.id": "01JQZ4W8X7J2Q9B4R5M6N7P8T9",
+                        "gen_ai.operation.type": "ai_client",
+                        "gen_ai.request.model": "gpt-4o-mini",
+                        "gen_ai.response.model": "gpt-4o-mini-2024-07-18",
+                        "gen_ai.request.messages": '[{"role":"user","content":"What is the weather in San Francisco?"}]',
+                        "gen_ai.response.text": "It is currently 18°C and sunny in San Francisco.",
+                        "gen_ai.usage.total_tokens": 485,
+                        "gen_ai.cost.total_tokens": 0.0042,
+                        "user.id": "123",
+                        "user.email": "user@example.com",
+                        "errors": [],
+                        "occurrences": [],
+                    }
+                ],
+            },
+            response_only=True,
+            status_codes=["200"],
+        )
+    ]
+
     LIST_AI_CONVERSATIONS = [
         OpenApiExample(
             "Return a list of AI conversations",
             value=[
                 {
                     "conversationId": "01JQZ4W8X7J2Q9B4R5M6N7P8T9",
-                    "title": "Weather assistant",
+                    "title": "Check San Francisco weather",
                     "projectId": 1,
                     "flow": ["Weather Assistant"],
                     "errors": 0,


### PR DESCRIPTION
AI conversation details API docs now show a realistic successful response with conversation metadata and span data instead of an empty example. Conversation examples also use an intent-focused title so consumers can distinguish conversation purpose from agent identity.
