### PR TITLE
feat(dynamic-sampling): Add killswitch option for the legacy jobs

### DIFF
--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -52,7 +52,10 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
     generate_boost_low_volume_projects_cache_key,
 )
 from sentry.dynamic_sampling.tasks.helpers.sample_rate import get_org_sample_rate
-from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task
+from sentry.dynamic_sampling.tasks.utils import (
+    dynamic_sampling_task,
+    legacy_dynamic_sampling_job,
+)
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.dynamic_sampling.utils import has_dynamic_sampling, is_project_mode_sampling
 from sentry.models.options import OrganizationOption
@@ -101,6 +104,7 @@ def _without_project_mode_orgs(org_ids: list[int]) -> list[int]:
     silo_mode=SiloMode.CELL,
 )
 @dynamic_sampling_task
+@legacy_dynamic_sampling_job
 def boost_low_volume_projects() -> None:
     """
     Task to adjusts the sample rates of all projects in all active organizations.

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_projects.py
@@ -54,7 +54,7 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
 from sentry.dynamic_sampling.tasks.helpers.sample_rate import get_org_sample_rate
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
-    legacy_dynamic_sampling_job,
+    legacy_pipeline_killswitched,
 )
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.dynamic_sampling.utils import has_dynamic_sampling, is_project_mode_sampling
@@ -104,11 +104,13 @@ def _without_project_mode_orgs(org_ids: list[int]) -> list[int]:
     silo_mode=SiloMode.CELL,
 )
 @dynamic_sampling_task
-@legacy_dynamic_sampling_job
 def boost_low_volume_projects() -> None:
     """
     Task to adjusts the sample rates of all projects in all active organizations.
     """
+    if legacy_pipeline_killswitched("boost_low_volume_projects"):
+        return
+
     for orgs in GetActiveOrgs(
         max_projects=MAX_PROJECTS_PER_QUERY,
         granularity=Granularity(60),

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -41,7 +41,7 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_transactions import 
 )
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
-    legacy_dynamic_sampling_job,
+    legacy_pipeline_killswitched,
 )
 from sentry.dynamic_sampling.types import SamplingMeasure
 from sentry.dynamic_sampling.utils import has_dynamic_sampling, is_project_mode_sampling
@@ -92,8 +92,10 @@ class ProjectTransactionsTotals(ProjectIdentity, total=True):
     silo_mode=SiloMode.CELL,
 )
 @dynamic_sampling_task
-@legacy_dynamic_sampling_job
 def boost_low_volume_transactions() -> None:
+    if legacy_pipeline_killswitched("boost_low_volume_transactions"):
+        return
+
     num_big_trans = int(
         options.get("dynamic-sampling.prioritise_transactions.num_explicit_large_transactions")
     )

--- a/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
+++ b/src/sentry/dynamic_sampling/tasks/boost_low_volume_transactions.py
@@ -39,7 +39,10 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
 from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_transactions import (
     set_transactions_resampling_rates,
 )
-from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task
+from sentry.dynamic_sampling.tasks.utils import (
+    dynamic_sampling_task,
+    legacy_dynamic_sampling_job,
+)
 from sentry.dynamic_sampling.types import SamplingMeasure
 from sentry.dynamic_sampling.utils import has_dynamic_sampling, is_project_mode_sampling
 from sentry.models.options.project_option import ProjectOption
@@ -89,6 +92,7 @@ class ProjectTransactionsTotals(ProjectIdentity, total=True):
     silo_mode=SiloMode.CELL,
 )
 @dynamic_sampling_task
+@legacy_dynamic_sampling_job
 def boost_low_volume_transactions() -> None:
     num_big_trans = int(
         options.get("dynamic-sampling.prioritise_transactions.num_explicit_large_transactions")

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -28,7 +28,7 @@ from sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs import (
 from sentry.dynamic_sampling.tasks.helpers.sample_rate import get_org_sample_rate
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
-    legacy_dynamic_sampling_job,
+    legacy_pipeline_killswitched,
 )
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.dynamic_sampling.utils import has_dynamic_sampling
@@ -49,8 +49,10 @@ from sentry.utils import metrics
     silo_mode=SiloMode.CELL,
 )
 @dynamic_sampling_task
-@legacy_dynamic_sampling_job
 def recalibrate_orgs() -> None:
+    if legacy_pipeline_killswitched("recalibrate_orgs"):
+        return
+
     for segment_volumes in GetActiveOrgsVolumes(measure=SamplingMeasure.SEGMENTS):
         _process_orgs_volumes(segment_volumes)
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -26,7 +26,10 @@ from sentry.dynamic_sampling.tasks.helpers.recalibrate_orgs import (
     set_guarded_adjusted_project_factor,
 )
 from sentry.dynamic_sampling.tasks.helpers.sample_rate import get_org_sample_rate
-from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task
+from sentry.dynamic_sampling.tasks.utils import (
+    dynamic_sampling_task,
+    legacy_dynamic_sampling_job,
+)
 from sentry.dynamic_sampling.types import DynamicSamplingMode, SamplingMeasure
 from sentry.dynamic_sampling.utils import has_dynamic_sampling
 from sentry.models.options.organization_option import OrganizationOption
@@ -46,6 +49,7 @@ from sentry.utils import metrics
     silo_mode=SiloMode.CELL,
 )
 @dynamic_sampling_task
+@legacy_dynamic_sampling_job
 def recalibrate_orgs() -> None:
     for segment_volumes in GetActiveOrgsVolumes(measure=SamplingMeasure.SEGMENTS):
         _process_orgs_volumes(segment_volumes)

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -17,7 +17,10 @@ from sentry.dynamic_sampling.tasks.helpers.sliding_window import (
     get_sliding_window_size,
     mark_sliding_window_org_executed,
 )
-from sentry.dynamic_sampling.tasks.utils import dynamic_sampling_task
+from sentry.dynamic_sampling.tasks.utils import (
+    dynamic_sampling_task,
+    legacy_dynamic_sampling_job,
+)
 from sentry.dynamic_sampling.types import SamplingMeasure
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
@@ -32,6 +35,7 @@ from sentry.taskworker.namespaces import telemetry_experience_tasks
     silo_mode=SiloMode.CELL,
 )
 @dynamic_sampling_task
+@legacy_dynamic_sampling_job
 def sliding_window_org() -> None:
     window_size = get_sliding_window_size()
     # In case the size is None it means that we disabled the sliding window entirely.

--- a/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
+++ b/src/sentry/dynamic_sampling/tasks/sliding_window_org.py
@@ -19,7 +19,7 @@ from sentry.dynamic_sampling.tasks.helpers.sliding_window import (
 )
 from sentry.dynamic_sampling.tasks.utils import (
     dynamic_sampling_task,
-    legacy_dynamic_sampling_job,
+    legacy_pipeline_killswitched,
 )
 from sentry.dynamic_sampling.types import SamplingMeasure
 from sentry.silo.base import SiloMode
@@ -35,8 +35,10 @@ from sentry.taskworker.namespaces import telemetry_experience_tasks
     silo_mode=SiloMode.CELL,
 )
 @dynamic_sampling_task
-@legacy_dynamic_sampling_job
 def sliding_window_org() -> None:
+    if legacy_pipeline_killswitched("sliding_window_org"):
+        return
+
     window_size = get_sliding_window_size()
     # In case the size is None it means that we disabled the sliding window entirely.
     if window_size is None:

--- a/src/sentry/dynamic_sampling/tasks/utils.py
+++ b/src/sentry/dynamic_sampling/tasks/utils.py
@@ -5,7 +5,10 @@ from typing import Any
 
 import sentry_sdk
 
+from sentry import options
 from sentry.utils import metrics
+
+LEGACY_KILLSWITCH_OPTION = "dynamic-sampling.legacy.killswitch"
 
 
 def sample_function(function: Callable[..., Any], _sample_rate: float = 1.0, **kwargs: Any) -> None:
@@ -37,5 +40,21 @@ def dynamic_sampling_task(func: Callable[..., Any]) -> Callable[..., Any]:
             except Exception as e:
                 sentry_sdk.capture_exception(e)
                 raise
+
+    return _wrapper
+
+
+def legacy_dynamic_sampling_job(func: Callable[..., Any]) -> Callable[..., Any]:
+    """
+    Decorator for the scheduled entry points of the legacy dynamic sampling pipeline.
+    While the legacy killswitch option is engaged, the job returns before it does any work.
+    """
+
+    @wraps(func)
+    def _wrapper(*args: Any, **kwargs: Any) -> Any:
+        if options.get(LEGACY_KILLSWITCH_OPTION):
+            metrics.incr(f"{_compute_task_name(func.__name__)}.killswitched", sample_rate=1.0)
+            return None
+        return func(*args, **kwargs)
 
     return _wrapper

--- a/src/sentry/dynamic_sampling/tasks/utils.py
+++ b/src/sentry/dynamic_sampling/tasks/utils.py
@@ -44,17 +44,12 @@ def dynamic_sampling_task(func: Callable[..., Any]) -> Callable[..., Any]:
     return _wrapper
 
 
-def legacy_dynamic_sampling_job(func: Callable[..., Any]) -> Callable[..., Any]:
+def legacy_pipeline_killswitched(task_name: str) -> bool:
     """
