### PR TITLE
feat(gitlab): Tag project webhook API calls with a request type

### DIFF
--- a/src/sentry/integrations/gitlab/client.py
+++ b/src/sentry/integrations/gitlab/client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping, Sequence
+from enum import StrEnum
 from typing import TYPE_CHECKING, Any
 from urllib.parse import quote
 
@@ -30,6 +31,12 @@ if TYPE_CHECKING:
     from sentry.integrations.gitlab.integration import GitlabIntegration
 
 logger = logging.getLogger("sentry.integrations.gitlab")
+
+
+class GitLabApiRequestType(StrEnum):
+    CREATE_PROJECT_WEBHOOK = "create_project_webhook"
+    UPDATE_PROJECT_WEBHOOK = "update_project_webhook"
+    DELETE_PROJECT_WEBHOOK = "delete_project_webhook"
 
 
 class GitLabSetupApiClient(IntegrationProxyClient):
@@ -540,7 +547,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
             "note_events": True,
             "enable_ssl_verification": model.metadata["verify_ssl"],
         }
-        resp = self.post(path, data=data)
+        resp = self.post(
+            path, data=data, api_request_type=GitLabApiRequestType.CREATE_PROJECT_WEBHOOK
+        )
 
         return resp["id"]
 
@@ -571,7 +580,9 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
             "note_events": True,
             "enable_ssl_verification": model.metadata["verify_ssl"],
         }
-        return self.put(path, data=data)
+        return self.put(
+            path, data=data, api_request_type=GitLabApiRequestType.UPDATE_PROJECT_WEBHOOK
+        )
 
     def delete_project_webhook(self, project_id, hook_id):
         """Delete a webhook from a project
@@ -581,7 +592,7 @@ class GitLabApiClient(IntegrationProxyClient, RepositoryClient, CommitContextCli
         path = GitLabApiClientPath.project_hook.format(
             project=safe_quote(project_id), hook_id=hook_id
         )
-        return self.delete(path)
+        return self.delete(path, api_request_type=GitLabApiRequestType.DELETE_PROJECT_WEBHOOK)
 
     def create_branch(self, project_id: str, branch: str, ref: str):
         """https://docs.gitlab.com/api/branches/#create-repository-branch"""

--- a/tests/sentry/integrations/gitlab/test_client.py
+++ b/tests/sentry/integrations/gitlab/test_client.py
@@ -13,6 +13,7 @@ from fixtures.gitlab import GET_COMMIT_RESPONSE, GitLabTestCase
 from sentry.auth.exceptions import IdentityNotValid
 from sentry.exceptions import RestrictedIPAddress
 from sentry.integrations.gitlab.blame import GitLabCommitResponse, GitLabFileBlameResponseItem
+from sentry.integrations.gitlab.client import GitLabApiRequestType
 from sentry.integrations.gitlab.utils import get_rate_limit_info_from_response
 from sentry.integrations.source_code_management.commit_context import (
     CommitInfo,
@@ -802,3 +803,29 @@ class GitLabGetMergeCommitShaFromCommitTest(GitLabClientTest):
 
         sha = self.gitlab_client.get_merge_commit_sha_from_commit(repo=self.repo, sha=commit_sha)
         assert sha is None
+
+
+@control_silo_test
+class GitLabProjectWebhookRequestTypeTest(GitLabClientTest):
+    @responses.activate
+    @mock.patch("sentry.shared_integrations.client.base.metrics.incr")
+    def test_hook_calls_are_tagged_by_request_type(self, mock_incr: mock.MagicMock) -> None:
+        hooks_url = f"https://example.gitlab.com/api/v4/projects/{self.gitlab_id}/hooks"
+        responses.add(responses.POST, hooks_url, status=201, json={"id": 7})
+        responses.add(responses.PUT, f"{hooks_url}/7", status=200, json={"id": 7})
+        responses.add(responses.DELETE, f"{hooks_url}/7", status=204)
+
+        self.gitlab_client.create_project_webhook(self.gitlab_id)
+        self.gitlab_client.update_project_webhook(self.gitlab_id, 7)
+        self.gitlab_client.delete_project_webhook(self.gitlab_id, 7)
+
+        for status, request_type in (
+            (201, GitLabApiRequestType.CREATE_PROJECT_WEBHOOK),
+            (200, GitLabApiRequestType.UPDATE_PROJECT_WEBHOOK),
+            (204, GitLabApiRequestType.DELETE_PROJECT_WEBHOOK),
+        ):
+            mock_incr.assert_any_call(
+                "integrations.http_response",
+                sample_rate=1.0,
+                tags={"integration": "gitlab", "status": status, "api_request_type": request_type},
+            )


### PR DESCRIPTION
Every call an integration client makes emits an `integrations.http_response` counter tagged with the provider and the HTTP status. Callers can also pass an `api_request_type` so the counter tells one kind of call apart from another; GitHub does this for most of its endpoints, GitLab passes nothing, so every GitLab call lands in the same bucket.

That matters for project webhooks. When the repo sync links a GitLab project it creates a hook on it, and that call fails whenever the installing user is below Maintainer on the project. Today a hook creation that fails with 403 is indistinguishable in the metric from a 403 on any other GitLab call, so the only way to see how often hooks fail is the sampled client log.

This tags the three hook calls (create, update, delete) with a request type. The tag key already exists on the metric, so nothing new needs allowlisting in Datadog; a query for `integration:gitlab api_request_type:create_project_webhook by status` is what becomes possible.
