### PR TITLE
feat: Add schema-validated apiOptions.schema() system for frontend api requests

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -34,6 +34,9 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:create", SystemFeature, FeatureHandlerStrategy.INTERNAL, default=True)
     # Controls whether or not the relocation endpoints can be used.
     manager.add("relocation:enabled", SystemFeature, FeatureHandlerStrategy.INTERNAL)
+    # Default for whether the frontend surfaces API responses that fail their zod schema as
+    # query errors. Off means those responses are still validated and reported, but returned.
+    manager.add("system:api-schema-strict", SystemFeature, FeatureHandlerStrategy.INTERNAL)
 
     # Organization scoped features that are in development or in customer trials. #
     ###############################################################################
@@ -223,6 +226,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:api-fetch-v2", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     # Enable derivation of the `client_kind` API-usage attribute.
     manager.add("organizations:api-client-kind-check", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=False)
+    # Opt an organization into strict frontend API schema validation ahead of the system default.
+    manager.add("organizations:api-schema-strict", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, default=False, api_expose=True)
     manager.add("organizations:sourcemap-issue-detection", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable profiling
     manager.add("organizations:profiling", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)

--- a/src/sentry/web/client_config.py
+++ b/src/sentry/web/client_config.py
@@ -229,6 +229,8 @@ class _ClientConfig:
             yield "relocation:enabled"
         if features.has("system:multi-region"):
             yield "system:multi-region"
+        if features.has("system:api-schema-strict"):
+            yield "system:api-schema-strict"
         if self.last_org and features.has(
             "organizations:api-fetch-v2", self.last_org, actor=self.user
         ):

--- a/static/app/utils/api/apiOptions.spec.tsx
+++ b/static/app/utils/api/apiOptions.spec.tsx
@@ -1,11 +1,16 @@
 /** @jest-environment jsdom */
-import {skipToken, useQuery} from '@tanstack/react-query';
+import {skipToken, useInfiniteQuery, useQuery} from '@tanstack/react-query';
 import {expectTypeOf} from 'expect-type';
+import {z} from 'zod';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
-import {apiOptions} from 'sentry/utils/api/apiOptions';
+import {
+  ApiSchemaValidationError,
+  apiOptions,
+  selectJsonWithHeaders,
+} from 'sentry/utils/api/apiOptions';
 import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
 
 type Promisable<T> = T | Promise<T>;
@@ -121,6 +126,22 @@ describe('apiOptions', () => {
 
   it('should extract content data per default', async () => {
     const options = apiOptions.as<string[]>()('/projects/', {
+      staleTime: 0,
+    });
+
+    MockApiClient.addMockResponse({
+      url: '/projects/',
+      body: ['Project 1', 'Project 2'],
+    });
+
+    const {result} = renderHookWithProviders(() => useQuery(options));
+    await waitFor(() => expect(result.current.isPending).toBe(false));
+
+    expect(result.current.data).toEqual(['Project 1', 'Project 2']);
+  });
+
+  it('should validate content data per default', async () => {
+    const options = apiOptions.schema(z.array(z.string()), '/projects/', {
       staleTime: 0,
     });
 
@@ -268,6 +289,164 @@ describe('apiOptions', () => {
       });
 
       expectTypeOf(options.select).returns.toEqualTypeOf<number>();
+    });
+  });
+
+  describe('schema', () => {
+    const ProjectSchema = z.object({
+      id: z.string(),
+      dateCreated: z.string().transform(value => new Date(value)),
+    });
+
+    it('should apply schema transforms to the returned data', async () => {
+      const options = apiOptions.schema(z.array(ProjectSchema), '/projects/', {
+        staleTime: 0,
+      });
+
+      MockApiClient.addMockResponse({
+        url: '/projects/',
+        body: [{id: '1', dateCreated: '2024-01-01T00:00:00Z'}],
+      });
+
+      const {result} = renderHookWithProviders(() => useQuery(options));
+      await waitFor(() => expect(result.current.isPending).toBe(false));
+
+      expect(result.current.data).toEqual([
+        {id: '1', dateCreated: new Date('2024-01-01T00:00:00Z')},
+      ]);
+    });
+
+    it('should fail the query when the body does not match the schema', async () => {
+      const options = apiOptions.schema(z.array(ProjectSchema), '/projects/', {
+        staleTime: 0,
+      });
+
+      MockApiClient.addMockResponse({
+        url: '/projects/',
+        body: [{id: 123}],
+      });
+
+      const {result} = renderHookWithProviders(() => useQuery(options));
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      expect(result.current.error).toBeInstanceOf(ApiSchemaValidationError);
+      expect(result.current.error?.message).toBe(
+        'Response from /projects/ did not match the expected schema'
+      );
+      const {result: parseResult} = result.current.error as ApiSchemaValidationError;
+      expect(parseResult.success).toBe(false);
+      expect(parseResult.error).toBeInstanceOf(z.ZodError);
+      expect(parseResult.error.issues).toEqual([
+        expect.objectContaining({path: [0, 'id'], expected: 'string'}),
+        expect.objectContaining({path: [0, 'dateCreated'], expected: 'string'}),
+      ]);
+    });
+
+    it('should expose the error chain and the unvalidated body on the error', async () => {
+      const invalidBody = [{id: 123, dateCreated: null}];
+
+      MockApiClient.addMockResponse({
+        url: '/projects/',
+        body: invalidBody,
+        headers: {Link: 'my-link'},
+      });
+
+      const {result} = renderHookWithProviders(() =>
+        useQuery(apiOptions.schema(z.array(ProjectSchema), '/projects/', {staleTime: 0}))
+      );
+      await waitFor(() => expect(result.current.isError).toBe(true));
+
+      const error = result.current.error as ApiSchemaValidationError;
+
+      expect(error.cause).toBeInstanceOf(z.ZodError);
+      expect(error.cause).toBe(error.result.error);
+      expect(error.cause.issues).toHaveLength(2);
+
+      // A caller that wants to press on can read the body that failed validation
+      expect(error.response.json).toEqual(invalidBody);
+      expect(error.response.headers.Link).toBe('my-link');
+    });
+
+    it('should validate the body but keep the headers when selecting both', async () => {
+      MockApiClient.addMockResponse({
+        url: '/projects/',
+        body: [{id: '1', dateCreated: '2024-01-01T00:00:00Z'}],
+        headers: {Link: 'my-link'},
+      });
+
+      const {result} = renderHookWithProviders(() =>
+        useQuery({
+          ...apiOptions.schema(z.array(ProjectSchema), '/projects/', {staleTime: 0}),
+          select: selectJsonWithHeaders,
+        })
+      );
+      await waitFor(() => expect(result.current.isPending).toBe(false));
+
+      expect(result.current.data?.json).toEqual([
+        {id: '1', dateCreated: new Date('2024-01-01T00:00:00Z')},
+      ]);
+      expect(result.current.data?.headers.Link).toBe('my-link');
+    });
+
+    it('should allow skipToken as path', () => {
+      function getOptions(tokenId: string | null) {
+        return apiOptions.schema(z.object({id: z.string()}), '/api-tokens/$tokenId/', {
+          staleTime: 0,
+          path: tokenId ? {tokenId} : skipToken,
+        });
+      }
+
+      expect(getOptions('123').queryFn).toEqual(expect.any(Function));
+      expect(getOptions(null).queryFn).toEqual(skipToken);
+      expect(getOptions(null).enabled).toBe(false);
+    });
+
+    it('should validate each page of an infinite query', async () => {
+      const options = apiOptions.schemaInfinite(z.array(ProjectSchema), '/projects/', {
+        staleTime: 0,
+      });
+
+      MockApiClient.addMockResponse({
+        url: '/projects/',
+        body: [{id: '1', dateCreated: '2024-01-01T00:00:00Z'}],
+      });
+
+      const {result} = renderHookWithProviders(() => useInfiniteQuery(options));
+      await waitFor(() => expect(result.current.isPending).toBe(false));
+
+      expect(result.current.data?.pages[0]?.json).toEqual([
+        {id: '1', dateCreated: new Date('2024-01-01T00:00:00Z')},
+      ]);
+    });
+
+    describe('types', () => {
+      it('should derive the data type from the schema output', () => {
+        const options = apiOptions.schema(ProjectSchema, '/api-tokens/$tokenId/', {
+          staleTime: 0,
+          path: {tokenId: 123},
+        });
+
+        expectTypeOf(options.select).returns.toEqualTypeOf<{
+          dateCreated: Date;
+          id: string;
+        }>();
+      });
+
+      it('should still enforce staleTime and path params', () => {
+        const schema = z.object({id: z.string()});
+
+        // @ts-expect-error staleTime is required
+        apiOptions.schema(schema, '/projects/', {});
+
+        expect(() => {
+          apiOptions.schema(
+            schema,
+            '/api-tokens/$tokenId/',
+            // @ts-expect-error Missing required path parameter
+            {staleTime: 0, path: {}}
+          );
+        }).toThrow('Missing path param: tokenId');
+      });
     });
   });
 });

