### PR TITLE
chore(deps): Bump uv from 0.9.28 to 0.12.10

### DIFF
--- a/.github/actions/setup-sentry/action.yml
+++ b/.github/actions/setup-sentry/action.yml
@@ -99,7 +99,7 @@ runs:
 
     - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
       with:
-        version: '0.9.28'
+        version: '0.12.10'
         # we just cache the venv-dir directly in action-setup-venv
         enable-cache: false
 

--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -433,7 +433,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
-          version: '0.9.28'
+          version: '0.12.10'
 
       - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:
@@ -581,7 +581,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
-          version: '0.9.28'
+          version: '0.12.10'
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -50,7 +50,7 @@ jobs:
           token: ${{ steps.getsentry.outputs.token }}
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
-          version: '0.9.28'
+          version: '0.12.10'
       - run: |
           set -euxo pipefail
 

--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -37,7 +37,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
-          version: '0.9.28'
+          version: '0.12.10'
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 
@@ -57,7 +57,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
-          version: '0.9.28'
+          version: '0.12.10'
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -61,7 +61,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
-          version: '0.9.28'
+          version: '0.12.10'
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 

--- a/.github/workflows/react-to-product-owners-yml-changes.yml
+++ b/.github/workflows/react-to-product-owners-yml-changes.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
-          version: '0.9.28'
+          version: '0.12.10'
           # we just cache the venv-dir directly in action-setup-venv
           enable-cache: false
 

--- a/.github/workflows/self-hosted.yml
+++ b/.github/workflows/self-hosted.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: pnpm/action-setup@9b5745cdf0a2e8c2620f0746130f809adb911c19 # v4
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
-          version: '0.9.28'
+          version: '0.12.10'
 
       - uses: getsentry/action-setup-venv@5a80476d175edf56cb205b08bc58986fa99d1725 # v3.2.0
         with:

--- a/self-hosted/Dockerfile
+++ b/self-hosted/Dockerfile
@@ -43,7 +43,7 @@ ENV PATH="/.venv/bin:$PATH" UV_PROJECT_ENVIRONMENT=/.venv \
     PIP_NO_CACHE_DIR=1 PIP_DISABLE_PIP_VERSION_CHECK=1 \
     UV_COMPILE_BYTECODE=1 UV_NO_CACHE=1
 
-RUN python3 -m pip install --index-url 'https://pypi.devinfra.sentry.io/simple' 'uv==0.9.28'
+RUN python3 -m pip install --index-url 'https://pypi.devinfra.sentry.io/simple' 'uv==0.12.10'
 
 # We don't want uv-managed python, we want to use python from the image.
 # We only want to use uv to manage dependencies.


### PR DESCRIPTION
Bumps our pinned `uv` from 0.9.28 to 0.12.10 — the nine `astral-sh/setup-uv` pins across CI, plus the `pip install 'uv==...'` in `self-hosted/Dockerfile`.

### Why

uv 0.11.25 changed how lockfile markers are written for projects that set `tool.uv.environments` (which we do): markers that are tautological within the configured environment are omitted, and conditional ones are factored. This was deliberate and is documented in that release under three entries — [#19933](https://github.com/astral-sh/uv/pull/19933) "Avoid writing redundant lockfile markers with `tool.uv.environments`", [#19969](https://github.com/astral-sh/uv/pull/19969) "Factor supported environments out of lockfile markers", and [#19971](https://github.com/astral-sh/uv/pull/19971) "Simplify dependency markers under parent reachability".

Our `uv.lock` on master is already in that normalized form, but CI was still pinned to 0.9.28, which writes the old form.

Nothing is broken today: uv does not rewrite a lockfile it considers current, so `requirements check` passes and `uv sync --frozen` is unaffected. The problem appears on the next real re-resolve. Against the current lock:

```
uv 0.9.28   --upgrade-package sentry-sdk -> 495 markers re-added, 1006 lines changed
uv 0.12.10  --upgrade-package sentry-sdk ->   0 markers re-added,    4 lines changed
```

So the first dependency bump on 0.9.28 reverts the normalization in a ~1000-line diff, `requirements check` auto-pushes that revert onto the PR, and the next Dependabot PR re-applies it. This ends the loop.

### Notes for review

- **No `uv.lock` change is needed or included.** `uv lock` is a no-op on the current lock under 0.9.28, 0.11.25 and 0.12.10 alike, and it stays at `revision = 3` — no lock-format migration.
- **The two pins interoperate**, so there's no flag-day: uv 0.9.28 reads a 0.12.10-written lock cleanly (`uv export --frozen` exits 0 and leaves the file byte-identical). Old checkouts and any straggling pin keep working.
- `self-hosted/Dockerfile` installs uv from our internal index, which until recently only carried 0.8.2 and 0.9.28. 0.12.10 has since been published there, and both `manylinux_2_28_aarch64` and `manylinux_2_17_x86_64` wheels are present — the base image is `python:3.13.1-slim-bookworm` (glibc 2.36), so both arches install.
- The `setup-uv@884ad927…` (v6) action SHA is intentionally left alone; the version is an input, resolved from GitHub releases.
- The floor for the fix is 0.11.25; 0.12.10 was chosen as current latest, to match what Dependabot's own toolchain already produces.

The main thing worth watching in CI is whether ~15 releases' worth of uv changes affect the other jobs (`uv sync --frozen --active`, devenv) beyond the lock behavior, which is verified inert above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)