### PR TITLE
fix(gitlab): Reconcile the project hook when a repository is relinked

### DIFF
--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -67,7 +67,7 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
             "gitlab.repository.organization_id": repo.organization_id,
             "gitlab.repository.integration_id": repo.integration_id,
             "gitlab.repository.repository_id": repo.id,
-            "gitlab.repository.project_id": repo.config.get("project_id"),
+            "gitlab.repository.project_id": repo.config["project_id"],
         }
         # Emitted on every invocation so we can gauge how often this path runs
         # (and therefore how many webhook create calls we make to GitLab).
@@ -78,12 +78,9 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
                 "gitlab.repository.has_existing_webhook": bool(repo.config.get("webhook_id")),
             },
         )
-        project_id = repo.config.get("project_id")
-        if not project_id:
-            logger.info("gitlab.repository.missing_project_id", extra=log_extra)
-            return
         installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
+        project_id = repo.config["project_id"]
         existing_webhook_id = repo.config.get("webhook_id")
         if existing_webhook_id:
             try:
@@ -117,16 +114,15 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
 
     def on_delete_repository(self, repo):
         """Clean up the attached webhook"""
-        project_id = repo.config.get("project_id")
         webhook_id = repo.config.get("webhook_id")
         # A repository whose hook creation failed has no webhook_id. There is no hook to
         # clean up then, and raising would only stop the user from deleting the repository.
-        if not project_id or not webhook_id:
+        if not webhook_id:
             return
         installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
         try:
-            client.delete_project_webhook(project_id, webhook_id)
+            client.delete_project_webhook(repo.config["project_id"], webhook_id)
         except ApiError as e:
             if e.code == 404:
                 return

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -119,8 +119,8 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
         """Clean up the attached webhook"""
         project_id = repo.config.get("project_id")
         webhook_id = repo.config.get("webhook_id")
-        # Legacy rows can lack either key. There is no hook to clean up then, and raising
-        # would only stop the user from deleting the repository.
+        # A repository whose hook creation failed has no webhook_id. There is no hook to
+        # clean up then, and raising would only stop the user from deleting the repository.
         if not project_id or not webhook_id:
             return
         installation = self.get_installation(repo.integration_id, repo.organization_id)

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -115,18 +115,19 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
             if e.code != 404:
                 raise installation.raise_error(e)
             return False
-        # A temporarily disabled hook re-enables itself once GitLab's backoff expires, but
-        # nothing short of replacing it revives one GitLab disabled for good.
-        if hook.get("alert_status") != "disabled":
-            logger.info(
-                "gitlab.repository.webhook_updated",
-                extra={**log_extra, "gitlab.repository.webhook_id": webhook_id},
-            )
+        # GitLab stops delivering to a hook after repeated failed deliveries. A temporarily
+        # disabled hook re-enables itself once the backoff expires, but nothing short of
+        # replacing it revives one disabled for good.
+        alert_status = hook.get("alert_status")
+        log_extra = {
+            **log_extra,
+            "gitlab.repository.webhook_id": webhook_id,
+            "gitlab.repository.alert_status": alert_status,
+        }
+        if alert_status != "disabled":
+            logger.info("gitlab.repository.webhook_updated", extra=log_extra)
             return True
-        logger.info(
-            "gitlab.repository.webhook_disabled",
-            extra={**log_extra, "gitlab.repository.webhook_id": webhook_id},
-        )
+        logger.info("gitlab.repository.replacing_webhook_disabled_by_gitlab", extra=log_extra)
         try:
             client.delete_project_webhook(project_id, webhook_id)
         except ApiError as e:

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -86,17 +86,20 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
         client = installation.get_client()
         existing_webhook_id = repo.config.get("webhook_id")
         if existing_webhook_id:
-            # The stored hook may be gone, disabled, or carrying a rotated token, so replace
-            # it. Swallowing anything but a 404 here would leave a duplicate hook behind.
             try:
-                client.delete_project_webhook(project_id, existing_webhook_id)
+                client.update_project_webhook(project_id, existing_webhook_id)
             except ApiError as e:
