### PR TITLE
feat(difs): Add flag to delete corrupt files during migration

### DIFF
--- a/src/sentry/debug_files/objectstore_migration/main.py
+++ b/src/sentry/debug_files/objectstore_migration/main.py
@@ -12,6 +12,7 @@ def start_migration(
     *,
     num_shards: int,
     cursors: Mapping[int, int] | None = None,
+    delete_corrupt: bool = False,
 ) -> None:
     """Start the migration of debug files to Objectstore.
 
@@ -46,4 +47,5 @@ def start_migration(
             shard_id=shard_id,
             num_shards=num_shards,
             cursor=cursor,
+            delete_corrupt=delete_corrupt,
         )

--- a/src/sentry/debug_files/objectstore_migration/tasks.py
+++ b/src/sentry/debug_files/objectstore_migration/tasks.py
@@ -35,14 +35,19 @@ def enqueue_shard(
     shard_id: int,
     num_shards: int,
     cursor: int,
+    delete_corrupt: bool = False,
 ) -> None:
     def enqueue() -> None:
+        task_kwargs = {
+            "shard_id": shard_id,
+            "num_shards": num_shards,
+            "cursor": cursor,
+        }
+        if delete_corrupt:
+            task_kwargs["delete_corrupt"] = True
+
         delivery = migrate_shard.apply_async_with_future(
-            kwargs={
-                "shard_id": shard_id,
-                "num_shards": num_shards,
-                "cursor": cursor,
-            },
+            kwargs=task_kwargs,
             headers={"sentry-propagate-traces": False},
         )
         if delivery is not None:
@@ -67,6 +72,7 @@ def migrate_shard(
     shard_id: int,
     num_shards: int,
     cursor: int,
+    delete_corrupt: bool = False,
     **kwargs: object,
 ) -> None:
     """Process one page of DIFs for a shard, then self-chain if more remain.
