### PR TITLE
fix(issues): align issue graphs with selected time range

### DIFF
--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -350,6 +350,7 @@ describe('IssueList', () => {
           project: '3559',
           query: DEFAULT_QUERY,
           statsPeriod: '14d',
+          groupStatsPeriod: 'auto',
           referrer: 'issue-list',
         });
       });
@@ -368,6 +369,7 @@ describe('IssueList', () => {
           project: '3559',
           query: DEFAULT_QUERY,
           statsPeriod: '14d',
+          groupStatsPeriod: 'auto',
           referrer: 'issue-list',
         });
       });
@@ -382,6 +384,7 @@ describe('IssueList', () => {
           project: '3559',
           query: DEFAULT_QUERY,
           statsPeriod: '14d',
+          groupStatsPeriod: 'auto',
           referrer: 'issue-list',
         });
       });
@@ -515,6 +518,7 @@ describe('IssueList', () => {
           project: project.id.toString(),
           query: 'is:ignored',
           statsPeriod: '14d',
+          groupStatsPeriod: 'auto',
           referrer: 'issue-list',
         });
       });

--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -607,7 +607,7 @@ describe('IssueList', () => {
       });
     });
 
-    it('uses correct statsPeriod when fetching issues list and no datetime given', async () => {
+    it('uses selected statsPeriod for issue list and graphs by default', async () => {
       const {rerender} = render(<IssueListOverview />, {
         initialRouterConfig: merge({}, initialRouterConfig, {
           location: {
@@ -632,7 +632,7 @@ describe('IssueList', () => {
         expect(fetchDataMock).toHaveBeenLastCalledWith(
           '/organizations/org-slug/issues/',
           expect.objectContaining({
-            data: 'collapse=stats&collapse=unhandled&expand=owners&expand=inbox&limit=25&project=99&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&shortIdLookup=1&statsPeriod=14d',
+            data: 'collapse=stats&collapse=unhandled&expand=owners&expand=inbox&groupStatsPeriod=auto&limit=25&project=99&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&shortIdLookup=1&statsPeriod=14d',
           })
         );
       });

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -83,7 +83,7 @@ import {
 
 const MAX_ITEMS = 25;
 // the default period for the graph in each issue row
-const DEFAULT_GRAPH_STATS_PERIOD = '24h';
+const DEFAULT_GRAPH_STATS_PERIOD = 'auto';
 // the allowed period choices for graph in each issue row
 const DYNAMIC_COUNTS_STATS_PERIODS = new Set(['14d', '24h', 'auto']);
 const MAX_ISSUES_COUNT = 100;

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -273,7 +273,7 @@ function IssueListOverviewInner({
     }
 
     const groupStatsPeriod = getGroupStatsPeriod();
-    if (groupStatsPeriod !== DEFAULT_GRAPH_STATS_PERIOD) {
+    if (groupStatsPeriod !== '24h') {
       params.groupStatsPeriod = groupStatsPeriod;
     }
 


### PR DESCRIPTION
## Summary

- default issue-row graph statistics to `auto`, so they follow the selected page time range
- cover the request parameters for a 14-day selection

Fixes #115090

### Testing

- Not run locally (the repository could not be cloned in this environment).

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.