### PR TITLE
fix(seer): Disable Autofix project setup for members

### DIFF
--- a/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.spec.tsx
@@ -91,12 +91,12 @@ describe('SeerProjectTable', () => {
     jest.restoreAllMocks();
   });
 
-  function renderTable() {
+  function renderTable(renderOrganization = organization) {
     render(
       <SentryNuqsTestingAdapter>
         <SeerProjectTable />
       </SentryNuqsTestingAdapter>,
-      {organization}
+      {organization: renderOrganization}
     );
   }
 
@@ -187,5 +187,11 @@ describe('SeerProjectTable', () => {
     // The check passes, so the selection is persisted and no warning is shown.
     await waitFor(() => expect(settingsPut).toHaveBeenCalled());
     expect(errorSpy).not.toHaveBeenCalled();
+  });
+
+  it('disables adding a project without organization write access', async () => {
+    renderTable(OrganizationFixture({slug: organization.slug, access: []}));
+
+    expect(await screen.findByRole('button', {name: 'Add Project'})).toBeDisabled();
   });
 });

--- a/static/app/components/seer/projectTable/seerProjectTable.tsx
+++ b/static/app/components/seer/projectTable/seerProjectTable.tsx
@@ -157,7 +157,7 @@ export function SeerProjectTable() {
                 )}
               </Text>
               <Flex>
-                <AddProjectButton />
+                <AddProjectButton disabled={!canWrite} />
               </Flex>
             </Stack>
           </Flex>
@@ -195,7 +195,7 @@ export function SeerProjectTable() {
               }
             />
           </InputGroup>
-          <AddProjectButton />
+          <AddProjectButton disabled={!canWrite} />
         </Flex>
       </Stack>
       <ListItemCheckboxProvider
@@ -401,7 +401,7 @@ function AgentSelectCell({
   );
 }
 
-function AddProjectButton() {
+function AddProjectButton({disabled}: {disabled: boolean}) {
   const {openModal} = useModal();
 
   const [isLoadingModal, setIsLoadingModal] = useState(false);
@@ -430,7 +430,7 @@ function AddProjectButton() {
       }}
       icon={<IconAdd />}
       busy={isLoadingModal}
-      disabled={isLoadingModal}
+      disabled={disabled || isLoadingModal}
     >
       {t('Add Project')}
     </Button>


### PR DESCRIPTION
Members without organization write access can no longer open the Add Project form in Autofix settings. The button now follows the existing permissions banner and other disabled settings controls, avoiding a form submission that the API would reject.

Fixes AIML-3379

| Before | After |
| --- | --- |
|<img width="493" height="163" alt="perms-before" src="https://github.com/user-attachments/assets/2b425f6a-9283-4a22-a0cf-4123d4b7a40d" />|<img width="491" height="166" alt="perms-after" src="https://github.com/user-attachments/assets/0b9d5297-3e4a-4f7c-8779-90de97f9ca1e" />|

