### PR TITLE
feat(agents): Add Cloudflare Agents SDK to agent onboarding

### DIFF
--- a/static/app/components/onboarding/platformOptionDropdown.tsx
+++ b/static/app/components/onboarding/platformOptionDropdown.tsx
@@ -57,6 +57,10 @@ function OptionControl({option, value, onChange, disabled}: OptionControlProps) 
       onChange={onChange}
       options={option.items}
       position="bottom-end"
+      // Size the menu to its widest option so long SDK names (e.g. "Cloudflare
+      // Agents SDK") aren't truncated. min-width:100% still keeps it at least as
+      // wide as the trigger for short lists.
+      menuWidth="max-content"
       disabled={disabled}
     />
   );

--- a/static/app/components/onboarding/platformOptionDropdown.tsx
+++ b/static/app/components/onboarding/platformOptionDropdown.tsx
@@ -56,7 +56,10 @@ function OptionControl({option, value, onChange, disabled}: OptionControlProps) 
       value={value}
       onChange={onChange}
       options={option.items}
-      position="bottom-end"
+      // Anchor the menu's left edge to the trigger and grow rightward. Paired
+      // with menuWidth below, a menu wider than the trigger extends right rather
+      // than hanging off to the left.
+      position="bottom-start"
       // Size the menu to its widest option so long SDK names (e.g. "Cloudflare
       // Agents SDK") aren't truncated. min-width:100% still keeps it at least as
       // wide as the trigger for short lists.

