### PR TITLE
ref(onboarding): Drop the Express error handler for v11

### DIFF
--- a/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
@@ -29,12 +29,12 @@ describe('express onboarding docs', () => {
     });
   });
 
-  it('includes error handler', () => {
+  it('does not include the deprecated express error handler', () => {
     renderWithOnboardingLayout(docs);
 
     expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry\.setupExpressErrorHandler\(app\)/))
-    ).toBeInTheDocument();
+      screen.queryByText(textWithMarkupMatcher(/Sentry\.setupExpressErrorHandler/))
+    ).not.toBeInTheDocument();
   });
 
   it('displays sample rates by default', () => {

--- a/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
@@ -34,7 +34,7 @@ describe('express onboarding docs', () => {
 
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/node --import \.\/instrument\.mjs index\.mjs/)
+        textWithMarkupMatcher(/node --import \.\/instrument\.js index\.js/)
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.spec.tsx
@@ -29,6 +29,16 @@ describe('express onboarding docs', () => {
     });
   });
 
+  it('starts the app with the --import flag', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/node --import \.\/instrument\.mjs index\.mjs/)
+      )
+    ).toBeInTheDocument();
+  });
+
   it('does not include the deprecated express error handler', () => {
     renderWithOnboardingLayout(docs);
 
@@ -115,7 +125,7 @@ describe('express onboarding docs', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+          /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
         )
       )
     ).toBeInTheDocument();
