### PR TITLE
fix(gitlab): Preserve the webhook secret across reinstall

### DIFF
--- a/src/sentry/integrations/gitlab/integration.py
+++ b/src/sentry/integrations/gitlab/integration.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import secrets
 from collections.abc import Mapping, MutableMapping
 from typing import Any
 from urllib.parse import urlparse
@@ -24,6 +25,7 @@ from sentry.integrations.base import (
 )
 from sentry.integrations.gitlab.constants import GITLAB_WEBHOOK_VERSION, GITLAB_WEBHOOK_VERSION_KEY
 from sentry.integrations.gitlab.types import GitLabIssueStatus
+from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.integration_external_project import IntegrationExternalProject
 from sentry.integrations.pipeline import IntegrationPipeline
 from sentry.integrations.referrer_ids import GITLAB_PR_BOT_REFERRER
@@ -58,7 +60,6 @@ from sentry.shared_integrations.exceptions import (
 from sentry.snuba.referrer import Referrer
 from sentry.users.models.identity import Identity
 from sentry.utils import metrics
-from sentry.utils.hashlib import sha1_text
 from sentry.utils.http import absolute_uri
 
 from .client import GitLabApiClient, GitLabSetupApiClient
@@ -711,19 +712,25 @@ class GitlabIntegrationProvider(IntegrationProvider):
         hostname = urlparse(base_url).netloc
         verify_ssl = state["installation_data"]["verify_ssl"]
 
-        # Generate a hash to prevent stray hooks from being accepted
-        # use a consistent hash so that reinstalls/shared integrations don't
-        # rotate secrets.
-        secret = sha1_text("".join([hostname, state["installation_data"]["client_id"]]))
+        # Splice the gitlab host and project together to
+        # act as unique link between a gitlab instance, group + sentry.
+        # This value is embedded then in the webhook token that we
+        # give to gitlab to allow us to find the integration a hook came
+        # from.
+        external_id = "{}:{}".format(hostname, group.get("id", "_instance_"))
+
+        # Hooks on GitLab outlive the org integration that created them, and one
+        # integration row is shared by every org on the group, so the secret has to
+        # survive a reinstall. No status filter: a disabled row still owns hooks
+        # carrying its secret.
+        existing = Integration.objects.filter(provider=self.key, external_id=external_id).first()
+        webhook_secret = existing.metadata.get("webhook_secret") if existing else None
+        if not webhook_secret:
+            webhook_secret = secrets.token_hex(20)
 
         return {
             "name": group.get("full_name", hostname),
-            # Splice the gitlab host and project together to
-            # act as unique link between a gitlab instance, group + sentry.
-            # This value is embedded then in the webhook token that we
-            # give to gitlab to allow us to find the integration a hook came
-            # from.
-            "external_id": "{}:{}".format(hostname, group.get("id", "_instance_")),
+            "external_id": external_id,
             "metadata": {
                 "icon": group.get("avatar_url"),
                 "instance": hostname,
@@ -731,7 +738,7 @@ class GitlabIntegrationProvider(IntegrationProvider):
                 "scopes": scopes,
                 "verify_ssl": verify_ssl,
                 "base_url": base_url,
-                "webhook_secret": secret.hexdigest(),
+                "webhook_secret": webhook_secret,
                 "group_id": group.get("id"),
                 "include_subgroups": include_subgroups,
             },

--- a/tests/sentry/integrations/gitlab/test_integration.py
+++ b/tests/sentry/integrations/gitlab/test_integration.py
@@ -11,6 +11,7 @@ from django.test import override_settings
 from django.urls import reverse
 
 from fixtures.gitlab import GET_COMMIT_RESPONSE, GitLabTestCase
+from sentry.constants import ObjectStatus
 from sentry.integrations.gitlab.client import GitLabApiClient, GitLabSetupApiClient
 from sentry.integrations.gitlab.constants import GITLAB_WEBHOOK_VERSION, GITLAB_WEBHOOK_VERSION_KEY
 from sentry.integrations.gitlab.integration import GitlabIntegration, GitlabIntegrationProvider
@@ -1276,6 +1277,16 @@ class GitLabIntegrationApiPipelineTest(APITestCase):
     def _get_pipeline_signature(self, resp: Any) -> str:
         return resp.data["data"]["oauthUrl"].split("state=")[1].split("&")[0]
 
+    def _run_pipeline(self, **overrides: Any) -> Any:
+        self._stub_gitlab_oauth()
+        self._stub_gitlab_user()
+        self._stub_gitlab_group()
+
+        self._initialize_pipeline()
+        resp = self._submit_config(**overrides)
+        pipeline_signature = self._get_pipeline_signature(resp)
+        return self._advance_step({"code": "gitlab-auth-code", "state": pipeline_signature})
+
     @responses.activate
     def test_initialize_pipeline(self) -> None:
         resp = self._initialize_pipeline()
@@ -1392,3 +1403,73 @@ class GitLabIntegrationApiPipelineTest(APITestCase):
         oauth_url = resp.data["data"]["oauthUrl"]
         assert "gitlab.example.com/oauth/authorize" in oauth_url
         assert "///" not in oauth_url
+
+    @responses.activate
+    def test_install_generates_webhook_secret(self) -> None:
+        self._run_pipeline()
+
+        integration = Integration.objects.get(provider="gitlab")
+        secret = integration.metadata["webhook_secret"]
+        assert secret
+        # The inbound webhook token is "<instance>:<group>:<secret>".
+        assert ":" not in secret
+
+    @responses.activate
+    def test_reinstall_preserves_webhook_secret(self) -> None:
+        self._run_pipeline()
+        integration = Integration.objects.get(provider="gitlab")
+        secret = integration.metadata["webhook_secret"]
+
+        resp = self._run_pipeline(clientId="app-id-def456", verifySsl=False)
+        assert resp.data["status"] == "complete"
+
+        assert Integration.objects.filter(provider="gitlab").count() == 1
+        integration.refresh_from_db()
+        assert integration.metadata["webhook_secret"] == secret
+        assert integration.metadata["verify_ssl"] is False
+        assert integration.metadata["scopes"] == ["api"]
+
+    @responses.activate
+    def test_reinstall_preserves_webhook_secret_shared_with_another_org(self) -> None:
+        self._run_pipeline()
+        integration = Integration.objects.get(provider="gitlab")
+        secret = integration.metadata["webhook_secret"]
+
+        with assume_test_silo_mode(SiloMode.CELL):
+            other_org = self.create_organization(name="other-org")
+        self.create_organization_integration(organization_id=other_org.id, integration=integration)
+
+        self._run_pipeline(clientId="app-id-def456")
+
+        integration.refresh_from_db()
+        assert integration.metadata["webhook_secret"] == secret
+        assert OrganizationIntegration.objects.filter(
+            organization_id=other_org.id, integration=integration
+        ).exists()
+
+    @responses.activate
+    def test_reinstall_preserves_webhook_secret_when_integration_is_disabled(self) -> None:
+        self._run_pipeline()
+        integration = Integration.objects.get(provider="gitlab")
+        secret = integration.metadata["webhook_secret"]
+        integration.update(status=ObjectStatus.DISABLED)
+
+        self._run_pipeline(clientId="app-id-def456")
+
+        integration.refresh_from_db()
+        assert integration.metadata["webhook_secret"] == secret
+        assert integration.status == ObjectStatus.ACTIVE
+
+    @responses.activate
+    def test_install_backfills_missing_webhook_secret(self) -> None:
+        integration = self.create_provider_integration(
+            provider="gitlab",
+            external_id="gitlab.example.com:1",
+            name="My Group",
+            metadata={"instance": "gitlab.example.com"},
+        )
+
+        self._run_pipeline()
+
+        integration.refresh_from_db()
+        assert integration.metadata["webhook_secret"]


### PR DESCRIPTION
Every GitLab webhook Sentry creates carries a secret token. Today, if you reinstall the integration with a different OAuth application the secret changes. The hooks sitting on GitLab still send the old one, and from that point on their deliveries are rejected.

That is worse than it sounds, because the hooks outlive the org integration. Uninstalling removes only the org's link to the integration, never the shared `Integration` row the hooks point at, and every org installed on the same GitLab group shares that one row. So one org reinstalling can break webhook delivery for all of them.

The fix: before writing the metadata, look up the existing `Integration` row for this host + group and reuse the secret it already has. Only a genuinely new row gets a secret, and it now gets a random one (`secrets.token_hex(20)`) since there is no longer a reason to derive it from anything.

Two things worth a reviewer's eye:
- The lookup deliberately has no status filter. A disabled row still owns hooks on GitLab that carry its secret, so a reinstall has to match it. There is a comment saying so, because it looks like an oversight otherwise.
- The generated secret is 40 hex characters, same length as the old sha1 hex and with no `:` in it. The inbound handler splits the token on `:`, so a colon would break parsing.

Existing rows are untouched: nothing recomputes the old derivation, the stored metadata value is the only thing inbound deliveries are compared against.

Fixes SCM-175