### PR TITLE
fix(utils): decode negative base32 numbers correctly

### DIFF
--- a/src/sentry/utils/numbers.py
+++ b/src/sentry/utils/numbers.py
@@ -30,7 +30,7 @@ def _decode(number: str, alphabet: str) -> int:
 
     if number[:1] == "-":
         inverse = True
-        number = number[:1]
+        number = number[1:]
 
     base = len(alphabet)
     for symbol in number:

--- a/tests/sentry/utils/test_numbers.py
+++ b/tests/sentry/utils/test_numbers.py
@@ -278,6 +278,14 @@ def test_base32() -> None:
     assert [base32_decode(base32_encode(x)) for x in range(128)] == list(range(128))
 
 
+def test_base32_negative_round_trip() -> None:
+    for x in [-1, -31, -32, -123, -99999, -1000000]:
+        assert base32_decode(base32_encode(x)) == x
+
+    assert base32_encode(-1) == "-1"
+    assert base32_encode(0) == "0"
+
+
 def test_format_bytes() -> None:
     assert format_bytes(50) == "50 B"
     assert format_bytes(1024) == "1.00 KB"


### PR DESCRIPTION
## Summary

`sentry.utils.numbers._decode` kept the leading `-` sign character (`number = number[:1]`) instead of stripping it (`number[1:]`). As a result `alphabet.index('-')` raised `ValueError: substring not found`, and `base32_decode` could not round-trip any negative value produced by `base32_encode` (e.g. `base32_decode(base32_encode(-123))` crashed).

This changes the slice to strip the sign before decoding, and adds a regression test covering negative round-trips (`[-1, -31, -32, -123, -99999, -1000000]`) plus the sign/zero edge cases. `base36` decoding is unaffected (it uses `int(s, 36)`).

## Commits (tiny & atomic)
- `fix(utils): strip leading '-' when decoding negative base32 numbers`  one-line fix in `src/sentry/utils/numbers.py` (1 insertion, 1 deletion)
- `test(utils): cover negative base32 round-trip decoding`  adds `test_base32_negative_round_trip` in `tests/sentry/utils/test_numbers.py` (+8 lines)

## Testing (local CI)
- `ruff check --force-exclude`  all checks passed
- `ruff format --check --force-exclude`  both files already formatted
- `flake8 --select=S` (Sentry local security S-rules)  clean
- `pytest tests/sentry/utils/test_numbers.py`  5 passed
- Regression proof: reverting the one-line fix makes exactly `test_base32_negative_round_trip` fail with the original `ValueError`, while the other 4 tests still pass.