### PR TITLE
fix: seerBadge tooltip

### DIFF
--- a/static/app/views/issueDetails/header/seerBadge.tsx
+++ b/static/app/views/issueDetails/header/seerBadge.tsx
@@ -1,6 +1,7 @@
-import styled from '@emotion/styled';
+import {Fragment} from 'react';
 
-import {Tooltip} from '@sentry/scraps/tooltip';
+import {InfoText} from '@sentry/scraps/info';
+import {Flex} from '@sentry/scraps/layout';
 
 import {isIssueQuickFixable} from 'sentry/components/events/autofix/utils';
 import {IconSeer} from 'sentry/icons';
@@ -22,19 +23,14 @@ export function SeerBadge({group}: {group: Group}) {
   }
 
   return (
-    <Tooltip title={t('Seer thinks this issue might be quick to fix')} skipWrapper>
-      <Wrapper>
-        <Divider />
-        <IconSeer size="sm" />
-        {seerFixable && <span>{t('Quick Fix')}</span>}
-      </Wrapper>
-    </Tooltip>
+    <Fragment>
+      <Divider />
+      <InfoText title={t('Seer thinks this issue might be quick to fix')} variant="muted">
+        <Flex align="center" gap="xs">
+          <IconSeer size="sm" />
+          {seerFixable && <span>{t('Quick Fix')}</span>}
+        </Flex>
+      </InfoText>
+    </Fragment>
   );
 }
-
-const Wrapper = styled('div')`
-  display: flex;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-  color: ${p => p.theme.tokens.content.secondary};
-`;

--- a/static/app/views/issueDetails/header/seerBadge.tsx
+++ b/static/app/views/issueDetails/header/seerBadge.tsx
@@ -28,7 +28,7 @@ export function SeerBadge({group}: {group: Group}) {
       <InfoText title={t('Seer thinks this issue might be quick to fix')} variant="muted">
         <Flex align="center" gap="xs">
           <IconSeer size="sm" />
-          {seerFixable && <span>{t('Quick Fix')}</span>}
+          <span>{t('Quick Fix')}</span>
         </Flex>
       </InfoText>
     </Fragment>


### PR DESCRIPTION
This PR fixes two small issues:

1. The spacing between dividers was inconsistent

| before | after |
|--------|--------|
| <img width="1027" height="168" alt="Screenshot 2026-09-04 at 14 39 03" src="https://github.com/user-attachments/assets/27299c00-10fe-42c8-ad75-f1978d7c6859" /> | <img width="1000" height="187" alt="Screenshot 2026-09-04 at 14 39 48" src="https://github.com/user-attachments/assets/c25d9021-98fe-4d51-aa13-b0cfec05bf59" /> | 

2. The tooltip was showing up on the Text, but it was not keyboard interactive and it wasn’t visible that there is a tooltip behind the text. By using `InfoText`, we get a streamlined behavior:

| before | after |
|--------|--------|
| <img width="918" height="161" alt="Screenshot 2026-09-04 at 14 39 07" src="https://github.com/user-attachments/assets/d3f54731-151e-4b86-be84-7257ee6c01ad" /> | <img width="945" height="183" alt="Screenshot 2026-09-04 at 14 39 53" src="https://github.com/user-attachments/assets/b34d7255-2871-4992-8393-9cd85ef84cb9" /> | 