### PR TITLE
feat(agents): Surface Eve in agent tracing onboarding

### DIFF
--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -9,6 +9,7 @@ import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {javascriptMetaFrameworks} from 'sentry/data/platformCategories';
 import {allPlatforms as platforms} from 'sentry/data/platforms';
 import {
+  eveOnboarding,
   getAgentIntegration,
   getInstallStep,
   getManualConfigureStep,
@@ -411,6 +412,11 @@ export function agentMonitoring({
         return mastraOnboarding.configure(params);
       }
 
+      // Eve is a Node/server-side framework, so it reuses the Node setup.
+      if (selected === AgentIntegration.EVE) {
+        return eveOnboarding.configure(params);
+      }
+
       return [
         {
           title: t('Configure'),
@@ -438,6 +444,11 @@ export function agentMonitoring({
 
       if (selected === AgentIntegration.MASTRA) {
         return mastraOnboarding.verify(params);
+      }
+
+      // Eve is a Node/server-side framework, so it reuses the Node setup.
+      if (selected === AgentIntegration.EVE) {
+        return eveOnboarding.verify(params);
       }
 
       return [

--- a/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
@@ -192,10 +192,10 @@ describe('node agentMonitoring onboarding', () => {
       const code = collectCode(config.configure(makeParams({integration: 'eve'})));
 
       expect(code).toContain(
-        'SENTRY_OTLP_TRACES_ENDPOINT=https://o1.ingest.sentry.io/api/1/otlp/v1/traces'
+        'SENTRY_OTLP_TRACES_ENDPOINT="https://o1.ingest.sentry.io/api/1/otlp/v1/traces"'
       );
       // The bare public key, not the full DSN
-      expect(code).toContain('SENTRY_PUBLIC_KEY=public');
+      expect(code).toContain('SENTRY_PUBLIC_KEY="public"');
       expect(code).toContain('defineInstrumentation');
       expect(code).not.toContain('Sentry.init(');
       expect(code).not.toContain('Sentry.withSentry(');

--- a/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
@@ -6,7 +6,10 @@ import {agentMonitoring} from 'sentry/gettingStartedDocs/node/agentMonitoring';
 
 function makeParams(platformOptions: Record<string, string> = {}): DocsParams {
   return {
-    dsn: {public: 'https://public@o1.ingest.sentry.io/1'},
+    dsn: {
+      public: 'https://public@o1.ingest.sentry.io/1',
+      otlp_traces: 'https://o1.ingest.sentry.io/api/1/otlp/v1/traces',
+    },
     platformOptions,
     project: {id: '1', slug: 'project-slug', platform: 'node'},
     isProfilingSelected: false,
@@ -174,6 +177,40 @@ describe('node agentMonitoring onboarding', () => {
 
       expect(code).toContain('Sentry.withSentry(');
       expect(code).not.toContain('Sentry.init(');
+    });
+  });
+
+  describe('Eve', () => {
+    it('installs via the eve CLI instead of an npm package', () => {
+      const code = collectCode(config.install(makeParams({integration: 'eve'})));
+
+      expect(code).toContain('eve add instrumentation/sentry');
+      expect(code).not.toContain('npm install @sentry/node');
+    });
+
+    it('configures the OTLP endpoint and public key from the DSN, without Sentry.init', () => {
+      const code = collectCode(config.configure(makeParams({integration: 'eve'})));
+
+      expect(code).toContain(
+        'SENTRY_OTLP_TRACES_ENDPOINT=https://o1.ingest.sentry.io/api/1/otlp/v1/traces'
+      );
+      // The bare public key, not the full DSN
+      expect(code).toContain('SENTRY_PUBLIC_KEY=public');
+      expect(code).toContain('defineInstrumentation');
+      expect(code).not.toContain('Sentry.init(');
+      expect(code).not.toContain('Sentry.withSentry(');
+    });
+
+    it('verifies by running the Eve agent', () => {
+      const steps = config.verify(makeParams({integration: 'eve'}));
+      const texts = steps
+        .flatMap(step => step.content ?? [])
+        .filter(block => block.type === 'text')
+        .map(block => block.text);
+
+      expect(
+        texts.some(text => typeof text === 'string' && text.includes('Start Eve'))
+      ).toBe(true);
     });
   });
 });

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -456,7 +456,9 @@ export const eveOnboarding: OnboardingConfig = {
 import { defineInstrumentation } from "eve/instrumentation";
 
 export default defineInstrumentation({
-  // Set recordInputs/recordOutputs to true to also capture prompts and responses.
+  // Capture prompts and responses; set either to false to omit them.
+  recordInputs: true,
+  recordOutputs: true,
   setup: ({ agentName }) =>
     registerOTel({
       serviceName: agentName,

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -431,8 +431,8 @@ export const eveOnboarding: OnboardingConfig = {
                 label: 'bash',
                 language: 'bash',
                 code: [
-                  `SENTRY_OTLP_TRACES_ENDPOINT=${params.dsn.otlp_traces}`,
-                  `SENTRY_PUBLIC_KEY=${publicKey}`,
+                  `SENTRY_OTLP_TRACES_ENDPOINT="${params.dsn.otlp_traces}"`,
+                  `SENTRY_PUBLIC_KEY="${publicKey}"`,
                 ].join('\n'),
               },
             ],
@@ -456,8 +456,7 @@ export const eveOnboarding: OnboardingConfig = {
 import { defineInstrumentation } from "eve/instrumentation";
 
 export default defineInstrumentation({
-  recordInputs: true,
-  recordOutputs: true,
+  // Set recordInputs/recordOutputs to true to also capture prompts and responses.
   setup: ({ agentName }) =>
     registerOTel({
       serviceName: agentName,

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -27,6 +27,8 @@ const CLOUDFLARE_DURABLE_OBJECTS_DOCS =
   'https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/durableobject/';
 const CLOUDFLARE_AGENTS_SDK_DOCS =
   'https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/agents-sdk/';
+const EVE_AGENT_TRACING_DOCS =
+  'https://docs.sentry.io/platforms/javascript/guides/node/agent-tracing/eve/';
 
 export function getAgentIntegration(params: DocsParams): AgentIntegration {
   return (params.platformOptions?.integration ??
@@ -36,6 +38,19 @@ export function getAgentIntegration(params: DocsParams): AgentIntegration {
 export function getDeploymentTarget(params: DocsParams): DeploymentTarget {
   return (params.platformOptions?.deploymentTarget ??
     DeploymentTarget.NODE) as DeploymentTarget;
+}
+
+/**
+ * Extracts the bare public key (the DSN's userinfo) from a full DSN, e.g.
+ * `https://abc123@o1.ingest.sentry.io/1` -> `abc123`. Used by the Eve setup,
+ * which passes only the key in its `x-sentry-auth` header.
+ */
+function getDsnPublicKey(dsn: string): string {
+  try {
+    return new URL(dsn).username;
+  } catch {
+    return dsn;
+  }
 }
 
 /**
@@ -368,6 +383,127 @@ const result = await agent.generate([{ role: "user", content: "Hello!" }]);`,
   ],
 };
 
+/**
+ * Eve is Vercel's filesystem-first framework for durable backend AI agents. It
+ * doesn't use `Sentry.init` - its `eve add instrumentation/sentry` command
+ * generates an `agent/instrumentation.ts` that wires `@vercel/otel` to Sentry's
+ * OTLP traces endpoint, reading the endpoint and public key from the
+ * environment. Eve runs on Node only.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/guides/node/agent-tracing/eve/
+ */
+export const eveOnboarding: OnboardingConfig = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Add the Sentry instrumentation to your Eve project. This generates [code:agent/instrumentation.ts] and installs the required OpenTelemetry packages.',
+            {
+              code: <code />,
+            }
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'bash',
+              language: 'bash',
+              code: 'eve add instrumentation/sentry',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  configure: params => {
+    // `dsn.public` is the full DSN; Eve's `x-sentry-auth` header only needs the
+    // public key portion (its userinfo).
+    const publicKey = getDsnPublicKey(params.dsn.public);
+
+    return [
+      {
+        title: t('Configure'),
+        content: [
+          {
+            type: 'text',
+            text: tct(
+              'The generated [code:agent/instrumentation.ts] reads your Sentry OTLP endpoint and public key from the environment. Set these variables so Eve exports traces to Sentry:',
+              {
+                code: <code />,
+              }
+            ),
+          },
+          {
+            type: 'code',
+            tabs: [
+              {
+                label: 'bash',
+                language: 'bash',
+                code: [
+                  `SENTRY_OTLP_TRACES_ENDPOINT=${params.dsn.otlp_traces}`,
+                  `SENTRY_PUBLIC_KEY=${publicKey}`,
+                ].join('\n'),
+              },
+            ],
+          },
+          {
+            type: 'text',
+            text: tct(
+              'For reference, the generated instrumentation looks like this. See the [link:Eve docs] for details.',
+              {
+                link: <ExternalLink href={EVE_AGENT_TRACING_DOCS} />,
+              }
+            ),
+          },
+          {
+            type: 'code',
+            tabs: [
+              {
+                label: 'agent/instrumentation.ts',
+                language: 'typescript',
+                code: `import { OTLPHttpProtoTraceExporter, registerOTel } from "@vercel/otel";
+import { defineInstrumentation } from "eve/instrumentation";
+
+export default defineInstrumentation({
+  recordInputs: true,
+  recordOutputs: true,
+  setup: ({ agentName }) =>
+    registerOTel({
+      serviceName: agentName,
+      traceExporter: new OTLPHttpProtoTraceExporter({
+        url: process.env.SENTRY_OTLP_TRACES_ENDPOINT!,
+        headers: {
+          "x-sentry-auth": \`sentry sentry_key=\${process.env.SENTRY_PUBLIC_KEY}\`,
+        },
+      }),
+    }),
+});`,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+  },
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Start Eve and send a prompt that calls a tool. The agent run shows up as AI spans in Sentry.'
+          ),
+        },
+      ],
+    },
+  ],
+};
+
 export function getManualConfigureStep(
   params: DocsParams,
   {
@@ -452,6 +588,10 @@ export function getInstallStep(
 
   if (selected === AgentIntegration.MASTRA) {
     return mastraOnboarding.install(params);
+  }
+
+  if (selected === AgentIntegration.EVE) {
+    return eveOnboarding.install(params);
   }
 
   const resolvedPackageName =
@@ -633,6 +773,10 @@ function getVerifyStep(params: DocsParams): OnboardingStep[] {
 
   if (selected === AgentIntegration.MASTRA) {
     return mastraOnboarding.verify(params);
+  }
+
+  if (selected === AgentIntegration.EVE) {
+    return eveOnboarding.verify(params);
   }
 
   // On Cloudflare these SDKs only produce spans through the wrapped client shown
@@ -829,6 +973,10 @@ export const agentMonitoring = ({
       return getManualConfigureStep(params, {
         packageName,
       });
+    }
+
+    if (selected === AgentIntegration.EVE) {
+      return eveOnboarding.configure(params);
     }
 
     return getConfigureStep({

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -41,19 +41,6 @@ export function getDeploymentTarget(params: DocsParams): DeploymentTarget {
 }
 
 /**
- * Extracts the bare public key (the DSN's userinfo) from a full DSN, e.g.
- * `https://abc123@o1.ingest.sentry.io/1` -> `abc123`. Used by the Eve setup,
- * which passes only the key in its `x-sentry-auth` header.
- */
-function getDsnPublicKey(dsn: string): string {
-  try {
-    return new URL(dsn).username;
-  } catch {
-    return dsn;
-  }
-}
-
-/**
  * Cloudflare Workers don't expose the public `Sentry.init()` API. Instead the
  * SDK is bootstrapped by wrapping the worker with `Sentry.withSentry`. The
  * Vercel AI SDK additionally requires the `nodejs_compat` entrypoint and its
@@ -421,8 +408,8 @@ export const eveOnboarding: OnboardingConfig = {
   ],
   configure: params => {
     // `dsn.public` is the full DSN; Eve's `x-sentry-auth` header only needs the
-    // public key portion (its userinfo).
-    const publicKey = getDsnPublicKey(params.dsn.public);
+    // public key portion (the DSN's userinfo).
+    const publicKey = new URL(params.dsn.public).username;
 
     return [
       {

--- a/static/app/views/explore/conversations/onboarding.spec.tsx
+++ b/static/app/views/explore/conversations/onboarding.spec.tsx
@@ -156,6 +156,23 @@ describe('ConversationOnboarding deployment target', () => {
     expect(screen.queryByRole('button', {name: 'Cloudflare'})).not.toBeInTheDocument();
   });
 
+  it('hides the conversation ID and user steps for Eve (OTel drain, no Sentry SDK)', async () => {
+    const {organization} = setupProject('node');
+
+    render(<ConversationOnboarding onDismiss={jest.fn()} />, {organization});
+
+    // The default SDK runs the Sentry SDK, so both steps are shown.
+    expect(await screen.findByText('Set Conversation ID')).toBeInTheDocument();
+    expect(screen.getByText('Identify Users (optional)')).toBeInTheDocument();
+
+    // Eve only drains OpenTelemetry traces, so those Sentry SDK steps drop out.
+    await userEvent.click(await screen.findByRole('button', {name: 'Vercel AI SDK'}));
+    await userEvent.click(await screen.findByRole('option', {name: 'Eve'}));
+
+    expect(screen.queryByText('Set Conversation ID')).not.toBeInTheDocument();
+    expect(screen.queryByText('Identify Users (optional)')).not.toBeInTheDocument();
+  });
+
   it('tracks AI prompt copy for conversations onboarding', async () => {
     const {organization} = setupProject('node');
 

--- a/static/app/views/explore/conversations/onboarding.tsx
+++ b/static/app/views/explore/conversations/onboarding.tsx
@@ -532,15 +532,23 @@ export function ConversationOnboarding({onDismiss}: {onDismiss: () => void}) {
     selectedPlatformOptions.integration ?? AgentIntegration.VERCEL_AI;
   const jsPackageName = isCloudflareTarget ? '@sentry/cloudflare' : '@sentry/node';
 
+  // Eve only drains OpenTelemetry traces to Sentry - it doesn't run the Sentry
+  // SDK, so there's no `Sentry.setConversationId` / `Sentry.setUser` to call.
+  const isEve = selectedIntegration === AgentIntegration.EVE;
+
   const steps: OnboardingStep[] = [
     ...(agentMonitoringDocs.install?.(docParams) || []),
     ...(agentMonitoringDocs.configure?.(docParams) || []),
-    getConversationIdStep(
-      selectedIntegration,
-      isPythonPlatform ? 'python' : isPhpPlatform ? 'php' : 'javascript',
-      jsPackageName
-    ),
-    ...(isPhpPlatform ? [] : [getSetUserStep(isPythonPlatform, jsPackageName)]),
+    ...(isEve
+      ? []
+      : [
+          getConversationIdStep(
+            selectedIntegration,
+            isPythonPlatform ? 'python' : isPhpPlatform ? 'php' : 'javascript',
+            jsPackageName
+          ),
+        ]),
+    ...(isPhpPlatform || isEve ? [] : [getSetUserStep(isPythonPlatform, jsPackageName)]),
     ...(isPhpPlatform
       ? [getPhpConversationVerifyStep()]
       : agentMonitoringDocs.verify?.(docParams) || []),

--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -54,6 +54,7 @@ import {LLM_ONBOARDING_COPY_MARKDOWN} from 'sentry/views/insights/pages/agents/l
 import {
   AGENT_INTEGRATION_ICONS,
   AGENT_INTEGRATION_LABELS,
+  AgentIntegration,
   DENO_AGENT_INTEGRATIONS,
   DEPLOYMENT_TARGET_ICONS,
   DEPLOYMENT_TARGET_LABELS,
@@ -399,19 +400,23 @@ export function Onboarding() {
         />
       </OptionsWrapper>
       {introduction && <DescriptionWrapper>{introduction}</DescriptionWrapper>}
-      <DescriptionWrapper>
-        <p>
-          {tct(
-            'To use [link:Conversations], set a conversation ID for each chat. Sentry uses the [code:gen_ai.conversation.id] attribute to group related AI spans.',
-            {
-              code: <code />,
-              link: (
-                <ExternalLink href="https://docs.sentry.io/ai/monitoring/conversations/" />
-              ),
-            }
-          )}
-        </p>
-      </DescriptionWrapper>
+      {/* Eve only drains OpenTelemetry traces, so there's no Sentry SDK call to
+          set a conversation ID - hide the Conversations pointer for it. */}
+      {selectedPlatformOptions.integration !== AgentIntegration.EVE && (
+        <DescriptionWrapper>
+          <p>
+            {tct(
+              'To use [link:Conversations], set a conversation ID for each chat. Sentry uses the [code:gen_ai.conversation.id] attribute to group related AI spans.',
+              {
+                code: <code />,
+                link: (
+                  <ExternalLink href="https://docs.sentry.io/ai/monitoring/conversations/" />
+                ),
+              }
+            )}
+          </p>
+        </DescriptionWrapper>
+      )}
       <GuidedSteps
         // Remount when the integration or runtime changes so the stepper doesn't
         // carry over stale per-step state from the previous selection.

--- a/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
+++ b/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
@@ -9,6 +9,9 @@ export enum AgentIntegration {
   MASTRA = 'mastra',
   PYDANTIC_AI = 'pydantic_ai',
   VERCEL_AI = 'vercel_ai',
+  // Node-only: Vercel's filesystem-first framework for durable backend AI
+  // agents, built on top of the Vercel AI SDK.
+  EVE = 'eve',
   // Cloudflare-only: the Workers AI binding (env.AI) auto-instruments once the
   // Worker is wrapped with Sentry.
   WORKERS_AI = 'workers_ai',
@@ -26,6 +29,7 @@ export const AGENT_INTEGRATION_LABELS = {
   [AgentIntegration.MASTRA]: 'Mastra',
   [AgentIntegration.PYDANTIC_AI]: 'Pydantic AI',
   [AgentIntegration.VERCEL_AI]: 'Vercel AI SDK',
+  [AgentIntegration.EVE]: 'Eve',
   [AgentIntegration.WORKERS_AI]: 'Workers AI',
   [AgentIntegration.MANUAL]: 'Other',
 };
@@ -41,6 +45,8 @@ export const AGENT_INTEGRATION_ICONS: Record<AgentIntegration, string> = {
   [AgentIntegration.MASTRA]: 'mastra',
   [AgentIntegration.PYDANTIC_AI]: 'pydantic-ai',
   [AgentIntegration.VERCEL_AI]: 'vercel',
+  // Eve is a Vercel framework, so it reuses the Vercel icon.
+  [AgentIntegration.EVE]: 'vercel',
   [AgentIntegration.WORKERS_AI]: 'cloudflare',
   [AgentIntegration.MANUAL]: 'default',
 };
@@ -65,6 +71,7 @@ export const PYTHON_AGENT_INTEGRATIONS = [
  */
 export const NODE_AGENT_INTEGRATIONS = [
   AgentIntegration.VERCEL_AI,
+  AgentIntegration.EVE,
   AgentIntegration.WORKERS_AI,
   AgentIntegration.ANTHROPIC,
   AgentIntegration.GOOGLE_GENAI,
@@ -110,6 +117,7 @@ export const DEPLOYMENT_TARGET_ICONS: Record<DeploymentTarget, string> = {
  * - Workers AI is the Cloudflare Workers AI binding (env.AI), Cloudflare-only.
  * - Mastra's `@mastra/sentry` exporter is not part of the Cloudflare `withSentry`
  *   flow, so it is Node-only.
+ * - Eve is a Vercel backend framework that runs on Node, so it is Node-only.
  *
  * @see https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/
  */
@@ -118,6 +126,7 @@ const INTEGRATION_DEPLOYMENT_TARGETS: Partial<
 > = {
   [AgentIntegration.WORKERS_AI]: DeploymentTarget.CLOUDFLARE,
   [AgentIntegration.MASTRA]: DeploymentTarget.NODE,
+  [AgentIntegration.EVE]: DeploymentTarget.NODE,
 };
 
 /**


### PR DESCRIPTION
Surfaces the Eve agent SDK in the agent tracing and Conversations onboarding empty states, so users building on Eve get first-class setup instructions instead of the generic manual fallback.

Eve is Vercel's filesystem-first framework for durable backend AI agents and runs on Node only, so picking it pins the onboarding runtime to Node and locks the runtime selector (the same behavior as Mastra). Its setup differs from the other SDKs: rather than `Sentry.init`, Eve's `eve add instrumentation/sentry` command generates an `agent/instrumentation.ts` that ships traces to Sentry's OTLP endpoint, so the install/configure/verify steps walk through that flow and prefill the OTLP endpoint and public key from the project's DSN.

This is the Eve slice only; flue and the Cloudflare agents SDK from the same ticket are out of scope here, so this uses `Refs` rather than `Closes`.

Refs TET-2937