### PR TITLE
ref(hybridcloud): Collapse the batched-delete and due-head gates

### DIFF
--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -11,7 +11,7 @@ from typing import Any
 import orjson
 import sentry_sdk
 from django.core.cache import cache
-from django.db.models import Case, CharField, Count, Exists, Min, Q, Subquery, Value, When
+from django.db.models import Count, Exists, Min, Q, Subquery
 from django.utils import timezone
 from requests import Response
 from requests.models import HTTPError
@@ -119,9 +119,8 @@ actions that have been made to the relevant resources.
 
 DELETE_BATCH_SIZE = 100
 """
-How many finished rows a batching drain accumulates before removing them. Small
-enough that a crash strands at most this many rows until the claim horizon
-passes.
+How many finished rows a drain accumulates before removing them. Small enough
+that a crash strands at most this many rows until the claim horizon passes.
 """
 
 # Define priorities for different webhook providers
@@ -253,8 +252,6 @@ def _dispatches_from_due_head(mailbox_name: str) -> bool:
     already deliver past failed records, so the head gate only parks every due
     record behind one failure's backoff.
     """
-    if not options.get("hybridcloud.webhookpayload.dispatch_from_due_head"):
-        return False
     provider = _provider_from_mailbox(mailbox_name)
     return provider in (options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ())
 
@@ -416,11 +413,11 @@ class _PayloadDeleter:
     Removes the rows a drain is finished with, whether they were delivered,
     discarded for exhausted attempts, or discarded as stale.
 
-    Batching drains accumulate ids and remove them DELETE_BATCH_SIZE at a time
-    rather than issuing one statement per row, which is most of the write
-    traffic a drain generates on this delete-heavy table. Only the drain thread
-    ever calls a deleter: parallel workers perform requests and hand their
-    results back to the drain loop, so no locking is needed.
+    Ids accumulate and are removed DELETE_BATCH_SIZE at a time rather than one
+    statement per row, which is most of the write traffic a drain generates on
+    this delete-heavy table. Only the drain thread ever calls a deleter:
+    parallel workers perform requests and hand their results back to the drain
+    loop, so no locking is needed.
 
     Batching is safe because every drain is bounded to a claim its dispatcher
     owns: nothing else can touch a row between the drain finishing with it and
@@ -429,15 +426,11 @@ class _PayloadDeleter:
     re-discarding the rest — the same window a claim-then-crash already has.
     """
 
-    def __init__(self, *, batched: bool) -> None:
-        self._batched = batched
+    def __init__(self) -> None:
         self._pending: list[int] = []
 
     def delete(self, payload: WebhookPayload) -> None:
-        """Remove the payload's row, either now or at the next flush."""
-        if not self._batched:
-            payload.delete()
-            return
+        """Hold the payload's row for the next flush."""
         self._pending.append(payload.id)
         if len(self._pending) >= DELETE_BATCH_SIZE:
             self.flush()
