### PR TITLE
feat(forms): make RowLayout responsive

### DIFF
--- a/static/app/components/core/form/layout/index.tsx
+++ b/static/app/components/core/form/layout/index.tsx
@@ -3,7 +3,13 @@ import styled from '@emotion/styled';
 
 import {FieldMeta} from '@sentry/scraps/form/field/meta';
 import {useFieldContext} from '@sentry/scraps/form/formContext';
-import {Container, Flex, Stack, type FlexProps} from '@sentry/scraps/layout';
+import {
+  Container,
+  Flex,
+  Stack,
+  useResponsivePropValue,
+  type FlexProps,
+} from '@sentry/scraps/layout';
 
 interface LayoutProps {
   children: React.ReactNode;
@@ -18,6 +24,12 @@ interface RowLayoutProps extends LayoutProps {
 }
 
 function RowLayout(props: RowLayoutProps) {
+  const isStackLayout = useResponsivePropValue({zero: true, md: false});
+
+  return isStackLayout ? <StackLayout {...props} /> : <RowLayoutContent {...props} />;
+}
+
+function RowLayoutContent(props: RowLayoutProps) {
   const isCompact = props.variant === 'compact';
   const field = useFieldContext();
 

--- a/static/app/components/core/form/layout/index.tsx
+++ b/static/app/components/core/form/layout/index.tsx
@@ -7,6 +7,7 @@ import {
   Container,
   Flex,
   Stack,
+  useHasContainerQuery,
   useResponsivePropValue,
   type FlexProps,
 } from '@sentry/scraps/layout';
@@ -24,7 +25,8 @@ interface RowLayoutProps extends LayoutProps {
 }
 
 function RowLayout(props: RowLayoutProps) {
-  const isStackLayout = useResponsivePropValue({zero: true, md: false});
+  const isStackAtBreakpoint = useResponsivePropValue({zero: true, md: false});
+  const isStackLayout = useHasContainerQuery() && isStackAtBreakpoint;
 
   return isStackLayout ? <StackLayout {...props} /> : <RowLayoutContent {...props} />;
 }


### PR DESCRIPTION
`RowLayout` will now automatically collapse into a `StackLayout` on smaller containers:


https://github.com/user-attachments/assets/344b154d-28fe-49ba-9431-50b455665376

