### PR TITLE
ref(hybridcloud): Register webhook worker threads at the deployed value

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2615,7 +2615,7 @@ register(
 
 # Webhook processing controls
 # Most threads a skip-on-failure claim delivers on, bounded by the records it
-# claimed. Strict providers deliver on one thread whatever this says.
+# claimed.
 register(
     "hybridcloud.webhookpayload.worker_threads",
     default=16,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2614,9 +2614,11 @@ register(
 )
 
 # Webhook processing controls
+# Most threads a skip-on-failure claim delivers on, bounded by the records it
+# claimed. Strict providers deliver on one thread whatever this says.
 register(
     "hybridcloud.webhookpayload.worker_threads",
-    default=4,
+    default=16,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 # Remove the rows a claim-bounded drain finishes with — delivered, attempts


### PR DESCRIPTION
`hybridcloud.webhookpayload.worker_threads` caps how many threads a webhook drain delivers on. The code registers `4`; every deployed environment has run `16` since [automator#928](https://github.com/getsentry/sentry-options-automator/pull/928) in March 2024. This registers `16`.

Production is unchanged — the automator value wins, and it is the value being registered. What the mismatch cost: `defaults.py` named a concurrency nobody runs, and the automator entry could not be dropped while `4` was the fallback, since unsetting it would quarter delivery concurrency with no code change.

An environment with no automator entry — self-hosted, or a region that never got one — goes from 4 threads to 16. A drain uses `min(worker_threads, records claimed)` threads, and only for skip-on-failure providers; strict providers deliver on one thread regardless.

The option stays registered: thread count is a real knob, and [#123449](https://github.com/getsentry/sentry/pull/123449) makes it load-bearing in mailbox sizing. Next is the automator dropping four now-redundant entries, all holding `16`, once this has deployed everywhere.

Verification: `tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py` 147 passed, `prek run -q` clean.

Fixes CW-1827
