### PR TITLE
feat(ai-monitoring): Sort conversation table from headers

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
@@ -46,15 +46,22 @@ const organization = OrganizationFixture({
   features: ['gen-ai-conversations'],
 });
 
-function mockConversations(body: Array<Record<string, unknown>>) {
-  MockApiClient.addMockResponse({
-    url: `/organizations/${organization.slug}/agents/conversations/`,
+const sortingOrganization = OrganizationFixture({
+  features: ['gen-ai-conversations', 'gen-ai-conversations-querying-enhancements'],
+});
+
+function mockConversations(
+  body: Array<Record<string, unknown>>,
+  currentOrganization = organization
+) {
+  return MockApiClient.addMockResponse({
+    url: `/organizations/${currentOrganization.slug}/agents/conversations/`,
     body,
   });
 }
 
-function renderTable() {
-  return render(<ConversationsTable />, {organization});
+function renderTable(currentOrganization = organization) {
+  return render(<ConversationsTable />, {organization: currentOrganization});
 }
 
 describe('ConversationsTable', () => {
@@ -225,6 +232,49 @@ describe('ConversationsTable', () => {
       const stored = localStorage.getItem(COLUMN_WIDTHS_STORAGE_KEY);
       expect(stored && JSON.parse(stored)).toEqual({tools: 300});
     });
+  });
+
+  it('sorts by supported headers when the feature is enabled', async () => {
+    const request = mockConversations(
+      [{...BASE_CONVERSATION, title: 'Sortable conversation'}],
+      sortingOrganization
+    );
+
+    renderTable(sortingOrganization);
+
+    await screen.findByText('Sortable conversation');
+    expect(screen.getByRole('columnheader', {name: 'Age'})).toHaveAttribute(
+      'aria-sort',
+      'descending'
+    );
+    expect(screen.queryByRole('button', {name: 'Conversation'})).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: 'Tools'})).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Cost'}));
+
+    await waitFor(() =>
+      expect(request).toHaveBeenCalledWith(
+        `/organizations/${sortingOrganization.slug}/agents/conversations/`,
+        expect.objectContaining({
+          query: expect.objectContaining({sort: ['-totalCost']}),
+        })
+      )
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('columnheader', {name: 'Cost'})).toHaveAttribute(
+        'aria-sort',
+        'descending'
+      )
+    );
+  });
+
+  it('does not make headers sortable when the feature is disabled', async () => {
+    mockConversations([{...BASE_CONVERSATION, title: 'Unsortable conversation'}]);
+
+    renderTable();
+
+    await screen.findByText('Unsortable conversation');
+    expect(screen.queryByRole('button', {name: 'Cost'})).not.toBeInTheDocument();
   });
 
   it('navigates to the conversation detail on row click', async () => {

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -201,6 +201,7 @@ export function ConversationsTable() {
     error,
     pageLinks,
     setCursor,
+    unsetCursor,
     isDirectHit,
     sort,
     setSort,
@@ -307,11 +308,11 @@ export function ConversationsTable() {
         direction,
         onSort: () => {
           setSort(direction === 'desc' ? field : `-${field}`);
-          setCursor(undefined);
+          unsetCursor();
         },
       };
     },
-    [setCursor, setSort, sort, sortingEnabled]
+    [setSort, sort, sortingEnabled, unsetCursor]
   );
 
   const renderBodyCell = useCallback(

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -19,6 +19,7 @@ import {
   GridEditable,
   type GridColumnHeader,
   type GridColumnOrder,
+  type GridColumnSort,
 } from 'sentry/components/tables/gridEditable';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconFire, IconUser} from 'sentry/icons';
@@ -37,6 +38,7 @@ import {useConversationDirectHitRedirect} from 'sentry/views/explore/conversatio
 import {
   useConversations,
   type Conversation,
+  type ConversationSortField,
   type ConversationUser,
 } from 'sentry/views/explore/conversations/hooks/useConversations';
 import {getConversationDetailUrl} from 'sentry/views/explore/conversations/utils/urlParams';
@@ -90,6 +92,14 @@ const COLUMN_DEFAULTS: Record<ColumnKey, {name: string; width: number}> = {
 };
 
 const RIGHT_ALIGNED_COLUMNS = new Set<ColumnKey>(['age']);
+
+const SORT_FIELD_BY_COLUMN: Partial<Record<ColumnKey, ConversationSortField>> = {
+  duration: 'generationDuration',
+  messages: 'llmCalls',
+  errors: 'errors',
+  cost: 'totalCost',
+  age: 'age',
+};
 
 // Persisted per-column widths. Only the widths are stored, keyed by column:
 // names are translated, and keying by column (rather than storing the whole
@@ -185,7 +195,17 @@ export function ConversationsTable() {
   const organization = useOrganization();
   const navigate = useNavigate();
   const {selection} = usePageFilters();
-  const {data, isFetching, error, pageLinks, setCursor, isDirectHit} = useConversations();
+  const {
+    data,
+    isFetching,
+    error,
+    pageLinks,
+    setCursor,
+    isDirectHit,
+    sort,
+    setSort,
+    sortingEnabled,
+  } = useConversations();
   useConversationDirectHitRedirect({isDirectHit, conversations: data});
 
   const [highlightedRowKey, setHighlightedRowKey] = useState<number | undefined>();
@@ -273,6 +293,27 @@ export function ConversationsTable() {
     []
   );
 
+  const getColumnSort = useCallback(
+    (column: GridColumnOrder<ColumnKey>): GridColumnSort | undefined => {
+      const field = SORT_FIELD_BY_COLUMN[column.key];
+      if (!sortingEnabled || !field) {
+        return undefined;
+      }
+
+      const direction =
+        sort === field ? 'asc' : sort === `-${field}` ? 'desc' : undefined;
+      return {
+        align: RIGHT_ALIGNED_COLUMNS.has(column.key) ? 'right' : undefined,
+        direction,
+        onSort: () => {
+          setSort(direction === 'desc' ? field : `-${field}`);
+          setCursor(undefined);
+        },
+      };
+    },
+    [setCursor, setSort, sort, sortingEnabled]
+  );
+
   const renderBodyCell = useCallback(
     (column: GridColumnOrder<ColumnKey>, dataRow: Conversation) => (
       <BodyCell column={column} conversation={dataRow} />
@@ -293,6 +334,7 @@ export function ConversationsTable() {
           // the Stack's `lg` gap is the only spacing before the pagination.
           bodyStyle={{marginBottom: 0}}
           grid={{
+            getColumnSort,
             renderHeadCell,
             renderBodyCell,
             onResizeColumn: handleResizeColumn,

--- a/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.spec.tsx
@@ -166,7 +166,7 @@ describe('useConversations', () => {
     expect(result.current.data[0]?.lastOutput).toBeNull();
   });
 
-  it('sorts conversations by endTimestamp descending', async () => {
+  it('preserves the server sort order', async () => {
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/agents/conversations/`,
       body: [
@@ -179,8 +179,8 @@ describe('useConversations', () => {
 
     await waitFor(() => expect(result.current.isFetching).toBe(false));
 
-    expect(result.current.data[0]?.conversationId).toBe('newer');
-    expect(result.current.data[1]?.conversationId).toBe('older');
+    expect(result.current.data[0]?.conversationId).toBe('older');
+    expect(result.current.data[1]?.conversationId).toBe('newer');
   });
 
   it('reports a direct hit when the header is present', async () => {

--- a/static/app/views/explore/conversations/hooks/useConversations.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.tsx
@@ -1,5 +1,6 @@
 import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
+import {parseAsStringLiteral, useQueryState} from 'nuqs';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
@@ -54,6 +55,21 @@ interface ConversationApiResponse extends Omit<
 
 const CONVERSATION_LIST_PER_PAGE = 50;
 
+const CONVERSATION_SORT_FIELDS = [
+  'age',
+  'generationDuration',
+  'llmCalls',
+  'errors',
+  'totalCost',
+] as const;
+
+export type ConversationSortField = (typeof CONVERSATION_SORT_FIELDS)[number];
+
+const CONVERSATION_SORTS = CONVERSATION_SORT_FIELDS.flatMap(field => [
+  field,
+  `-${field}`,
+]);
+
 function normalizeConversationPreview(
   content: ConversationApiResponse['firstInput']
 ): string | null {
@@ -67,6 +83,13 @@ export function useConversations() {
   const {cursor, setCursor} = useTableCursor();
   const pageFilters = usePageFilters();
   const combinedQuery = useCombinedQuery();
+  const sortingEnabled = organization.features.includes(
+    'gen-ai-conversations-querying-enhancements'
+  );
+  const [sort, setSort] = useQueryState(
+    'sort',
+    parseAsStringLiteral(CONVERSATION_SORTS).withDefault('-age')
+  );
 
   const {
     data: response,
@@ -83,6 +106,7 @@ export function useConversations() {
           project: pageFilters.selection.projects,
           environment: pageFilters.selection.environments,
           per_page: CONVERSATION_LIST_PER_PAGE,
+          sort: sortingEnabled ? [sort] : undefined,
           ...normalizeDateTimeParams(pageFilters.selection.datetime),
         },
         staleTime: 0,
@@ -95,19 +119,13 @@ export function useConversations() {
   const isDirectHit = response?.headers['X-Sentry-Direct-Hit'] === '1';
 
   const data = useMemo(() => {
-    return (response?.json ?? [])
-      .map(
-        ({
-          firstInput: rawFirstInput,
-          lastOutput: rawLastOutput,
-          ...rest
-        }): Conversation => {
-          const firstInput = normalizeConversationPreview(rawFirstInput);
-          const lastOutput = normalizeConversationPreview(rawLastOutput);
-          return {...rest, firstInput, lastOutput};
-        }
-      )
-      .sort((a, b) => b.endTimestamp - a.endTimestamp);
+    return (response?.json ?? []).map(
+      ({firstInput: rawFirstInput, lastOutput: rawLastOutput, ...rest}): Conversation => {
+        const firstInput = normalizeConversationPreview(rawFirstInput);
+        const lastOutput = normalizeConversationPreview(rawLastOutput);
+        return {...rest, firstInput, lastOutput};
+      }
+    );
   }, [response?.json]);
 
   return {
@@ -117,5 +135,8 @@ export function useConversations() {
     pageLinks,
     setCursor,
     isDirectHit,
+    sort,
+    setSort,
+    sortingEnabled,
   };
 }

--- a/static/app/views/explore/conversations/hooks/useConversations.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.tsx
@@ -80,7 +80,7 @@ function normalizeConversationPreview(
 
 export function useConversations() {
   const organization = useOrganization();
-  const {cursor, setCursor} = useTableCursor();
+  const {cursor, setCursor, unsetCursor} = useTableCursor();
   const pageFilters = usePageFilters();
   const combinedQuery = useCombinedQuery();
   const sortingEnabled = organization.features.includes(
@@ -134,6 +134,7 @@ export function useConversations() {
     error,
     pageLinks,
     setCursor,
+    unsetCursor,
     isDirectHit,
     sort,
     setSort,


### PR DESCRIPTION
AI Conversations table can now order conversations by clicking Duration, Messages, Errors, Cost, or Age headers. Sorting happens in list endpoint before pagination, and changing order resets table cursor while preserving selection in URL.

Header controls and sort request stay behind existing `gen-ai-conversations-querying-enhancements` organization flag. Conversation Title and Tools remain unsortable because displayed values do not match supported backend sort fields.
