### PR TITLE
fix(issues): Cap page size on full=true event and hash listings

### DIFF
--- a/src/sentry/api/serializers/models/event.py
+++ b/src/sentry/api/serializers/models/event.py
@@ -45,6 +45,9 @@ SQL_DOUBLEQUOTES_REGEX = re.compile(r"\"([a-zA-Z0-9_]+?)\"")
 MAX_SQL_FORMAT_OPS = 20
 MAX_SQL_FORMAT_LENGTH = 1500
 
+# Page-size ceiling for endpoints that serialize a full event body per row (full=true).
+FULL_PAYLOAD_MAX_PER_PAGE = 10
+
 
 class EventTagOptional(TypedDict, total=False):
     query: str

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -962,7 +962,7 @@ class EventParams:
         name="full",
         type=OpenApiTypes.BOOL,
         location=OpenApiParameter.QUERY,
-        description="Specify true to include the full event body, including the stacktrace, in the event payload.",
+        description="Specify true to include the full event body, including the stacktrace, in the event payload. When true, the page size is capped at 10.",
         required=False,
         default=False,
     )

--- a/src/sentry/issues/endpoints/group_events.py
+++ b/src/sentry/issues/endpoints/group_events.py
@@ -19,7 +19,10 @@ from sentry.api.helpers.environments import get_environments
 from sentry.api.helpers.events import get_direct_hit_response, run_group_events_query
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
-from sentry.api.serializers.models.event import SimpleEventSerializerResponse
+from sentry.api.serializers.models.event import (
+    FULL_PAYLOAD_MAX_PER_PAGE,
+    SimpleEventSerializerResponse,
+)
 from sentry.api.utils import get_date_range_from_params, handle_query_errors
 from sentry.apidocs.constants import (
     RESPONSE_BAD_REQUEST,
@@ -56,9 +59,6 @@ class NoResults(Exception):
 
 class GroupEventsError(Exception):
     pass
-
-
-FULL_PAYLOAD_MAX_PER_PAGE = 10
 
 
 @extend_schema(tags=["Events"])

--- a/src/sentry/issues/endpoints/group_hashes.py
+++ b/src/sentry/issues/endpoints/group_hashes.py
@@ -15,6 +15,7 @@ from sentry.api.helpers.deprecation import deprecated
 from sentry.api.paginator import GenericOffsetPaginator
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
 from sentry.api.serializers.models.event import (
+    FULL_PAYLOAD_MAX_PER_PAGE,
     EventSerializerResponse,
     SimpleEventSerializerResponse,
 )
@@ -53,6 +54,14 @@ class GroupHashesEndpoint(GroupEndpoint):
         "PUT": ApiPublishStatus.PRIVATE,
         "GET": ApiPublishStatus.PUBLIC,
     }
+
+    def get_per_page(
+        self, request: Request, default_per_page: int | None = None, max_per_page: int | None = None
+    ) -> int:
+        per_page = super().get_per_page(request, default_per_page, max_per_page)
+        if request.GET.get("full") not in ("0", "false"):
+            return min(per_page, FULL_PAYLOAD_MAX_PER_PAGE)
+        return per_page
 
     @extend_schema(
         operation_id="listOrganizationIssueHashes",

--- a/src/sentry/issues/endpoints/group_hashes.py
+++ b/src/sentry/issues/endpoints/group_hashes.py
@@ -78,7 +78,7 @@ class GroupHashesEndpoint(GroupEndpoint):
                 location=OpenApiParameter.QUERY,
                 required=False,
                 default=True,
-                description="Specify true to include the full event body, including the stacktrace, in the event payload.",
+                description="Specify true to include the full event body, including the stacktrace, in the event payload. When true, the page size is capped at 10.",
             ),
             CursorQueryParam,
         ],

--- a/src/sentry/issues/endpoints/project_events.py
+++ b/src/sentry/issues/endpoints/project_events.py
@@ -12,7 +12,10 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.project import ProjectEndpoint
 from sentry.api.serializers import EventSerializer, SimpleEventSerializer, serialize
-from sentry.api.serializers.models.event import SimpleEventSerializerResponse
+from sentry.api.serializers.models.event import (
+    FULL_PAYLOAD_MAX_PER_PAGE,
+    SimpleEventSerializerResponse,
+)
 from sentry.api.utils import get_date_range_from_params
 from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
 from sentry.apidocs.examples.event_examples import EventExamples