+                # Only a missing hook may fall through to create. An update that reached
+                # GitLab but reported anything else may well have applied, and creating a
+                # second hook on top of it would double every delivery.
                 if e.code != 404:
                     raise installation.raise_error(e)
+            else:
                 logger.info(
-                    "gitlab.repository.webhook_already_gone",
+                    "gitlab.repository.webhook_updated",
                     extra={**log_extra, "gitlab.repository.webhook_id": existing_webhook_id},
                 )
+                return
         try:
             hook_id = client.create_project_webhook(project_id)
         except Exception as e:
@@ -104,7 +107,11 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
         repo.config["webhook_id"] = hook_id
         repository_service.update_repository(organization_id=organization.id, update=repo)
         logger.info(
-            "gitlab.repository.webhook_created",
+            (
+                "gitlab.repository.webhook_recreated"
+                if existing_webhook_id
+                else "gitlab.repository.webhook_created"
+            ),
             extra={**log_extra, "gitlab.repository.webhook_id": hook_id},
         )
 

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -82,21 +82,10 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
         client = installation.get_client()
         project_id = repo.config["project_id"]
         existing_webhook_id = repo.config.get("webhook_id")
-        if existing_webhook_id:
-            try:
-                client.update_project_webhook(project_id, existing_webhook_id)
-            except ApiError as e:
-                # Only a missing hook may fall through to create. An update that reached
-                # GitLab but reported anything else may well have applied, and creating a
-                # second hook on top of it would double every delivery.
-                if e.code != 404:
-                    raise installation.raise_error(e)
-            else:
-                logger.info(
-                    "gitlab.repository.webhook_updated",
-                    extra={**log_extra, "gitlab.repository.webhook_id": existing_webhook_id},
-                )
-                return
+        if existing_webhook_id and self._update_webhook(
+            installation, client, project_id, existing_webhook_id, log_extra
+        ):
+            return
         try:
             hook_id = client.create_project_webhook(project_id)
         except Exception as e:
@@ -111,6 +100,39 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
             ),
             extra={**log_extra, "gitlab.repository.webhook_id": hook_id},
         )
+
+    def _update_webhook(self, installation, client, project_id, webhook_id, log_extra) -> bool:
+        """Push the current hook config to the stored hook.
+
+        Returns False when the hook has to be created afresh instead.
+        """
+        try:
+            hook = client.update_project_webhook(project_id, webhook_id)
+        except ApiError as e:
+            # Only a missing hook may fall through to create. An update that reached
+            # GitLab but reported anything else may well have applied, and creating a
+            # second hook on top of it would double every delivery.
+            if e.code != 404:
+                raise installation.raise_error(e)
+            return False
+        # A temporarily disabled hook re-enables itself once GitLab's backoff expires, but
+        # nothing short of replacing it revives one GitLab disabled for good.
+        if hook.get("alert_status") != "disabled":
+            logger.info(
+                "gitlab.repository.webhook_updated",
+                extra={**log_extra, "gitlab.repository.webhook_id": webhook_id},
+            )
+            return True
+        logger.info(
+            "gitlab.repository.webhook_disabled",
+            extra={**log_extra, "gitlab.repository.webhook_id": webhook_id},
+        )
+        try:
+            client.delete_project_webhook(project_id, webhook_id)
+        except ApiError as e:
+            if e.code != 404:
+                raise installation.raise_error(e)
+        return False
 
     def on_delete_repository(self, repo):
         """Clean up the attached webhook"""

--- a/src/sentry/integrations/gitlab/repository.py
+++ b/src/sentry/integrations/gitlab/repository.py
@@ -78,16 +78,27 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
                 "gitlab.repository.has_existing_webhook": bool(repo.config.get("webhook_id")),
             },
         )
-        if repo.config.get("webhook_id"):
-            logger.info(
-                "gitlab.repository.webhook_creation_skipped",
-                extra={**log_extra, "gitlab.repository.webhook_id": repo.config.get("webhook_id")},
-            )
+        project_id = repo.config.get("project_id")
+        if not project_id:
+            logger.info("gitlab.repository.missing_project_id", extra=log_extra)
             return
         installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
