### PR TITLE
ref(attachments): Track false positives in pending attachment cleanup

### DIFF
--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -368,18 +368,20 @@ class PendingEventAttachment(EventAttachmentBase):
 
         if is_owner:
             # Verify once more that no event exists.
-            if in_random_rollout("attachments.pending.premature_deletion_check_rate"):
-                event = eventstore.backend.get_event_by_id(self.project_id, self.event_id)
-                if event is not None:
-                    # NOTE: If this actually happens, we should guard against it by promoting the pending attachment just-in-time.
-                    logger.warning(
-                        "attachments.pending.premature_deletion",
-                        extra={
-                            "project_id": self.project_id,
-                            "event_id": self.event_id,
-                            "attachment_id": self.id,
-                        },
-                    )
+            try:
+                if in_random_rollout("attachments.pending.premature_deletion_check_rate"):
+                    event = eventstore.backend.get_event_by_id(self.project_id, self.event_id)
+                    if event is not None:
+                        # NOTE: If this actually happens, we should guard against it by promoting the pending attachment just-in-time.
+                        logger.warning(
+                            "attachments.pending.premature_deletion",
+                            extra={
+                                "project_id": self.project_id,
+                                "event_id": self.event_id,
+                            },
+                        )
+            except Exception as e:
+                logger.exception(e)
 
             self.delete_blob()
         return rv

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -367,18 +367,19 @@ class PendingEventAttachment(EventAttachmentBase):
             rv = super().delete(*args, **kwargs)
 
         if is_owner:
-            # Verify once more that no event exists:
-            event = eventstore.backend.get_event_by_id(self.project_id, self.event_id)
-            if event is not None:
-                # NOTE: If this actually happens, we should guard against it by promoting the pending attachment just-in-time.
-                logger.warning(
-                    "attachments.pending.premature_deletion",
-                    extra={
-                        "project_id": self.project_id,
-                        "event_id": self.event_id,
-                        "attachment_id": self.id,
-                    },
-                )
+            # Verify once more that no event exists.
+            if in_random_rollout("attachments.pending.premature_deletion_check_rate"):
+                event = eventstore.backend.get_event_by_id(self.project_id, self.event_id)
+                if event is not None:
+                    # NOTE: If this actually happens, we should guard against it by promoting the pending attachment just-in-time.
+                    logger.warning(
+                        "attachments.pending.premature_deletion",
+                        extra={
+                            "project_id": self.project_id,
+                            "event_id": self.event_id,
+                            "attachment_id": self.id,
+                        },
+                    )
 
             self.delete_blob()
         return rv

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import mimetypes
 from dataclasses import dataclass
 from datetime import datetime, timedelta
@@ -16,6 +17,7 @@ from django.http import HttpRequest
 from django.utils import timezone
 from objectstore_client import TimeToLive
 
+from sentry import eventstore
 from sentry.attachments.base import CachedAttachment
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import BoundedBigIntegerField, Model, cell_silo_model, sane_repr
@@ -36,6 +38,9 @@ CRASH_REPORT_TYPES = ("event.minidump", "event.applecrashreport")
 
 V1_PREFIX = "eventattachments/v1/"
 V2_PREFIX = "v2/"
+
+
+logger = logging.getLogger(__name__)
 
 
 def get_crashreport_key(group_id: int) -> str:
@@ -362,6 +367,19 @@ class PendingEventAttachment(EventAttachmentBase):
             rv = super().delete(*args, **kwargs)
 
         if is_owner:
+            # Verify once more that no event exists:
+            event = eventstore.backend.get_event_by_id(self.project_id, self.event_id)
+            if event is not None:
+                # NOTE: If this actually happens, we should guard against it by promoting the pending attachment just-in-time.
+                logger.warning(
+                    "attachments.pending.premature_deletion",
+                    extra={
+                        "project_id": self.project_id,
+                        "event_id": self.event_id,
+                        "attachment_id": self.id,
+                    },
+                )
+
             self.delete_blob()
         return rv
 

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3981,6 +3981,15 @@ register(
 # Fraction of attachments that are being stored exclusively in the new objectstore.
 register("objectstore.enable_for.attachments", default=0.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Fraction of expiring pending attachments that are checked for a matching event before
+# being deleted. Each check costs one nodestore read.
+register(
+    "attachments.pending.premature_deletion_check_rate",
+    type=Float,
+    default=0.0,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 
 register(
     "sentry.send_onboarding_task_metrics",


### PR DESCRIPTION
Issue a warning If a pending attachment expires even though there is now an event for it.

ref: INGEST-1177