--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.spec.tsx
@@ -1,0 +1,105 @@
+import type {
+  DocsParams,
+  OnboardingStep,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {reactNodeToText} from 'sentry/components/onboarding/utils/stepsToMarkdown';
+import {agentMonitoring} from 'sentry/gettingStartedDocs/javascript/agentMonitoring';
+
+function makeParams(platformOptions: Record<string, string> = {}): DocsParams {
+  return {
+    dsn: {public: 'https://public@o1.ingest.sentry.io/1'},
+    platformOptions,
+    // A meta-framework platform: these render via the JS agent monitoring config
+    // but still surface the full Node integration list, including Cloudflare-only
+    // SDKs.
+    platformKey: 'javascript-nextjs',
+    project: {id: '1', slug: 'project-slug', platform: 'javascript-nextjs'},
+    isProfilingSelected: false,
+    isLogsSelected: false,
+    isFeedbackSelected: false,
+    isMetricsSelected: false,
+    isPerformanceSelected: true,
+    isReplaySelected: false,
+    sourcePackageRegistries: {isLoading: false, data: undefined},
+  } as unknown as DocsParams;
+}
+
+function collectCode(steps: OnboardingStep[]): string {
+  const codes: string[] = [];
+  for (const step of steps) {
+    for (const block of step.content ?? []) {
+      if (block.type !== 'code') {
+        continue;
+      }
+      if ('tabs' in block) {
+        block.tabs.forEach(tab => codes.push(tab.code));
+      } else {
+        codes.push(block.code);
+      }
+    }
+  }
+  return codes.join('\n\n');
+}
+
+function collectText(steps: OnboardingStep[]): string {
+  const parts: string[] = [];
+  for (const step of steps) {
+    for (const block of step.content ?? []) {
+      if (block.type === 'text') {
+        parts.push(reactNodeToText(block.text));
+      }
+    }
+  }
+  return parts.join(' ');
+}
+
+describe('javascript agentMonitoring onboarding', () => {
+  const config = agentMonitoring();
+
+  // Workers AI and the Cloudflare Agents SDK only run on Cloudflare Workers, so
+  // even on a meta-framework platform they must show the Node package's
+  // Cloudflare setup rather than the browser Sentry.init flow.
+  describe('Cloudflare-only SDKs reuse the Node Cloudflare setup', () => {
+    it('wraps the Worker with Sentry.withSentry for Workers AI', () => {
+      const code = collectCode(
+        config.configure(
+          makeParams({integration: 'workers_ai', deploymentTarget: 'cloudflare'})
+        )
+      );
+
+      expect(code).toContain('Sentry.withSentry(');
+      expect(code).toContain('import * as Sentry from "@sentry/cloudflare"');
+      expect(code).not.toContain('Sentry.init(');
+    });
+
+    it('wraps the agent class with instrumentAgentWithSentry for the Agents SDK', () => {
+      const code = collectCode(
+        config.configure(
+          makeParams({integration: 'cloudflare_agents', deploymentTarget: 'cloudflare'})
+        )
+      );
+
+      expect(code).toContain('Sentry.instrumentAgentWithSentry(');
+      expect(code).toContain('import * as Sentry from "@sentry/cloudflare"');
+      expect(code).not.toContain('Sentry.init(');
+    });
+
+    it('installs @sentry/cloudflare at the Agents SDK minimum version', () => {
+      const steps = config.install(
+        makeParams({integration: 'cloudflare_agents', deploymentTarget: 'cloudflare'})
+      );
+
+      expect(collectCode(steps)).toContain('npm install @sentry/cloudflare');
+      expect(collectText(steps)).toContain('10.69.0');
+    });
+
+    it('verifies the Agents SDK by triggering the agent, not a browser LLM call', () => {
+      const steps = config.verify(
+        makeParams({integration: 'cloudflare_agents', deploymentTarget: 'cloudflare'})
+      );
+
+      expect(collectText(steps)).toContain('Trigger your agent');
+      expect(collectText(steps)).not.toContain('calling your LLM');
+    });
+  });
+});

--- a/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/javascript/agentMonitoring.tsx
@@ -13,6 +13,7 @@ import {
   getAgentIntegration,
   getInstallStep,
   getManualConfigureStep,
+  getMinRequiredVersion,
   mastraOnboarding,
   MIN_REQUIRED_VERSION,
   agentMonitoring as nodeAgentMonitoring,
@@ -376,7 +377,7 @@ export function agentMonitoring({
     introduction: params => (
       <SdkUpdateAlert
         projectId={params.project.id}
-        minVersion={minVersion}
+        minVersion={getMinRequiredVersion(params, minVersion)}
         packageName={packageName}
       />
     ),
@@ -417,6 +418,19 @@ export function agentMonitoring({
         return eveOnboarding.configure(params);
       }
 
+      // Workers AI and the Cloudflare Agents SDK only run on Cloudflare Workers.
+      // Selecting either pins the runtime to Cloudflare, so reuse the Node
+      // package's Cloudflare setup instead of the browser init flow.
+      if (
+        selected === AgentIntegration.WORKERS_AI ||
+        selected === AgentIntegration.CLOUDFLARE_AGENTS
+      ) {
+        return nodeAgentMonitoring({
+          packageName,
+          configFileName: serverConfigFileName,
+        }).configure(params);
+      }
+
       return [
         {
           title: t('Configure'),
@@ -449,6 +463,19 @@ export function agentMonitoring({
       // Eve is a Node/server-side framework, so it reuses the Node setup.
       if (selected === AgentIntegration.EVE) {
         return eveOnboarding.verify(params);
+      }
+
+      // Workers AI and the Cloudflare Agents SDK only run on Cloudflare Workers.
+      // Selecting either pins the runtime to Cloudflare, so reuse the Node
+      // package's Cloudflare verification instead of the browser flow.
+      if (
+        selected === AgentIntegration.WORKERS_AI ||
+        selected === AgentIntegration.CLOUDFLARE_AGENTS
+      ) {
+        return nodeAgentMonitoring({
+          packageName,
+          configFileName: serverConfigFileName,
+        }).verify(params);
       }
 
       return [

--- a/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.spec.tsx
@@ -2,6 +2,7 @@ import type {
   DocsParams,
   OnboardingStep,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {reactNodeToText} from 'sentry/components/onboarding/utils/stepsToMarkdown';
 import {agentMonitoring} from 'sentry/gettingStartedDocs/node/agentMonitoring';
 
 function makeParams(platformOptions: Record<string, string> = {}): DocsParams {
@@ -34,6 +35,20 @@ function collectCode(steps: OnboardingStep[]): string {
     }
   }
   return codes.join('\n\n');
+}
+
+// Flattens the (possibly `tct`-produced) React nodes of every text block into a
+// plain string so tests can assert on copy like the minimum SDK version.
+function collectText(steps: OnboardingStep[]): string {
+  const parts: string[] = [];
+  for (const step of steps) {
+    for (const block of step.content ?? []) {
+      if (block.type === 'text') {
+        parts.push(reactNodeToText(block.text));
+      }
+    }
+  }
+  return parts.join(' ');
 }
 
 describe('node agentMonitoring onboarding', () => {
@@ -174,6 +189,37 @@ describe('node agentMonitoring onboarding', () => {
 
       expect(code).toContain('Sentry.withSentry(');
       expect(code).not.toContain('Sentry.init(');
+    });
+  });
+
+  describe('Cloudflare Agents SDK', () => {
+    const agentsParams = makeParams({
+      integration: 'cloudflare_agents',
+      deploymentTarget: 'cloudflare',
+    });
+
+    it('wraps the agent class with instrumentAgentWithSentry', () => {
+      const code = collectCode(config.configure(agentsParams));
+
+      expect(code).toContain('Sentry.instrumentAgentWithSentry(');
+      expect(code).toContain('import * as Sentry from "@sentry/cloudflare"');
+      expect(code).toContain('enableRpcTracePropagation: true');
+      expect(code).not.toContain('Sentry.withSentry(');
+      expect(code).not.toContain('Sentry.init(');
+    });
+
+    it('installs @sentry/cloudflare at the Agents SDK minimum version', () => {
+      const steps = config.install(agentsParams);
+
+      expect(collectCode(steps)).toContain('npm install @sentry/cloudflare');
+      expect(collectText(steps)).toContain('10.69.0');
+    });
+
+    it('verifies by triggering the agent instead of a raw-SDK snippet', () => {
+      const steps = config.verify(agentsParams);
+
+      expect(collectCode(steps)).toBe('');
+      expect(collectText(steps)).toContain('Trigger your agent');
     });
   });
 });

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -21,6 +21,11 @@ import {
 // auto-instruments the `env.AI` binding only from that version.
 export const MIN_REQUIRED_VERSION = '10.67.0';
 
+// The Cloudflare Agents SDK helper `instrumentAgentWithSentry` only exists from
+// this version; earlier SDKs expose `instrumentDurableObjectWithSentry` instead.
+// @see https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/agents-sdk/
+const CLOUDFLARE_AGENTS_MIN_VERSION = '10.69.0';
+
 const CLOUDFLARE_AGENT_TRACING_DOCS =
   'https://docs.sentry.io/platforms/javascript/guides/cloudflare/agent-tracing/';
 const CLOUDFLARE_DURABLE_OBJECTS_DOCS =
@@ -36,6 +41,16 @@ export function getAgentIntegration(params: DocsParams): AgentIntegration {
 export function getDeploymentTarget(params: DocsParams): DeploymentTarget {
   return (params.platformOptions?.deploymentTarget ??
     DeploymentTarget.NODE) as DeploymentTarget;
+}
+
+/**
+ * The minimum SDK version required for the selected integration. Most SDKs share
+ * MIN_REQUIRED_VERSION, but the Cloudflare Agents SDK needs a newer release.
+ */
+function getMinRequiredVersion(params: DocsParams, fallback: string): string {
+  return getAgentIntegration(params) === AgentIntegration.CLOUDFLARE_AGENTS
+    ? CLOUDFLARE_AGENTS_MIN_VERSION
+    : fallback;
 }
 
 /**
@@ -458,6 +473,7 @@ export function getInstallStep(
     getDeploymentTarget(params) === DeploymentTarget.CLOUDFLARE
       ? '@sentry/cloudflare'
       : packageName;
+  const resolvedMinVersion = getMinRequiredVersion(params, minVersion);
 
   return [
     {
@@ -468,13 +484,76 @@ export function getInstallStep(
           text: tct(
             'To enable agent monitoring, you need to install the Sentry SDK with a minimum version of [minVersion].',
             {
-              minVersion: <code>{minVersion}</code>,
+              minVersion: <code>{resolvedMinVersion}</code>,
             }
           ),
         },
         getInstallCodeBlock(params, {
           packageName: resolvedPackageName,
         }),
+      ],
+    },
+  ];
+}
+
+/**
+ * The Cloudflare Agents SDK is bootstrapped by wrapping the agent class with
+ * `instrumentAgentWithSentry` (Durable Object instrumentation under the hood),
+ * a different entry point than `withSentry`, so it gets its own configure step.
+ *
+ * @see https://docs.sentry.io/platforms/javascript/guides/cloudflare/features/agents-sdk/
+ */
+function getCloudflareAgentsConfigureStep(params: DocsParams): OnboardingStep[] {
+  return [
+    {
+      title: t('Configure'),
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Wrap your agent class with [code:Sentry.instrumentAgentWithSentry]. It applies Durable Object instrumentation plus agent-specific telemetry, including callable RPC spans and automatic conversation ID tracking.',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'JavaScript',
+              language: 'javascript',
+              code: `import * as Sentry from "@sentry/cloudflare";
+import { Agent } from "agents";
+
+class MyAgentBase extends Agent {
+  // Your agent logic goes here
+}
+
+// Wrap the agent so its RPC calls and model invocations are captured as AI spans
+export const MyAgent = Sentry.instrumentAgentWithSentry(
+  (env) => ({
+    dsn: "${params.dsn.public}",
+    // Tracing must be enabled for agent monitoring to work
+    tracesSampleRate: 1.0,
+    // Propagate traces across callable RPC methods
+    enableRpcTracePropagation: true,
+  }),
+  MyAgentBase,
+);`,
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'The wrapper also supports [aiChatAgent:AIChatAgent] and [mcpAgent:McpAgent]. For per-user or singleton agents, call [code:Sentry.setConversationId] at the start of [code:onChatMessage] to override the automatic conversation ID. See the [link:Agents SDK docs] for details.',
+            {
+              code: <code />,
+              aiChatAgent: <code />,
+              mcpAgent: <code />,
+              link: <ExternalLink href={CLOUDFLARE_AGENTS_SDK_DOCS} />,
+            }
+          ),
+        },
       ],
     },
   ];
@@ -633,6 +712,24 @@ function getVerifyStep(params: DocsParams): OnboardingStep[] {
 
   if (selected === AgentIntegration.MASTRA) {
     return mastraOnboarding.verify(params);
+  }
+
+  // The Agents SDK only produces spans once the wrapped agent runs, so there's
+  // no standalone snippet to verify - trigger the agent instead.
+  if (selected === AgentIntegration.CLOUDFLARE_AGENTS) {
+    return [
+      {
+        type: StepType.VERIFY,
+        content: [
+          {
+            type: 'text',
+            text: t(
+              'Trigger your agent so it invokes a model, then confirm the agent spans show up in Sentry.'
+            ),
+          },
+        ],
+      },
+    ];
   }
 
   // On Cloudflare these SDKs only produce spans through the wrapped client shown
@@ -813,7 +910,7 @@ export const agentMonitoring = ({
   introduction: params => (
     <SdkUpdateAlert
       projectId={params.project.id}
-      minVersion={minVersion}
+      minVersion={getMinRequiredVersion(params, minVersion)}
       packageName={packageName}
     />
   ),
@@ -829,6 +926,10 @@ export const agentMonitoring = ({
       return getManualConfigureStep(params, {
         packageName,
       });
+    }
+
+    if (selected === AgentIntegration.CLOUDFLARE_AGENTS) {
+      return getCloudflareAgentsConfigureStep(params);
     }
 
     return getConfigureStep({

--- a/static/app/gettingStartedDocs/node/agentMonitoring.tsx
+++ b/static/app/gettingStartedDocs/node/agentMonitoring.tsx
@@ -49,7 +49,7 @@ export function getDeploymentTarget(params: DocsParams): DeploymentTarget {
  * The minimum SDK version required for the selected integration. Most SDKs share
  * MIN_REQUIRED_VERSION, but the Cloudflare Agents SDK needs a newer release.
  */
-function getMinRequiredVersion(params: DocsParams, fallback: string): string {
+export function getMinRequiredVersion(params: DocsParams, fallback: string): string {
   return getAgentIntegration(params) === AgentIntegration.CLOUDFLARE_AGENTS
     ? CLOUDFLARE_AGENTS_MIN_VERSION
     : fallback;

--- a/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
+++ b/static/app/views/insights/pages/agents/utils/agentIntegrations.tsx
@@ -12,6 +12,8 @@ export enum AgentIntegration {
   // Cloudflare-only: the Workers AI binding (env.AI) auto-instruments once the
   // Worker is wrapped with Sentry.
   WORKERS_AI = 'workers_ai',
+  // Cloudflare-only: the Agents SDK, instrumented via instrumentAgentWithSentry.
+  CLOUDFLARE_AGENTS = 'cloudflare_agents',
   MANUAL = 'manual',
 }
 
@@ -27,6 +29,7 @@ export const AGENT_INTEGRATION_LABELS = {
   [AgentIntegration.PYDANTIC_AI]: 'Pydantic AI',
   [AgentIntegration.VERCEL_AI]: 'Vercel AI SDK',
   [AgentIntegration.WORKERS_AI]: 'Workers AI',
+  [AgentIntegration.CLOUDFLARE_AGENTS]: 'Cloudflare Agents SDK',
   [AgentIntegration.MANUAL]: 'Other',
 };
 
@@ -42,6 +45,7 @@ export const AGENT_INTEGRATION_ICONS: Record<AgentIntegration, string> = {
   [AgentIntegration.PYDANTIC_AI]: 'pydantic-ai',
   [AgentIntegration.VERCEL_AI]: 'vercel',
   [AgentIntegration.WORKERS_AI]: 'cloudflare',
+  [AgentIntegration.CLOUDFLARE_AGENTS]: 'cloudflare',
   [AgentIntegration.MANUAL]: 'default',
 };
 
@@ -66,6 +70,7 @@ export const PYTHON_AGENT_INTEGRATIONS = [
 export const NODE_AGENT_INTEGRATIONS = [
   AgentIntegration.VERCEL_AI,
   AgentIntegration.WORKERS_AI,
+  AgentIntegration.CLOUDFLARE_AGENTS,
   AgentIntegration.ANTHROPIC,
   AgentIntegration.GOOGLE_GENAI,
   AgentIntegration.LANGCHAIN,
@@ -108,6 +113,7 @@ export const DEPLOYMENT_TARGET_ICONS: Record<DeploymentTarget, string> = {
  * than the runtime filtering which SDKs are shown.
  *
  * - Workers AI is the Cloudflare Workers AI binding (env.AI), Cloudflare-only.
+ * - The Cloudflare Agents SDK runs only on the Cloudflare runtime.
  * - Mastra's `@mastra/sentry` exporter is not part of the Cloudflare `withSentry`
  *   flow, so it is Node-only.
  *
@@ -117,6 +123,7 @@ const INTEGRATION_DEPLOYMENT_TARGETS: Partial<
   Record<AgentIntegration, DeploymentTarget>
 > = {
   [AgentIntegration.WORKERS_AI]: DeploymentTarget.CLOUDFLARE,
+  [AgentIntegration.CLOUDFLARE_AGENTS]: DeploymentTarget.CLOUDFLARE,
   [AgentIntegration.MASTRA]: DeploymentTarget.NODE,
 };
 


### PR DESCRIPTION
Surfaces the Cloudflare Agents SDK as a selectable integration in the conversations and agent monitoring onboarding empty states, so Cloudflare users get setup instructions tailored to it rather than the generic flow.

The Agents SDK is instrumented by wrapping the agent class with `instrumentAgentWithSentry`, a different entry point than the `withSentry`/`Sentry.init` flows the onboarding already covers. Selecting it pins the deployment runtime to Cloudflare (like Workers AI) and raises the minimum SDK version to 10.69.0, where the helper was introduced.

Part of TET-2937, which covers Eve, Flue, and the Agents SDK; this is the Agents SDK slice only. Eve and Flue land separately.

Closes TET-2937