+        existing_webhook_id = repo.config.get("webhook_id")
+        if existing_webhook_id:
+            # The stored hook may be gone, disabled, or carrying a rotated token, so replace
+            # it. Swallowing anything but a 404 here would leave a duplicate hook behind.
+            try:
+                client.delete_project_webhook(project_id, existing_webhook_id)
+            except ApiError as e:
+                if e.code != 404:
+                    raise installation.raise_error(e)
+                logger.info(
+                    "gitlab.repository.webhook_already_gone",
+                    extra={**log_extra, "gitlab.repository.webhook_id": existing_webhook_id},
+                )
         try:
-            hook_id = client.create_project_webhook(repo.config["project_id"])
+            hook_id = client.create_project_webhook(project_id)
         except Exception as e:
             raise installation.raise_error(e)
         repo.config["webhook_id"] = hook_id
@@ -99,10 +110,16 @@ class GitlabRepositoryProvider(IntegrationRepositoryProvider["GitlabIntegration"
 
     def on_delete_repository(self, repo):
         """Clean up the attached webhook"""
+        project_id = repo.config.get("project_id")
+        webhook_id = repo.config.get("webhook_id")
+        # Legacy rows can lack either key. There is no hook to clean up then, and raising
+        # would only stop the user from deleting the repository.
+        if not project_id or not webhook_id:
+            return
         installation = self.get_installation(repo.integration_id, repo.organization_id)
         client = installation.get_client()
         try:
-            client.delete_project_webhook(repo.config["project_id"], repo.config["webhook_id"])
+            client.delete_project_webhook(project_id, webhook_id)
         except ApiError as e:
             if e.code == 404:
                 return

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -208,21 +208,16 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         assert self.get_repository(pk=repo.id).config["webhook_id"] == 99
 
     @responses.activate
-    def test_repository_without_project_id(self) -> None:
+    def test_on_delete_repository_without_webhook_does_not_call_gitlab(self) -> None:
         response = self.create_repository(self.default_repository_config, self.integration.id)
-        responses.reset()
-        self.add_relink_responses(update_status=200)
-
         repo = self.get_repository(pk=response.data["id"])
         with assume_test_silo_mode(SiloMode.CELL):
-            del repo.config["project_id"]
+            del repo.config["webhook_id"]
             repo.save()
+        responses.reset()
 
-        with self.assertLogs("sentry.integrations.gitlab", level="INFO") as logs:
-            self.relink_repository(repo)
         self.provider.on_delete_repository(repo)
 
-        assert "gitlab.repository.missing_project_id" in "\n".join(logs.output)
         assert len(responses.calls) == 0
 
     @responses.activate

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -135,11 +135,12 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             serialize_repository(repo), serialize_rpc_organization(self.organization)
         )
 
-    def add_webhook_recreate_responses(self, delete_status: int) -> None:
+    def add_relink_responses(self, update_status: int) -> None:
         responses.add(
-            responses.DELETE,
+            responses.PUT,
             "https://example.gitlab.com/api/v4/projects/%s/hooks/99" % self.gitlab_id,
-            status=delete_status,
+            status=update_status,
+            json={"id": 99},
         )
         responses.add(
             responses.POST,
@@ -148,47 +149,69 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         )
 
     @responses.activate
-    def test_on_create_repository_relink_recreates_webhook(self) -> None:
+    def test_on_create_repository_relink_updates_webhook(self) -> None:
         response = self.create_repository(self.default_repository_config, self.integration.id)
         responses.reset()
-        self.add_webhook_recreate_responses(delete_status=204)
+
+        def request_callback(request):
+            payload = orjson.loads(request.body)
+            assert "url" in payload
+            assert payload["push_events"]
+            assert payload["merge_requests_events"]
+            expected_token = "{}:{}".format(
+                self.integration.external_id, self.integration.metadata["webhook_secret"]
+            )
+            assert payload["token"] == expected_token
+
+            return 200, {}, orjson.dumps({"id": 99}).decode()
+
+        responses.add_callback(
+            responses.PUT,
+            "https://example.gitlab.com/api/v4/projects/%s/hooks/99" % self.gitlab_id,
+            callback=request_callback,
+        )
+        responses.add(
+            responses.POST,
+            "https://example.gitlab.com/api/v4/projects/%s/hooks" % self.gitlab_id,
+            json={"id": 100},
+        )
 
         repo = self.get_repository(pk=response.data["id"])
         self.relink_repository(repo)
 
-        assert [call.request.method for call in responses.calls] == ["DELETE", "POST"]
-        assert self.get_repository(pk=repo.id).config["webhook_id"] == 100
+        assert [call.request.method for call in responses.calls] == ["PUT"]
+        assert self.get_repository(pk=repo.id).config["webhook_id"] == 99
 
     @responses.activate
-    def test_on_create_repository_relink_when_webhook_already_gone(self) -> None:
+    def test_on_create_repository_relink_recreates_missing_webhook(self) -> None:
         response = self.create_repository(self.default_repository_config, self.integration.id)
         responses.reset()
-        self.add_webhook_recreate_responses(delete_status=404)
+        self.add_relink_responses(update_status=404)
 
         repo = self.get_repository(pk=response.data["id"])
         self.relink_repository(repo)
 
-        assert [call.request.method for call in responses.calls] == ["DELETE", "POST"]
+        assert [call.request.method for call in responses.calls] == ["PUT", "POST"]
         assert self.get_repository(pk=repo.id).config["webhook_id"] == 100
 
     @responses.activate
-    def test_on_create_repository_relink_delete_failure_creates_no_duplicate(self) -> None:
+    def test_on_create_repository_relink_update_failure_creates_no_duplicate(self) -> None:
         response = self.create_repository(self.default_repository_config, self.integration.id)
         responses.reset()
-        self.add_webhook_recreate_responses(delete_status=403)
+        self.add_relink_responses(update_status=500)
 
         repo = self.get_repository(pk=response.data["id"])
         with pytest.raises(IntegrationError):
             self.relink_repository(repo)
 
-        assert [call.request.method for call in responses.calls] == ["DELETE"]
+        assert [call.request.method for call in responses.calls] == ["PUT"]
         assert self.get_repository(pk=repo.id).config["webhook_id"] == 99
 
     @responses.activate
     def test_repository_without_project_id(self) -> None:
         response = self.create_repository(self.default_repository_config, self.integration.id)
         responses.reset()
-        self.add_webhook_recreate_responses(delete_status=204)
+        self.add_relink_responses(update_status=200)
 
         repo = self.get_repository(pk=response.data["id"])
         with assume_test_silo_mode(SiloMode.CELL):

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -135,12 +135,22 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             serialize_repository(repo), serialize_rpc_organization(self.organization)
         )
 
