### PR TITLE
ref(conversations): Type focused tool test props

### DIFF
--- a/static/app/views/explore/conversations/hooks/useFocusedToolSpan.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useFocusedToolSpan.spec.tsx
@@ -23,18 +23,16 @@ describe('useFocusedToolSpan', () => {
       createToolNode({id: 'span-b', toolName: 'second-tool'}),
     ];
 
+    const initialProps: {focusedTool: string | null} = {focusedTool: 'first-tool'};
     const {rerender} = renderHook(
-      ({focusedTool}) =>
+      ({focusedTool}: {focusedTool: string | null}) =>
         useFocusedToolSpan({
           nodes,
           focusedTool,
           isLoading: false,
           onSpanFound,
         }),
-      {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-        initialProps: {focusedTool: 'first-tool' as string | null},
-      }
+      {initialProps}
     );
 
     expect(onSpanFound).toHaveBeenNthCalledWith(1, 'span-a');


### PR DESCRIPTION
The focused-tool hook test widened a literal prop with a type assertion and needed a lint suppression to permit it.

Type the render hook props as nullable directly, preserving the rerender coverage while removing the assertion and suppression.
