### PR TITLE
feat(issues): Add native variables tree preview

### DIFF
--- a/static/app/components/stackTrace/frame/frameVariablesGrid.stories.tsx
+++ b/static/app/components/stackTrace/frame/frameVariablesGrid.stories.tsx
@@ -1,0 +1,171 @@
+import {Container, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {FrameVariablesGrid} from 'sentry/components/stackTrace/frame/frameVariablesGrid';
+import {
+  NativeFrameVariables,
+  type NativeFrameVariable,
+} from 'sentry/components/stackTrace/frame/nativeFrameVariables';
+import * as Storybook from 'sentry/stories';
+
+const position = [
+  {name: 'x', type: 'float', kind: 'number', value: '1.5'},
+  {name: 'y', type: 'float', kind: 'number', value: '-3.2'},
+  {name: 'z', type: 'float', kind: 'number', value: '0.0'},
+] satisfies NativeFrameVariable[];
+
+// Synthetic, decoded presentation fixtures. These are not the current API format.
+const nativeVariables: NativeFrameVariable[] = [
+  {
+    name: 'player',
+    type: 'Player *',
+    kind: 'object',
+    children: [
+      {name: 'id', type: 'int', kind: 'number', value: '1'},
+      {name: 'name', type: 'char[64]', kind: 'string', value: 'Alice'},
+      {
+        name: 'status',
+        type: 'RequestStatus',
+        kind: 'enum',
+        value: 'STATUS_OK',
+      },
+      {name: 'position', type: 'Vec3', kind: 'object', children: position},
+      {name: 'health', type: 'float', kind: 'number', value: '-5.5'},
+      {
+        name: 'inventory',
+        type: 'Inventory *',
+        kind: 'object',
+        children: [
+          {name: 'capacity', type: 'int', kind: 'number', value: '16'},
+          {name: 'count', type: 'int', kind: 'number', value: '2'},
+          {
+            name: 'items',
+            type: 'int[2]',
+            kind: 'object',
+            children: [
+              {name: '[0]', type: 'int', kind: 'number', value: '42'},
+              {name: '[1]', type: 'int', kind: 'number', value: '7'},
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  {name: 'frame_number', type: 'int', kind: 'number', value: '1'},
+  {name: 'local_counter', type: 'int', kind: 'number', value: '10'},
+  {
+    name: 'm_attachmentDescriptorPoolAllocator',
+    type: 'vk::DescriptorPoolAllocator *',
+    kind: 'object',
+    children: [
+      {name: 'capacity', type: 'uint32_t', kind: 'number', value: '128'},
+      {name: 'allocated', type: 'uint32_t', kind: 'number', value: '12'},
+    ],
+  },
+  {
+    name: 'deferredLightingResolveFullscreenPass',
+    type: 'vk::RenderPass',
+    kind: 'object',
+    children: [
+      {
+        name: 'handle',
+        type: 'VkRenderPass',
+        kind: 'pointer',
+        value: '0x102a4c1e0',
+      },
+    ],
+  },
+  {name: 'damage', type: 'float', kind: 'number', value: '25.5'},
+  {name: 'velocity', type: 'Vec3', kind: 'object', children: position},
+  {name: 'pos_ptr', type: 'Vec3 *', kind: 'object', children: position},
+  {name: 'health_ptr', type: 'float *', kind: 'number', value: '-5.5'},
+  {name: 'status_ptr', type: 'RequestStatus *', kind: 'unavailable'},
+  {name: 'null_player', type: 'Player *', kind: 'null'},
+];
+
+export default Storybook.story('Frame variables', story => {
+  story('Native variables — typed tree preview', () => (
+    <Stack gap="lg">
+      <Text>Design preview with synthetic typed values. API integration is pending.</Text>
+      <Container
+        border="primary"
+        radius="md"
+        overflow="hidden"
+        maxWidth="960px"
+        background="secondary"
+      >
+        <NativeFrameVariables variables={nativeVariables} defaultExpanded={['player']} />
+      </Container>
+    </Stack>
+  ));
+
+  story('Native variables — narrow', () => (
+    <Container
+      width="360px"
+      maxWidth="100%"
+      border="primary"
+      radius="md"
+      overflow="hidden"
+    >
+      <NativeFrameVariables variables={nativeVariables} defaultExpanded={['player']} />
+    </Container>
+  ));
+
+  story('Native variables — empty, unavailable, and exact values', () => (
+    <NativeFrameVariables
+      variables={[
+        {name: 'empty', type: 'Container', kind: 'object', children: []},
+        {name: 'unknown', type: '<unknown>', kind: 'unavailable'},
+        {name: 'zero', type: 'int', kind: 'number', value: '0'},
+        {
+          name: 'large_counter',
+          type: 'uint64_t',
+          kind: 'number',
+          value: '18446744073709551615',
+        },
+        {
+          name: 'address',
+          type: 'void *',
+          kind: 'pointer',
+          value: '0xffffffffffffffff',
+        },
+        {
+          name: 'message',
+          type: 'char[128]',
+          kind: 'string',
+          value:
+            'A long string with "quotes" and a newline\nfor checking wrapping in the value column.',
+        },
+      ]}
+    />
+  ));
+
+  story('Current native wire values', () => (
+    <FrameVariablesGrid
+      platform="native"
+      data={{
+        count: '0x2a (int)',
+        damage: '0x3fc00000 (float)',
+        player: '0x16dc05ff0 (void*)',
+        null_pointer: '0x0 (int*)',
+        local_counter: 'int',
+        health_ptr: 'float*',
+        unknown_type: '<unknown>',
+      }}
+    />
+  ));
+
+  story('Existing JSON variables', () => (
+    <FrameVariablesGrid
+      platform="node"
+      data={{
+        count: 42,
+        enabled: true,
+        player: {name: 'Alice', position: {x: 1.5, y: -3.2, z: 0}},
+        items: [1, 2, 3],
+        empty: null,
+        message: '0x2a (int)',
+      }}
+    />
+  ));
+});

--- a/static/app/components/stackTrace/frame/frameVariablesGrid.stories.tsx
+++ b/static/app/components/stackTrace/frame/frameVariablesGrid.stories.tsx
@@ -2,11 +2,9 @@ import {Container, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {FrameVariablesGrid} from 'sentry/components/stackTrace/frame/frameVariablesGrid';
-import {
-  NativeFrameVariables,
-  type NativeFrameVariable,
-} from 'sentry/components/stackTrace/frame/nativeFrameVariables';
+import {NativeFrameVariables} from 'sentry/components/stackTrace/frame/nativeFrameVariables';
 import * as Storybook from 'sentry/stories';
+import type {NativeFrameVariable} from 'sentry/types/event';
 
 const position = [
   {name: 'x', type: 'float', kind: 'number', value: '1.5'},

--- a/static/app/components/stackTrace/frame/nativeFrameVariables.spec.tsx
+++ b/static/app/components/stackTrace/frame/nativeFrameVariables.spec.tsx
@@ -1,0 +1,65 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {NativeFrameVariables} from 'sentry/components/stackTrace/frame/nativeFrameVariables';
+
+it('expands nested variables with the keyboard and the item summary', async () => {
+  render(
+    <NativeFrameVariables
+      defaultExpanded={['player']}
+      variables={[
+        {
+          name: 'player',
+          type: 'Player *',
+          kind: 'object',
+          children: [
+            {
+              name: 'position',
+              type: 'Vec3',
+              kind: 'object',
+              children: [{name: 'x', type: 'float', kind: 'number', value: '1.5'}],
+            },
+          ],
+        },
+      ]}
+    />
+  );
+
+  expect(screen.getByRole('button', {name: 'Collapse player'})).toHaveAttribute(
+    'aria-expanded',
+    'true'
+  );
+  expect(screen.queryByText('1.5')).not.toBeInTheDocument();
+  await userEvent.click(screen.getByText('{ 1 item }'));
+  expect(screen.getByText('1.5')).toBeInTheDocument();
+  const toggle = screen.getByRole('button', {name: 'Collapse position'});
+  toggle.focus();
+  await userEvent.keyboard('{Enter}');
+  expect(screen.queryByText('1.5')).not.toBeInTheDocument();
+  expect(screen.getAllByRole('button', {name: 'Expand position'})[0]).toHaveAttribute(
+    'aria-expanded',
+    'false'
+  );
+});
+
+it('keeps unavailable values distinct from null and preserves exact numbers', () => {
+  render(
+    <NativeFrameVariables
+      variables={[
+        {name: 'unavailable', type: 'int *', kind: 'unavailable'},
+        {name: 'null_pointer', type: 'int *', kind: 'null'},
+        {
+          name: 'counter',
+          type: 'uint64_t',
+          kind: 'number',
+          value: '18446744073709551615',
+        },
+        {name: 'zero', type: 'int', kind: 'number', value: '0'},
+      ]}
+    />
+  );
+
+  expect(screen.getByText('Unavailable')).toBeInTheDocument();
+  expect(screen.getByText('nullptr')).toBeInTheDocument();
+  expect(screen.getByText('18446744073709551615')).toBeInTheDocument();
+  expect(screen.getByText('0')).toBeInTheDocument();
+});

--- a/static/app/components/stackTrace/frame/nativeFrameVariables.tsx
+++ b/static/app/components/stackTrace/frame/nativeFrameVariables.tsx
@@ -1,0 +1,231 @@
+import {useState} from 'react';
+import styled from '@emotion/styled';
+
+import {Button} from '@sentry/scraps/button';
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Container, Grid, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {t, tn} from 'sentry/locale';
+
+/** Presentation model for the native variables preview, independent of frame.vars. */
+export type NativeFrameVariable = {
+  name: string;
+  type: string;
+} & (
+  | {children: readonly NativeFrameVariable[]; kind: 'object'}
+  | {kind: 'number' | 'string' | 'enum' | 'pointer'; value: string}
+  | {kind: 'null'}
+  | {kind: 'unavailable'}
+);
+
+interface Props {
+  variables: readonly NativeFrameVariable[];
+  defaultExpanded?: readonly string[];
+}
+
+export function NativeFrameVariables({variables, defaultExpanded = []}: Props) {
+  return (
+    <Stack borderTop="primary" aria-label={t('Native variables')}>
+      {variables.map((variable, index) => (
+        <Container
+          key={variable.name}
+          borderBottom={index < variables.length - 1 ? 'secondary' : undefined}
+        >
+          <Variable
+            variable={variable}
+            depth={0}
+            defaultExpanded={defaultExpanded.includes(variable.name)}
+          />
+        </Container>
+      ))}
+    </Stack>
+  );
+}
+
+function Variable({
+  variable,
+  depth,
+  defaultExpanded = false,
+}: {
+  depth: number;
+  variable: NativeFrameVariable;
+  defaultExpanded?: boolean;
+}) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const label = (
+    <Stack minWidth="0" gap="xs" align="start">
+      <VariableName
+        as="div"
+        monospace
+        size="sm"
+        bold={depth === 0}
+        nested={depth > 0}
+        density="comfortable"
+        ellipsis
+        title={variable.name}
+      >
+        {variable.name}
+      </VariableName>
+      <Text as="div" monospace size="xs" variant="muted" ellipsis title={variable.type}>
+        {variable.type}
+      </Text>
+    </Stack>
+  );
+
+  const row = (
+    <VariableRow
+      columns="minmax(0, 192px) minmax(0, 1fr)"
+      width="100%"
+      position="relative"
+    >
+      <NameCell
+        depth={depth}
+        paddingTop={depth > 0 ? 'sm' : 'md'}
+        paddingBottom={depth > 0 ? 'sm' : 'md'}
+        paddingRight="md"
+        minWidth="0"
+      >
+        {variable.kind === 'object' ? (
+          <VariableTitle
+            aria-label={
+              expanded ? t('Collapse %s', variable.name) : t('Expand %s', variable.name)
+            }
+          >
+            {label}
+          </VariableTitle>
+        ) : (
+          <Container paddingLeft="xl" minWidth="0">
+            {label}
+          </Container>
+        )}
+      </NameCell>
+      <Stack
+        borderLeft="secondary"
+        padding={depth > 0 ? 'sm md' : 'md'}
+        minWidth="0"
+        align="start"
+      >
+        {variable.kind === 'object' ? (
+          !expanded && (
+            <SummaryButton
+              variant="transparent"
+              size="zero"
+              aria-label={t('Expand %s', variable.name)}
+              onClick={() => setExpanded(true)}
+            >
+              <Text monospace size="sm" variant="muted" density="comfortable">
+                {'{ '}
+                {tn('%s item', '%s items', variable.children.length)}
+                {' }'}
+              </Text>
+            </SummaryButton>
+          )
+        ) : variable.kind === 'unavailable' ? (
+          <Text monospace size="sm" variant="muted" density="comfortable">
+            {t('Unavailable')}
+          </Text>
+        ) : (
+          <VariableValue
+            monospace
+            size="sm"
+            kind={variable.kind}
+            density="comfortable"
+            wrap="pre-wrap"
+            wordBreak="break-word"
+          >
+            {variable.kind === 'null'
+              ? 'nullptr'
+              : variable.kind === 'string'
+                ? JSON.stringify(variable.value)
+                : variable.value}
+          </VariableValue>
+        )}
+      </Stack>
+    </VariableRow>
+  );
+
+  if (variable.kind !== 'object') {
+    return row;
+  }
+
+  return (
+    <Disclosure expanded={expanded} onExpandedChange={setExpanded} width="100%" size="xs">
+      {row}
+      <VariableContent>
+        {expanded &&
+          variable.children.map(child => (
+            <Variable key={child.name} variable={child} depth={depth + 1} />
+          ))}
+      </VariableContent>
+    </Disclosure>
+  );
+}
+
+const VariableRow = styled(Grid)`
+  &:hover,
+  &:focus-within {
+    background: ${p => p.theme.tokens.interactive.transparent.neutral.background.hover};
+  }
+
+  &::before {
+    content: '';
+    position: absolute;
+    inset: 0 auto 0 0;
+    border-left: 2px solid transparent;
+    pointer-events: none;
+  }
+
+  &:hover::before,
+  &:focus-within::before {
+    border-left-color: ${p => p.theme.tokens.border.accent.vibrant};
+  }
+`;
+
+const NameCell = styled(Container)<{depth: number}>`
+  padding-left: ${p => 12 + p.depth * 16}px;
+
+  /* The variable row owns the background instead of Disclosure's title wrapper. */
+  > div:hover,
+  > div:active {
+    background: transparent;
+  }
+`;
+
+const SummaryButton = styled(Button)`
+  height: auto;
+  min-height: 0;
+  padding: 0;
+
+  &&:hover,
+  &&:active {
+    background: transparent;
+  }
+`;
+
+const VariableTitle = styled(Disclosure.Title)`
+  height: auto;
+  min-width: 0;
+  padding: 0;
+  text-align: left;
+  width: 100%;
+`;
+
+const VariableContent = styled(Disclosure.Content)`
+  padding: 0;
+`;
+
+const VariableName = styled(Text)<{nested: boolean}>`
+  max-width: 100%;
+  color: ${p =>
+    p.nested ? p.theme.tokens.content.danger : p.theme.tokens.content.primary};
+`;
+
+const VariableValue = styled(Text)<{kind: NativeFrameVariable['kind']}>`
+  color: ${p =>
+    p.kind === 'string'
+      ? p.theme.tokens.content.success
+      : p.kind === 'number' || p.kind === 'null' || p.kind === 'pointer'
+        ? p.theme.tokens.content.accent
+        : p.theme.tokens.content.primary};
+`;

--- a/static/app/components/stackTrace/frame/nativeFrameVariables.tsx
+++ b/static/app/components/stackTrace/frame/nativeFrameVariables.tsx
@@ -7,17 +7,7 @@ import {Container, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t, tn} from 'sentry/locale';
-
-/** Presentation model for the native variables preview, independent of frame.vars. */
-export type NativeFrameVariable = {
-  name: string;
-  type: string;
-} & (
-  | {children: readonly NativeFrameVariable[]; kind: 'object'}
-  | {kind: 'number' | 'string' | 'enum' | 'pointer'; value: string}
-  | {kind: 'null'}
-  | {kind: 'unavailable'}
-);
+import type {NativeFrameVariable} from 'sentry/types/event';
 
 interface Props {
   variables: readonly NativeFrameVariable[];

--- a/static/app/types/event.tsx
+++ b/static/app/types/event.tsx
@@ -160,6 +160,21 @@ export enum LockType {
   BLOCKED = 8,
 }
 
+/**
+ * Typed native variable tree shared by frame renderers and extraction adapters.
+ * This is a frontend model; the current Frame.vars payload is not decoded into it yet.
+ * Scalar values stay strings to preserve pointer addresses and full numeric precision.
+ */
+export type NativeFrameVariable = {
+  name: string;
+  type: string;
+} & (
+  | {children: readonly NativeFrameVariable[]; kind: 'object'}
+  | {kind: 'number' | 'string' | 'enum' | 'pointer'; value: string}
+  | {kind: 'null'}
+  | {kind: 'unavailable'}
+);
+
 export type Frame = {
   absPath: string | null;
   colNo: number | null;


### PR DESCRIPTION
Adds a native variables tree preview with types beneath names, expandable children, and full-row hover highlighting. Child rows are a little denser, and names and values share the same alignment.

This is story-only for now, using synthetic typed fixtures. The live frame.vars renderer stays unchanged until the native extraction format is ready. Includes narrow layouts, unavailable values, and exact large numbers.

Current renderer with raw native values

<img width="802" height="325" alt="Current renderer with raw native values" src="https://github.com/user-attachments/assets/96fb8521-abd0-4097-9e88-2ac9f7aae482" />

Typed tree preview with synthetic values

<img width="802" height="849" alt="Native variables typed tree preview" src="https://github.com/user-attachments/assets/4a24f565-152a-4777-b275-c202c9fadbd1" />