-    def add_relink_responses(self, update_status: int) -> None:
+    def add_relink_responses(
+        self, update_status: int, alert_status: str | None = None, delete_status: int = 204
+    ) -> None:
+        hook: dict[str, int | str] = {"id": 99}
+        if alert_status:
+            hook["alert_status"] = alert_status
         responses.add(
             responses.PUT,
             "https://example.gitlab.com/api/v4/projects/%s/hooks/99" % self.gitlab_id,
             status=update_status,
-            json={"id": 99},
+            json=hook,
+        )
+        responses.add(
+            responses.DELETE,
+            "https://example.gitlab.com/api/v4/projects/%s/hooks/99" % self.gitlab_id,
+            status=delete_status,
         )
         responses.add(
             responses.POST,
@@ -205,6 +215,57 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
             self.relink_repository(repo)
 
         assert [call.request.method for call in responses.calls] == ["PUT"]
+        assert self.get_repository(pk=repo.id).config["webhook_id"] == 99
+
+    @responses.activate
+    def test_on_create_repository_relink_replaces_permanently_disabled_webhook(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+        self.add_relink_responses(update_status=200, alert_status="disabled")
+
+        repo = self.get_repository(pk=response.data["id"])
+        self.relink_repository(repo)
+
+        assert [call.request.method for call in responses.calls] == ["PUT", "DELETE", "POST"]
+        assert self.get_repository(pk=repo.id).config["webhook_id"] == 100
+
+    @responses.activate
+    def test_on_create_repository_relink_keeps_live_webhook(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        repo = self.get_repository(pk=response.data["id"])
+
+        for alert_status in ("executable", "temporarily_disabled"):
+            responses.reset()
+            self.add_relink_responses(update_status=200, alert_status=alert_status)
+
+            self.relink_repository(repo)
+
+            assert [call.request.method for call in responses.calls] == ["PUT"], alert_status
+            assert self.get_repository(pk=repo.id).config["webhook_id"] == 99
+
+    @responses.activate
+    def test_on_create_repository_relink_disabled_webhook_already_gone(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+        self.add_relink_responses(update_status=200, alert_status="disabled", delete_status=404)
+
+        repo = self.get_repository(pk=response.data["id"])
+        self.relink_repository(repo)
+
+        assert [call.request.method for call in responses.calls] == ["PUT", "DELETE", "POST"]
+        assert self.get_repository(pk=repo.id).config["webhook_id"] == 100
+
+    @responses.activate
+    def test_on_create_repository_relink_disabled_webhook_delete_failure(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+        self.add_relink_responses(update_status=200, alert_status="disabled", delete_status=403)
+
+        repo = self.get_repository(pk=response.data["id"])
+        with pytest.raises(IntegrationError):
+            self.relink_repository(repo)
+
+        assert [call.request.method for call in responses.calls] == ["PUT", "DELETE"]
         assert self.get_repository(pk=repo.id).config["webhook_id"] == 99
 
     @responses.activate

--- a/tests/sentry/integrations/gitlab/test_repository.py
+++ b/tests/sentry/integrations/gitlab/test_repository.py
@@ -6,8 +6,10 @@ import responses
 
 from fixtures.gitlab import COMMIT_DIFF_RESPONSE, COMMIT_LIST_RESPONSE, COMPARE_RESPONSE
 from sentry.integrations.gitlab.repository import GitlabRepositoryProvider
+from sentry.integrations.services.repository.serial import serialize_repository
 from sentry.models.pullrequest import PullRequest
 from sentry.models.repository import Repository
+from sentry.organizations.services.organization.serial import serialize_rpc_organization
 from sentry.shared_integrations.exceptions import IntegrationError
 from sentry.silo.base import SiloMode
 from sentry.testutils.asserts import assert_commit_shape
@@ -125,6 +127,80 @@ class GitLabRepositoryProviderTest(IntegrationRepositoryTestCase):
         response = self.create_repository(self.default_repository_config, self.integration.id)
         assert response.status_code == 201
         self.assert_repository(self.default_repository_config)
+
+    @assume_test_silo_mode(SiloMode.CELL)
+    def relink_repository(self, repo: Repository) -> None:
+        """Replay what the repo sync does when it reattaches an already-linked repository."""
+        self.provider.on_create_repository(
+            serialize_repository(repo), serialize_rpc_organization(self.organization)
+        )
+
+    def add_webhook_recreate_responses(self, delete_status: int) -> None:
+        responses.add(
+            responses.DELETE,
+            "https://example.gitlab.com/api/v4/projects/%s/hooks/99" % self.gitlab_id,
+            status=delete_status,
+        )
+        responses.add(
+            responses.POST,
+            "https://example.gitlab.com/api/v4/projects/%s/hooks" % self.gitlab_id,
+            json={"id": 100},
+        )
+
+    @responses.activate
+    def test_on_create_repository_relink_recreates_webhook(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+        self.add_webhook_recreate_responses(delete_status=204)
+
+        repo = self.get_repository(pk=response.data["id"])
+        self.relink_repository(repo)
+
+        assert [call.request.method for call in responses.calls] == ["DELETE", "POST"]
+        assert self.get_repository(pk=repo.id).config["webhook_id"] == 100
+
+    @responses.activate
+    def test_on_create_repository_relink_when_webhook_already_gone(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+        self.add_webhook_recreate_responses(delete_status=404)
+
+        repo = self.get_repository(pk=response.data["id"])
+        self.relink_repository(repo)
+
+        assert [call.request.method for call in responses.calls] == ["DELETE", "POST"]
+        assert self.get_repository(pk=repo.id).config["webhook_id"] == 100
+
+    @responses.activate
+    def test_on_create_repository_relink_delete_failure_creates_no_duplicate(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+        self.add_webhook_recreate_responses(delete_status=403)
+
+        repo = self.get_repository(pk=response.data["id"])
+        with pytest.raises(IntegrationError):
+            self.relink_repository(repo)
+
+        assert [call.request.method for call in responses.calls] == ["DELETE"]
+        assert self.get_repository(pk=repo.id).config["webhook_id"] == 99
+
+    @responses.activate
+    def test_repository_without_project_id(self) -> None:
+        response = self.create_repository(self.default_repository_config, self.integration.id)
+        responses.reset()
+        self.add_webhook_recreate_responses(delete_status=204)
+
+        repo = self.get_repository(pk=response.data["id"])
+        with assume_test_silo_mode(SiloMode.CELL):
+            del repo.config["project_id"]
+            repo.save()
+
+        with self.assertLogs("sentry.integrations.gitlab", level="INFO") as logs:
+            self.relink_repository(repo)
+        self.provider.on_delete_repository(repo)
+
+        assert "gitlab.repository.missing_project_id" in "\n".join(logs.output)
+        assert len(responses.calls) == 0
 
     @responses.activate
     def test_create_repository_request_invalid_url(self) -> None:


### PR DESCRIPTION
Uninstalling a GitLab integration detaches its repositories but leaves their config alone, `webhook_id` included. When the repo sync relinks them after a reinstall, we saw that stored id and skipped the webhook setup entirely. A hook that GitLab deleted, that GitLab disabled after repeated failed deliveries, or that still carries a token we no longer accept therefore stays broken forever. Nothing else revisits a linked repository, so short of deleting and re-adding the repo by hand there was no way back to a working hook.

On relink we now reconcile the hook instead of skipping it. We update it in place by its stored id, which rewrites both the callback URL and the token in a single call, so a hook holding a stale token starts delivering again. If GitLab says that hook no longer exists, we create a new one and store its id. Any other failure raises instead of falling through to create: an update that reached GitLab and still reported an error may well have applied, and putting a second hook on top of it would double every delivery to that project.

Update in place rather than delete-then-create, because deleting first opens a window the update path does not have. If the delete lands and the create then fails, the project has no hook at all and the row still holds a dead id, which is exactly the silent no-delivery state this work exists to remove, and nothing at this stage would come back to heal it. Updating never removes a hook it might fail to replace, and costs one API call instead of two.

Updating is not enough for a hook GitLab has disabled. Verified against GitLab's source: the edit path is a plain attribute save, and the only thing that clears the disabled state is a successful delivery, which a disabled hook never gets outside the test endpoint. Hooks disabled temporarily (after 4 consecutive failures) come back on their own once the backoff expires, so the token update covers them. Hooks disabled permanently (after 40, which with GitLab's backoff means roughly a month of rejected deliveries) are recognised from the `alert_status` in the update response and replaced: delete, then create. The delete-then-create window does not matter here, because a permanently disabled hook delivers nothing anyway, and if the create fails the next relink hits the 404 branch and recreates it. GitLab's test endpoint is not used to re-enable, since it replays recent commits and Sentry would act on any "Fixes" references in them.

Separately, since hook creation moved after the row is saved, a repository whose hook creation failed exists with no `webhook_id`. Deleting it raised a `KeyError` that reached the user as "An unknown error occurred", so delete now skips the GitLab call when there is no hook to remove. `project_id` is still read directly: every GitLab repository row has one, so there is nothing to guard.

Together with #123741, uninstalling and reinstalling the integration becomes a working repair for a broken hook.

Fixes SCM-176