@@ -140,7 +150,7 @@ describe('express onboarding docs', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+          /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node-express/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.tsx
@@ -7,19 +7,15 @@ import type {
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {
-  getImportInstrumentSnippet,
+  getImport,
   getInstallCodeBlock,
   getSdkInitSnippet,
-  getSentryImportSnippet,
 } from 'sentry/gettingStartedDocs/node/utils';
 import {t, tct} from 'sentry/locale';
 
 const getSdkSetupSnippet = () => `
-${getImportInstrumentSnippet()}
-
-// All other imports below
-${getSentryImportSnippet('@sentry/node')}
-const express = require("express");
+${getImport('@sentry/node', 'esm-only').join('\n')}
+import express from "express";
 
 const app = express();
 
@@ -65,7 +61,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.mjs].',
             {code: <code />}
           ),
         },
@@ -75,15 +71,15 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs)',
-              code: getSdkInitSnippet(params, 'node'),
+              filename: 'instrument.mjs',
+              code: getSdkInitSnippet(params, 'node', 'esm-only'),
             },
           ],
         },
         {
           type: 'text',
           text: tct(
-            "Make sure to import [code:instrument.js/mjs] at the top of your file. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)]. If you're running your application in ESM mode, or looking for alternative ways to set up Sentry, read about [docs:installation methods in our docs].",
+            'Start your application with the [code:--import] flag, so that [code:instrument.mjs] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
             {
               code: <code />,
               docs: (
@@ -94,11 +90,23 @@ export const onboarding: OnboardingConfig = {
         },
         {
           type: 'code',
+          language: 'bash',
+          code: 'node --import ./instrument.mjs index.mjs',
+        },
+        {
+          type: 'text',
+          text: tct(
+            'This is what your application entry point, usually [code:index.mjs], looks like:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           tabs: [
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'index.(js|mjs)',
+              filename: 'index.mjs',
               code: getSdkSetupSnippet(),
             },
           ],

--- a/static/app/gettingStartedDocs/node-express/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.tsx
@@ -61,7 +61,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.mjs].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.js]. These snippets use ESM syntax, so your [code:package.json] needs [code:"type": "module"].',
             {code: <code />}
           ),
         },
@@ -71,7 +71,7 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'instrument.mjs',
+              filename: 'instrument.js',
               code: getSdkInitSnippet(params, 'node', 'esm-only'),
             },
           ],
@@ -79,7 +79,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'Start your application with the [code:--import] flag, so that [code:instrument.mjs] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
+            'Start your application with the [code:--import] flag, so that [code:instrument.js] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
             {
               code: <code />,
               docs: (
@@ -91,12 +91,12 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'code',
           language: 'bash',
-          code: 'node --import ./instrument.mjs index.mjs',
+          code: 'node --import ./instrument.js index.js',
         },
         {
           type: 'text',
           text: tct(
-            'This is what your application entry point, usually [code:index.mjs], looks like:',
+            'This is what your application entry point, usually [code:index.js], looks like:',
             {code: <code />}
           ),
         },
@@ -106,7 +106,7 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'index.mjs',
+              filename: 'index.js',
               code: getSdkSetupSnippet(),
             },
           ],

--- a/static/app/gettingStartedDocs/node-express/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.tsx
@@ -114,7 +114,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'The [code:expressIntegration] captures errors from your route handlers automatically. You do not have to add an error handler.',
+            'The default [code:expressIntegration] captures errors from your route handlers automatically. You do not have to add an error handler.',
             {code: <code />}
           ),
         },

--- a/static/app/gettingStartedDocs/node-express/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-express/onboarding.tsx
@@ -29,17 +29,6 @@ app.get("/", function rootHandler(req, res) {
   res.end("Hello world!");
 });
 
-// The error handler must be registered before any other error middleware and after all controllers
-Sentry.setupExpressErrorHandler(app);
-
-// Optional fallthrough error handler
-app.use(function onError(err, req, res, next) {
-  // The error id is attached to \`res.sentry\` to be returned
-  // and optionally displayed to the user for support.
-  res.statusCode = 500;
-  res.end(res.sentry + "\\n");
-});
-
 app.listen(3000);
 `;
 
@@ -94,7 +83,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            "Make sure to import [code:instrument.js/mjs] at the top of your file. Set up the error handler after all controllers and before any other error middleware. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)]. If you're running your application in ESM mode, or looking for alternative ways to set up Sentry, read about [docs:installation methods in our docs].",
+            "Make sure to import [code:instrument.js/mjs] at the top of your file. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)]. If you're running your application in ESM mode, or looking for alternative ways to set up Sentry, read about [docs:installation methods in our docs].",
             {
               code: <code />,
               docs: (
@@ -113,6 +102,13 @@ export const onboarding: OnboardingConfig = {
               code: getSdkSetupSnippet(),
             },
           ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'The [code:expressIntegration] captures errors from your route handlers automatically. You do not have to add an error handler.',
+            {code: <code />}
+          ),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -102,8 +102,8 @@ export function getImport(
       ];
 }
 
-function getProfilingImport(defaultMode?: 'esm' | 'cjs'): string {
-  return defaultMode === 'esm'
+function getProfilingImport(defaultMode?: 'esm' | 'cjs' | 'esm-only'): string {
+  return defaultMode === 'esm' || defaultMode === 'esm-only'
     ? 'import { nodeProfilingIntegration } from "@sentry/profiling-node";'
     : 'const { nodeProfilingIntegration } = require("@sentry/profiling-node");';
 }
@@ -144,7 +144,7 @@ function getDefaultNodeImports({
 }: {
   params: DocsParams;
   sdkImport: 'node' | 'aws' | 'gpc' | 'nestjs' | null;
-  defaultMode?: 'esm' | 'cjs';
+  defaultMode?: 'esm' | 'cjs' | 'esm-only';
 }) {
   if (sdkImport === null || !libraryMap[sdkImport]) {
     return '';
@@ -579,7 +579,7 @@ Sentry.logger.info('User triggered test log', { action: 'test_log' })`,
 export const getSdkInitSnippet = (
   params: DocsParams,
   sdkImport: 'node' | 'aws' | 'gpc' | 'nestjs' | null,
-  defaultMode?: 'esm' | 'cjs'
+  defaultMode?: 'esm' | 'cjs' | 'esm-only'
 ) => `${getDefaultNodeImports({params, sdkImport, defaultMode})}
 
 Sentry.init({


### PR DESCRIPTION
## What

Switches the Express onboarding to ESM with a `node --import ./instrument.js` start command, and removes the `Sentry.setupExpressErrorHandler(app)` call together with the `res.sentry` fallthrough handler.

## Why

v11 no longer supports `--require`, and `expressIntegration()` now captures route handler errors automatically.