### PR TITLE
feat(attachments): Emit outcomes when deleting pending attachments

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2529,7 +2529,8 @@ def save_attachment(
         # The event this attachment belongs to has not been ingested (yet), so we do not
         # know whether it will be accepted at all. Park the attachment in
         # `PendingEventAttachment` with a short TTL; `save_pending_attachments` promotes it
-        # to an `EventAttachment` (and emits the outcome) once the event is saved.
+        # to an `EventAttachment` (and emits the ACCEPTED outcome) once the event is saved.
+        # A row that is never promoted records INVALID(missing_event) when it is deleted.
         metrics.incr("attachments.pending.create")
         db_fields.pop("group_id")
         db_fields["date_expires_retention"] = db_fields["date_expires"]
@@ -2593,9 +2594,11 @@ def save_pending_attachments(
     ``date_expires_retention``; promoting them restores the retention date and
     attaches the ``group_id``.
 
-    Outcomes are only emitted here, on promotion: an attachment whose event never
-    arrives expires without ever being accepted. That is what keeps the race described
-    in :func:`sentry.tasks.post_process.update_existing_attachments` from costing the
+    The ACCEPTED outcome is emitted here, on promotion: an attachment whose event never
+    arrives expires without ever being accepted, and records INVALID(missing_event) when
+    it is deleted instead (see :meth:`PendingEventAttachment.track_dropped_outcome`).
+    That is what keeps the race described in
+    :func:`sentry.tasks.post_process.update_existing_attachments` from costing the
     customer money -- an attachment we drop is an attachment we never billed for.
 
     Safe to call more than once for the same event, and called from two places for

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -19,6 +19,7 @@ from objectstore_client import TimeToLive
 
 from sentry.attachments.base import CachedAttachment
 from sentry.backup.scopes import RelocationScope
+from sentry.constants import DataCategory
 from sentry.db.models import BoundedBigIntegerField, Model, cell_silo_model, sane_repr
 from sentry.db.models.fields.bounded import BoundedIntegerField
 from sentry.db.models.manager.base_query_set import BaseQuerySet
@@ -356,7 +357,41 @@ class PendingEventAttachment(EventAttachmentBase):
 
         if is_owner:
             self.delete_blob()
+            self.track_dropped_outcome()
         return rv
+
+    def track_dropped_outcome(self) -> None:
+        """
+        Record the outcome for an attachment that is dropped instead of promoted.
+
+        Promotion is the only place an accepted outcome is emitted, so a pending
+        attachment that expires has no outcome at all unless it gets one here.
+        """
+        from sentry.models.project import Project
+        from sentry.utils.outcomes import Outcome, track_outcome
+
+        try:
+            organization_id = _get_organization(self.project_id)
+        except Project.DoesNotExist:
+            # The project was deleted while the attachment was parked. There is nobody
+            # left to report the drop to.
+            return
+
+        track_outcome(
+            org_id=organization_id,
+            project_id=self.project_id,
+            # NOTE: the standalone attachment consumer does not know the DSN that was used,
+            # so pending attachments are never attributed to a key.
+            key_id=None,
+            outcome=Outcome.INVALID,
+            reason="missing_event",
+            # Report the drop at the time the attachment was ingested, matching the
+            # accepted outcome that promotion would have emitted for the same row.
+            timestamp=self.date_added,
+            event_id=self.event_id,
+            category=DataCategory.ATTACHMENT,
+            quantity=self.size or 1,
+        )
 
 
 def normalize_content_type(content_type: str | None, name: str) -> str:

--- a/src/sentry/models/eventattachment.py
+++ b/src/sentry/models/eventattachment.py
@@ -363,9 +363,6 @@ class PendingEventAttachment(EventAttachmentBase):
     def track_dropped_outcome(self) -> None:
         """
         Record the outcome for an attachment that is dropped instead of promoted.
-
-        Promotion is the only place an accepted outcome is emitted, so a pending
-        attachment that expires has no outcome at all unless it gets one here.
         """
         from sentry.models.project import Project
         from sentry.utils.outcomes import Outcome, track_outcome
@@ -377,20 +374,25 @@ class PendingEventAttachment(EventAttachmentBase):
             # left to report the drop to.
             return
 
-        track_outcome(
+        kwargs = dict(
             org_id=organization_id,
             project_id=self.project_id,
-            # NOTE: the standalone attachment consumer does not know the DSN that was used,
-            # so pending attachments are never attributed to a key.
-            key_id=None,
+            key_id=None,  # DSN is unknown at this point
             outcome=Outcome.INVALID,
             reason="missing_event",
-            # Report the drop at the time the attachment was ingested, matching the
-            # accepted outcome that promotion would have emitted for the same row.
-            timestamp=self.date_added,
+            timestamp=self.date_added,  # matches accepted outcome
             event_id=self.event_id,
+        )
+
+        track_outcome(
+            **kwargs,
             category=DataCategory.ATTACHMENT,
             quantity=self.size or 1,
+        )
+        track_outcome(
+            **kwargs,
+            category=DataCategory.ATTACHMENT_ITEM,
+            quantity=1,
         )
 
 

--- a/src/sentry/tasks/post_process.py
+++ b/src/sentry/tasks/post_process.py
@@ -480,9 +480,10 @@ def update_existing_attachments(job: PostProcessJob) -> None:
     # consumer can usually see the event and never takes the pending path at all.
     #
     # It does NOT close the window. An attachment can still be parked after this runs, and
-    # it will be dropped when `PENDING_ATTACHMENT_TTL` expires. What that costs is the
-    # attachment, not the customer's money: `save_pending_attachments` only emits the
-    # ACCEPTED outcome on promotion, so an attachment we lose is one we never billed for.
+    # it will be dropped when `PENDING_ATTACHMENT_TTL` expires, which records an
+    # INVALID(missing_event) outcome. What that costs is the attachment, not the
+    # customer's money: `save_pending_attachments` only emits the ACCEPTED outcome on
+    # promotion, so an attachment we lose is one we never billed for.
     # Closing it properly needs a periodic sweep over pending rows that re-checks
     # eventstore once Snuba has certainly caught up.
     #

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -8,6 +8,7 @@ from django.db import connections, router
 from django.test.utils import CaptureQueriesContext
 
 from sentry.attachments.base import CachedAttachment
+from sentry.constants import DataCategory
 from sentry.models.eventattachment import (
     EventAttachment,
     PendingEventAttachment,
@@ -15,6 +16,7 @@ from sentry.models.eventattachment import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
+from sentry.utils.outcomes import Outcome
 
 
 class EventAttachmentDeleteTest(TestCase):
@@ -73,6 +75,7 @@ class PendingEventAttachmentDeleteTest(TestCase):
             project_id=self.project.id,
             type="event.attachment",
             name="test.txt",
+            size=42,
             blob_path="eventattachments/v1/some-key",
         )
 
@@ -106,6 +109,52 @@ class PendingEventAttachmentDeleteTest(TestCase):
 
         mock_get_storage.return_value.delete.assert_not_called()
         assert EventAttachment.objects.filter(id=promoted.id).exists()
+
+    @mock.patch("sentry.models.eventattachment.get_storage")
+    @mock.patch("sentry.utils.outcomes.track_outcome")
+    def test_delete_records_the_dropped_outcome(
+        self, mock_track_outcome: mock.Mock, mock_get_storage: mock.Mock
+    ) -> None:
+        pending = self._create_pending()
+
+        pending.delete()
+
+        kwargs = mock_track_outcome.mock_calls[0].kwargs
+        assert kwargs["org_id"] == self.project.organization_id
+        assert kwargs["project_id"] == self.project.id
+        assert kwargs["key_id"] is None
+        assert kwargs["outcome"] == Outcome.INVALID
+        assert kwargs["reason"] == "missing_event"
+        assert kwargs["timestamp"] == pending.date_added
+        assert kwargs["event_id"] == pending.event_id
+        assert kwargs["category"] == DataCategory.ATTACHMENT
+        assert kwargs["quantity"] == 42
+
+    @mock.patch("sentry.models.eventattachment.get_storage")
+    @mock.patch("sentry.utils.outcomes.track_outcome")
+    def test_delete_does_not_record_an_outcome_for_a_promoted_row(
+        self, mock_track_outcome: mock.Mock, mock_get_storage: mock.Mock
+    ) -> None:
+        pending = self._create_pending()
+        PendingEventAttachment.objects.filter(id=pending.id).delete()
+
+        # The stale instance `cleanup` is holding. Promotion already emitted ACCEPTED for
+        # this attachment, so recording a drop here would report it twice.
+        pending.delete()
+
+        assert mock_track_outcome.call_count == 0
+
+    @mock.patch("sentry.models.eventattachment.get_storage")
+    @mock.patch("sentry.utils.outcomes.track_outcome")
+    def test_delete_records_at_least_one_byte(
+        self, mock_track_outcome: mock.Mock, mock_get_storage: mock.Mock
+    ) -> None:
+        pending = self._create_pending()
+        pending.update(size=0)
+
+        pending.delete()
+
+        assert mock_track_outcome.mock_calls[0].kwargs["quantity"] == 1
 
     def test_delete_locks_the_row_before_dropping_the_blob(self) -> None:
         pending = self._create_pending()

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -132,7 +132,7 @@ class PendingEventAttachmentDeleteTest(TestCase):
         assert len(mock_track_outcome.mock_calls) == 2
 
         outcomes_by_category = {
-            call.kwargs.pop("category"): call.kwargs for call in mock_track_outcome.mock_calls
+            call.kwargs["category"]: call.kwargs for call in mock_track_outcome.mock_calls
         }
 
         assert outcomes_by_category == {
@@ -145,6 +145,7 @@ class PendingEventAttachmentDeleteTest(TestCase):
                 "quantity": 42,
                 "reason": "missing_event",
                 "timestamp": pending.date_added,
+                "category": DataCategory.ATTACHMENT,
             },
             DataCategory.ATTACHMENT_ITEM: {
                 "event_id": pending.event_id,
@@ -155,6 +156,7 @@ class PendingEventAttachmentDeleteTest(TestCase):
                 "quantity": 1,
                 "reason": "missing_event",
                 "timestamp": pending.date_added,
+                "category": DataCategory.ATTACHMENT_ITEM,
             },
         }
 

--- a/tests/sentry/models/test_eventattachment.py
+++ b/tests/sentry/models/test_eventattachment.py
@@ -119,16 +119,34 @@ class PendingEventAttachmentDeleteTest(TestCase):
 
         pending.delete()
 
-        kwargs = mock_track_outcome.mock_calls[0].kwargs
-        assert kwargs["org_id"] == self.project.organization_id
-        assert kwargs["project_id"] == self.project.id
-        assert kwargs["key_id"] is None
-        assert kwargs["outcome"] == Outcome.INVALID
-        assert kwargs["reason"] == "missing_event"
-        assert kwargs["timestamp"] == pending.date_added
-        assert kwargs["event_id"] == pending.event_id
-        assert kwargs["category"] == DataCategory.ATTACHMENT
-        assert kwargs["quantity"] == 42
+        assert len(mock_track_outcome.mock_calls) == 2
+
+        outcomes_by_category = {
+            call.kwargs.pop("category"): call.kwargs for call in mock_track_outcome.mock_calls
+        }
+
+        assert outcomes_by_category == {
+            DataCategory.ATTACHMENT: {
+                "event_id": pending.event_id,
+                "key_id": None,
+                "org_id": self.organization.id,
+                "outcome": Outcome.INVALID,
+                "project_id": self.project.id,
+                "quantity": 42,
+                "reason": "missing_event",
+                "timestamp": pending.date_added,
+            },
+            DataCategory.ATTACHMENT_ITEM: {
+                "event_id": pending.event_id,
+                "key_id": None,
+                "org_id": self.organization.id,
+                "outcome": Outcome.INVALID,
+                "project_id": self.project.id,
+                "quantity": 1,
+                "reason": "missing_event",
+                "timestamp": pending.date_added,
+            },
+        }
 
     @mock.patch("sentry.models.eventattachment.get_storage")
     @mock.patch("sentry.utils.outcomes.track_outcome")


### PR DESCRIPTION
When a pending attachment does not receive its corresponding event within the 1-hour grace period, it gets deleted by the cleanup job.

Emit an `INVALID` outcome in this case to make the data loss observable.

Closes INGEST-1175