### PR TITLE
fix(cleanup): Delete pending attachments from objectstore

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -148,7 +148,9 @@ class EventAttachmentBase(Model):
             # explicit delete to avoid unnecessary load on the objectstore service.
             #
             # Pending attachments are always deleted, because they get cleaned up long before their objectstore TTL expires.
-            if not (self.__class__ is EventAttachment and os.environ.get("_SENTRY_CLEANUP")):
+            is_pending = isinstance(self, PendingEventAttachment)
+            is_cleanup = os.environ.get("_SENTRY_CLEANUP")
+            if is_pending or not is_cleanup:
                 organization_id = _get_organization(self.project_id)
                 get_session(UsecaseId.ATTACHMENTS, self.project_id, org=organization_id).delete(
                     self.blob_path.removeprefix(V2_PREFIX)

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -147,8 +147,8 @@ class EventAttachmentBase(Model):
             # During cleanup, V2 objectstore blobs expire via TTL — skip the
             # explicit delete to avoid unnecessary load on the objectstore service.
             #
-            # We want to special-case pending attachments in a follow-up. See INGEST-1176.
-            if not os.environ.get("_SENTRY_CLEANUP"):
+            # Pending attachments are always deleted, because they get cleaned up long before their objectstore TTL expires.
+            if not (self.__class__ is EventAttachment and os.environ.get("_SENTRY_CLEANUP")):
                 organization_id = _get_organization(self.project_id)
                 get_session(UsecaseId.ATTACHMENTS, self.project_id, org=organization_id).delete(
                     self.blob_path.removeprefix(V2_PREFIX)

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import mimetypes
-import os
 from dataclasses import dataclass
-from datetime import timedelta
+from datetime import datetime, timedelta
 from hashlib import sha1
 from io import BytesIO
 from typing import IO, Any
@@ -123,6 +122,10 @@ class EventAttachmentBase(Model):
     class Meta:
         abstract = True
 
+    def final_expiry_date(self) -> datetime:
+        """The end of the retention window for this entry"""
+        raise NotImplementedError
+
     def delete_blob(self) -> None:
         """
         Delete this attachment's payload from its backing store.
@@ -144,13 +147,9 @@ class EventAttachmentBase(Model):
                 storage.delete(self.blob_path)
 
         elif self.blob_path.startswith(V2_PREFIX):
-            # During cleanup, V2 objectstore blobs expire via TTL — skip the
+            # V2 objectstore blobs expire via TTL — if TTL is imminent, skip the
             # explicit delete to avoid unnecessary load on the objectstore service.
-            #
-            # Pending attachments are always deleted, because they get cleaned up long before their objectstore TTL expires.
-            is_pending = isinstance(self, PendingEventAttachment)
-            is_cleanup = os.environ.get("_SENTRY_CLEANUP")
-            if is_pending or not is_cleanup:
+            if self.final_expiry_date() > (timezone.now() + timedelta(days=1)):
                 organization_id = _get_organization(self.project_id)
                 get_session(UsecaseId.ATTACHMENTS, self.project_id, org=organization_id).delete(
                     self.blob_path.removeprefix(V2_PREFIX)
@@ -180,6 +179,9 @@ class EventAttachment(EventAttachmentBase):
         )
 
     __repr__ = sane_repr("event_id", "name")
+
+    def final_expiry_date(self) -> datetime:
+        return self.date_expires
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         # Computed here rather than as a field default to avoid freezing a callable
@@ -343,6 +345,9 @@ class PendingEventAttachment(EventAttachmentBase):
         indexes = (models.Index(fields=("project_id", "event_id")),)
 
     __repr__ = sane_repr("event_id", "name")
+
+    def final_expiry_date(self) -> datetime:
+        return self.date_expires_retention
 
     def delete(self, *args: Any, **kwargs: Any) -> tuple[int, dict[str, int]]:
         # A pending attachment that is deleted rather than promoted (its event never

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from unittest import mock
 from uuid import uuid4
 
@@ -48,12 +47,9 @@ class EventAttachmentDeleteTest(TestCase):
         mock_get_session: mock.Mock,
     ) -> None:
         attachment = self._create_v2_attachment()
+        attachment.date_expires = attachment.date_added
 
-        os.environ["_SENTRY_CLEANUP"] = "1"
-        try:
-            attachment.delete()
-        finally:
-            del os.environ["_SENTRY_CLEANUP"]
+        attachment.delete()
 
         mock_get_session.return_value.delete.assert_not_called()
         assert not EventAttachment.objects.filter(id=attachment.id).exists()
@@ -94,11 +90,7 @@ class PendingEventAttachmentDeleteTest(TestCase):
     ) -> None:
         pending = self._create_pending("v2")
 
-        os.environ["_SENTRY_CLEANUP"] = "1"
-        try:
-            pending.delete()
-        finally:
-            del os.environ["_SENTRY_CLEANUP"]
+        pending.delete()
 
         mock_get_session.return_value.delete.assert_called_once_with("some-key")
         assert not PendingEventAttachment.objects.filter(id=pending.id).exists()

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -67,13 +67,13 @@ class PendingEventAttachmentDeleteTest(TestCase):
     blob is only safe while we still own the row.
     """
 
-    def _create_pending(self) -> PendingEventAttachment:
+    def _create_pending(self, prefix="eventattachments/v1") -> PendingEventAttachment:
         return PendingEventAttachment.objects.create(
             event_id=uuid4().hex,
             project_id=self.project.id,
             type="event.attachment",
             name="test.txt",
-            blob_path="eventattachments/v1/some-key",
+            blob_path=f"{prefix}/some-key",
         )
 
     @mock.patch("sentry.models.eventattachment.get_storage")
@@ -84,6 +84,24 @@ class PendingEventAttachmentDeleteTest(TestCase):
 
         assert not PendingEventAttachment.objects.filter(id=pending.id).exists()
         mock_get_storage.return_value.delete.assert_called_once_with("eventattachments/v1/some-key")
+
+    @mock.patch("sentry.models.eventattachment.get_session")
+    @mock.patch("sentry.models.eventattachment._get_organization", return_value=1)
+    def test_v2_delete_removes_objectstore(
+        self,
+        mock_get_org: mock.Mock,
+        mock_get_session: mock.Mock,
+    ) -> None:
+        pending = self._create_pending("v2")
+
+        os.environ["_SENTRY_CLEANUP"] = "1"
+        try:
+            pending.delete()
+        finally:
+            del os.environ["_SENTRY_CLEANUP"]
+
+        mock_get_session.return_value.delete.assert_called_once_with("some-key")
+        assert not PendingEventAttachment.objects.filter(id=pending.id).exists()
 
     @mock.patch("sentry.models.eventattachment.get_storage")
     def test_delete_keeps_the_blob_a_promotion_took_over(self, mock_get_storage: mock.Mock) -> None:


### PR DESCRIPTION
Delete attachments from objectstore if they weren't claimed by an event within one hour. This prevents keeping them in storage for 30 days.

Fixes: INGEST-1176