### PR TITLE
feat(symbolication): Add request headers for project and event ID

### DIFF
--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -425,7 +425,7 @@ def normalize_user_source(source, project_id=None, event_id=None):
 
         # Event & project ID
         if project_id:
-            headers[PROJECT_ID_HEADER] = project_id
+            headers[PROJECT_ID_HEADER] = str(project_id)
         if event_id:
             headers[EVENT_ID_HEADER] = event_id
 

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -394,23 +394,36 @@ def is_internal_source_id(source_id: str):
     return source_id.startswith("sentry")
 
 
-def normalize_user_source(source):
+def normalize_user_source(source, project_id=None, event_id=None):
     """Sources supplied from the user frontend might not match the format that
     symbolicator expects.  For instance we currently do not permit headers to be
     configured in the UI, but we allow basic auth to be configured for HTTP.
     This means that we need to convert from username/password into the HTTP
     basic auth header.
+
+    Moreover, this inserts the project and event ID into the `x-sentry-project-id`
+    and `x-sentry-event-id` headers, respectively.
     """
     if source.get("type") == "http":
+        headers = {}
+
+        # Auth
         username = source.pop("username", None)
         password = source.pop("password", None)
         if username or password:
             auth = base64.b64encode(
                 ("{}:{}".format(username or "", password or "")).encode("utf-8")
             )
-            source["headers"] = {
-                "authorization": "Basic %s" % auth.decode("ascii"),
-            }
+            headers["authorization"] = "Basic %s" % auth.decode("ascii")
+
+        # Event & project ID
+        if project_id:
+            headers["x-sentry-project-id"] = project_id
+        if event_id:
+            headers["x-sentry-event-id"] = event_id
+
+        if headers:
+            source["headers"] = headers
     return source
 
 
@@ -531,7 +544,7 @@ def redact_source_secrets(config_sources: Any) -> Any:
     return redacted_sources
 
 
-def get_sources_for_project(project):
+def get_sources_for_project(project, event_id=None):
     """
     Returns a list of symbol sources for this project.
     """
@@ -555,7 +568,7 @@ def get_sources_for_project(project):
         try:
             custom_sources = parse_sources(sources_config, filter_appconnect=True)
             sources.extend(
-                normalize_user_source(source)
+                normalize_user_source(source, project.id, event_id)
                 for source in custom_sources
                 if source["type"] != "appStoreConnect"
             )
@@ -757,13 +770,13 @@ def redact_internal_sources_from_module(module):
         module["candidates"] = [c for c in new_candidates if should_keep(c)]
 
 
-def sources_for_symbolication(project):
+def sources_for_symbolication(project, event_id=None):
     """
     Returns a list of symbol sources to attach to a native symbolication request,
     as well as a closure to post-process the resulting JSON response.
     """
 
-    sources = get_sources_for_project(project) or []
+    sources = get_sources_for_project(project, event_id) or []
 
     # Build some maps for use in _process_response()
     reverse_source_aliases = reverse_aliases_map(settings.SENTRY_BUILTIN_SOURCES)

--- a/src/sentry/lang/native/sources.py
+++ b/src/sentry/lang/native/sources.py
@@ -217,6 +217,13 @@ HIDDEN_SECRET_SCHEMA = {
 }
 
 
+# The header in which to send the project ID to custom symbol sources.
+PROJECT_ID_HEADER = "x-sentry-project-id"
+
+# The header in which to send the event ID to custom symbol sources.
+EVENT_ID_HEADER = "x-sentry-event-id"
+
+
 def _redact_schema(schema: dict, keys_to_redact: list[str]) -> dict:
     """
     Returns a deepcopy of the input schema, overriding any keys in keys_to_redact
@@ -418,9 +425,9 @@ def normalize_user_source(source, project_id=None, event_id=None):
 
         # Event & project ID
         if project_id:
-            headers["x-sentry-project-id"] = project_id
+            headers[PROJECT_ID_HEADER] = project_id
         if event_id:
-            headers["x-sentry-event-id"] = event_id
+            headers[EVENT_ID_HEADER] = event_id
 
         if headers:
             source["headers"] = headers

--- a/src/sentry/lang/native/symbolicator.py
+++ b/src/sentry/lang/native/symbolicator.py
@@ -229,7 +229,7 @@ class Symbolicator:
     def process_minidump(
         self, platform: str, minidump: CachedAttachment, rewrite_first_module: list[Any]
     ):
-        (sources, process_response) = sources_for_symbolication(self.project)
+        (sources, process_response) = sources_for_symbolication(self.project, self.event_id)
         scraping_config = get_scraping_config(self.project)
 
         if minidump.stored_id:
@@ -273,7 +273,7 @@ class Symbolicator:
         return process_response(res)
 
     def process_applecrashreport(self, platform: str, report: CachedAttachment):
-        (sources, process_response) = sources_for_symbolication(self.project)
+        (sources, process_response) = sources_for_symbolication(self.project, self.event_id)
         scraping_config = get_scraping_config(self.project)
 
         if report.stored_id:
@@ -329,7 +329,7 @@ class Symbolicator:
         :param signal: A numeric crash signal value. This is optional.
         :param apply_source_context: Whether to add source context to frames.
         """
-        (sources, process_response) = sources_for_symbolication(self.project)
+        (sources, process_response) = sources_for_symbolication(self.project, self.event_id)
         scraping_config = get_scraping_config(self.project)
         json = {
             "platform": platform,

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -1,5 +1,6 @@
 import copy
 
+import orjson
 import pytest
 
 from sentry.lang.native.sources import (
@@ -74,6 +75,28 @@ def test_sources_custom(default_project) -> None:
     # The appStoreConnect source should be filtered out.
     source_ids = list(map(lambda s: s["id"], sources))
     assert source_ids == ["sentry:project", "custom"]
+
+
+@django_db_all
+def test_sources_custom_with_event_id(default_project) -> None:
+    features = {"organizations:custom-symbol-sources": True}
+
+    # Remove builtin sources explicitly to avoid defaults
+    default_project.update_option("sentry:builtin_symbol_sources", [])
+    default_project.update_option("sentry:symbol_sources", CUSTOM_SOURCE_CONFIG)
+
+    event_id = "a" * 32
+    with Feature(features):
+        sources = get_sources_for_project(default_project, event_id)
+
+    custom_source = sources[1]
+    headers = custom_source.pop("headers")
+    assert headers == {
+        "x-sentry-project-id": default_project.id,
+        "x-sentry-event-id": event_id,
+    }
+
+    assert custom_source == orjson.loads(CUSTOM_SOURCE_CONFIG)[0]
 
 
 # Test that previously saved custom sources are not returned if the feature for

--- a/tests/sentry/lang/native/test_symbolicator.py
+++ b/tests/sentry/lang/native/test_symbolicator.py
@@ -92,7 +92,7 @@ def test_sources_custom_with_event_id(default_project) -> None:
     custom_source = sources[1]
     headers = custom_source.pop("headers")
     assert headers == {
-        "x-sentry-project-id": default_project.id,
+        "x-sentry-project-id": str(default_project.id),
         "x-sentry-event-id": event_id,
     }
 


### PR DESCRIPTION
This adds the project ID in the header `x-sentry-project-id` and the event ID in the header `x-sentry-event-id` to all requests to HTTP custom symbol sources. The purpose of this is to increase transparency for native symbolication users.

Fixes INGEST-1171