### PR TITLE
fix(features): Honor entity handler in `has_for_batch`

### DIFF
--- a/src/sentry/features/manager.py
+++ b/src/sentry/features/manager.py
@@ -21,7 +21,7 @@ from sentry.utils.flag import record_feature_flag
 from sentry.utils.tracing import set_span_data, start_span
 from sentry.utils.types import Dict
 
-from .base import Feature, FeatureHandlerStrategy
+from .base import Feature, FeatureHandlerStrategy, ProjectFeature
 from .exceptions import FeatureNotRegistered
 
 if TYPE_CHECKING:
@@ -57,6 +57,7 @@ class RegisteredFeatureManager:
 
     def __init__(self) -> None:
         self._handler_registry: dict[str, list[FeatureHandler]] = defaultdict(list)
+        self._entity_handler: FeatureHandler | None = None
 
     def add_handler(self, handler: FeatureHandler) -> None:
         """
@@ -98,6 +99,9 @@ class RegisteredFeatureManager:
         """
         Determine if a feature is enabled for a batch of objects.
 
+        Features use the same precedence as ``has``: feature-specific handlers,
+        the entity handler, then the configured default.
+
         This method enables checking a feature for an organization and a collection
         of objects (e.g. projects). Feature handlers for batch checks are expected to
         subclass `features.BatchFeatureHandler` and implement `has_for_batch` or
@@ -111,8 +115,6 @@ class RegisteredFeatureManager:
         The return value is a dictionary with the objects as keys, and each
         value is the result of the feature check on the organization.
 
-        This method *does not* work with the `entity_handler`.
-
         >>> FeatureManager.has_for_batch('projects:feature', organization, [project1, project2], actor=request.user)
         """
 
@@ -122,14 +124,42 @@ class RegisteredFeatureManager:
             result.update(evaluation.decisions)
 
             if evaluation.failed:
+                for project in evaluation.unresolved_projects:
+                    result[project] = False
                 return result
 
+            unresolved_projects = evaluation.unresolved_projects
+            if self._entity_handler and unresolved_projects:
+                is_project_feature = issubclass(self._get_feature_class(name), ProjectFeature)
+                projects = [project for project in objects if project in unresolved_projects]
+                with metrics.timer("features.entity_batch_has", sample_rate=0.01):
+                    entity_results = self._entity_handler.batch_has(
+                        [name],
+                        actor,
+                        projects=projects if is_project_feature else None,
+                        organization=organization,
+                    )
+
+                if entity_results:
+                    for project in projects:
+                        entity_key = (
+                            f"project:{project.id}"
+                            if is_project_feature
+                            else f"organization:{organization.id}"
+                        )
+                        value = entity_results.get(entity_key, {}).get(name)
+                        if value is not None:
+                            result[project] = value
+                            unresolved_projects.remove(project)
+
             default_flag = settings.SENTRY_FEATURES.get(name, False)
-            for project in evaluation.unresolved_projects:
-                result[project] = default_flag
+            for project in unresolved_projects:
+                result[project] = default_flag if default_flag is not None else False
         except Exception as e:
             if in_random_rollout("features.error.capture_rate"):
                 sentry_sdk.capture_exception(e)
+            for project in objects:
+                result.setdefault(project, False)
 
         return result
 
@@ -185,7 +215,6 @@ class FeatureManager(RegisteredFeatureManager):
         self.entity_features: set[str] = set()
         self.exposed_features: set[str] = set()
         self.flagpole_features: set[str] = set()
-        self._entity_handler: FeatureHandler | None = None
 
     def all(
         self, feature_type: type[Feature] = Feature, api_expose_only: bool = False

--- a/tests/sentry/features/test_manager.py
+++ b/tests/sentry/features/test_manager.py
@@ -290,7 +290,7 @@ class FeatureManagerTest(TestCase):
         handler.has_for_batch.side_effect = ValueError("invalid thing")
 
         manager = features.FeatureManager()
-        manager.add("oragnizations:faulty", OrganizationFeature)
+        manager.add("organizations:faulty", OrganizationFeature)
         manager.add_handler(handler)
 
         with (
@@ -298,8 +298,71 @@ class FeatureManagerTest(TestCase):
             override_options({"features.error.capture_rate": 1.0}),
         ):
             res = manager.has_for_batch("organizations:faulty", org, [project])
-            assert res == {}
+            assert res == {project: False}
             assert mock_capture.call_count == 1
+
+    def test_has_for_batch_respects_handler_entity_and_default_precedence(self) -> None:
+        feature_name = "projects:feature"
+        entity_project = self.create_project(organization=self.organization)
+        default_project = self.create_project(organization=self.organization)
+
+        feature_handler = mock.Mock(spec=features.FeatureHandler)
+        feature_handler.features = {feature_name}
+        feature_handler.has_for_batch.return_value = {
+            self.project: True,
+            entity_project: None,
+            default_project: None,
+        }
+
+        entity_handler = mock.Mock(spec=features.FeatureHandler)
+        entity_handler.batch_has.return_value = {
+            f"project:{entity_project.id}": {feature_name: False},
+            f"project:{default_project.id}": {feature_name: None},
+        }
+
+        manager = features.FeatureManager()
+        manager.add(feature_name, ProjectFeature)
+        manager.add_handler(feature_handler)
+        manager.add_entity_handler(entity_handler)
+
+        projects = [self.project, entity_project, default_project]
+        with override_settings(SENTRY_FEATURES={feature_name: True}):
+            result = manager.has_for_batch(
+                feature_name, self.organization, projects, actor=self.user
+            )
+
+        assert result == {
+            self.project: True,
+            entity_project: False,
+            default_project: True,
+        }
+        entity_handler.batch_has.assert_called_once_with(
+            [feature_name],
+            self.user,
+            projects=[entity_project, default_project],
+            organization=self.organization,
+        )
+
+    def test_has_for_batch_uses_organization_entity_result(self) -> None:
+        feature_name = "organizations:feature"
+        other_project = self.create_project(organization=self.organization)
+        projects = [self.project, other_project]
+
+        entity_handler = mock.Mock(spec=features.FeatureHandler)
+        entity_handler.batch_has.return_value = {
+            f"organization:{self.organization.id}": {feature_name: True}
+        }
+
+        manager = features.FeatureManager()
+        manager.add(feature_name, OrganizationFeature)
+        manager.add_entity_handler(entity_handler)
+
+        result = manager.has_for_batch(feature_name, self.organization, projects, actor=self.user)
+
+        assert result == {project: True for project in projects}
+        entity_handler.batch_has.assert_called_once_with(
+            [feature_name], self.user, projects=None, organization=self.organization
+        )
 
     def test_batch_has(self) -> None:
         manager = features.FeatureManager()


### PR DESCRIPTION
Follow up to https://github.com/getsentry/sentry/pull/123181, also have `has_for_batch` respect getsentry -> flagpole (feature handlers -> entity handlers) ordering.