@@ -480,7 +473,7 @@ def _claim_mailbox_batch(
     them past the drain deadline. The UPDATE gates on the head still being due, so
     a lost race claims nothing and returns None.
 
-    In due-head mode the claim stops at the first not-due record, which is what
+    For a due-head mailbox the claim stops at the first not-due record, which is what
     keeps concurrent drains apart: an in-flight drain's records carry a future
     schedule_for, so a claim starting behind it ends before its range, and a
     backoff record keeps its backoff.
@@ -599,8 +592,8 @@ def maybe_trigger_drain(mailbox_name: str) -> None:
         if not guard:
             metrics.incr("hybridcloud.deliver_webhooks.push_trigger.skipped", tags=trigger_tags)
             return
-        # Only drain if the mailbox head is ready to deliver. In due-head mode the
-        # head is the oldest due payload, so a failed payload in retry backoff at
+        # Only drain if the mailbox head is ready to deliver. For a due-head mailbox
+        # the head is the oldest due payload, so a failed payload in retry backoff at
         # the front delays only itself. Otherwise the head is the true head
         # (lowest ID), checked specifically — filtering by schedule_for there
         # would skip a claimed or backing-off head and return a later payload,
@@ -633,62 +626,6 @@ def maybe_trigger_drain(mailbox_name: str) -> None:
             _release_drain_lock(mailbox_name)
 
 
-def _gated_mailbox_heads() -> list[dict[str, Any]]:
-    """
-    Head-of-line discovery gated on the absolute mailbox head being due — the
-    ordering guarantee for strict providers, and what keeps a mailbox to one
-    drain at a time since claims always start at the true head.
-    """
-    # The double call to .values() ensures that the group by includes mailbox_name
-    # but only id_min is selected
-    head_of_line = (
-        WebhookPayload.objects.all()
-        .values("mailbox_name")
-        .annotate(id_min=Min("id"))
-        .values("id_min")
-    )
-
-    # Get any heads that are scheduled to run
-    # Use provider field directly, with default priority for null values
-    scheduled_mailboxes = (
-        WebhookPayload.objects.filter(
-            schedule_for__lte=timezone.now(),
-            id__in=Subquery(head_of_line),
-        )
-        # Set priority value based on provider field
-        .annotate(
-            provider_priority=Case(
-                # For providers that match our priority list
-                *[
-                    When(provider=provider, then=Value(priority))
-                    for provider, priority in PROVIDER_PRIORITY.items()
-                ],
-                # Default value for all other cases (including null providers)
-                default=Value(DEFAULT_PROVIDER_PRIORITY),
-                output_field=CharField(),
-            )
-        )
-        # Order by priority first (lowest number = highest priority), then ID
-        .order_by("provider_priority", "id")
-        .values("id", "mailbox_name")
-    )
-
-    records = list(scheduled_mailboxes[:BATCH_SELECT_LIMIT])
-    # The selected batch already answers the metric for every normal cycle. Only
-    # when it fills is the real number unknown, and only then is re-running the
-    # head-of-line discovery worth it -- those wide cycles are the ones worth seeing.
-    # `source` records which branch produced the value, so the share of cycles
-    # still paying for the count query is visible rather than inferred.
-    batch_full = len(records) == BATCH_SELECT_LIMIT
-    mailbox_count = scheduled_mailboxes.count() if batch_full else len(records)
-    metrics.distribution(
-        "hybridcloud.schedule_webhook_delivery.mailbox_count",
-        mailbox_count,
-        tags={"source": "count_query" if batch_full else "batch"},
-    )
-    return records
-
-
 def _record_backlog_depth(due_rows: Mapping[str, int], in_flight_rows: Mapping[str, int]) -> None:
     """
     Report the scanned backlog's depth per provider: due rows await dispatch,
@@ -710,11 +647,10 @@ def _record_backlog_depth(due_rows: Mapping[str, int], in_flight_rows: Mapping[s
 
 def _due_mailbox_heads() -> list[dict[str, Any]]:
     """
-    Discovery for due-head mode: one aggregate pass finds two mailbox records:
-    unconditionally oldest and the oldest due record. Skip-on-failure providers
-    dispatch from the oldest due record; strict providers still require the true
-    head to be due (see `_gated_mailbox_heads`). Provider comes from the mailbox
-    name — the aggregate never fetches rows.
+    One aggregate pass finds two records per mailbox: the unconditionally oldest
+    and the oldest due one. Skip-on-failure providers dispatch from the oldest
+    due record; strict providers still require the true head to be due. Provider
+    comes from the mailbox name — the aggregate never fetches rows.
 
     The same pass counts each mailbox's due and in-flight rows for the per-provider
     backlog metrics; it already visits every row to find the heads.
@@ -861,10 +797,7 @@ def schedule_webhook_delivery() -> None:
         # short interval and can scan the whole table; on a replica they contend with
         # WAL replay and amplify replication lag, and lag also produces spurious
         # DoesNotExist races in the drains they enqueue (see INC-2398).
-        if options.get("hybridcloud.webhookpayload.dispatch_from_due_head"):
-            records = _due_mailbox_heads()
-        else:
-            records = _gated_mailbox_heads()
+        records = _due_mailbox_heads()
     metrics.incr(
         "hybridcloud.schedule_webhook_delivery.cycle",
         tags={"source": "carryover" if carryover else "discovery"},
@@ -1011,7 +944,7 @@ def _drain_mailbox(claim: _MailboxClaim) -> bool:
         worker_threads = max(
             1, min(options.get("hybridcloud.webhookpayload.worker_threads"), len(records))
         )
-    deleter = _PayloadDeleter(batched=options.get("hybridcloud.webhookpayload.drain_batch_deletes"))
+    deleter = _PayloadDeleter()
     pool = _DeliveryPool(
         deleter,
         worker_threads=worker_threads,

--- a/src/sentry/hybridcloud/tasks/deliver_webhooks.py
+++ b/src/sentry/hybridcloud/tasks/deliver_webhooks.py
@@ -126,12 +126,10 @@ that a crash strands at most this many rows until the claim horizon passes.
 # Define priorities for different webhook providers
 # Lower number means higher priority
 #
-# Deliberately unbacked by an index. A matching expression index was tried and went
-# unused: the discovery query below must aggregate every mailbox to find the heads
+# Applied in Python: discovery aggregates every mailbox to find the heads
 # regardless, and sorting that small result beats scanning the table in priority
-# order by orders of magnitude. Such an index also silently stops matching the
-# moment this dict gains an entry, since the two expressions must be textually
-# identical for Postgres to use it.
+# order by orders of magnitude. An expression index for the SQL ordering this
+# replaced was tried and went unused.
 PROVIDER_PRIORITY = {
     "stripe": 1,
 }
@@ -245,6 +243,11 @@ def _is_due(schedule_for: datetime.datetime) -> bool:
     return schedule_for <= timezone.now()
 
 
+def _skip_on_failure_providers() -> frozenset[str]:
+    """Providers whose drains skip a failed record instead of stopping at it."""
+    return frozenset(options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ())
+
+
 def _dispatches_from_due_head(mailbox_name: str) -> bool:
     """
     Whether this mailbox dispatches from its oldest due record instead of gating
@@ -252,8 +255,7 @@ def _dispatches_from_due_head(mailbox_name: str) -> bool:
     already deliver past failed records, so the head gate only parks every due
     record behind one failure's backoff.
     """
-    provider = _provider_from_mailbox(mailbox_name)
-    return provider in (options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ())
+    return _provider_from_mailbox(mailbox_name) in _skip_on_failure_providers()
 
 
 class Dispatcher(enum.StrEnum):
@@ -290,8 +292,7 @@ class _MailboxClaim:
     @property
     def skip_on_failure(self) -> bool:
         """Whether this provider may skip a failed record rather than stop."""
-        allowlist = options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
-        return self.provider in allowlist
+        return self.provider in _skip_on_failure_providers()
 
     @property
     def log_context(self) -> dict[str, Any]:
@@ -662,9 +663,7 @@ def _due_mailbox_heads() -> list[dict[str, Any]]:
         due_count=Count("id", filter=Q(schedule_for__lte=now)),
         in_flight_count=Count("id", filter=Q(schedule_for__gt=now)),
     )
-    skip_on_failure_providers = frozenset(
-        options.get("hybridcloud.webhookpayload.skip_on_failure_providers") or ()
-    )
+    skip_on_failure_providers = _skip_on_failure_providers()
     due_rows: defaultdict[str, int] = defaultdict(int)
     in_flight_rows: defaultdict[str, int] = defaultdict(int)
     heads = []

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -396,10 +396,8 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
     def test_strict_claim_and_dispatch_claims_in_a_single_query(
         self, mock_drain: MagicMock
     ) -> None:
-        # A strict mailbox claims its whole window in one statement: the due-gate
-        # rides in the claim UPDATE's WHERE clause. A separate primary read before
-        # the claim would double the per-mailbox dispatch round trips, so lock in
-        # the single-statement shape.
+        # The due-gate rides in the claim UPDATE's WHERE clause. A separate primary
+        # read before it would double the per-mailbox dispatch round trips.
         webhook = self.create_webhook_payload(
             mailbox_name="jira:123",
             cell_name="us",
@@ -433,9 +431,8 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_due_head_claim_scans_the_prefix_before_claiming(self, mock_drain: MagicMock) -> None:
-        # A due-head mailbox pays one extra read: the claim must stop at the first
-        # record that is not due, which SQL cannot express in the UPDATE's window.
-        # Two statements per dispatch is the shape to hold it to.
+        # The extra read a due-head claim pays: it stops at the first not-due
+        # record, which the UPDATE's window cannot express.
         webhook = self.create_webhook_payload(
             mailbox_name="github:123",
             cell_name="us",
@@ -2723,7 +2720,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             for record in records:
                 pool.submit(record)
             lowest_cancelled = pool.wind_down(reason="deadline")
-            # Deletes are batched, so the rows go with the drain's flush.
+            # Batched deletes land on the flush, as they do in a drain.
             deleter.flush()
 
         assert lowest_cancelled == records[2].id
@@ -2799,7 +2796,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             assert stuck_started.wait(timeout=5)
             assert answered_returned.wait(timeout=5)
             pool.wind_down(reason="deadline")
-            # Deletes are batched, so the answered row goes with the flush.
+            # Batched deletes land on the flush, as they do in a drain.
             deleter.flush()
 
         assert pool.delivered == 1

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -2649,8 +2649,16 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
     @override_cells(cell_config)
     @override_options({"hybridcloud.webhookpayload.worker_threads": 2})
     def test_release_settles_in_flight_requests_before_covering_the_tail(self) -> None:
-        responses.add(
-            responses.POST, "http://us.testserver/extensions/github/webhook/", status=200, body=""
+        # Neither request answers until both have arrived, so "in flight" is a
+        # fact rather than a race against the second worker thread starting.
+        both_in_flight = threading.Barrier(2, timeout=5)
+
+        def answer(request: Any) -> tuple[int, dict[str, str], str]:
+            both_in_flight.wait()
+            return (200, {}, "")
+
+        responses.add_callback(
+            responses.POST, "http://us.testserver/extensions/github/webhook/", callback=answer
         )
         valid_until = timezone.now() + BATCH_SCHEDULE_OFFSET
         records = create_payloads(4, "github:123", provider="github")
@@ -2658,8 +2666,8 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             schedule_for=valid_until
         )
 
-        # The deadline nears once the first two requests are in flight: both must
-        # settle — delivered and deleted — before the tail behind them is released.
+        # The deadline nears once both requests are in flight: both must settle —
+        # delivered and deleted — before the tail behind them is released.
         with patch.object(
             deliver_webhooks._MailboxClaim,
             "nearing_deadline",

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -91,7 +91,6 @@ class MetricCallsMixin:
         return [tags for _, tags in self.distribution_calls(mock_metrics, metric)]
 
 
-DUE_HEAD_OPTIONS = {"hybridcloud.webhookpayload.dispatch_from_due_head": True}
 cell_config_with_gateway = [
     Cell(
         name="us",
@@ -169,26 +168,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_schedule_head_in_backoff_blocks_mailbox(self, mock_deliver: MagicMock) -> None:
-        # The mailbox head (lowest id) is in a backoff window while a later
-        # message is due. The whole mailbox must be skipped — scheduling the
-        # later message would break head-of-line delivery ordering.
-        self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-            schedule_for=timezone.now() + timedelta(minutes=1),
-        )
-        webhook_two = self.create_webhook_payload(
-            mailbox_name="github:123",
-            cell_name="us",
-        )
-        assert webhook_two.schedule_for < timezone.now()
-
-        schedule_webhook_delivery()
-        assert mock_deliver.delay.call_count == 0
-
-    @override_options(DUE_HEAD_OPTIONS)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_schedule_due_head_dispatches_past_backoff_head(self, mock_deliver: MagicMock) -> None:
         # Head in backoff, later message due: due-head mode dispatches the due
         # message instead of gating the mailbox.
@@ -217,7 +196,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         backoff.refresh_from_db()
         assert backoff.schedule_for == backoff_schedule
 
-    @override_options(DUE_HEAD_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_schedule_due_head_strict_provider_still_gated(self, mock_deliver: MagicMock) -> None:
         # Jira is not skip-on-failure, so the head gate still applies.
@@ -235,7 +213,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
         assert mock_deliver.delay.call_count == 0
 
-    @override_options(DUE_HEAD_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_schedule_due_head_claim_stops_at_backoff_record(self, mock_deliver: MagicMock) -> None:
         # A backing-off record bounds the claim; records behind it wait.
@@ -264,7 +241,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         due_two.refresh_from_db()
         assert due_two.schedule_for < timezone.now()
 
-    @override_options(DUE_HEAD_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_schedule_due_head_does_not_reclaim_active_drain(self, mock_deliver: MagicMock) -> None:
         # A backoff expiring behind an in-flight drain's claim must not sweep
@@ -286,7 +262,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
             chain_depth=1,
         )
 
-    @override_options(DUE_HEAD_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_schedule_due_head_nothing_due(self, mock_deliver: MagicMock) -> None:
         self.create_webhook_payload(
@@ -297,7 +272,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         schedule_webhook_delivery()
         assert mock_deliver.delay.call_count == 0
 
-    @override_options(DUE_HEAD_OPTIONS)
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_schedule_due_head_prioritizes_by_provider(self, mock_deliver: MagicMock) -> None:
         github_webhook = self.create_webhook_payload(
@@ -419,12 +393,15 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         assert webhook.schedule_for == claimed_for
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_claim_and_dispatch_claims_in_a_single_query(self, mock_drain: MagicMock) -> None:
-        # The due-gate rides in the claim UPDATE's WHERE clause. A separate
-        # primary read before the claim would double the per-mailbox dispatch
-        # round trips, so lock in the single-statement shape.
+    def test_strict_claim_and_dispatch_claims_in_a_single_query(
+        self, mock_drain: MagicMock
+    ) -> None:
+        # A strict mailbox claims its whole window in one statement: the due-gate
+        # rides in the claim UPDATE's WHERE clause. A separate primary read before
+        # the claim would double the per-mailbox dispatch round trips, so lock in
+        # the single-statement shape.
         webhook = self.create_webhook_payload(
-            mailbox_name="github:123",
+            mailbox_name="jira:123",
             cell_name="us",
         )
 
@@ -453,6 +430,31 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         assert "EXISTS" in queries[0]
         webhook.refresh_from_db()
         assert webhook.schedule_for > timezone.now()
+
+    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
+    def test_due_head_claim_scans_the_prefix_before_claiming(self, mock_drain: MagicMock) -> None:
+        # A due-head mailbox pays one extra read: the claim must stop at the first
+        # record that is not due, which SQL cannot express in the UPDATE's window.
+        # Two statements per dispatch is the shape to hold it to.
+        webhook = self.create_webhook_payload(
+            mailbox_name="github:123",
+            cell_name="us",
+        )
+
+        with CaptureQueriesContext(connections["control"]) as ctx:
+            claim = _claim_and_dispatch(
+                webhook.id, webhook.mailbox_name, dispatcher=Dispatcher.SCHEDULER
+            )
+
+        assert claim is not None
+        assert claim.claimed == 1
+        queries = [
+            q["sql"] for q in ctx.captured_queries if "hybridcloud_webhookpayload" in q["sql"]
+        ]
+        assert len(queries) == 2, queries
+        assert queries[0].startswith("SELECT")
+        assert "UPDATE" in queries[1]
+        assert "EXISTS" in queries[1]
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     @patch(
@@ -689,18 +691,6 @@ class ScheduleCarryoverTest(CarryoverTestBase):
         )
         assert self.distribution_calls(mock_metrics, CARRYOVER_METRIC) == [(1, {})]
 
-    @override_options(DUE_HEAD_OPTIONS)
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_due_head_discovery_carries_its_surplus_too(self, mock_drain: MagicMock) -> None:
-        webhooks = self.create_mailboxes(3)
-
-        schedule_webhook_delivery()
-
-        assert self.dispatched_ids(mock_drain) == [webhooks[0].id, webhooks[1].id]
-        assert self.carryover() == [
-            {"id": webhooks[2].id, "mailbox_name": webhooks[2].mailbox_name}
-        ]
-
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_carried_heads_dispatch_without_discovery(
@@ -710,13 +700,9 @@ class ScheduleCarryoverTest(CarryoverTestBase):
         schedule_webhook_delivery()
         mock_drain.delay.reset_mock()
 
-        with (
-            patch.object(deliver_webhooks, "_gated_mailbox_heads") as mock_gated,
-            patch.object(deliver_webhooks, "_due_mailbox_heads") as mock_due,
-        ):
+        with patch.object(deliver_webhooks, "_due_mailbox_heads") as mock_due:
             schedule_webhook_delivery()
 
-        mock_gated.assert_not_called()
         mock_due.assert_not_called()
         assert self.dispatched_ids(mock_drain) == [webhooks[2].id]
         assert self.tags_for(mock_metrics, CYCLE_METRIC) == [
@@ -731,10 +717,10 @@ class ScheduleCarryoverTest(CarryoverTestBase):
         schedule_webhook_delivery()
         assert self.carryover() is None
 
-        with patch.object(deliver_webhooks, "_gated_mailbox_heads", return_value=[]) as mock_gated:
+        with patch.object(deliver_webhooks, "_due_mailbox_heads", return_value=[]) as mock_due:
             schedule_webhook_delivery()
 
-        mock_gated.assert_called_once()
+        mock_due.assert_called_once()
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.metrics")
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
@@ -1348,7 +1334,6 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
     def test_drain_batch_deletes_delivered_rows(self) -> None:
         url = "http://us.testserver/extensions/github/webhook/"
         responses.add(responses.POST, url, status=200, body="")
@@ -1368,7 +1353,6 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
     def test_drain_batch_deletes_flush_when_drain_stops_on_failure(self) -> None:
         url = "http://us.testserver/extensions/jira/webhook/"
         responses.add(responses.POST, url, status=200, body="")
@@ -1388,7 +1372,6 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
     def test_drain_batch_deletes_discarded_rows(self) -> None:
         # Discards are the other half of a drain's delete traffic, and on a
         # backlogged mailbox the larger half: they must share the batch rather
@@ -1426,7 +1409,6 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
     @patch.object(deliver_webhooks, "DELETE_BATCH_SIZE", 2)
     def test_drain_batch_deletes_are_bounded(self) -> None:
         # A crash strands whatever has not been flushed, so batches must stay
@@ -1447,7 +1429,6 @@ class DrainMailboxTest(MetricCallsMixin, TestCase):
 
     @responses.activate
     @override_cells(cell_config)
-    @override_options({"hybridcloud.webhookpayload.drain_batch_deletes": True})
     def test_drain_batch_deletes_span_concurrent_deliveries(self) -> None:
         # The delete batch belongs to the drain, not to one result: eight
         # concurrent deliveries flush as a single DELETE.
@@ -2730,9 +2711,10 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             time.sleep(0.2)
             return (payload, None)
 
+        deleter = deliver_webhooks._PayloadDeleter()
         with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
             pool = deliver_webhooks._DeliveryPool(
-                deliver_webhooks._PayloadDeleter(batched=False),
+                deleter,
                 worker_threads=2,
                 delivery_tags={**UNATTRIBUTED, "provider": "github"},
                 valid_until=timezone.now() + BATCH_SCHEDULE_OFFSET,
@@ -2741,6 +2723,8 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             for record in records:
                 pool.submit(record)
             lowest_cancelled = pool.wind_down(reason="deadline")
+            # Deletes are batched, so the rows go with the drain's flush.
+            deleter.flush()
 
         assert lowest_cancelled == records[2].id
         assert pool.delivered == 2
@@ -2762,7 +2746,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
 
         with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
             pool = deliver_webhooks._DeliveryPool(
-                deliver_webhooks._PayloadDeleter(batched=False),
+                deliver_webhooks._PayloadDeleter(),
                 worker_threads=1,
                 delivery_tags=tags,
                 valid_until=timezone.now() + BATCH_SCHEDULE_OFFSET,
@@ -2800,9 +2784,10 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
                 answered_returned.set()
             return (payload, None)
 
+        deleter = deliver_webhooks._PayloadDeleter()
         with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
             pool = deliver_webhooks._DeliveryPool(
-                deliver_webhooks._PayloadDeleter(batched=False),
+                deleter,
                 worker_threads=2,
                 delivery_tags={**UNATTRIBUTED, "provider": "github"},
                 valid_until=timezone.now() + BATCH_SCHEDULE_OFFSET,
@@ -2814,6 +2799,8 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
             assert stuck_started.wait(timeout=5)
             assert answered_returned.wait(timeout=5)
             pool.wind_down(reason="deadline")
+            # Deletes are batched, so the answered row goes with the flush.
+            deleter.flush()
 
         assert pool.delivered == 1
         assert pool.failed == 1
@@ -2886,7 +2873,7 @@ class DeadlineReleaseTest(MetricCallsMixin, TestCase):
 
         with patch.object(deliver_webhooks, "deliver_message", side_effect=deliver):
             pool = deliver_webhooks._DeliveryPool(
-                deliver_webhooks._PayloadDeleter(batched=False),
+                deliver_webhooks._PayloadDeleter(),
                 worker_threads=2,
                 delivery_tags={**UNATTRIBUTED, "provider": "github"},
                 valid_until=timezone.now() + BATCH_SCHEDULE_OFFSET,
@@ -3169,7 +3156,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         assert mock_drain.delay.call_count == 2
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(DUE_HEAD_OPTIONS)
     def test_push_trigger_due_head_dispatches_past_backoff_head(
         self, mock_drain: MagicMock
     ) -> None:
@@ -3192,7 +3178,6 @@ class PushTriggerTest(MetricCallsMixin, TestCase):
         )
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    @override_options(DUE_HEAD_OPTIONS)
     def test_push_trigger_due_head_skips_backoff_only_mailbox(self, mock_drain: MagicMock) -> None:
         self.create_webhook_payload(
             mailbox_name="github:123",

--- a/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
+++ b/tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py
@@ -273,25 +273,6 @@ class ScheduleWebhooksTest(MetricCallsMixin, TestCase):
         assert mock_deliver.delay.call_count == 0
 
     @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
-    def test_schedule_due_head_prioritizes_by_provider(self, mock_deliver: MagicMock) -> None:
-        github_webhook = self.create_webhook_payload(
-            mailbox_name="github:123",
-            provider="github",
-            cell_name="us",
-        )
-        stripe_webhook = self.create_webhook_payload(
-            mailbox_name="stripe:123",
-            provider="stripe",
-            cell_name="us",
-        )
-
-        schedule_webhook_delivery()
-
-        assert mock_deliver.delay.call_count == 2
-        call_args_list = [call.kwargs["payload_id"] for call in mock_deliver.delay.call_args_list]
-        assert call_args_list == [stripe_webhook.id, github_webhook.id]
-
-    @patch("sentry.hybridcloud.tasks.deliver_webhooks.drain_mailbox")
     def test_schedule_updates_mailbox_attributes(self, mock_deliver: MagicMock) -> None:
         webhook_one = self.create_webhook_payload(
             mailbox_name="github:123",


### PR DESCRIPTION
Two options finished their rollout in August and have been at their production value since. This deletes the branch each one gated.

| Option | On in production since |
| --- | --- |
| `hybridcloud.webhookpayload.drain_batch_deletes` | [automator#9344](https://github.com/getsentry/sentry-options-automator/pull/9344), 2026-08-25 |
| `hybridcloud.webhookpayload.dispatch_from_due_head` | [automator#9368](https://github.com/getsentry/sentry-options-automator/pull/9368), 2026-08-27 |

Together because they are the same cleanup in the same file; splitting them means two three-PR chains for one deploy's worth of risk.

## What each collapses to

**Batched deletes are what `_PayloadDeleter` does.** A drain accumulates the ids of rows it is finished with — delivered, exhausted, or stale — and removes them `DELETE_BATCH_SIZE` at a time. The safety argument is unchanged: a drain is bounded to a claim its dispatcher owns, so nothing else can touch a row between the drain finishing with it and deleting it.

**Due-head dispatch is a property of the mailbox, not a mode.** A skip-on-failure mailbox dispatches from its oldest *due* record, so one record in retry backoff cannot park every due record behind it. A strict mailbox still gates on its absolute head.

That retires `_gated_mailbox_heads`, and the extra `count()` it ran whenever its batch filled. Discovery is now the single aggregate pass, which also feeds the per-provider backlog depth metrics. `hybridcloud.schedule_webhook_delivery.mailbox_count` keeps its `source` tag: only `aggregate` is produced now, but the historical `batch` and `count_query` series are on the dashboards.

## Cleanups this opened

- `_dispatches_from_due_head` was left as a second spelling of "is this provider skip-on-failure". The allowlist is read through one helper now.
- The `PROVIDER_PRIORITY` comment argued against an expression index for a discovery query that ordered in SQL. That query went with the gate; ordering happens in Python.
- **The single-statement claim was never universal.** `test_claim_and_dispatch_claims_in_a_single_query` used a `github` mailbox, which has claimed through the due-head path: the claim scans the prefix to find where the due run ends, then issues the UPDATE. One test now pins the one-statement shape on a strict mailbox, another the two-statement shape on a due-head one.
- Tests driving `_DeliveryPool` directly now flush, as a drain does in its `finally`.
- Deleted: `test_schedule_head_in_backoff_blocks_mailbox` asserted the gate; `test_due_head_discovery_carries_its_surplus_too` and `test_schedule_due_head_prioritizes_by_provider` are duplicates once there is one discovery.

## Follow-up, in order

The other two are open as drafts and **must not merge before this one is deployed to every region**:

1. **This PR** — collapse the reads.
2. https://github.com/getsentry/sentry-options-automator/pull/9621 — unset both values. Blocked on this deploying everywhere; the fallback is the registered default `False` for both, which is the regime this PR deletes.
3. https://github.com/getsentry/sentry/pull/123718 — remove both registrations. Blocked on 2 running green; landing it early turns `options-drift` red on the automator's `main`.

## Verification

- `tests/sentry/hybridcloud/tasks/test_deliver_webhooks.py` — 145 passed
- `tests/sentry/hybridcloud/` + `tests/sentry/middleware/integrations/` — 627 passed
- `prek run -q` clean, pre-push mypy clean

Refs CW-1925
