### PR TITLE
ref(agents): Let the selected SDK drive the onboarding runtime

### DIFF
--- a/static/app/components/onboarding/platformOptionDropdown.tsx
+++ b/static/app/components/onboarding/platformOptionDropdown.tsx
@@ -33,6 +33,12 @@ type PlatformOptionsControlProps = {
    * Whether the option is disabled
    */
   disabled?: boolean;
+  /**
+   * Option values pinned by another selection, keyed by option key. A locked
+   * option renders the given value and is disabled, e.g. a Cloudflare-only SDK
+   * pins the runtime selector to "cloudflare".
+   */
+  lockedValues?: Record<string, string>;
 };
 
 function OptionControl({option, value, onChange, disabled}: OptionControlProps) {
@@ -60,6 +66,7 @@ export function PlatformOptionDropdown({
   platformOptions,
   disabled,
   connectors,
+  lockedValues,
 }: PlatformOptionsControlProps) {
   const navigate = useNavigate();
   const location = useLocation();
@@ -85,17 +92,20 @@ export function PlatformOptionDropdown({
   return (
     <Fragment>
       {t('with')}
-      {Object.keys(platformOptions).map(key => (
-        <Fragment key={key}>
-          {connectors?.[key]}
-          <OptionControl
-            option={platformOptions[key]!}
-            value={urlOptionValues[key]!}
-            onChange={v => handleChange(key, v.value)}
-            disabled={disabled}
-          />
-        </Fragment>
-      ))}
+      {Object.keys(platformOptions).map(key => {
+        const lockedValue = lockedValues?.[key];
+        return (
+          <Fragment key={key}>
+            {connectors?.[key]}
+            <OptionControl
+              option={platformOptions[key]!}
+              value={lockedValue ?? urlOptionValues[key]!}
+              onChange={v => handleChange(key, v.value)}
+              disabled={disabled || lockedValue !== undefined}
+            />
+          </Fragment>
+        );
+      })}
     </Fragment>
   );
 }

--- a/static/app/views/explore/conversations/onboarding.spec.tsx
+++ b/static/app/views/explore/conversations/onboarding.spec.tsx
@@ -103,6 +103,59 @@ describe('ConversationOnboarding deployment target', () => {
     ).toBeGreaterThan(0);
   });
 
+  it('offers every SDK regardless of the selected runtime', async () => {
+    const {organization} = setupProject('node');
+
+    render(<ConversationOnboarding onDismiss={jest.fn()} />, {organization});
+
+    // Both the Node-only (Mastra) and Cloudflare-only (Workers AI) SDKs are
+    // offered on the Node runtime; the list is no longer filtered by runtime.
+    await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
+    expect(await screen.findByRole('option', {name: 'Workers AI'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Mastra'})).toBeInTheDocument();
+  });
+
+  it('pins and locks the runtime to Cloudflare when a Cloudflare-only SDK is selected', async () => {
+    const {organization} = setupProject('node');
+
+    render(<ConversationOnboarding onDismiss={jest.fn()} />, {organization});
+
+    expect(await screen.findByRole('button', {name: 'Node'})).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Workers AI'}));
+
+    const runtimeSelector = await screen.findByRole('button', {name: 'Cloudflare'});
+    expect(runtimeSelector).toBeDisabled();
+    expect(screen.queryByRole('button', {name: 'Node'})).not.toBeInTheDocument();
+    expect(
+      (
+        await screen.findAllByText(
+          textWithMarkupMatcher(/npm install @sentry\/cloudflare/)
+        )
+      ).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('pins and locks the runtime to Node when a Node-only SDK is selected', async () => {
+    const {organization} = setupProject('node');
+
+    render(<ConversationOnboarding onDismiss={jest.fn()} />, {organization});
+
+    // Manually switch to Cloudflare first
+    await userEvent.click(await screen.findByRole('button', {name: 'Node'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Cloudflare'}));
+    expect(await screen.findByRole('button', {name: 'Cloudflare'})).toBeInTheDocument();
+
+    // Selecting Mastra (Node-only) flips the runtime back to Node and locks it
+    await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Mastra'}));
+
+    const runtimeSelector = await screen.findByRole('button', {name: 'Node'});
+    expect(runtimeSelector).toBeDisabled();
+    expect(screen.queryByRole('button', {name: 'Cloudflare'})).not.toBeInTheDocument();
+  });
+
   it('tracks AI prompt copy for conversations onboarding', async () => {
     const {organization} = setupProject('node');
 

--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -59,10 +59,10 @@ import {
   AGENT_INTEGRATION_ICONS,
   AGENT_INTEGRATION_LABELS,
   AgentIntegration,
-  CLOUDFLARE_AGENT_INTEGRATIONS,
   DEPLOYMENT_TARGET_ICONS,
   DEPLOYMENT_TARGET_LABELS,
   DeploymentTarget,
+  getIntegrationDeploymentTarget,
   NODE_AGENT_INTEGRATIONS,
   PHP_AGENT_INTEGRATIONS,
   PYTHON_AGENT_INTEGRATIONS,
@@ -429,23 +429,13 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
       }
     : {};
 
-  const selectedDeploymentTarget = useUrlPlatformOptions(deploymentTargetOptions)
-    .deploymentTarget as DeploymentTarget | undefined;
-  // Cloudflare Workers projects are pinned to the Cloudflare runtime; other Node
-  // projects follow the selector (defaulting to Node).
-  const deploymentTarget = isCloudflareWorkers
-    ? DeploymentTarget.CLOUDFLARE
-    : selectedDeploymentTarget;
-  const isCloudflareTarget =
-    isNodePlatform && deploymentTarget === DeploymentTarget.CLOUDFLARE;
-
+  // The SDK list is no longer filtered by runtime: Node projects see every
+  // Node/Cloudflare agent SDK, and the chosen SDK drives the runtime below.
   const integrations = isPythonPlatform
     ? PYTHON_AGENT_INTEGRATIONS
     : isPhpPlatform
       ? PHP_AGENT_INTEGRATIONS
-      : isCloudflareTarget
-        ? CLOUDFLARE_AGENT_INTEGRATIONS
-        : NODE_AGENT_INTEGRATIONS;
+      : NODE_AGENT_INTEGRATIONS;
 
   const platformOptions: BasePlatformOptions = {
     integration: {
@@ -472,6 +462,22 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
   };
 
   const selectedPlatformOptions = useUrlPlatformOptions(platformOptions);
+
+  // A runtime-specific SDK (e.g. Workers AI -> Cloudflare, Mastra -> Node) pins
+  // the runtime and locks the selector; otherwise the user's dropdown choice
+  // wins (the selector defaults to Node). Cloudflare Workers projects stay
+  // pinned to Cloudflare regardless of the SDK.
+  const integrationDeploymentTarget = getIntegrationDeploymentTarget(
+    selectedPlatformOptions.integration
+  );
+  const selectedDeploymentTarget = selectedPlatformOptions.deploymentTarget as
+    | DeploymentTarget
+    | undefined;
+  const deploymentTarget = isCloudflareWorkers
+    ? DeploymentTarget.CLOUDFLARE
+    : (integrationDeploymentTarget ?? selectedDeploymentTarget);
+  const isCloudflareTarget =
+    isNodePlatform && deploymentTarget === DeploymentTarget.CLOUDFLARE;
 
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
@@ -550,6 +556,11 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
           <PlatformOptionDropdown
             platformOptions={platformOptions}
             connectors={{deploymentTarget: t('on')}}
+            lockedValues={
+              integrationDeploymentTarget
+                ? {deploymentTarget: integrationDeploymentTarget}
+                : undefined
+            }
           />
         </Flex>
         {introduction && <Prose>{introduction}</Prose>}

--- a/static/app/views/insights/pages/agents/onboarding.spec.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.spec.tsx
@@ -138,23 +138,60 @@ describe('Onboarding deployment target', () => {
     expect(screen.queryByRole('button', {name: 'Cloudflare'})).not.toBeInTheDocument();
   });
 
-  it('offers Workers AI as an integration only on the Cloudflare target', async () => {
+  it('offers every SDK regardless of the selected runtime', async () => {
     const {organization} = setupProject('node');
 
     render(<Onboarding />, {organization});
 
-    // Node target: Workers AI is not in the integration list
-    await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
-    expect(screen.queryByRole('option', {name: 'Workers AI'})).not.toBeInTheDocument();
-    await userEvent.keyboard('{Escape}');
-
-    // Switch to the Cloudflare target
-    await userEvent.click(screen.getByRole('button', {name: 'Node'}));
-    await userEvent.click(await screen.findByRole('option', {name: 'Cloudflare'}));
-
-    // Cloudflare target: Workers AI is now offered
+    // On the Node runtime both the Node-only (Mastra) and Cloudflare-only
+    // (Workers AI) SDKs are offered; the list is no longer filtered by runtime.
     await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
     expect(await screen.findByRole('option', {name: 'Workers AI'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Mastra'})).toBeInTheDocument();
+  });
+
+  it('pins and locks the runtime to Cloudflare when a Cloudflare-only SDK is selected', async () => {
+    const {organization} = setupProject('node');
+
+    render(<Onboarding />, {organization});
+
+    // Node runtime is selected by default
+    expect(await screen.findByRole('button', {name: 'Node'})).toBeInTheDocument();
+
+    await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Workers AI'}));
+
+    // The runtime flips to Cloudflare, the selector is locked, and the Cloudflare
+    // install instructions render.
+    const runtimeSelector = await screen.findByRole('button', {name: 'Cloudflare'});
+    expect(runtimeSelector).toBeDisabled();
+    expect(screen.queryByRole('button', {name: 'Node'})).not.toBeInTheDocument();
+    expect(
+      (
+        await screen.findAllByText(
+          textWithMarkupMatcher(/npm install @sentry\/cloudflare/)
+        )
+      ).length
+    ).toBeGreaterThan(0);
+  });
+
+  it('pins and locks the runtime to Node when a Node-only SDK is selected', async () => {
+    const {organization} = setupProject('node');
+
+    render(<Onboarding />, {organization});
+
+    // Manually switch to the Cloudflare runtime first
+    await userEvent.click(await screen.findByRole('button', {name: 'Node'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Cloudflare'}));
+    expect(await screen.findByRole('button', {name: 'Cloudflare'})).toBeInTheDocument();
+
+    // Selecting Mastra (Node-only) flips the runtime back to Node and locks it
+    await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Mastra'}));
+
+    const runtimeSelector = await screen.findByRole('button', {name: 'Node'});
+    expect(runtimeSelector).toBeDisabled();
+    expect(screen.queryByRole('button', {name: 'Cloudflare'})).not.toBeInTheDocument();
   });
 
   it('switches instructions when the deployment target changes', async () => {

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -54,11 +54,11 @@ import {LLM_ONBOARDING_COPY_MARKDOWN} from 'sentry/views/insights/pages/agents/l
 import {
   AGENT_INTEGRATION_ICONS,
   AGENT_INTEGRATION_LABELS,
-  CLOUDFLARE_AGENT_INTEGRATIONS,
   DENO_AGENT_INTEGRATIONS,
   DEPLOYMENT_TARGET_ICONS,
   DEPLOYMENT_TARGET_LABELS,
   DeploymentTarget,
+  getIntegrationDeploymentTarget,
   NODE_AGENT_INTEGRATIONS,
   PHP_AGENT_INTEGRATIONS,
   PYTHON_AGENT_INTEGRATIONS,
@@ -277,25 +277,15 @@ export function Onboarding() {
       }
     : {};
 
-  const selectedDeploymentTarget = useUrlPlatformOptions(deploymentTargetOptions)
-    .deploymentTarget as DeploymentTarget | undefined;
-  // Cloudflare Workers projects are pinned to the Cloudflare runtime; other Node
-  // projects follow the selector (defaulting to Node).
-  const deploymentTarget = isCloudflareWorkers
-    ? DeploymentTarget.CLOUDFLARE
-    : selectedDeploymentTarget;
-  const isCloudflareTarget =
-    isNodePlatform && deploymentTarget === DeploymentTarget.CLOUDFLARE;
-
+  // The SDK list is no longer filtered by runtime: Node projects see every
+  // Node/Cloudflare agent SDK, and the chosen SDK drives the runtime below.
   const integrations = isPythonPlatform
     ? PYTHON_AGENT_INTEGRATIONS
     : isDenoPlatform
       ? DENO_AGENT_INTEGRATIONS
       : isPhpPlatform
         ? PHP_AGENT_INTEGRATIONS
-        : isCloudflareTarget
-          ? CLOUDFLARE_AGENT_INTEGRATIONS
-          : NODE_AGENT_INTEGRATIONS;
+        : NODE_AGENT_INTEGRATIONS;
 
   const platformOptions: BasePlatformOptions = {
     integration: {
@@ -322,6 +312,20 @@ export function Onboarding() {
   };
 
   const selectedPlatformOptions = useUrlPlatformOptions(platformOptions);
+
+  // A runtime-specific SDK (e.g. Workers AI -> Cloudflare, Mastra -> Node) pins
+  // the runtime and locks the selector; otherwise the user's dropdown choice
+  // wins (the selector defaults to Node). Cloudflare Workers projects stay
+  // pinned to Cloudflare regardless of the SDK.
+  const integrationDeploymentTarget = getIntegrationDeploymentTarget(
+    selectedPlatformOptions.integration
+  );
+  const selectedDeploymentTarget = selectedPlatformOptions.deploymentTarget as
+    | DeploymentTarget
+    | undefined;
+  const deploymentTarget = isCloudflareWorkers
+    ? DeploymentTarget.CLOUDFLARE
+    : (integrationDeploymentTarget ?? selectedDeploymentTarget);
 
   const {isPending: isLoadingRegistry, data: registryData} =
     useSourcePackageRegistries(organization);
@@ -387,6 +391,11 @@ export function Onboarding() {
         <PlatformOptionDropdown
           platformOptions={platformOptions}
           connectors={{deploymentTarget: t('on')}}
+          lockedValues={
+            integrationDeploymentTarget
+              ? {deploymentTarget: integrationDeploymentTarget}
+              : undefined
+          }
         />
       </OptionsWrapper>
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}

--- a/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
+++ b/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
@@ -57,8 +57,15 @@ export const PYTHON_AGENT_INTEGRATIONS = [
   AgentIntegration.MANUAL,
 ];
 
+/**
+ * Every agent SDK offered for Node-based projects, regardless of runtime. The
+ * onboarding no longer filters this list by the selected runtime; instead a
+ * runtime-specific SDK drives the runtime selection (see
+ * INTEGRATION_DEPLOYMENT_TARGETS).
+ */
 export const NODE_AGENT_INTEGRATIONS = [
   AgentIntegration.VERCEL_AI,
+  AgentIntegration.WORKERS_AI,
   AgentIntegration.ANTHROPIC,
   AgentIntegration.GOOGLE_GENAI,
   AgentIntegration.LANGCHAIN,
@@ -96,19 +103,31 @@ export const DEPLOYMENT_TARGET_ICONS: Record<DeploymentTarget, string> = {
 };
 
 /**
- * Integrations documented for the Cloudflare deployment target. Mirrors the
- * Node list minus Mastra, whose `@mastra/sentry` exporter is not part of the
- * Cloudflare `withSentry` flow.
+ * Agent SDKs that only work on a single Node deployment runtime. Selecting one
+ * of these pins the runtime accordingly (and locks the runtime selector), rather
+ * than the runtime filtering which SDKs are shown.
+ *
+ * - Workers AI is the Cloudflare Workers AI binding (env.AI), Cloudflare-only.
+ * - Mastra's `@mastra/sentry` exporter is not part of the Cloudflare `withSentry`
+ *   flow, so it is Node-only.
  *
  * @see https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/
  */
-export const CLOUDFLARE_AGENT_INTEGRATIONS = [
-  AgentIntegration.VERCEL_AI,
-  AgentIntegration.WORKERS_AI,
-  AgentIntegration.ANTHROPIC,
-  AgentIntegration.GOOGLE_GENAI,
-  AgentIntegration.LANGCHAIN,
-  AgentIntegration.LANGGRAPH,
-  AgentIntegration.OPENAI,
-  AgentIntegration.MANUAL,
-];
+export const INTEGRATION_DEPLOYMENT_TARGETS: Partial<
+  Record<AgentIntegration, DeploymentTarget>
+> = {
+  [AgentIntegration.WORKERS_AI]: DeploymentTarget.CLOUDFLARE,
+  [AgentIntegration.MASTRA]: DeploymentTarget.NODE,
+};
+
+/**
+ * Returns the runtime a given SDK is pinned to, or undefined when the SDK works
+ * on any runtime and the user is free to pick the deployment target.
+ */
+export function getIntegrationDeploymentTarget(
+  integration: string | undefined
+): DeploymentTarget | undefined {
+  return integration
+    ? INTEGRATION_DEPLOYMENT_TARGETS[integration as AgentIntegration]
+    : undefined;
+}

--- a/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
+++ b/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
@@ -113,7 +113,7 @@ export const DEPLOYMENT_TARGET_ICONS: Record<DeploymentTarget, string> = {
  *
  * @see https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/
  */
-export const INTEGRATION_DEPLOYMENT_TARGETS: Partial<
+const INTEGRATION_DEPLOYMENT_TARGETS: Partial<
   Record<AgentIntegration, DeploymentTarget>
 > = {
   [AgentIntegration.WORKERS_AI]: DeploymentTarget.CLOUDFLARE,


### PR DESCRIPTION
The agent SDK list in the Conversations and Agents onboarding is no longer filtered by the selected deployment runtime. Node projects now see every SDK at once, and the chosen SDK drives the runtime instead of the other way around: a runtime-specific SDK selects and locks the matching runtime (Workers AI pins Cloudflare, Mastra pins Node), while runtime-agnostic SDKs leave the runtime selector free to change.

<img width="672" height="333" alt="Screenshot 2026-09-04 at 12 32 58" src="https://github.com/user-attachments/assets/5922e643-1b64-47d3-af0e-eec16c3c2cd3" />

Part of TET-2937