### PR TITLE
chore: drop unnecessary `threading.local`s from the codebase

### DIFF
--- a/src/sentry/metrics/base.py
+++ b/src/sentry/metrics/base.py
@@ -2,7 +2,6 @@ __all__ = ["MetricsBackend"]
 
 from collections.abc import Mapping, MutableMapping
 from random import random
-from threading import local
 from typing import Union
 
 from django.conf import settings
@@ -18,7 +17,7 @@ Tags = Mapping[str, TagValue]
 MutableTags = MutableMapping[str, TagValue]
 
 
-class MetricsBackend(local):
+class MetricsBackend:
     def __init__(self, prefix: str | None = None) -> None:
         if prefix is None:
             prefix = settings.SENTRY_METRICS_PREFIX

--- a/src/sentry/metrics/dogstatsd.py
+++ b/src/sentry/metrics/dogstatsd.py
@@ -3,6 +3,7 @@ from typing import Any
 
 from datadog import initialize
 from datadog.dogstatsd.base import statsd
+from datadog.util.hostname import get_hostname
 
 from .base import MetricsBackend, Tags
 
@@ -24,6 +25,7 @@ class DogStatsdMetricsBackend(MetricsBackend):
     def __init__(self, prefix: str | None = None, **kwargs: Any) -> None:
         # TODO(dcramer): it'd be nice if the initialize call wasn't a global
         self.tags = kwargs.pop("tags", None)
+        self.host: str | None = kwargs.pop("host", None) or get_hostname(hostname_from_config=True)
         kwargs["statsd_disable_buffering"] = False
 
         initialize(**kwargs)

--- a/src/sentry/metrics/precise_dogstatsd.py
+++ b/src/sentry/metrics/precise_dogstatsd.py
@@ -2,6 +2,7 @@ import atexit
 from typing import Any
 
 from datadog.dogstatsd.base import DogStatsd
+from datadog.util.hostname import get_hostname
 
 from .base import MetricsBackend, Tags
 
@@ -11,6 +12,7 @@ __all__ = ["PreciseDogStatsdMetricsBackend"]
 class PreciseDogStatsdMetricsBackend(MetricsBackend):
     def __init__(self, prefix: str | None = None, **kwargs: Any) -> None:
         self.tags = kwargs.pop("tags", None)
+        self.host: str | None = kwargs.pop("host", None) or get_hostname(hostname_from_config=True)
 
         instance_kwargs: dict[str, Any] = {
             "disable_telemetry": True,

--- a/src/sentry/taskworker/adapters.py
+++ b/src/sentry/taskworker/adapters.py
@@ -142,28 +142,29 @@ class ViewerContextHook:
         return viewer_context_scope(ctx)
 
 
-_producer_local = threading.local()
+_producers: dict[str, SingletonProducer] = {}
+_producers_lock = threading.Lock()
 
 
 def make_producer(topic: str) -> SingletonProducer:
     """
     Producer factory for taskbroker-client.
 
-    Returns a thread-local KafkaProducer for the given topic, creating one
-    on first access.
+    Returns a process-wide KafkaProducer for the given topic, creating one
+    on first access. Producers are safe to share across threads, thus there's
+    no need for a threading.local instance.
     """
-    if not hasattr(_producer_local, "producers"):
-        _producer_local.producers = {}
+    with _producers_lock:
+        producer = _producers.get(topic)
+        if producer is None:
 
-    if topic not in _producer_local.producers:
+            def factory() -> KafkaProducer:
+                return get_arroyo_producer(f"sentry.taskworker.{topic}", topic)
 
-        def factory() -> KafkaProducer:
-            return get_arroyo_producer(f"sentry.taskworker.{topic}", topic)
-
-        _producer_local.producers[topic] = SingletonProducer(
-            factory, max_futures=options.get("taskworker.producer.max_futures")
-        )
-    return _producer_local.producers[topic]
+            producer = _producers[topic] = SingletonProducer(
+                factory, max_futures=options.get("taskworker.producer.max_futures")
+            )
+        return producer
 
 
 def _extract_metrics_config() -> tuple[str | None, int | None]:

--- a/src/sentry/utils/arroyo_producer.py
+++ b/src/sentry/utils/arroyo_producer.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import atexit
 import os
+import threading
 from collections import deque
 from collections.abc import Callable
 
@@ -30,6 +31,9 @@ class SingletonProducer:
 
     It is supposed to be used in tasks, where we want to flush the
     producer on process shutdown.
+
+    Instances can be shared across threads. The underlying ``KafkaProducer`` is
+    thread-safe; the lock here only guards our own state.
     """
 
     def __init__(
@@ -38,6 +42,7 @@ class SingletonProducer:
         self._producer: KafkaProducer | None = None
         self._factory = kafka_producer_factory
         self._futures: deque[_ProducerFuture] = deque()
+        self._lock = threading.Lock()
         self.max_futures = max_futures
 
         # This fixes a shutdown-ordering bug with OutcomeAggregator, which
@@ -58,30 +63,39 @@ class SingletonProducer:
         return future
 
     def _get(self) -> KafkaProducer:
-        if self._producer is None:
-            self._producer = self._factory()
+        producer = self._producer
+        if producer is None:
+            with self._lock:
+                producer = self._producer
+                if producer is None:
+                    producer = self._producer = self._factory()
 
-        return self._producer
+        return producer
 
     def _track_futures(self, future: _ProducerFuture) -> None:
-        self._futures.append(future)
-        if len(self._futures) >= self.max_futures:
-            try:
-                future = self._futures.popleft()
-            except IndexError:
-                return
-            else:
-                future.result()
+        oldest: _ProducerFuture | None = None
+        with self._lock:
+            self._futures.append(future)
+            if len(self._futures) >= self.max_futures:
+                oldest = self._futures.popleft()
+
+        if oldest is not None:
+            oldest.result()
 
     def _shutdown(self) -> None:
-        for future in self._futures:
+        with self._lock:
+            pending = list(self._futures)
+            self._futures.clear()
+            producer = self._producer
+
+        for future in pending:
             try:
                 future.result()
             except Exception:
                 pass
 
-        if self._producer:
-            self._producer.close()
+        if producer:
+            producer.close()
 
 
 def get_arroyo_producer(


### PR DESCRIPTION
Specifically:
- remove `threading.local` inheritance on `MetricsBackend`
- use per-process singletons for arroyo producers

### Rationale

Nowadays Sentry web processes run under Granian, under a dynamic threadpool. Using `threading.local` for singletons only means wasting compute resources on a fresh thread initialization, and memory allocations (including arenas fragmentation).

Every client using `MetricsBackend` nowadays is safe to share across threads.

`librdkafka` producers are already thread-safe, thus this PR makes `SingletonProducer` thread-safe and swaps the `threading.local` object to a process-owned dictionary of singletons.