@@ -139,7 +145,10 @@ def migrate_shard(
                 return
 
             for debug_file in to_migrate:
-                migrate_debug_file(debug_file)
+                if delete_corrupt:
+                    migrate_debug_file(debug_file, delete_corrupt=True)
+                else:
+                    migrate_debug_file(debug_file)
 
             lowest_id = to_migrate[-1].id
             duration_seconds = monotonic() - shard_started_at
@@ -163,6 +172,7 @@ def migrate_shard(
                 shard_id=shard_id,
                 num_shards=num_shards,
                 cursor=lowest_id - 1,
+                delete_corrupt=delete_corrupt,
             )
             if activation_id:
                 mark_spawned(_SHARD_TASK_KEY, activation_id)

--- a/src/sentry/debug_files/objectstore_migration/tasks.py
+++ b/src/sentry/debug_files/objectstore_migration/tasks.py
@@ -145,10 +145,7 @@ def migrate_shard(
                 return
 
             for debug_file in to_migrate:
-                if delete_corrupt:
-                    migrate_debug_file(debug_file, delete_corrupt=True)
-                else:
-                    migrate_debug_file(debug_file)
+                migrate_debug_file(debug_file, delete_corrupt=delete_corrupt)
 
             lowest_id = to_migrate[-1].id
             duration_seconds = monotonic() - shard_started_at

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -113,11 +113,7 @@ def _handle_filestore_integrity_error(
         )
 
     logger.warning(
-        (
-            "debug_files.objectstore_migration.filestore_integrity_mismatch.deleted"
-            if deleted
-            else "debug_files.objectstore_migration.filestore_integrity_mismatch"
-        ),
+        "debug_files.objectstore_migration.filestore_integrity_mismatch",
         extra={
             "debug_file_id": dif_id,
             "file_id": source_file_id,
@@ -125,6 +121,7 @@ def _handle_filestore_integrity_error(
             "expected_checksum": error.expected_checksum,
             "size": error.size,
             "expected_size": error.expected_size,
+            "deleted": deleted,
         },
     )
 

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 def migrate_debug_file(
     debug_file: ProjectDebugFile,
-    *,
     delete_corrupt: bool = False,
 ) -> None:
     """Migrate one File-backed DIF, or drop the legacy File from a dual-written DIF."""
@@ -102,18 +101,20 @@ class FilestoreIntegrityError(Exception):
 
 def _handle_filestore_integrity_error(
     dif_id: int,
-    *,
     source_file_id: int,
     error: FilestoreIntegrityError,
     delete_corrupt: bool,
 ) -> None:
-    deleted = delete_corrupt and delete_corrupt_debug_file(
-        dif_id,
-        source_file_id=source_file_id,
-    )
+    deleted = False
+    if delete_corrupt:
+        deleted = delete_corrupt_debug_file(
+            dif_id,
+            source_file_id=source_file_id,
+        )
+
     logger.warning(
         (
-            "debug_files.objectstore_migration.filestore_integrity_mismatch_deleted"
+            "debug_files.objectstore_migration.filestore_integrity_mismatch.deleted"
             if deleted
             else "debug_files.objectstore_migration.filestore_integrity_mismatch"
         ),

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -43,7 +43,16 @@ def migrate_debug_file(
             drop_legacy_file(debug_file.id, source_file_id=source_file_id)
             return
 
-        metadata = upload_and_verify(debug_file, delete_corrupt=delete_corrupt)
+        try:
+            metadata = upload_and_verify(debug_file)
+        except FilestoreIntegrityError as error:
+            _handle_filestore_integrity_error(
+                debug_file.id,
+                source_file_id=source_file_id,
+                error=error,
+                delete_corrupt=delete_corrupt,
+            )
+            return
         if metadata is None:
             return
         commit(debug_file.id, metadata, source_file_id=source_file_id)
@@ -89,6 +98,34 @@ class FilestoreIntegrityError(Exception):
             f"(checksum={checksum!r} expected={expected_checksum!r}, "
             f"size={size} expected={expected_size})"
         )
+
+
+def _handle_filestore_integrity_error(
+    dif_id: int,
+    *,
+    source_file_id: int,
+    error: FilestoreIntegrityError,
+    delete_corrupt: bool,
+) -> None:
+    deleted = delete_corrupt and delete_corrupt_debug_file(
+        dif_id,
+        source_file_id=source_file_id,
+    )
+    logger.warning(
+        (
+            "debug_files.objectstore_migration.filestore_integrity_mismatch_deleted"
+            if deleted
+            else "debug_files.objectstore_migration.filestore_integrity_mismatch"
+        ),
+        extra={
+            "debug_file_id": dif_id,
+            "file_id": source_file_id,
+            "checksum": error.checksum,
+            "expected_checksum": error.expected_checksum,
+            "size": error.size,
+            "expected_size": error.expected_size,
+        },
+    )
 
 
 def _sha1_stream(stream: IO[bytes]) -> tuple[str, int]:
@@ -178,17 +215,14 @@ def _get_object_with_retry(session: Session, storage_path: str) -> GetResponse:
     return policy(get_object)
 
 
-def upload_and_verify(
-    debug_file: ProjectDebugFile,
-    *,
-    delete_corrupt: bool = False,
-) -> PostMigrationMetadata | None:
+def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | None:
     """Read the File, write it to Objectstore, and verify the stored object.
 
     Returns:
         Metadata to commit, or ``None`` to skip.
 
     Raises:
+        FilestoreIntegrityError: Downloaded filestore payload mismatch.
         ObjectstoreIntegrityError: Objectstore payload mismatch.
         Exception: I/O, network, or other failures during spool/upload/verify.
     """
@@ -225,33 +259,11 @@ def upload_and_verify(
             extra={"debug_file_id": debug_file.id, "file_id": file.id},
         )
 
-    try:
-        tmp, local_checksum, local_size = _spool_and_validate_with_retry(
-            file,
-            expected_checksum=recorded_checksum,
-            expected_size=recorded_size,
-        )
-    except FilestoreIntegrityError as error:
-        deleted = delete_corrupt and delete_corrupt_debug_file(
-            debug_file.id,
-            source_file_id=file.id,
-        )
-        logger.warning(
-            (
-                "debug_files.objectstore_migration.filestore_integrity_mismatch_deleted"
-                if deleted
-                else "debug_files.objectstore_migration.filestore_integrity_mismatch"
-            ),
-            extra={
-                "debug_file_id": debug_file.id,
-                "file_id": file.id,
-                "checksum": error.checksum,
-                "expected_checksum": error.expected_checksum,
-                "size": error.size,
-                "expected_size": error.expected_size,
-            },
-        )
-        return None
+    tmp, local_checksum, local_size = _spool_and_validate_with_retry(
+        file,
+        expected_checksum=recorded_checksum,
+        expected_size=recorded_size,
+    )
 
     try:
         expected_checksum = recorded_checksum if recorded_checksum is not None else local_checksum

--- a/src/sentry/debug_files/objectstore_migration/utils.py
+++ b/src/sentry/debug_files/objectstore_migration/utils.py
@@ -27,7 +27,11 @@ from sentry.utils.retries import ConditionalRetryPolicy, exponential_delay
 logger = logging.getLogger(__name__)
 
 
-def migrate_debug_file(debug_file: ProjectDebugFile) -> None:
+def migrate_debug_file(
+    debug_file: ProjectDebugFile,
+    *,
+    delete_corrupt: bool = False,
+) -> None:
     """Migrate one File-backed DIF, or drop the legacy File from a dual-written DIF."""
 
     def attempt() -> None:
@@ -39,7 +43,7 @@ def migrate_debug_file(debug_file: ProjectDebugFile) -> None:
             drop_legacy_file(debug_file.id, source_file_id=source_file_id)
             return
 
-        metadata = upload_and_verify(debug_file)
+        metadata = upload_and_verify(debug_file, delete_corrupt=delete_corrupt)
         if metadata is None:
             return
         commit(debug_file.id, metadata, source_file_id=source_file_id)
@@ -174,7 +178,11 @@ def _get_object_with_retry(session: Session, storage_path: str) -> GetResponse:
     return policy(get_object)
 
 
-def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | None:
+def upload_and_verify(
+    debug_file: ProjectDebugFile,
+    *,
+    delete_corrupt: bool = False,
+) -> PostMigrationMetadata | None:
     """Read the File, write it to Objectstore, and verify the stored object.
 
     Returns:
@@ -224,8 +232,16 @@ def upload_and_verify(debug_file: ProjectDebugFile) -> PostMigrationMetadata | N
             expected_size=recorded_size,
         )
     except FilestoreIntegrityError as error:
+        deleted = delete_corrupt and delete_corrupt_debug_file(
+            debug_file.id,
+            source_file_id=file.id,
+        )
         logger.warning(
-            "debug_files.objectstore_migration.filestore_integrity_mismatch",
+            (
+                "debug_files.objectstore_migration.filestore_integrity_mismatch_deleted"
+                if deleted
+                else "debug_files.objectstore_migration.filestore_integrity_mismatch"
+            ),
             extra={
                 "debug_file_id": debug_file.id,
                 "file_id": file.id,
@@ -318,6 +334,22 @@ def drop_legacy_file(dif_id: int, *, source_file_id: int) -> None:
             return
 
         transaction.on_commit(lambda: try_cleanup_file(source_file_id), using=database)
+
+
+def delete_corrupt_debug_file(dif_id: int, *, source_file_id: int) -> bool:
+    """Delete a corrupt DIF and clean up its legacy File if it is unreferenced."""
+    database = router.db_for_write(ProjectDebugFile)
+    with atomic_transaction(using=database):
+        deleted, _ = ProjectDebugFile.objects.filter(
+            id=dif_id,
+            file_id=source_file_id,
+            storage_path__isnull=True,
+        ).delete()
+        if not deleted:
+            return False
+
+        transaction.on_commit(lambda: try_cleanup_file(source_file_id), using=database)
+        return True
 
 
 def try_cleanup_file(file_id: int | None) -> None:


### PR DESCRIPTION
Adds an opt-in mode to the debug file Objectstore migration that removes legacy debug files whose filestore payload fails checksum or size validation. The migration deletes the `ProjectDebugFile` row first, schedules cleanup of the now-unreferenced `File` after commit, and emits a dedicated warning for the deletion.

The default migration behavior remains unchanged: integrity mismatches are logged and skipped, and the new task argument is omitted unless deletion is explicitly enabled.

Refs FS-505
