### PR TITLE
chore(dynamic-sampling): Stop serving legacy caches as fallback

### DIFF
--- a/src/sentry/dynamic_sampling/per_org/cache.py
+++ b/src/sentry/dynamic_sampling/per_org/cache.py
@@ -237,11 +237,6 @@ def set_project_sample_rates(org_id: int, rebalanced_projects: Iterable[Rebalanc
     return bool(changed)
 
 
-def has_project_rates(org_id: int) -> bool:
-    redis_client = get_redis_client_for_ds()
-    return bool(redis_client.exists(generate_project_sample_rates_cache_key(org_id)))
-
-
 def get_project_sample_rate(org_id: int, project_id: int) -> float | None:
     """The balanced sample rate of a project, or None when this pipeline has not stored one."""
     redis_client = get_redis_client_for_ds()

--- a/src/sentry/dynamic_sampling/per_org/serving.py
+++ b/src/sentry/dynamic_sampling/per_org/serving.py
@@ -8,7 +8,6 @@ from sentry.dynamic_sampling.per_org.telemetry import (
     ServedValue,
     ServingSource,
     emit_serving_source,
-    log_serving_fallback,
 )
 from sentry.dynamic_sampling.tasks.helpers import recalibrate_orgs as legacy_cache
 from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_projects import (
@@ -20,11 +19,9 @@ from sentry.dynamic_sampling.tasks.helpers.boost_low_volume_transactions import 
 
 
 def _serving_source(org_id: int) -> ServingSource:
-    if not is_org_in_serving_rollout(org_id):
-        return ServingSource.LEGACY
-    if not cache.has_project_rates(org_id):
-        return ServingSource.PER_ORG_FALLBACK
-    return ServingSource.PER_ORG
+    if is_org_in_serving_rollout(org_id):
+        return ServingSource.PER_ORG
+    return ServingSource.LEGACY
 
 
 def get_project_sample_rate(
@@ -46,10 +43,6 @@ def get_project_sample_rate(
         project_id=project_id,
         error_sample_rate_fallback=error_sample_rate_fallback,
     )
-    if source is ServingSource.PER_ORG_FALLBACK:
-        log_serving_fallback(
-            ServedValue.PROJECT_SAMPLE_RATE, org_id, project_id, sample_rate=legacy_sample_rate
-        )
     return legacy_sample_rate
 
 
@@ -65,19 +58,7 @@ def get_transaction_sample_rates(
     named_rates, implicit_rate = get_transactions_resampling_rates(
         org_id=org_id, proj_id=project_id, default_rate=default_rate
     )
-    if source is ServingSource.PER_ORG_FALLBACK:
-        log_serving_fallback(
-            ServedValue.TRANSACTION_SAMPLE_RATES,
-            org_id,
-            project_id,
-            named_rates=named_rates,
-            implicit_rate=implicit_rate,
-        )
     return named_rates, implicit_rate
-
-
-def is_recalibration_factor_served_per_org(org_id: int) -> bool:
-    return _serving_source(org_id) is ServingSource.PER_ORG
 
 
 # Tags the read of the factor an organization was served by the other pipeline.
@@ -107,10 +88,7 @@ def _recalibration_factor(org_id: int, source: ServingSource, *, read_by: str) -
 def get_recalibration_factor(org_id: int) -> float:
     source = _serving_source(org_id)
     emit_serving_source(ServedValue.RECALIBRATION_FACTOR, source)
-    factor = _recalibration_factor(org_id, source, read_by="serving")
-    if source is ServingSource.PER_ORG_FALLBACK:
-        log_serving_fallback(ServedValue.RECALIBRATION_FACTOR, org_id, factor=factor)
-    return factor
+    return _recalibration_factor(org_id, source, read_by="serving")
 
 
 def get_previous_recalibration_factor(org_id: int) -> float:

--- a/src/sentry/dynamic_sampling/per_org/telemetry.py
+++ b/src/sentry/dynamic_sampling/per_org/telemetry.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import functools
-import logging
 from collections.abc import Callable, Generator, Mapping
 from contextlib import contextmanager
 from enum import StrEnum
@@ -19,8 +18,6 @@ from sentry.utils.snuba_rpc import SnubaRPCError, SnubaRPCTimeout
 
 F = TypeVar("F", bound=Callable[..., object])
 
-logger = logging.getLogger(__name__)
-
 METRIC_PREFIX = "dynamic_sampling"
 
 SCHEDULER_BUCKET_ORG_STATUS_METRIC = (
@@ -28,7 +25,6 @@ SCHEDULER_BUCKET_ORG_STATUS_METRIC = (
 )
 
 SERVING_SOURCE_METRIC = "dynamic_sampling.per_org.serving_source"
-SERVING_FALLBACK_LOG = "dynamic_sampling.per_org.serving_fallback"
 
 
 class ServedValue(StrEnum):
@@ -45,7 +41,7 @@ class ServingSource(StrEnum):
     # The organization is not in the serving rollout.
     LEGACY = "legacy"
     PER_ORG = "per_org"
-    PER_ORG_FALLBACK = "per_org_fallback"
+    # The organization is in the serving rollout, but no pass has stored a value for it.
     PER_ORG_NO_DATA = "per_org_no_data"
 
 
@@ -59,18 +55,6 @@ def emit_serving_source(value: ServedValue, source: ServingSource) -> None:
         SERVING_SOURCE_METRIC,
         sample_rate=metrics_sample_rate(),
         tags={"value": value.value, "source": source.value},
-    )
-
-
-def log_serving_fallback(
-    value: ServedValue, org_id: int, project_id: int | None = None, **served: object
-) -> None:
-    """Record the legacy value an organization in the rollout was served while its per-org
-    caches are cold, so the metric's fallback count can be traced back to organizations.
-    """
-    logger.info(
-        SERVING_FALLBACK_LOG,
-        extra={"value": value.value, "org_id": org_id, "ds_proj_id": project_id, **served},
     )
 
 

--- a/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
+++ b/src/sentry/dynamic_sampling/tasks/recalibrate_orgs.py
@@ -7,10 +7,8 @@ from taskbroker_client.retry import Retry
 
 from sentry import quotas
 from sentry.constants import SAMPLING_MODE_DEFAULT, TARGET_SAMPLE_RATE_DEFAULT
-from sentry.dynamic_sampling.per_org.serving import (
-    get_previous_recalibration_factor,
-    is_recalibration_factor_served_per_org,
-)
+from sentry.dynamic_sampling.per_org.gate import is_org_in_serving_rollout
+from sentry.dynamic_sampling.per_org.serving import get_previous_recalibration_factor
 from sentry.dynamic_sampling.rules.utils import DecisionKeepCount, OrganizationId, ProjectId
 from sentry.dynamic_sampling.tasks.boost_low_volume_projects import (
     fetch_projects_with_total_root_transaction_count_and_rates,
@@ -104,7 +102,7 @@ def recalibrate_orgs_batch(orgs: Sequence[tuple[OrganizationId, int, int]]) -> N
 
 
 def recalibrate_org(org_id: OrganizationId, total: int, indexed: int) -> None:
-    if is_recalibration_factor_served_per_org(org_id):
+    if is_org_in_serving_rollout(org_id):
         metrics.incr("dynamic_sampling.tasks.recalibrate_orgs.skipped_served_per_org")
         return
 

--- a/tests/sentry/dynamic_sampling/per_org/test_serving.py
+++ b/tests/sentry/dynamic_sampling/per_org/test_serving.py
@@ -12,7 +12,6 @@ from sentry.dynamic_sampling.per_org.serving import (
     get_project_sample_rate,
     get_recalibration_factor,
     get_transaction_sample_rates,
-    is_recalibration_factor_served_per_org,
 )
 from sentry.dynamic_sampling.per_org.telemetry import SERVING_SOURCE_METRIC
 from sentry.dynamic_sampling.rules.utils import get_redis_client_for_ds
@@ -72,8 +71,7 @@ def store_legacy_project_sample_rate(sample_rate: float) -> None:
     )
 
 
-def switch_org_to_per_org(sample_rate: float = 0.8, project_id: int = PROJECT_ID) -> None:
-    """Store the project rates that move the organization onto the per-org caches."""
+def store_per_org_project_sample_rate(sample_rate: float, project_id: int = PROJECT_ID) -> None:
     per_org_cache.set_project_sample_rates(
         ORG_ID, [RebalancedItem(id=project_id, count=10, new_sample_rate=sample_rate)]
     )
@@ -86,9 +84,7 @@ class TestGetProjectSampleRate:
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
         store_legacy_project_sample_rate(0.2)
-        per_org_cache.set_project_sample_rates(
-            ORG_ID, [RebalancedItem(id=PROJECT_ID, count=10, new_sample_rate=0.8)]
-        )
+        store_per_org_project_sample_rate(0.8)
 
         assert get_project_sample_rate(ORG_ID, PROJECT_ID, error_sample_rate_fallback=1.0) == 0.2
         assert emitted_sources == [("project_sample_rate", "legacy")]
@@ -98,30 +94,28 @@ class TestGetProjectSampleRate:
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
         store_legacy_project_sample_rate(0.2)
-        per_org_cache.set_project_sample_rates(
-            ORG_ID, [RebalancedItem(id=PROJECT_ID, count=10, new_sample_rate=0.8)]
-        )
+        store_per_org_project_sample_rate(0.8)
 
         assert get_project_sample_rate(ORG_ID, PROJECT_ID, error_sample_rate_fallback=1.0) == 0.8
         assert emitted_sources == [("project_sample_rate", "per_org")]
 
     @override_options(SERVING_ON)
-    def test_an_org_without_stored_rates_still_serves_the_legacy_cache(
+    def test_an_org_without_stored_rates_is_sampled_in_full(
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
+        # The legacy cache is never borrowed, no matter how cold the per-org caches are.
         store_legacy_project_sample_rate(0.2)
 
-        assert get_project_sample_rate(ORG_ID, PROJECT_ID, error_sample_rate_fallback=1.0) == 0.2
-        assert emitted_sources == [("project_sample_rate", "per_org_fallback")]
+        assert get_project_sample_rate(ORG_ID, PROJECT_ID, error_sample_rate_fallback=0.5) == 1.0
+        assert emitted_sources == [("project_sample_rate", "per_org_no_data")]
 
     @override_options(SERVING_ON)
     def test_a_project_the_pass_has_not_reached_is_sampled_in_full(
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
         store_legacy_project_sample_rate(0.2)
-        # The organization switched over, but this project was created after the pass, so
-        # its rate must not be borrowed back from the legacy cache.
-        switch_org_to_per_org(project_id=PROJECT_ID + 1)
+        # This project was created after the pass, so it has no stored rate yet.
+        store_per_org_project_sample_rate(0.8, project_id=PROJECT_ID + 1)
 
         assert get_project_sample_rate(ORG_ID, PROJECT_ID, error_sample_rate_fallback=0.5) == 1.0
         assert emitted_sources == [("project_sample_rate", "per_org_no_data")]
@@ -131,9 +125,7 @@ class TestGetProjectSampleRate:
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
         store_legacy_project_sample_rate(0.2)
-        per_org_cache.set_project_sample_rates(
-            ORG_ID, [RebalancedItem(id=PROJECT_ID, count=10, new_sample_rate=0.8)]
-        )
+        store_per_org_project_sample_rate(0.8)
 
         assert get_project_sample_rate(ORG_ID, PROJECT_ID, error_sample_rate_fallback=1.0) == 0.2
         assert emitted_sources == [("project_sample_rate", "legacy")]
@@ -174,7 +166,6 @@ class TestGetTransactionSampleRates:
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
         self.store_legacy_rates()
-        switch_org_to_per_org()
         self.store_per_org_rates()
 
         assert get_transaction_sample_rates(ORG_ID, PROJECT_ID, default_rate=1.0) == (
@@ -184,24 +175,10 @@ class TestGetTransactionSampleRates:
         assert emitted_sources == [("transaction_sample_rates", "per_org")]
 
     @override_options(SERVING_ON)
-    def test_an_org_without_stored_rates_still_serves_the_legacy_cache(
+    def test_a_project_without_stored_rates_never_reads_the_legacy_cache(
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
         self.store_legacy_rates()
-        self.store_per_org_rates()
-
-        assert get_transaction_sample_rates(ORG_ID, PROJECT_ID, default_rate=1.0) == (
-            {"/legacy": 0.1},
-            0.2,
-        )
-        assert emitted_sources == [("transaction_sample_rates", "per_org_fallback")]
-
-    @override_options(SERVING_ON)
-    def test_a_switched_org_never_reads_the_legacy_transaction_rates(
-        self, emitted_sources: list[tuple[str, str]]
-    ) -> None:
-        self.store_legacy_rates()
-        switch_org_to_per_org()
 
         # The pass balanced no transaction for this project, so it has no per-transaction
         # rules. Borrowing the legacy ones would mix two budgets.
@@ -213,7 +190,6 @@ class TestGetTransactionSampleRates:
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
         self.store_legacy_rates()
-        switch_org_to_per_org()
         per_org_cache.set_transaction_sample_rates(ORG_ID, {PROJECT_ID: ([], 0.5)})
 
         assert get_transaction_sample_rates(ORG_ID, PROJECT_ID, default_rate=1.0) == ({}, 0.5)
@@ -227,7 +203,6 @@ class TestGetRecalibrationFactor:
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
         legacy_recalibration_cache.set_guarded_adjusted_factor(ORG_ID, 2.0)
-        switch_org_to_per_org()
         per_org_cache.set_adjusted_factor(ORG_ID, 3.0)
 
         assert get_recalibration_factor(ORG_ID) == 3.0
@@ -248,7 +223,6 @@ class TestGetRecalibrationFactor:
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
         legacy_recalibration_cache.set_guarded_adjusted_factor(ORG_ID, 2.0)
-        switch_org_to_per_org()
         per_org_cache.set_adjusted_factor(ORG_ID, 3.0)
 
         assert get_recalibration_factor(ORG_ID) == 3.0
@@ -268,8 +242,6 @@ class TestGetRecalibrationFactor:
     def test_a_missing_factor_on_both_sides_is_the_identity_factor(
         self, emitted_sources: list[tuple[str, str]]
     ) -> None:
-        switch_org_to_per_org()
-
         assert get_recalibration_factor(ORG_ID) == 1.0
         assert emitted_sources == [("recalibration_factor", "per_org")]
 
@@ -285,7 +257,6 @@ class TestRecalibrationFactorCarryOver:
     @override_options(SERVING_ON)
     def test_the_per_org_pipeline_carries_the_legacy_factor_over(self) -> None:
         legacy_recalibration_cache.set_guarded_adjusted_factor(ORG_ID, 2.0)
-        switch_org_to_per_org()
 
         assert get_recalibration_factor(ORG_ID) == 2.0
         assert get_previous_recalibration_factor(ORG_ID) == 2.0
@@ -300,7 +271,6 @@ class TestRecalibrationFactorCarryOver:
     @override_options(SERVING_ON)
     def test_the_per_org_factor_wins_once_it_is_written(self) -> None:
         legacy_recalibration_cache.set_guarded_adjusted_factor(ORG_ID, 2.0)
-        switch_org_to_per_org()
         per_org_cache.set_adjusted_factor(ORG_ID, 3.0)
 
         assert get_previous_recalibration_factor(ORG_ID) == 3.0
@@ -312,55 +282,8 @@ class TestRecalibrationFactorCarryOver:
 
         assert get_previous_recalibration_factor(ORG_ID) == 2.0
 
-    @override_options(SERVING_ON)
-    def test_an_org_without_per_org_project_rates_reads_the_legacy_factor(self) -> None:
-        legacy_recalibration_cache.set_guarded_adjusted_factor(ORG_ID, 2.0)
-        per_org_cache.set_adjusted_factor(ORG_ID, 3.0)
-
-        assert get_previous_recalibration_factor(ORG_ID) == 2.0
-
     @override_options({**SERVING_ON, "dynamic-sampling.per_org.killswitch": True})
     def test_the_killswitch_carries_the_per_org_factor_over(self) -> None:
-        switch_org_to_per_org()
         per_org_cache.set_adjusted_factor(ORG_ID, 3.0)
 
         assert get_recalibration_factor(ORG_ID) == 3.0
-
-
-@pytest.mark.django_db
-class TestIsRecalibrationFactorServedPerOrg:
-    """The legacy recalibration task reads this to decide whether to write its factor."""
-
-    @override_options(SERVING_ON)
-    def test_true_inside_the_serving_rollout(self) -> None:
-        switch_org_to_per_org()
-
-        assert is_recalibration_factor_served_per_org(ORG_ID) is True
-
-    @override_options(SERVING_OFF)
-    def test_false_outside_the_serving_rollout(self) -> None:
-        switch_org_to_per_org()
-
-        assert is_recalibration_factor_served_per_org(ORG_ID) is False
-
-    @override_options(SERVING_ON)
-    def test_false_while_the_per_org_project_rates_are_cold(self) -> None:
-        assert is_recalibration_factor_served_per_org(ORG_ID) is False
-
-    @override_options({**SERVING_ON, "dynamic-sampling.per_org.killswitch": True})
-    def test_false_under_the_killswitch(self) -> None:
-        switch_org_to_per_org()
-
-        assert is_recalibration_factor_served_per_org(ORG_ID) is False
-
-    @override_options(SERVING_BY_ORG_ID)
-    def test_true_for_a_listed_org_at_a_rate_of_zero(self) -> None:
-        switch_org_to_per_org()
-
-        assert is_recalibration_factor_served_per_org(ORG_ID) is True
-
-    @override_options(SERVING_BY_ORG_ID)
-    def test_false_for_an_unlisted_org(self) -> None:
-        switch_org_to_per_org()
-
-        assert is_recalibration_factor_served_per_org(ORG_ID + 1) is False

--- a/tests/sentry/dynamic_sampling/tasks/test_tasks.py
+++ b/tests/sentry/dynamic_sampling/tasks/test_tasks.py
@@ -6,7 +6,6 @@ import pytest
 from django.utils import timezone
 
 from sentry.dynamic_sampling import RuleType, generate_rules, get_redis_client_for_ds
-from sentry.dynamic_sampling.models.common import RebalancedItem
 from sentry.dynamic_sampling.per_org import cache as per_org_cache
 from sentry.dynamic_sampling.rules.base import NEW_MODEL_THRESHOLD_IN_MINUTES
 from sentry.dynamic_sampling.rules.biases.recalibration_bias import RecalibrationBias
@@ -762,7 +761,6 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
             assert redis_client.get(generate_recalibrate_orgs_cache_key(org.id)) is None
 
     @with_feature("organizations:dynamic-sampling")
-    @override_options({"dynamic-sampling.per_org.serving-rollout-rate": 1.0})
     @patch("sentry.quotas.backend.get_blended_sample_rate")
     def test_recalibrate_orgs_skips_orgs_served_the_per_org_factor(
         self, get_blended_sample_rate: MagicMock
@@ -776,14 +774,12 @@ class TestRecalibrateOrgsTasks(TasksTestCase):
         self.set_sliding_window_org_sample_rate_for_all(0.2)
 
         served_org = self.orgs[0]
-        per_org_cache.set_project_sample_rates(
-            served_org.id,
-            [RebalancedItem(id=self.orgs_info[0]["project_ids"][0], count=10, new_sample_rate=0.2)],
-        )
-
         redis_client = get_redis_client_for_ds()
 
-        with self.tasks():
+        with (
+            override_options({"dynamic-sampling.per_org.serving-org-ids": [served_org.id]}),
+            self.tasks(),
+        ):
             recalibrate_orgs()
 
         # The served org sampled at 10% against a 20% target, so the legacy task would have


### PR DESCRIPTION
- Only serve the new per-org caches, and remove the fallback to legacy cache
- This is done so we can turn off the legacy tasks in https://github.com/getsentry/sentry-options-automator/pull/9626

Contributes to TET-2946