-    Decorator for the scheduled entry points of the legacy dynamic sampling pipeline.
-    While the legacy killswitch option is engaged, the job returns before it does any work.
+    Reports whether the legacy dynamic sampling pipeline is switched off.
+    Scheduled legacy jobs call this first and return before they do any work when it is True.
     """
-
-    @wraps(func)
-    def _wrapper(*args: Any, **kwargs: Any) -> Any:
-        if options.get(LEGACY_KILLSWITCH_OPTION):
-            metrics.incr(f"{_compute_task_name(func.__name__)}.killswitched", sample_rate=1.0)
-            return None
-        return func(*args, **kwargs)
-
-    return _wrapper
+    if not options.get(LEGACY_KILLSWITCH_OPTION):
+        return False
+    metrics.incr(f"{_compute_task_name(task_name)}.killswitched", sample_rate=1.0)
+    return True

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2459,6 +2459,15 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# Killswitch for the legacy dynamic sampling pipeline. When set to True, the four
+# scheduled jobs (sliding_window_org, boost_low_volume_projects,
+# boost_low_volume_transactions, recalibrate_orgs) exit before they do any work.
+register(
+    "dynamic-sampling.legacy.killswitch",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Deterministic % rollout of the per-org dynamic sampling pipeline, keyed on
 # organization id. A value of 0.0 disables the pipeline for every org; 1.0
 # enables it for every org. Intermediate values select a stable hash-based

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -184,6 +184,21 @@ class TestBoostLowVolumeProjectsTasks(TasksTestCase):
         assert generate_rules(proj_d)[0]["samplingValue"] == {"type": "sampleRate", "value": 1.0}
 
     @with_feature("organizations:dynamic-sampling")
+    @override_options({"dynamic-sampling.legacy.killswitch": True})
+    @patch("sentry.quotas.backend.get_blended_sample_rate")
+    def test_boost_low_volume_projects_killswitch(self, get_blended_sample_rate: MagicMock) -> None:
+        get_blended_sample_rate.return_value = 0.25
+        test_org = self.create_old_organization(name="sample-org")
+        self.create_project_and_add_metrics("a", 9, test_org)
+        self.create_project_and_add_metrics("b", 1, test_org)
+
+        with self.tasks():
+            boost_low_volume_projects()
+
+        redis_client = get_redis_client_for_ds()
+        assert redis_client.hgetall(generate_boost_low_volume_projects_cache_key(test_org.id)) == {}
+
+    @with_feature("organizations:dynamic-sampling")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_boost_low_volume_projects_simple_with_empty_project(
         self,
@@ -450,6 +465,24 @@ class TestBoostLowVolumeTransactionsTasks(TasksTestCase):
                 assert global_rate == BLENDED_RATE
 
     @with_feature("organizations:dynamic-sampling")
+    @override_options({"dynamic-sampling.legacy.killswitch": True})
+    @patch("sentry.quotas.backend.get_blended_sample_rate")
+    def test_boost_low_volume_transactions_killswitch(
+        self, get_blended_sample_rate: MagicMock
+    ) -> None:
+        get_blended_sample_rate.return_value = 0.25
+
+        with self.tasks():
+            boost_low_volume_transactions()
+
+        for org in self.orgs_info:
+            for proj_id in org["project_ids"]:
+                tran_rate, _ = get_transactions_resampling_rates(
+                    org_id=org["org_id"], proj_id=proj_id, default_rate=0.1
+                )
+                assert tran_rate == {}
+
+    @with_feature("organizations:dynamic-sampling")
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_boost_low_volume_transactions_with_sliding_window_org(
         self, get_blended_sample_rate: MagicMock
@@ -713,6 +746,20 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
                 # we sampled at 40% twice as much as we wanted we already have a factor of 0.5
                 # half it again to 0.25
                 assert float(val) == 0.25
+
+    @with_feature("organizations:dynamic-sampling")
+    @override_options({"dynamic-sampling.legacy.killswitch": True})
+    @patch("sentry.quotas.backend.get_blended_sample_rate")
+    def test_recalibrate_orgs_killswitch(self, get_blended_sample_rate: MagicMock) -> None:
+        get_blended_sample_rate.return_value = 0.1
+        self.set_sliding_window_org_sample_rate_for_all(0.2)
+
+        with self.tasks():
+            recalibrate_orgs()
+
+        redis_client = get_redis_client_for_ds()
+        for org in self.orgs:
+            assert redis_client.get(generate_recalibrate_orgs_cache_key(org.id)) is None
 
     @with_feature("organizations:dynamic-sampling")
     @override_options({"dynamic-sampling.per_org.serving-rollout-rate": 1.0})
@@ -990,3 +1037,22 @@ class TestSlidingWindowOrgTask(TasksTestCase):
             cache_key = generate_sliding_window_org_cache_key(org.id)
             val = redis_client.get(cache_key)
             assert val is not None, f"Org {org.id} should have sliding window cache entry"
+
+    @with_feature("organizations:dynamic-sampling")
+    @override_options({"dynamic-sampling.legacy.killswitch": True})
+    @patch("sentry.dynamic_sampling.tasks.common.extrapolate_monthly_volume")
+    @patch("sentry.quotas.backend.get_transaction_sampling_tier_for_volume")
+    def test_sliding_window_org_killswitch(
+        self,
+        get_transaction_sampling_tier_for_volume: MagicMock,
+        extrapolate_monthly_volume: MagicMock,
+    ) -> None:
+        extrapolate_monthly_volume.side_effect = lambda volume, hours: volume
+        get_transaction_sampling_tier_for_volume.return_value = (1000, 0.25)
+        redis_client = get_redis_client_for_ds()
+
+        with self.tasks():
+            sliding_window_org()
+
+        for org in self.orgs:
+            assert redis_client.get(generate_sliding_window_org_cache_key(org.id)) is None


### PR DESCRIPTION
- Register option `dynamic-sampling.legacy.killswitch` to turn off the legacy generic metrics based dynamic sampling jobs

Closes TET-2946