--- a/static/app/utils/api/apiOptions.spec.tsx
+++ b/static/app/utils/api/apiOptions.spec.tsx
@@ -1,10 +1,14 @@
+import * as Sentry from '@sentry/react';
 /** @jest-environment jsdom */
 import {skipToken, useInfiniteQuery, useQuery} from '@tanstack/react-query';
 import {expectTypeOf} from 'expect-type';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 import {z} from 'zod';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {ConfigStore} from 'sentry/stores/configStore';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {
   ApiSchemaValidationError,
@@ -319,6 +323,7 @@ describe('apiOptions', () => {
     it('should fail the query when the body does not match the schema', async () => {
       const options = apiOptions.schema(z.array(ProjectSchema), '/projects/', {
         staleTime: 0,
+        onInvalid: 'throw',
       });
 
       MockApiClient.addMockResponse({
@@ -352,7 +357,12 @@ describe('apiOptions', () => {
       });
 
       const {result} = renderHookWithProviders(() =>
-        useQuery(apiOptions.schema(z.array(ProjectSchema), '/projects/', {staleTime: 0}))
+        useQuery(
+          apiOptions.schema(z.array(ProjectSchema), '/projects/', {
+            staleTime: 0,
+            onInvalid: 'throw',
+          })
+        )
       );
       await waitFor(() => expect(result.current.isError).toBe(true));
 
@@ -417,6 +427,112 @@ describe('apiOptions', () => {
       expect(result.current.data?.pages[0]?.json).toEqual([
         {id: '1', dateCreated: new Date('2024-01-01T00:00:00Z')},
       ]);
+    });
+
+    describe('onInvalid', () => {
+      const invalidBody = [{id: 123, dateCreated: null}];
+
+      function renderInvalidResponse(onInvalid?: 'throw' | 'passthrough') {
+        MockApiClient.addMockResponse({url: '/projects/', body: invalidBody});
+
+        return renderHookWithProviders(() =>
+          useQuery(
+            apiOptions.schema(z.array(ProjectSchema), '/projects/', {
+              staleTime: 0,
+              onInvalid,
+            })
+          )
+        );
+      }
+
+      beforeEach(() => {
+        ConfigStore.set('features', new Set());
+        OrganizationStore.reset();
+      });
+
+      afterEach(() => {
+        ConfigStore.set('features', new Set());
+        OrganizationStore.reset();
+        jest.restoreAllMocks();
+      });
+
+      it('should default to returning the unvalidated body', async () => {
+        const {result} = renderInvalidResponse();
+        await waitFor(() => expect(result.current.isPending).toBe(false));
+
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toEqual(invalidBody);
+      });
+
+      it('should report to Sentry even when it returns the unvalidated body', async () => {
+        const captureException = jest.spyOn(Sentry, 'captureException');
+
+        const {result} = renderInvalidResponse();
+        await waitFor(() => expect(result.current.isPending).toBe(false));
+
+        expect(captureException).toHaveBeenCalledWith(
+          expect.any(ApiSchemaValidationError)
+        );
+      });
+
+      it('should report to Sentry when it throws', async () => {
+        const captureException = jest.spyOn(Sentry, 'captureException');
+
+        const {result} = renderInvalidResponse('throw');
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(captureException).toHaveBeenCalledWith(
+          expect.any(ApiSchemaValidationError)
+        );
+      });
+
+      it('should throw when the system feature is enabled', async () => {
+        ConfigStore.set('features', new Set(['system:api-schema-strict']));
+
+        const {result} = renderInvalidResponse();
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(result.current.error).toBeInstanceOf(ApiSchemaValidationError);
+      });
+
+      it('should throw when the organization feature is enabled', async () => {
+        OrganizationStore.onUpdate(
+          OrganizationFixture({features: ['api-schema-strict']}),
+          {replace: true}
+        );
+
+        const {result} = renderInvalidResponse();
+        await waitFor(() => expect(result.current.isError).toBe(true));
+
+        expect(result.current.error).toBeInstanceOf(ApiSchemaValidationError);
+      });
+
+      it('should let the call site opt out of a feature that is enabled', async () => {
+        ConfigStore.set('features', new Set(['system:api-schema-strict']));
+        OrganizationStore.onUpdate(
+          OrganizationFixture({features: ['api-schema-strict']}),
+          {replace: true}
+        );
+
+        const {result} = renderInvalidResponse('passthrough');
+        await waitFor(() => expect(result.current.isPending).toBe(false));
+
+        expect(result.current.isError).toBe(false);
+        expect(result.current.data).toEqual(invalidBody);
+      });
+
+      it('should keep onInvalid out of the queryKey', () => {
+        const strict = apiOptions.schema(ProjectSchema, '/projects/', {
+          staleTime: 0,
+          onInvalid: 'throw',
+        });
+        const lenient = apiOptions.schema(ProjectSchema, '/projects/', {
+          staleTime: 0,
+          onInvalid: 'passthrough',
+        });
+
+        expect(strict.queryKey).toEqual(lenient.queryKey);
+      });
     });
 
     describe('types', () => {

--- a/static/app/utils/api/apiOptions.ts
+++ b/static/app/utils/api/apiOptions.ts
@@ -1,14 +1,20 @@
-import type {SkipToken} from '@tanstack/react-query';
+import type {QueryFunctionContext, SkipToken} from '@tanstack/react-query';
 import {infiniteQueryOptions, queryOptions, skipToken} from '@tanstack/react-query';
+import type {z} from 'zod';
 
 import {apiFetch, apiFetchInfinite} from 'sentry/utils/api/apiFetch';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
-import type {QueryKeyEndpointOptions} from 'sentry/utils/api/apiQueryKey';
+import type {
+  ApiQueryKey,
+  InfiniteApiQueryKey,
+  QueryKeyEndpointOptions,
+} from 'sentry/utils/api/apiQueryKey';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import type {ExtractPathParams, OptionalPathParams} from 'sentry/utils/api/getApiUrl';
 import type {KnownGetsentryApiUrls} from 'sentry/utils/api/knownGetsentryApiUrls';
 import type {KnownSentryApiUrls} from 'sentry/utils/api/knownSentryApiUrls.generated';
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
+import type {ParsedHeader} from 'sentry/utils/parseLinkHeader';
 
 type KnownApiUrls = KnownGetsentryApiUrls | KnownSentryApiUrls;
 
@@ -18,7 +24,6 @@ type PathParamOptions<TApiPath extends string> =
   ExtractPathParams<TApiPath> extends never
     ? {path?: never}
     : {path: Record<ExtractPathParams<TApiPath>, string | number> | SkipToken};
-
 function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -110,6 +115,106 @@ function _apiOptionsInfinite<
 }
 
 /**
+ * Thrown when a response body does not match the schema passed to
+ * `apiOptions.schema()`.
+ *
+ * `cause` is the `z.ZodError`, so the standard error chain leads to the
+ * individual issues. `result` is the whole failed `safeParse()` result, and
+ * `response` is the untouched `ApiResponse`, which lets a caller that catches
+ * this error fall back to the unvalidated `response.json`.
+ */
+export class ApiSchemaValidationError extends Error {
+  name = 'ApiSchemaValidationError';
+  cause: z.ZodError;
+  result: z.ZodSafeParseError<unknown>;
+  response: ApiResponse;
+
+  constructor(url: string, result: z.ZodSafeParseError<unknown>, response: ApiResponse) {
+    super(`Response from ${url} did not match the expected schema`);
+    this.cause = result.error;
+    this.result = result;
+    this.response = response;
+  }
+}
+
+function validateResponse<TSchema extends z.ZodType>(
+  schema: TSchema,
+  url: string,
+  response: ApiResponse
+): ApiResponse<z.output<TSchema>> {
+  const result = schema.safeParse(response.json);
+  if (!result.success) {
+    throw new ApiSchemaValidationError(url, result, response);
+  }
+  return {headers: response.headers, json: result.data};
+}
+
+function _apiOptionsSchema<TSchema extends z.ZodType, TApiPath extends KnownApiUrls>(
+  schema: TSchema,
+  path: TApiPath,
+  ...[
+    {staleTime, path: pathParams, ...options},
+  ]: ExtractPathParams<TApiPath> extends never
+    ? [Options & {path?: never}]
+    : [Options & PathParamOptions<TApiPath>]
+) {
+  const url = getApiUrl(path, ...([{path: pathParams}] as OptionalPathParams<TApiPath>));
+  const strippedOptions = stripUndefinedValues(options);
+
+  // The schema is deliberately absent from the queryKey: it is a parsing
+  // concern, not part of the cache identity, and keying on it would give an
+  // inline schema a new identity on every render.
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps
+  return queryOptions({
+    queryKey: [url, strippedOptions, {infinite: false}] as const,
+    queryFn:
+      pathParams === skipToken
+        ? skipToken
+        : async (context: QueryFunctionContext<ApiQueryKey>) =>
+            validateResponse(schema, url, await apiFetch(context)),
+    enabled: pathParams !== skipToken,
+    staleTime,
+    select: selectJson,
+  });
+}
+
+function _apiOptionsSchemaInfinite<
+  TSchema extends z.ZodType,
+  TApiPath extends KnownApiUrls,
+>(
+  schema: TSchema,
+  path: TApiPath,
+  ...[
+    {staleTime, path: pathParams, ...options},
+  ]: ExtractPathParams<TApiPath> extends never
+    ? [Options & {path?: never}]
+    : [Options & PathParamOptions<TApiPath>]
+) {
+  const url = getApiUrl(path, ...([{path: pathParams}] as OptionalPathParams<TApiPath>));
+  const strippedOptions = stripUndefinedValues(options);
+
+  // See the note in `_apiOptionsSchema` about keeping the schema out of the queryKey.
+  // eslint-disable-next-line @tanstack/query/exhaustive-deps
+  return infiniteQueryOptions({
+    queryKey: [url, strippedOptions, {infinite: true}] as const,
+    queryFn:
+      pathParams === skipToken
+        ? skipToken
+        : async (
+            context: QueryFunctionContext<
+              InfiniteApiQueryKey,
+              null | undefined | ParsedHeader
+            >
+          ) => validateResponse(schema, url, await apiFetchInfinite(context)),
+    getPreviousPageParam: parsePageParam('previous'),
+    getNextPageParam: parsePageParam('next'),
+    initialPageParam: undefined,
+    enabled: pathParams !== skipToken,
+    staleTime,
+  });
+}
+
+/**
  * Type-safe factory for TanStack Query options that hit Sentry API endpoints.
  *
  * By default, `select` extracts the JSON body. To also access response headers
@@ -152,6 +257,20 @@ function _apiOptionsInfinite<
  * const items = data?.json ?? [];
  * const pageLinks = data?.headers.Link;
  * ```
+ *
+ * @example Validating the response with a zod schema
+ * ```ts
+ * const ProjectSchema = z.object({id: z.string(), slug: z.string()});
+ *
+ * const query = useQuery(
+ *   apiOptions.schema(
+ *     z.array(ProjectSchema),
+ *     '/organizations/$organizationIdOrSlug/projects/',
+ *     {path: {organizationIdOrSlug: organization.slug}, staleTime: 30_000}
+ *   )
+ * );
+ * // query.data is z.infer<typeof ProjectSchema>[]
+ * ```
  */
 export const apiOptions = {
   as:
@@ -169,4 +288,31 @@ export const apiOptions = {
       options: Options & PathParamOptions<TApiPath>
     ) =>
       _apiOptionsInfinite<TManualData>(path, options as never),
+
+  /**
+   * Like `apiOptions.as()`, but the response body is validated against `schema`
+   * before it enters the query cache. `data` is typed as the schema's output,
+   * so any transforms/defaults/coercions the schema declares are applied.
+   *
+   * A response that fails validation rejects the query with an
+   * `ApiSchemaValidationError`.
+   */
+  schema: <TSchema extends z.ZodType, TApiPath extends KnownApiUrls = KnownApiUrls>(
+    schema: TSchema,
+    path: TApiPath,
+    options: Options & PathParamOptions<TApiPath>
+  ) => _apiOptionsSchema<TSchema, TApiPath>(schema, path, options as never),
+
+  /**
+   * The infinite-query counterpart to `apiOptions.schema()`. Each page is
+   * validated as it is fetched.
+   */
+  schemaInfinite: <
+    TSchema extends z.ZodType,
+    TApiPath extends KnownApiUrls = KnownApiUrls,
+  >(
+    schema: TSchema,
+    path: TApiPath,
+    options: Options & PathParamOptions<TApiPath>
+  ) => _apiOptionsSchemaInfinite<TSchema, TApiPath>(schema, path, options as never),
 };

--- a/static/app/utils/api/apiOptions.ts
+++ b/static/app/utils/api/apiOptions.ts
@@ -1,7 +1,10 @@
+import * as Sentry from '@sentry/react';
 import type {QueryFunctionContext, SkipToken} from '@tanstack/react-query';
 import {infiniteQueryOptions, queryOptions, skipToken} from '@tanstack/react-query';
 import type {z} from 'zod';
 
+import {ConfigStore} from 'sentry/stores/configStore';
+import {OrganizationStore} from 'sentry/stores/organizationStore';
 import {apiFetch, apiFetchInfinite} from 'sentry/utils/api/apiFetch';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import type {
@@ -20,10 +23,19 @@ type KnownApiUrls = KnownGetsentryApiUrls | KnownSentryApiUrls;
 
 type Options = QueryKeyEndpointOptions & {staleTime: number | 'static'};
 
+/**
+ * What to do with a response that fails its schema. Both modes validate and
+ * report to Sentry; only `throw` lets the failure reach the caller.
+ */
+type OnInvalidSchema = 'throw' | 'passthrough';
+
+type SchemaOptions = Options & {onInvalid?: OnInvalidSchema};
+
 type PathParamOptions<TApiPath extends string> =
   ExtractPathParams<TApiPath> extends never
     ? {path?: never}
     : {path: Record<ExtractPathParams<TApiPath>, string | number> | SkipToken};
+
 function isObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === 'object' && !Array.isArray(value);
 }
@@ -137,29 +149,81 @@ export class ApiSchemaValidationError extends Error {
   }
 }
 
-function validateResponse<TSchema extends z.ZodType>(
-  schema: TSchema,
-  url: string,
-  response: ApiResponse
-): ApiResponse<z.output<TSchema>> {
-  const result = schema.safeParse(response.json);
-  if (!result.success) {
-    throw new ApiSchemaValidationError(url, result, response);
+const SYSTEM_STRICT_FEATURE = 'system:api-schema-strict';
+const ORG_STRICT_FEATURE = 'api-schema-strict';
+
+/**
+ * Either flag can escalate to `throw`, neither can relax it. Once a flag is on,
+ * only an explicit call site `onInvalid` can opt back out.
+ */
+function resolveOnInvalid(override: OnInvalidSchema | undefined): OnInvalidSchema {
+  if (override) {
+    return override;
   }
-  return {headers: response.headers, json: result.data};
+
+  const isStrict =
+    ConfigStore.get('features').has(SYSTEM_STRICT_FEATURE) ||
+    OrganizationStore.get().organization?.features.includes(ORG_STRICT_FEATURE);
+
+  return isStrict ? 'throw' : 'passthrough';
+}
+
+/**
+ * Fingerprint on the templated path rather than `error.message`, which contains
+ * the resolved url. Otherwise every organization slug becomes its own issue.
+ */
+function reportInvalidSchema(error: ApiSchemaValidationError, path: string) {
+  Sentry.withScope(scope => {
+    scope.setFingerprint(['api-schema-validation', path]);
+    scope.setTag('api_schema.path', path);
+    scope.setContext('Schema issues', {issues: error.result.error.issues});
+    Sentry.captureException(error);
+  });
+}
+
+/**
+ * Builds the queryFn's response handler. The mode is resolved per fetch rather
+ * than when the options are built, since an organization-scoped flag is not
+ * readable until the organization has loaded.
+ */
+function makeSchemaValidator<TSchema extends z.ZodType>(
+  schema: TSchema,
+  path: string,
+  url: string,
+  onInvalid: OnInvalidSchema | undefined
+) {
+  return (response: ApiResponse): ApiResponse<z.output<TSchema>> => {
+    const result = schema.safeParse(response.json);
+    if (result.success) {
+      return {headers: response.headers, json: result.data};
+    }
+
+    const error = new ApiSchemaValidationError(url, result, response);
+    reportInvalidSchema(error, path);
+
+    if (resolveOnInvalid(onInvalid) === 'throw') {
+      throw error;
+    }
+
+    // Knowingly unsound: the body did not match, and for a schema with
+    // transforms it is not even shaped like the output type. Passthrough trades
+    // that risk for not breaking the page over a schema we are still proving out.
+    return response as ApiResponse<z.output<TSchema>>;
+  };
 }
 
 function _apiOptionsSchema<TSchema extends z.ZodType, TApiPath extends KnownApiUrls>(
   schema: TSchema,
   path: TApiPath,
   ...[
-    {staleTime, path: pathParams, ...options},
+    {staleTime, path: pathParams, onInvalid, ...options},
   ]: ExtractPathParams<TApiPath> extends never
-    ? [Options & {path?: never}]
-    : [Options & PathParamOptions<TApiPath>]
+    ? [SchemaOptions & {path?: never}]
+    : [SchemaOptions & PathParamOptions<TApiPath>]
 ) {
   const url = getApiUrl(path, ...([{path: pathParams}] as OptionalPathParams<TApiPath>));
   const strippedOptions = stripUndefinedValues(options);
+  const validate = makeSchemaValidator(schema, path, url, onInvalid);
 
   // The schema is deliberately absent from the queryKey: it is a parsing
   // concern, not part of the cache identity, and keying on it would give an
@@ -171,7 +235,7 @@ function _apiOptionsSchema<TSchema extends z.ZodType, TApiPath extends KnownApiU
       pathParams === skipToken
         ? skipToken
         : async (context: QueryFunctionContext<ApiQueryKey>) =>
-            validateResponse(schema, url, await apiFetch(context)),
+            validate(await apiFetch(context)),
     enabled: pathParams !== skipToken,
     staleTime,
     select: selectJson,
@@ -185,13 +249,14 @@ function _apiOptionsSchemaInfinite<
   schema: TSchema,
   path: TApiPath,
   ...[
-    {staleTime, path: pathParams, ...options},
+    {staleTime, path: pathParams, onInvalid, ...options},
   ]: ExtractPathParams<TApiPath> extends never
-    ? [Options & {path?: never}]
-    : [Options & PathParamOptions<TApiPath>]
+    ? [SchemaOptions & {path?: never}]
+    : [SchemaOptions & PathParamOptions<TApiPath>]
 ) {
   const url = getApiUrl(path, ...([{path: pathParams}] as OptionalPathParams<TApiPath>));
   const strippedOptions = stripUndefinedValues(options);
+  const validate = makeSchemaValidator(schema, path, url, onInvalid);
 
   // See the note in `_apiOptionsSchema` about keeping the schema out of the queryKey.
   // eslint-disable-next-line @tanstack/query/exhaustive-deps
@@ -205,7 +270,7 @@ function _apiOptionsSchemaInfinite<
               InfiniteApiQueryKey,
               null | undefined | ParsedHeader
             >
-          ) => validateResponse(schema, url, await apiFetchInfinite(context)),
+          ) => validate(await apiFetchInfinite(context)),
     getPreviousPageParam: parsePageParam('previous'),
     getNextPageParam: parsePageParam('next'),
     initialPageParam: undefined,
@@ -294,13 +359,15 @@ export const apiOptions = {
    * before it enters the query cache. `data` is typed as the schema's output,
    * so any transforms/defaults/coercions the schema declares are applied.
    *
-   * A response that fails validation rejects the query with an
-   * `ApiSchemaValidationError`.
+   * A response that fails validation is always reported to Sentry. Whether it
+   * also rejects the query with an `ApiSchemaValidationError` depends on
+   * `onInvalid`, falling back to the `system:api-schema-strict` and
+   * `organizations:api-schema-strict` feature flags.
    */
   schema: <TSchema extends z.ZodType, TApiPath extends KnownApiUrls = KnownApiUrls>(
     schema: TSchema,
     path: TApiPath,
-    options: Options & PathParamOptions<TApiPath>
+    options: SchemaOptions & PathParamOptions<TApiPath>
   ) => _apiOptionsSchema<TSchema, TApiPath>(schema, path, options as never),
 
   /**
@@ -313,6 +380,6 @@ export const apiOptions = {
   >(
     schema: TSchema,
     path: TApiPath,
-    options: Options & PathParamOptions<TApiPath>
+    options: SchemaOptions & PathParamOptions<TApiPath>
   ) => _apiOptionsSchemaInfinite<TSchema, TApiPath>(schema, path, options as never),
 };

--- a/static/app/utils/queryClient.tsx
+++ b/static/app/utils/queryClient.tsx
@@ -11,7 +11,7 @@ import {useQuery} from '@tanstack/react-query';
 import {Client} from 'sentry/api';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {apiFetch} from 'sentry/utils/api/apiFetch';
-import {selectJson} from 'sentry/utils/api/apiOptions';
+import {ApiSchemaValidationError, selectJson} from 'sentry/utils/api/apiOptions';
 import {normalizeQueryKey} from 'sentry/utils/api/apiQueryKey';
 import type {ApiQueryKey, QueryKeyEndpointOptions} from 'sentry/utils/api/apiQueryKey';
 import {RequestError} from 'sentry/utils/requestError/requestError';
@@ -28,6 +28,11 @@ export const DEFAULT_QUERY_CLIENT_CONFIG: QueryClientConfig = {
       retry: (failureCount, err) => {
         // Disable retries for client errors that won't succeed on retry
         if (err instanceof RequestError && nonRetryCodes.has(err.status)) {
+          return false;
+        }
+
+        // A response that doesn't match its schema will not match it on retry
+        if (err instanceof ApiSchemaValidationError) {
           return false;
         }
 

--- a/tests/sentry/web/test_client_config.py
+++ b/tests/sentry/web/test_client_config.py
@@ -157,6 +157,7 @@ def test_client_config_features() -> None:
     assert "features" in result
     assert "organizations:create" in result["features"]
     assert "system:multi-region" not in result["features"]
+    assert "system:api-schema-strict" not in result["features"]
 
     with (
         override_options({"auth.allow-registration": True}),
@@ -164,6 +165,7 @@ def test_client_config_features() -> None:
             {
                 "auth:register": True,
                 "system:multi-region": True,
+                "system:api-schema-strict": True,
             }
         ),
     ):
@@ -172,6 +174,7 @@ def test_client_config_features() -> None:
         assert "features" in result
         assert "system:multi-region" in result["features"]
         assert "auth:register" in result["features"]
+        assert "system:api-schema-strict" in result["features"]
 
 
 @no_silo_test


### PR DESCRIPTION
`apiOptions.schema(schema, path, options)` and `apiOptions.schemaInfinite()` derive the data type
from a zod schema rather than a manual generic, and validate the response body against it.

Validation runs in queryFn rather than select, so the parsed value is what lands in the query
cache. Schema transforms, defaults and coercions therefore apply everywhere the data is read,
including `getQueryData` and `selectJsonWithHeaders`, instead of only at the component call site.

A mismatch rejects the query with an `ApiSchemaValidationError` carrying the `ZodError` as cause,
the full `safeParse` result, and the untouched `ApiResponse`, so a caller that catches it can fall
back to the unvalidated body and its headers rather than losing the response entirely.

A response that fails its zod schema is always reported to Sentry. Three layers now decide
whether it also reaches the caller as a query error, in increasing precedence: the
`system:api-schema-strict` SystemFeature, the `organizations:api-schema-strict` organization
feature, and an `onInvalid` option at the call site.

The default is `passthrough`, which returns the unvalidated body, so schemas can be rolled out
and observed before they are able to break a page. Both flags can only escalate to throwing;
only an explicit onInvalid can opt back out once a flag is on.

System features are not surfaced to the frontend automatically, so the new one is added to the
allowlist in client_config. The mode is resolved per fetch rather than when the options are
built, since the organization feature is not readable until the organization has loaded, and
onInvalid is kept out of the queryKey so toggling it does not fragment the cache.

Reports are fingerprinted on the templated path rather than the resolved url, otherwise every
organization slug would group as its own issue.