### PR TITLE
fix(ai-monitoring): Prefer last user message for conversation titles

### DIFF
--- a/src/sentry/ai_monitoring/conversation_titles.py
+++ b/src/sentry/ai_monitoring/conversation_titles.py
@@ -130,7 +130,8 @@ def _extract_first_user_message(messages: Any) -> str | None:
     parsed = normalize_to_messages(messages, "user")
     if not parsed:
         return None
-    for msg in parsed:
+    # Clients often prepend context as user messages, so the last user message is usually relevant.
+    for msg in reversed(parsed):
         if msg.get("role") != "user":
             continue
         content = stringify_message_content(msg.get("content"))

--- a/tests/sentry/ai_monitoring/test_tasks.py
+++ b/tests/sentry/ai_monitoring/test_tasks.py
@@ -115,20 +115,21 @@ class TitleHelpersTest(TestCase):
             make_gen_ai_span(project_id=1, start_timestamp=TS + 0.5)
         ) == _ts(0.5)
 
-    def test_first_user_message_prefers_input_messages(self) -> None:
+    def test_first_user_message_prefers_latest_input_message(self) -> None:
         span = make_gen_ai_span(
             project_id=1,
             messages=json.dumps(
                 [
                     {"role": "system", "content": "sys"},
-                    {"role": "user", "content": "from input"},
+                    {"role": "user", "content": "earlier input"},
+                    {"role": "user", "content": "latest input"},
                 ]
             ),
         )
         span["attributes"][LEGACY_GEN_AI_REQUEST_MESSAGES] = _attr(
             json.dumps([{"role": "user", "content": "from request"}])
         )
-        assert first_user_message_from_span(span) == "from input"
+        assert first_user_message_from_span(span) == "latest input"
 
     def test_first_user_message_falls_back_to_request_messages(self) -> None:
         assert (


### PR DESCRIPTION
Conversation title generation now uses the last user-role message from the earliest eligible span. Some clients prepend context as user messages before the actual request, which caused titles to describe injected context instead of the conversation.

Earliest-span selection and fallback to legacy message attributes remain unchanged.