### PR TITLE
ref(agents): Reuse trace query state

### DIFF
--- a/static/app/views/insights/pages/agents/components/tracesTable.tsx
+++ b/static/app/views/insights/pages/agents/components/tracesTable.tsx
@@ -165,6 +165,7 @@ export function TracesTable({
 
   const pageLinks = tracesRequest?.data?.headers.Link;
   const tracesData = tracesRequest.data?.json?.data;
+  const hasTraces = Boolean(tracesData?.length);
 
   const spansRequest = useSpans(
     {
@@ -178,7 +179,7 @@ export function TracesTable({
         'sum(gen_ai.cost.total_tokens)',
       ],
       limit: tracesData?.length ?? 0,
-      enabled: Boolean(tracesData && tracesData.length > 0),
+      enabled: hasTraces,
       samplingMode: SAMPLING_MODE.HIGH_ACCURACY,
       extrapolationMode: 'none',
     },
@@ -191,7 +192,7 @@ export function TracesTable({
       fields: ['trace', 'gen_ai.agent.name', 'gen_ai.function_id', 'timestamp'],
       sorts: [{field: 'timestamp', kind: 'asc'}],
       samplingMode: SAMPLING_MODE.HIGH_ACCURACY,
-      enabled: Boolean(tracesData && tracesData.length > 0),
+      enabled: hasTraces,
     },
     Referrer.TRACES_TABLE
   );
@@ -216,7 +217,7 @@ export function TracesTable({
       search: `span.status:[internal_error,error] trace:[${tracesData?.map(span => `"${span.trace}"`).join(',')}] has:gen_ai.operation.name`,
       fields: ['trace', 'count(span.duration)'],
       limit: tracesData?.length ?? 0,
-      enabled: Boolean(tracesData && tracesData.length > 0),
+      enabled: hasTraces,
       samplingMode: SAMPLING_MODE.HIGH_ACCURACY,
       extrapolationMode: 'none',
     },


### PR DESCRIPTION
The agents traces table repeats the same non-empty trace-data check for each of its three dependent span queries, making their shared gating condition unnecessarily easy to drift.

Name that condition once and reuse it for all three queries. This removes the local duplication while preserving exactly when each query is enabled.