### PR TITLE
ref(agents): Normalize boolean tag values without suppression

### DIFF
--- a/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
+++ b/static/app/views/insights/pages/agents/utils/aiTraceNodes.tsx
@@ -28,8 +28,7 @@ function getAttributeValue(
     return Number(attribute.value);
   }
   if (attribute.type === 'bool') {
-    /* @ts-expect-error - tags are always returned as strings */
-    return attribute.value === 'true';
+    return String(attribute.value) === 'true';
   }
   return attribute.value;
 }


### PR DESCRIPTION
Boolean tag normalization compares a value declared as boolean against a string, requiring a TypeScript suppression to accommodate the string-backed tag response.

Normalize either representation through String before comparison, preserving the existing result while removing the obsolete suppression with a one-line source change.
