### PR TITLE
chore(dynamic-sampling): Log the value served on per-org fallback

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/serving.py
+++ b/src/sentry/dynamic_sampling/per_org/serving.py
@@ -8,6 +8,7 @@ from sentry.dynamic_sampling.per_org.telemetry import (
     ServedValue,
     ServingSource,
     emit_serving_source,
+    log_serving_fallback,
 )
 from sentry.dynamic_sampling.tasks.helpers import recalibrate_orgs as legacy_cache
 from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
@@ -45,6 +46,10 @@ def get_project_sample_rate(
         project_id=project_id,
         error_sample_rate_fallback=error_sample_rate_fallback,
     )
+    if source is ServingSource.PER_ORG_FALLBACK:
+        log_serving_fallback(
+            ServedValue.PROJECT_SAMPLE_RATE, org_id, project_id, sample_rate=legacy_sample_rate
+        )
     return legacy_sample_rate
 
 
@@ -60,6 +65,14 @@ def get_transaction_sample_rates(
     named_rates, implicit_rate = get_transactions_resampling_rates(
         org_id=org_id, proj_id=project_id, default_rate=default_rate
     )
+    if source is ServingSource.PER_ORG_FALLBACK:
+        log_serving_fallback(
+            ServedValue.TRANSACTION_SAMPLE_RATES,
+            org_id,
+            project_id,
+            named_rates=named_rates,
+            implicit_rate=implicit_rate,
+        )
     return named_rates, implicit_rate
 
 
@@ -94,7 +107,10 @@ def _recalibration_factor(org_id: int, source: ServingSource, *, read_by: str) -
 def get_recalibration_factor(org_id: int) -> float:
     source = _serving_source(org_id)
     emit_serving_source(ServedValue.RECALIBRATION_FACTOR, source)
-    return _recalibration_factor(org_id, source, read_by="serving")
+    factor = _recalibration_factor(org_id, source, read_by="serving")
+    if source is ServingSource.PER_ORG_FALLBACK:
+        log_serving_fallback(ServedValue.RECALIBRATION_FACTOR, org_id, factor=factor)
+    return factor
 
 
 def get_previous_recalibration_factor(org_id: int) -> float:

--- a/src/sentry/dynamic_sampling/per_org/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/telemetry.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import logging
 from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from enum import StrEnum
@@ -18,6 +19,8 @@ from sentry.utils.snuba_rpc import SnubaRPCError, SnubaRPCTimeout
 
 F = TypeVar("F", bound=Callable[..., object])
 
+logger = logging.getLogger(__name__)
+
 METRIC_PREFIX = "dynamic_sampling"
 
 SCHEDULER_BUCKET_ORG_STATUS_METRIC = (
@@ -25,6 +28,7 @@ SCHEDULER_BUCKET_ORG_STATUS_METRIC = (
 )
 
 SERVING_SOURCE_METRIC = "dynamic_sampling.per_org.serving_source"
+SERVING_FALLBACK_LOG = "dynamic_sampling.per_org.serving_fallback"
 
 
 class ServedValue(StrEnum):
@@ -55,6 +59,18 @@ def emit_serving_source(value: ServedValue, source: ServingSource) -> None:
         SERVING_SOURCE_METRIC,
         sample_rate=metrics_sample_rate(),
         tags={"value": value.value, "source": source.value},
+    )
+
+
+def log_serving_fallback(
+    value: ServedValue, org_id: int, project_id: int | None = None, **served: object
+) -> None:
+    """Record the legacy value an organization in the rollout was served while its per-org
+    caches are cold, so the metric's fallback count can be traced back to organizations.
+    """
+    logger.info(
+        SERVING_FALLBACK_LOG,
+        extra={"value": value.value, "org_id": org_id, "ds_proj_id": project_id, **served},
     )
 
 


### PR DESCRIPTION
- We have a handful of orgs that fallback to the legacy sample rates - add some logs to figure out which orgs these are and what the sample rates are to see if we can turn off the old system without worry. 