@@ -43,6 +46,14 @@ class ProjectEventsEndpoint(ProjectEndpoint):
             }
         }
     )
+
+    def get_per_page(
+        self, request: Request, default_per_page: int | None = None, max_per_page: int | None = None
+    ) -> int:
+        per_page = super().get_per_page(request, default_per_page, max_per_page)
+        if request.GET.get("full") in ("1", "true"):
+            return min(per_page, FULL_PAYLOAD_MAX_PER_PAGE)
+        return per_page
 
     @extend_schema(
         operation_id="listProjectEvents",

--- a/tests/sentry/issues/endpoints/test_group_events.py
+++ b/tests/sentry/issues/endpoints/test_group_events.py
@@ -6,7 +6,7 @@ from rest_framework.response import Response
 from urllib3.connectionpool import ConnectionPool
 from urllib3.exceptions import ReadTimeoutError
 
-from sentry.issues.endpoints.group_events import FULL_PAYLOAD_MAX_PER_PAGE
+from sentry.api.serializers.models.event import FULL_PAYLOAD_MAX_PER_PAGE
 from sentry.issues.grouptype import ProfileFileIOGroupType
 from sentry.models.group import Group
 from sentry.search.eap.occurrences.rollout_utils import EAP_OCCURRENCES_SHOULD_RUN_EXPERIMENT_OPTION

--- a/tests/sentry/issues/endpoints/test_group_hashes.py
+++ b/tests/sentry/issues/endpoints/test_group_hashes.py
@@ -1,7 +1,11 @@
 from unittest.mock import patch
 from urllib.parse import urlencode
 
+from django.test import RequestFactory
+
+from sentry.api.serializers.models.event import FULL_PAYLOAD_MAX_PER_PAGE
 from sentry.eventstream.snuba import SnubaEventStream
+from sentry.issues.endpoints.group_hashes import GroupHashesEndpoint
 from sentry.models.grouphash import GroupHash
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
@@ -174,6 +178,20 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
         response = self.client.get(f"{url}?full=false", format="json")
         assert response.status_code == 200, response.content
         assert "entries" not in response.data[0]["latestEvent"]
+
+    def test_per_page_clamped_when_full(self) -> None:
+        endpoint = GroupHashesEndpoint()
+
+        # full defaults to true on this endpoint, so an unqualified request clamps
+        assert endpoint.get_per_page(RequestFactory().get("/")) == FULL_PAYLOAD_MAX_PER_PAGE
+        assert (
+            endpoint.get_per_page(RequestFactory().get("/?per_page=100"))
+            == FULL_PAYLOAD_MAX_PER_PAGE
+        )
+        # a smaller explicit page is honored
+        assert endpoint.get_per_page(RequestFactory().get("/?per_page=5")) == 5
+        # opting out of full removes the clamp
+        assert endpoint.get_per_page(RequestFactory().get("/?full=false&per_page=100")) == 100
 
     def test_unmerge(self) -> None:
         self.login_as(user=self.user)

--- a/tests/sentry/issues/endpoints/test_group_hashes.py
+++ b/tests/sentry/issues/endpoints/test_group_hashes.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 from urllib.parse import urlencode
 
 from django.test import RequestFactory
+from rest_framework.request import Request
 
 from sentry.api.serializers.models.event import FULL_PAYLOAD_MAX_PER_PAGE
 from sentry.eventstream.snuba import SnubaEventStream
@@ -182,16 +183,16 @@ class GroupHashesTest(APITestCase, SnubaTestCase):
     def test_per_page_clamped_when_full(self) -> None:
         endpoint = GroupHashesEndpoint()
 
+        def req(path: str) -> Request:
+            return Request(RequestFactory().get(path))
+
         # full defaults to true on this endpoint, so an unqualified request clamps
-        assert endpoint.get_per_page(RequestFactory().get("/")) == FULL_PAYLOAD_MAX_PER_PAGE
-        assert (
-            endpoint.get_per_page(RequestFactory().get("/?per_page=100"))
-            == FULL_PAYLOAD_MAX_PER_PAGE
-        )
+        assert endpoint.get_per_page(req("/")) == FULL_PAYLOAD_MAX_PER_PAGE
+        assert endpoint.get_per_page(req("/?per_page=100")) == FULL_PAYLOAD_MAX_PER_PAGE
         # a smaller explicit page is honored
-        assert endpoint.get_per_page(RequestFactory().get("/?per_page=5")) == 5
+        assert endpoint.get_per_page(req("/?per_page=5")) == 5
         # opting out of full removes the clamp
-        assert endpoint.get_per_page(RequestFactory().get("/?full=false&per_page=100")) == 100
+        assert endpoint.get_per_page(req("/?full=false&per_page=100")) == 100
 
     def test_unmerge(self) -> None:
         self.login_as(user=self.user)

--- a/tests/snuba/api/endpoints/test_project_events.py
+++ b/tests/snuba/api/endpoints/test_project_events.py
@@ -1,5 +1,6 @@
 from django.urls import reverse
 
+from sentry.api.serializers.models.event import FULL_PAYLOAD_MAX_PER_PAGE
 from sentry.testutils.cases import APITestCase, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now
 
@@ -258,6 +259,57 @@ class ProjectEventsTest(APITestCase, SnubaTestCase):
         response = self.client.get(url, {"full": "false"}, format="json")
         assert response.status_code == 200, response.content
         assert "entries" not in response.data[0]
+
+    def test_full_clamps_per_page(self) -> None:
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        for i in range(FULL_PAYLOAD_MAX_PER_PAGE + 5):
+            self.store_event(
+                data={"event_id": f"{i:032x}", "timestamp": before_now(minutes=1).isoformat()},
+                project_id=project.id,
+            )
+
+        url = reverse(
+            "sentry-api-0-project-events",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+
+        response = self.client.get(url, {"full": "true", "per_page": "100"}, format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data) == FULL_PAYLOAD_MAX_PER_PAGE
+        assert "entries" in response.data[0]
+
+        # a large per_page is clamped, not rejected
+        assert (
+            self.client.get(url, {"full": "1", "per_page": "100"}, format="json").status_code == 200
+        )
+
+    def test_per_page_not_clamped_without_full(self) -> None:
+        self.login_as(user=self.user)
+
+        project = self.create_project()
+        total = FULL_PAYLOAD_MAX_PER_PAGE + 5
+        for i in range(total):
+            self.store_event(
+                data={"event_id": f"{i:032x}", "timestamp": before_now(minutes=1).isoformat()},
+                project_id=project.id,
+            )
+
+        url = reverse(
+            "sentry-api-0-project-events",
+            kwargs={
+                "organization_id_or_slug": project.organization.slug,
+                "project_id_or_slug": project.slug,
+            },
+        )
+
+        response = self.client.get(url, {"per_page": "100"}, format="json")
+        assert response.status_code == 200, response.content
+        assert len(response.data) == total
 
     def test_sample(self) -> None:
         self.login_as(user=self.user)


### PR DESCRIPTION
`full=true` serializes a complete event body per row with `EventSerializer`, so the cost of a page scales with the frames inside the events, not the row count. `per_page` counts rows and defaults to 100 — a poor fit for native events, whose bodies can be very large, where a single page can reach hundreds of megabytes and take a long time to build.

#122718 clamped this on `GroupEventsEndpoint`. The same pattern lives on two endpoints that were missed:

- `ProjectEventsEndpoint` — `full` opt-in, project-scoped (so the page can pull heavy events from anywhere in the project).
- `GroupHashesEndpoint` — `full` **defaults to true**, and each row already serializes a full `latestEvent`.

This moves the shared cap out of `group_events` and into the event serializer module — next to `EventSerializer`, the thing that makes `full` expensive and which all three endpoints already import from — then applies the same `get_per_page` override on all three.

Cursors are unaffected (`GenericOffsetPaginator` encodes only the offset), so callers still page through the whole set; the page is just smaller. Because `full` defaults to true on `GroupHashesEndpoint`, this lowers its default page size for every caller, not only opt-in ones — that is the one behavior change worth a careful look.

The cap is denominated in rows, so a single very large event still costs what it costs; bounding an individual event body is a separate change.

Fixes VULN-2870
Refs VULN-2871