### PR TITLE
chore(autofix): Only render bash evidence for employees

### DIFF
--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -1,43 +1,43 @@
-import {OrganizationFixture} from 'sentry-fixture/organization';
-import {ProjectFixture} from 'sentry-fixture/project';
+import { OrganizationFixture } from 'sentry-fixture/organization';
+import { ProjectFixture } from 'sentry-fixture/project';
 
-import {render, renderHookWithProviders, screen} from 'sentry-test/reactTestingLibrary';
+import { render, renderHookWithProviders, screen } from 'sentry-test/reactTestingLibrary';
 
-import type {AutofixSection} from 'sentry/components/events/autofix/useExplorerAutofix';
-import {ProjectsStore} from 'sentry/stores/projectsStore';
-import type {Block, ToolCall, ToolLink} from 'sentry/views/seerExplorer/types';
+import type { AutofixSection } from 'sentry/components/events/autofix/useExplorerAutofix';
+import { ProjectsStore } from 'sentry/stores/projectsStore';
+import type { Block, ToolCall, ToolLink } from 'sentry/views/seerExplorer/types';
 
 import {
   AutofixEvidence,
   AUTOFIX_EVIDENCE_PROPS_RESOLVER,
   type EvidenceButtonProps,
 } from './autofixEvidence';
-import {useAutofixSectionEvidence} from './useAutofixSectionEvidence';
+import { useAutofixSectionEvidence } from './useAutofixSectionEvidence';
 
 function makeToolCall(fn: string, args: Record<string, any> = {}, id = 'tc-1'): ToolCall {
-  return {id, function: fn, args: JSON.stringify(args)};
+  return { id, function: fn, args: JSON.stringify(args) };
 }
 
 function makeToolLink(kind: string, params: Record<string, any> = {}): ToolLink {
-  return {kind, params};
+  return { kind, params };
 }
 
 function makeBlock(overrides: Partial<Block> = {}): Block {
   return {
     id: 'block-1',
     timestamp: '2024-01-01T00:00:00Z',
-    message: {content: '', role: 'assistant'},
+    message: { content: '', role: 'assistant' },
     ...overrides,
   };
 }
 
 function makeSection(blocks: Block[]): AutofixSection {
-  return {step: 'exploration', status: 'completed', artifacts: [], blocks};
+  return { step: 'exploration', status: 'completed', artifacts: [], blocks };
 }
 
 describe('AutofixEvidence', () => {
   const organization = OrganizationFixture();
-  const project = ProjectFixture({id: '1', slug: 'test-project'});
+  const project = ProjectFixture({ id: '1', slug: 'test-project' });
 
   function resolveProps({
     toolCall,
@@ -67,19 +67,19 @@ describe('AutofixEvidence', () => {
   describe('null rendering', () => {
     it('returns null when toolLink is missing', () => {
       const toolCall = makeToolCall('telemetry_live_search');
-      expect(resolveProps({toolCall})).toBeNull();
+      expect(resolveProps({ toolCall })).toBeNull();
     });
 
     it('returns null when toolLink kind is unknown', () => {
       const toolCall = makeToolCall('telemetry_live_search');
       const toolLink = makeToolLink('unknown_kind');
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null for unknown toolCall function with valid toolLink', () => {
       const toolCall = makeToolCall('unknown_function');
-      const toolLink = makeToolLink('telemetry_live_search', {query: 'test'});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      const toolLink = makeToolLink('telemetry_live_search', { query: 'test' });
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
   });
 
@@ -90,14 +90,14 @@ describe('AutofixEvidence', () => {
         dataset: 'spans',
         query: 'test',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Query: Spans')).toBeInTheDocument();
     });
@@ -108,14 +108,14 @@ describe('AutofixEvidence', () => {
         dataset: 'issues',
         query: 'test',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Query: Issues')).toBeInTheDocument();
     });
@@ -126,14 +126,14 @@ describe('AutofixEvidence', () => {
         dataset: 'errors',
         query: 'test',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Query: Errors')).toBeInTheDocument();
     });
@@ -144,14 +144,14 @@ describe('AutofixEvidence', () => {
         dataset: 'logs',
         query: 'test',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Query: Logs')).toBeInTheDocument();
     });
@@ -161,16 +161,16 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('telemetry_live_search', {
         dataset: 'metrics',
         query: 'test',
-        trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
+        trace_metric: { name: 'tool.duration', type: 'distribution', unit: 'second' },
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Query: Metrics')).toBeInTheDocument();
     });
@@ -180,31 +180,31 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('telemetry_live_search', {
         dataset: 'tracemetrics',
         query: 'test',
-        trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
+        trace_metric: { name: 'tool.duration', type: 'distribution', unit: 'second' },
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Query: Metrics')).toBeInTheDocument();
     });
 
     it('defaults to "Query: Spans" when dataset is undefined', () => {
       const toolCall = makeToolCall('telemetry_live_search');
-      const toolLink = makeToolLink('telemetry_live_search', {query: 'test'});
-      const props = resolveProps({toolCall, toolLink});
+      const toolLink = makeToolLink('telemetry_live_search', { query: 'test' });
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Query: Spans')).toBeInTheDocument();
     });
@@ -217,14 +217,14 @@ describe('AutofixEvidence', () => {
         trace_id: 'abc123def4567890',
         span_id: '11223344aabbccdd',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Span: 11223344')).toBeInTheDocument();
     });
@@ -234,14 +234,14 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('get_trace_waterfall', {
         trace_id: 'abc123def4567890',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Trace: abc123de')).toBeInTheDocument();
     });
@@ -254,14 +254,14 @@ describe('AutofixEvidence', () => {
         event_id: 'abcd1234efgh5678',
         issue_id: '12345',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Error: abcd1234')).toBeInTheDocument();
     });
@@ -272,22 +272,22 @@ describe('AutofixEvidence', () => {
         issue_id: '12345',
         event_id: 'abcd1234efgh5678',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Error: abcd1234')).toBeInTheDocument();
     });
 
     it('returns null when event_id is missing for get_issue_details', () => {
       const toolCall = makeToolCall('get_issue_details');
-      const toolLink = makeToolLink('get_issue_details', {issue_id: '12345'});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      const toolLink = makeToolLink('get_issue_details', { issue_id: '12345' });
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
   });
 
@@ -297,14 +297,14 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('get_replay_details', {
         replay_id: 'aabbccdd11223344',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Replay: aabbccdd')).toBeInTheDocument();
     });
@@ -317,14 +317,14 @@ describe('AutofixEvidence', () => {
         profile_id: 'prof1234abcd5678',
         project_id: '1',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Profile: prof1234')).toBeInTheDocument();
     });
@@ -339,14 +339,14 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('File: bar.py')).toBeInTheDocument();
       expect(screen.getByText('File: bar.py').closest('a')).toHaveAttribute(
@@ -363,14 +363,14 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('File: thisisal\u2026ename.py')).toBeInTheDocument();
       expect(
@@ -382,19 +382,19 @@ describe('AutofixEvidence', () => {
     });
 
     it('returns null when mode is not read_file', () => {
-      const toolCall = makeToolCall('code_search', {mode: 'search', query: 'foo'});
+      const toolCall = makeToolCall('code_search', { mode: 'search', query: 'foo' });
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo',
       });
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when mode is missing', () => {
-      const toolCall = makeToolCall('code_search', {path: 'src/foo/bar.py'});
+      const toolCall = makeToolCall('code_search', { path: 'src/foo/bar.py' });
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
       });
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when toolLink is missing', () => {
@@ -402,7 +402,7 @@ describe('AutofixEvidence', () => {
         mode: 'read_file',
         path: 'src/foo/bar.py',
       });
-      expect(resolveProps({toolCall})).toBeNull();
+      expect(resolveProps({ toolCall })).toBeNull();
     });
 
     it('returns null when code_url is missing from toolLink params', () => {
@@ -411,23 +411,23 @@ describe('AutofixEvidence', () => {
         path: 'src/foo/bar.py',
       });
       const toolLink = makeToolLink('code_search', {});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when path is missing from args', () => {
-      const toolCall = makeToolCall('code_search', {mode: 'read_file'});
+      const toolCall = makeToolCall('code_search', { mode: 'read_file' });
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
       });
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when args is invalid JSON', () => {
-      const toolCall = {id: 'tc-1', function: 'code_search', args: '{invalid json'};
+      const toolCall = { id: 'tc-1', function: 'code_search', args: '{invalid json' };
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
       });
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
   });
 
@@ -435,16 +435,16 @@ describe('AutofixEvidence', () => {
     const CODE_URL = 'https://github.com/org/repo/blob/main/src/foo/bar.py';
 
     it('renders filename with code_url link', () => {
-      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
-      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
-      const props = resolveProps({toolCall, toolLink});
+      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
+      const toolLink = makeToolLink('read_file', { code_url: CODE_URL });
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('File: bar.py')).toBeInTheDocument();
       expect(screen.getByText('File: bar.py').closest('a')).toHaveAttribute(
@@ -454,20 +454,20 @@ describe('AutofixEvidence', () => {
     });
 
     it('renders single line anchor when start_line equals end_line', () => {
-      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
       const toolLink = makeToolLink('read_file', {
         code_url: CODE_URL,
         start_line: 10,
         end_line: 10,
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('File: bar.py L10')).toBeInTheDocument();
       expect(screen.getByText('File: bar.py L10').closest('a')).toHaveAttribute(
@@ -477,20 +477,20 @@ describe('AutofixEvidence', () => {
     });
 
     it('renders line range anchor when start_line and end_line differ', () => {
-      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
       const toolLink = makeToolLink('read_file', {
         code_url: CODE_URL,
         start_line: 10,
         end_line: 20,
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('File: bar.py L10-L20')).toBeInTheDocument();
       expect(screen.getByText('File: bar.py L10-L20').closest('a')).toHaveAttribute(
@@ -506,45 +506,45 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('read_file', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('File: thisisal\u2026ename.py')).toBeInTheDocument();
     });
 
     it('returns null when toolLink is missing', () => {
-      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
-      expect(resolveProps({toolCall})).toBeNull();
+      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
+      expect(resolveProps({ toolCall })).toBeNull();
     });
 
     it('returns null when path is missing from args', () => {
       const toolCall = makeToolCall('read_file', {});
-      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      const toolLink = makeToolLink('read_file', { code_url: CODE_URL });
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when path is not a string', () => {
-      const toolCall = makeToolCall('read_file', {path: 123});
-      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      const toolCall = makeToolCall('read_file', { path: 123 });
+      const toolLink = makeToolLink('read_file', { code_url: CODE_URL });
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when code_url is missing from toolLink params', () => {
-      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
       const toolLink = makeToolLink('read_file', {});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when args is invalid JSON', () => {
-      const toolCall = {id: 'tc-1', function: 'read_file', args: '{invalid json'};
-      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      const toolCall = { id: 'tc-1', function: 'read_file', args: '{invalid json' };
+      const toolLink = makeToolLink('read_file', { code_url: CODE_URL });
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
   });
 
@@ -554,14 +554,14 @@ describe('AutofixEvidence', () => {
         description: 'Run tests',
         command: 'pytest tests/ -q',
       });
-      const props = resolveProps({toolCall});
+      const props = resolveProps({ toolCall, isEmployee: true });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Command: Run tests')).toBeInTheDocument();
     });
@@ -571,14 +571,14 @@ describe('AutofixEvidence', () => {
         description: 'Run tests',
         command: 'pytest tests/ -q',
       });
-      const props = resolveProps({toolCall});
+      const props = resolveProps({ toolCall, isEmployee: true });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       const chip = screen.queryByText('Command: Run tests');
       expect(chip).toBeInTheDocument();
@@ -586,15 +586,15 @@ describe('AutofixEvidence', () => {
     });
 
     it('falls back to the command when description is absent', () => {
-      const toolCall = makeToolCall('bash', {command: 'pytest -q'});
-      const props = resolveProps({toolCall});
+      const toolCall = makeToolCall('bash', { command: 'pytest -q' });
+      const props = resolveProps({ toolCall, isEmployee: true });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Command: pytest -q')).toBeInTheDocument();
     });
@@ -603,26 +603,34 @@ describe('AutofixEvidence', () => {
       const toolCall = makeToolCall('bash', {
         description: 'this is a very long description that should be truncated',
       });
-      const props = resolveProps({toolCall});
+      const props = resolveProps({ toolCall, isEmployee: true });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Command: this is \u2026runcated')).toBeInTheDocument();
     });
 
     it('returns null when neither description nor command is present', () => {
       const toolCall = makeToolCall('bash');
-      expect(resolveProps({toolCall})).toBeNull();
+      expect(resolveProps({ toolCall, isEmployee: true })).toBeNull();
     });
 
     it('returns null when args is invalid JSON', () => {
-      const toolCall = {id: 'tc-1', function: 'bash', args: '{invalid json'};
-      expect(resolveProps({toolCall})).toBeNull();
+      const toolCall = { id: 'tc-1', function: 'bash', args: '{invalid json' };
+      expect(resolveProps({ toolCall, isEmployee: true })).toBeNull();
+    });
+
+    it('renders null when not employee', () => {
+      const toolCall = makeToolCall('bash', {
+        description: 'Run tests',
+        command: 'pytest tests/ -q',
+      });
+      expect(resolveProps({ toolCall })).toBeNull();
     });
   });
 
@@ -641,14 +649,14 @@ describe('AutofixEvidence', () => {
         commit_url: COMMIT_URL,
         sha: FULL_SHA,
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Commit: a1b2c3d')).toBeInTheDocument();
       expect(screen.getByText('Commit: a1b2c3d').closest('a')).toHaveAttribute(
@@ -664,14 +672,14 @@ describe('AutofixEvidence', () => {
         commit_url: COMMIT_URL,
         sha: shortSha,
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Commit: abc1234')).toBeInTheDocument();
     });
@@ -684,14 +692,14 @@ describe('AutofixEvidence', () => {
         start_date: START_DATE,
         end_date: END_DATE,
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText(`Commits: ${REPO_NAME}`)).toBeInTheDocument();
       expect(screen.getByText(`Commits: ${REPO_NAME}`).closest('a')).toHaveAttribute(
@@ -709,14 +717,14 @@ describe('AutofixEvidence', () => {
         end_date: END_DATE,
         file_path: 'src/foo/bar.py',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Commits: bar.py')).toBeInTheDocument();
     });
@@ -730,14 +738,14 @@ describe('AutofixEvidence', () => {
         end_date: END_DATE,
         file_path: 'src/components/thisisalongfilename.tsx',
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Commits: thisisal\u2026name.tsx')).toBeInTheDocument();
     });
@@ -752,39 +760,39 @@ describe('AutofixEvidence', () => {
         start_date: START_DATE,
         end_date: END_DATE,
       });
-      const props = resolveProps({toolCall, toolLink});
+      const props = resolveProps({ toolCall, toolLink });
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        {organization}
+        { organization }
       );
       expect(screen.getByText('Commit: a1b2c3d')).toBeInTheDocument();
     });
 
     it('returns null when toolLink is missing', () => {
       const toolCall = makeToolCall('git_search');
-      expect(resolveProps({toolCall})).toBeNull();
+      expect(resolveProps({ toolCall })).toBeNull();
     });
 
     it('returns null when toolLink params are empty', () => {
       const toolCall = makeToolCall('git_search');
       const toolLink = makeToolLink('git_search', {});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when commit_url is present but sha is missing', () => {
       const toolCall = makeToolCall('git_search');
-      const toolLink = makeToolLink('git_search', {commit_url: COMMIT_URL});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      const toolLink = makeToolLink('git_search', { commit_url: COMMIT_URL });
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when sha is present but commit_url is missing', () => {
       const toolCall = makeToolCall('git_search');
-      const toolLink = makeToolLink('git_search', {sha: FULL_SHA});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      const toolLink = makeToolLink('git_search', { sha: FULL_SHA });
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when commits_url path is missing end_date', () => {
@@ -794,7 +802,7 @@ describe('AutofixEvidence', () => {
         repo_name: REPO_NAME,
         start_date: START_DATE,
       });
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when commits_url path is missing repo_name', () => {
@@ -804,13 +812,13 @@ describe('AutofixEvidence', () => {
         start_date: START_DATE,
         end_date: END_DATE,
       });
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
 
     it('returns null when commit_url is not a string', () => {
       const toolCall = makeToolCall('git_search');
-      const toolLink = makeToolLink('git_search', {commit_url: 123, sha: FULL_SHA});
-      expect(resolveProps({toolCall, toolLink})).toBeNull();
+      const toolLink = makeToolLink('git_search', { commit_url: 123, sha: FULL_SHA });
+      expect(resolveProps({ toolCall, toolLink })).toBeNull();
     });
   });
 });
@@ -831,11 +839,11 @@ describe('useAutofixSectionEvidence', () => {
             content: 'results',
           },
         ],
-        tool_links: [makeToolLink('telemetry_live_search', {dataset: 'spans'})],
+        tool_links: [makeToolLink('telemetry_live_search', { dataset: 'spans' })],
       }),
     ]);
 
-    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
 
     expect(result.current).toHaveLength(1);
     expect(result.current[0]!.toolCall.id).toBe('tc-1');
@@ -867,13 +875,13 @@ describe('useAutofixSectionEvidence', () => {
           },
         ],
         tool_links: [
-          makeToolLink('telemetry_live_search', {dataset: 'spans'}),
-          makeToolLink('get_trace_waterfall', {trace_id: 'abc'}),
+          makeToolLink('telemetry_live_search', { dataset: 'spans' }),
+          makeToolLink('get_trace_waterfall', { trace_id: 'abc' }),
         ],
       }),
     ]);
 
-    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
 
     expect(result.current).toHaveLength(2);
     expect(result.current[0]!.toolCall.id).toBe('tc-1');
@@ -896,7 +904,7 @@ describe('useAutofixSectionEvidence', () => {
             content: 'r1',
           },
         ],
-        tool_links: [makeToolLink('telemetry_live_search', {dataset: 'spans'})],
+        tool_links: [makeToolLink('telemetry_live_search', { dataset: 'spans' })],
       }),
       makeBlock({
         id: 'b2',
@@ -912,11 +920,11 @@ describe('useAutofixSectionEvidence', () => {
             content: 'r2',
           },
         ],
-        tool_links: [makeToolLink('get_trace_waterfall', {trace_id: 'abc'})],
+        tool_links: [makeToolLink('get_trace_waterfall', { trace_id: 'abc' })],
       }),
     ]);
 
-    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
 
     expect(result.current).toHaveLength(2);
   });
@@ -924,15 +932,15 @@ describe('useAutofixSectionEvidence', () => {
   it('returns empty array for empty blocks', () => {
     const section = makeSection([]);
 
-    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
 
     expect(result.current).toEqual([]);
   });
 
   it('returns empty array when blocks have no tool_calls', () => {
-    const section = makeSection([makeBlock({message: {content: '', role: 'assistant'}})]);
+    const section = makeSection([makeBlock({ message: { content: '', role: 'assistant' } })]);
 
-    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
 
     expect(result.current).toEqual([]);
   });
@@ -948,7 +956,7 @@ describe('useAutofixSectionEvidence', () => {
       }),
     ]);
 
-    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
 
     expect(result.current).toEqual([]);
   });
@@ -971,7 +979,7 @@ describe('useAutofixSectionEvidence', () => {
       }),
     ]);
 
-    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
+    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
 
     expect(result.current).toEqual([]);
   });

--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -39,12 +39,25 @@ describe('AutofixEvidence', () => {
   const organization = OrganizationFixture();
   const project = ProjectFixture({id: '1', slug: 'test-project'});
 
-  function resolveProps(
-    toolCall: ToolCall,
-    toolLink?: ToolLink
-  ): EvidenceButtonProps | null {
+  function resolveProps({
+    toolCall,
+    toolLink,
+    isEmployee,
+  }: {
+    toolCall: ToolCall;
+    toolLink?: ToolLink;
+    isEmployee?: boolean;
+  }): EvidenceButtonProps | null {
     const resolver = AUTOFIX_EVIDENCE_PROPS_RESOLVER[toolCall.function];
-    return resolver?.({organization, projects: [project], toolCall, toolLink}) ?? null;
+    return (
+      resolver?.({
+        organization,
+        projects: [project],
+        toolCall,
+        toolLink,
+        isEmployee: isEmployee ?? false,
+      }) ?? null
+    );
   }
 
   beforeEach(() => {
@@ -53,22 +66,20 @@ describe('AutofixEvidence', () => {
 
   describe('null rendering', () => {
     it('returns null when toolLink is missing', () => {
-      expect(resolveProps(makeToolCall('telemetry_live_search'))).toBeNull();
+      const toolCall = makeToolCall('telemetry_live_search');
+      expect(resolveProps({toolCall})).toBeNull();
     });
 
     it('returns null when toolLink kind is unknown', () => {
-      expect(
-        resolveProps(makeToolCall('telemetry_live_search'), makeToolLink('unknown_kind'))
-      ).toBeNull();
+      const toolCall = makeToolCall('telemetry_live_search');
+      const toolLink = makeToolLink('unknown_kind');
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null for unknown toolCall function with valid toolLink', () => {
-      expect(
-        resolveProps(
-          makeToolCall('unknown_function'),
-          makeToolLink('telemetry_live_search', {query: 'test'})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('unknown_function');
+      const toolLink = makeToolLink('telemetry_live_search', {query: 'test'});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 
@@ -79,7 +90,7 @@ describe('AutofixEvidence', () => {
         dataset: 'spans',
         query: 'test',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -97,7 +108,7 @@ describe('AutofixEvidence', () => {
         dataset: 'issues',
         query: 'test',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -115,7 +126,7 @@ describe('AutofixEvidence', () => {
         dataset: 'errors',
         query: 'test',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -133,7 +144,7 @@ describe('AutofixEvidence', () => {
         dataset: 'logs',
         query: 'test',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -152,7 +163,7 @@ describe('AutofixEvidence', () => {
         query: 'test',
         trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -171,7 +182,7 @@ describe('AutofixEvidence', () => {
         query: 'test',
         trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -186,7 +197,7 @@ describe('AutofixEvidence', () => {
     it('defaults to "Query: Spans" when dataset is undefined', () => {
       const toolCall = makeToolCall('telemetry_live_search');
       const toolLink = makeToolLink('telemetry_live_search', {query: 'test'});
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -206,7 +217,7 @@ describe('AutofixEvidence', () => {
         trace_id: 'abc123def4567890',
         span_id: '11223344aabbccdd',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -223,7 +234,7 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('get_trace_waterfall', {
         trace_id: 'abc123def4567890',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -243,7 +254,7 @@ describe('AutofixEvidence', () => {
         event_id: 'abcd1234efgh5678',
         issue_id: '12345',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -261,7 +272,7 @@ describe('AutofixEvidence', () => {
         issue_id: '12345',
         event_id: 'abcd1234efgh5678',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -274,12 +285,9 @@ describe('AutofixEvidence', () => {
     });
 
     it('returns null when event_id is missing for get_issue_details', () => {
-      expect(
-        resolveProps(
-          makeToolCall('get_issue_details'),
-          makeToolLink('get_issue_details', {issue_id: '12345'})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('get_issue_details');
+      const toolLink = makeToolLink('get_issue_details', {issue_id: '12345'});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 
@@ -289,7 +297,7 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('get_replay_details', {
         replay_id: 'aabbccdd11223344',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -309,7 +317,7 @@ describe('AutofixEvidence', () => {
         profile_id: 'prof1234abcd5678',
         project_id: '1',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -331,7 +339,7 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -355,7 +363,7 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -374,62 +382,52 @@ describe('AutofixEvidence', () => {
     });
 
     it('returns null when mode is not read_file', () => {
-      expect(
-        resolveProps(
-          makeToolCall('code_search', {mode: 'search', query: 'foo'}),
-          makeToolLink('code_search', {code_url: 'https://github.com/org/repo'})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('code_search', {mode: 'search', query: 'foo'});
+      const toolLink = makeToolLink('code_search', {
+        code_url: 'https://github.com/org/repo',
+      });
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when mode is missing', () => {
-      expect(
-        resolveProps(
-          makeToolCall('code_search', {path: 'src/foo/bar.py'}),
-          makeToolLink('code_search', {
-            code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
-          })
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('code_search', {path: 'src/foo/bar.py'});
+      const toolLink = makeToolLink('code_search', {
+        code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
+      });
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when toolLink is missing', () => {
-      expect(
-        resolveProps(
-          makeToolCall('code_search', {mode: 'read_file', path: 'src/foo/bar.py'})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('code_search', {
+        mode: 'read_file',
+        path: 'src/foo/bar.py',
+      });
+      expect(resolveProps({toolCall})).toBeNull();
     });
 
     it('returns null when code_url is missing from toolLink params', () => {
-      expect(
-        resolveProps(
-          makeToolCall('code_search', {mode: 'read_file', path: 'src/foo/bar.py'}),
-          makeToolLink('code_search', {})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('code_search', {
+        mode: 'read_file',
+        path: 'src/foo/bar.py',
+      });
+      const toolLink = makeToolLink('code_search', {});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when path is missing from args', () => {
-      expect(
-        resolveProps(
-          makeToolCall('code_search', {mode: 'read_file'}),
-          makeToolLink('code_search', {
-            code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
-          })
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('code_search', {mode: 'read_file'});
+      const toolLink = makeToolLink('code_search', {
+        code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
+      });
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when args is invalid JSON', () => {
-      expect(
-        resolveProps(
-          {id: 'tc-1', function: 'code_search', args: '{invalid json'},
-          makeToolLink('code_search', {
-            code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
-          })
-        )
-      ).toBeNull();
+      const toolCall = {id: 'tc-1', function: 'code_search', args: '{invalid json'};
+      const toolLink = makeToolLink('code_search', {
+        code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
+      });
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 
@@ -439,7 +437,7 @@ describe('AutofixEvidence', () => {
     it('renders filename with code_url link', () => {
       const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
       const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -462,7 +460,7 @@ describe('AutofixEvidence', () => {
         start_line: 10,
         end_line: 10,
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -485,7 +483,7 @@ describe('AutofixEvidence', () => {
         start_line: 10,
         end_line: 20,
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -508,7 +506,7 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('read_file', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -521,45 +519,32 @@ describe('AutofixEvidence', () => {
     });
 
     it('returns null when toolLink is missing', () => {
-      expect(
-        resolveProps(makeToolCall('read_file', {path: 'src/foo/bar.py'}))
-      ).toBeNull();
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      expect(resolveProps({toolCall})).toBeNull();
     });
 
     it('returns null when path is missing from args', () => {
-      expect(
-        resolveProps(
-          makeToolCall('read_file', {}),
-          makeToolLink('read_file', {code_url: CODE_URL})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('read_file', {});
+      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when path is not a string', () => {
-      expect(
-        resolveProps(
-          makeToolCall('read_file', {path: 123}),
-          makeToolLink('read_file', {code_url: CODE_URL})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('read_file', {path: 123});
+      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when code_url is missing from toolLink params', () => {
-      expect(
-        resolveProps(
-          makeToolCall('read_file', {path: 'src/foo/bar.py'}),
-          makeToolLink('read_file', {})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      const toolLink = makeToolLink('read_file', {});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when args is invalid JSON', () => {
-      expect(
-        resolveProps(
-          {id: 'tc-1', function: 'read_file', args: '{invalid json'},
-          makeToolLink('read_file', {code_url: CODE_URL})
-        )
-      ).toBeNull();
+      const toolCall = {id: 'tc-1', function: 'read_file', args: '{invalid json'};
+      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 
@@ -569,7 +554,7 @@ describe('AutofixEvidence', () => {
         description: 'Run tests',
         command: 'pytest tests/ -q',
       });
-      const props = resolveProps(toolCall);
+      const props = resolveProps({toolCall});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -586,7 +571,7 @@ describe('AutofixEvidence', () => {
         description: 'Run tests',
         command: 'pytest tests/ -q',
       });
-      const props = resolveProps(toolCall);
+      const props = resolveProps({toolCall});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -602,7 +587,7 @@ describe('AutofixEvidence', () => {
 
     it('falls back to the command when description is absent', () => {
       const toolCall = makeToolCall('bash', {command: 'pytest -q'});
-      const props = resolveProps(toolCall);
+      const props = resolveProps({toolCall});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -618,7 +603,7 @@ describe('AutofixEvidence', () => {
       const toolCall = makeToolCall('bash', {
         description: 'this is a very long description that should be truncated',
       });
-      const props = resolveProps(toolCall);
+      const props = resolveProps({toolCall});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -631,13 +616,13 @@ describe('AutofixEvidence', () => {
     });
 
     it('returns null when neither description nor command is present', () => {
-      expect(resolveProps(makeToolCall('bash'))).toBeNull();
+      const toolCall = makeToolCall('bash');
+      expect(resolveProps({toolCall})).toBeNull();
     });
 
     it('returns null when args is invalid JSON', () => {
-      expect(
-        resolveProps({id: 'tc-1', function: 'bash', args: '{invalid json'})
-      ).toBeNull();
+      const toolCall = {id: 'tc-1', function: 'bash', args: '{invalid json'};
+      expect(resolveProps({toolCall})).toBeNull();
     });
   });
 
@@ -656,7 +641,7 @@ describe('AutofixEvidence', () => {
         commit_url: COMMIT_URL,
         sha: FULL_SHA,
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -679,7 +664,7 @@ describe('AutofixEvidence', () => {
         commit_url: COMMIT_URL,
         sha: shortSha,
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -699,7 +684,7 @@ describe('AutofixEvidence', () => {
         start_date: START_DATE,
         end_date: END_DATE,
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -724,7 +709,7 @@ describe('AutofixEvidence', () => {
         end_date: END_DATE,
         file_path: 'src/foo/bar.py',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -745,7 +730,7 @@ describe('AutofixEvidence', () => {
         end_date: END_DATE,
         file_path: 'src/components/thisisalongfilename.tsx',
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -767,7 +752,7 @@ describe('AutofixEvidence', () => {
         start_date: START_DATE,
         end_date: END_DATE,
       });
-      const props = resolveProps(toolCall, toolLink);
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
@@ -780,66 +765,52 @@ describe('AutofixEvidence', () => {
     });
 
     it('returns null when toolLink is missing', () => {
-      expect(resolveProps(makeToolCall('git_search'))).toBeNull();
+      const toolCall = makeToolCall('git_search');
+      expect(resolveProps({toolCall})).toBeNull();
     });
 
     it('returns null when toolLink params are empty', () => {
-      expect(
-        resolveProps(makeToolCall('git_search'), makeToolLink('git_search', {}))
-      ).toBeNull();
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when commit_url is present but sha is missing', () => {
-      expect(
-        resolveProps(
-          makeToolCall('git_search'),
-          makeToolLink('git_search', {commit_url: COMMIT_URL})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {commit_url: COMMIT_URL});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when sha is present but commit_url is missing', () => {
-      expect(
-        resolveProps(
-          makeToolCall('git_search'),
-          makeToolLink('git_search', {sha: FULL_SHA})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {sha: FULL_SHA});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when commits_url path is missing end_date', () => {
-      expect(
-        resolveProps(
-          makeToolCall('git_search'),
-          makeToolLink('git_search', {
-            commits_url: COMMITS_URL,
-            repo_name: REPO_NAME,
-            start_date: START_DATE,
-          })
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {
+        commits_url: COMMITS_URL,
+        repo_name: REPO_NAME,
+        start_date: START_DATE,
+      });
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when commits_url path is missing repo_name', () => {
-      expect(
-        resolveProps(
-          makeToolCall('git_search'),
-          makeToolLink('git_search', {
-            commits_url: COMMITS_URL,
-            start_date: START_DATE,
-            end_date: END_DATE,
-          })
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {
+        commits_url: COMMITS_URL,
+        start_date: START_DATE,
+        end_date: END_DATE,
+      });
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when commit_url is not a string', () => {
-      expect(
-        resolveProps(
-          makeToolCall('git_search'),
-          makeToolLink('git_search', {commit_url: 123, sha: FULL_SHA})
-        )
-      ).toBeNull();
+      const toolCall = makeToolCall('git_search');
+      const toolLink = makeToolLink('git_search', {commit_url: 123, sha: FULL_SHA});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 });

--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -45,8 +45,8 @@ describe('AutofixEvidence', () => {
     isEmployee,
   }: {
     toolCall: ToolCall;
-    toolLink?: ToolLink;
     isEmployee?: boolean;
+    toolLink?: ToolLink;
   }): EvidenceButtonProps | null {
     const resolver = AUTOFIX_EVIDENCE_PROPS_RESOLVER[toolCall.function];
     return (

--- a/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.spec.tsx
@@ -1,43 +1,43 @@
-import { OrganizationFixture } from 'sentry-fixture/organization';
-import { ProjectFixture } from 'sentry-fixture/project';
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
 
-import { render, renderHookWithProviders, screen } from 'sentry-test/reactTestingLibrary';
+import {render, renderHookWithProviders, screen} from 'sentry-test/reactTestingLibrary';
 
-import type { AutofixSection } from 'sentry/components/events/autofix/useExplorerAutofix';
-import { ProjectsStore } from 'sentry/stores/projectsStore';
-import type { Block, ToolCall, ToolLink } from 'sentry/views/seerExplorer/types';
+import type {AutofixSection} from 'sentry/components/events/autofix/useExplorerAutofix';
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {Block, ToolCall, ToolLink} from 'sentry/views/seerExplorer/types';
 
 import {
   AutofixEvidence,
   AUTOFIX_EVIDENCE_PROPS_RESOLVER,
   type EvidenceButtonProps,
 } from './autofixEvidence';
-import { useAutofixSectionEvidence } from './useAutofixSectionEvidence';
+import {useAutofixSectionEvidence} from './useAutofixSectionEvidence';
 
 function makeToolCall(fn: string, args: Record<string, any> = {}, id = 'tc-1'): ToolCall {
-  return { id, function: fn, args: JSON.stringify(args) };
+  return {id, function: fn, args: JSON.stringify(args)};
 }
 
 function makeToolLink(kind: string, params: Record<string, any> = {}): ToolLink {
-  return { kind, params };
+  return {kind, params};
 }
 
 function makeBlock(overrides: Partial<Block> = {}): Block {
   return {
     id: 'block-1',
     timestamp: '2024-01-01T00:00:00Z',
-    message: { content: '', role: 'assistant' },
+    message: {content: '', role: 'assistant'},
     ...overrides,
   };
 }
 
 function makeSection(blocks: Block[]): AutofixSection {
-  return { step: 'exploration', status: 'completed', artifacts: [], blocks };
+  return {step: 'exploration', status: 'completed', artifacts: [], blocks};
 }
 
 describe('AutofixEvidence', () => {
   const organization = OrganizationFixture();
-  const project = ProjectFixture({ id: '1', slug: 'test-project' });
+  const project = ProjectFixture({id: '1', slug: 'test-project'});
 
   function resolveProps({
     toolCall,
@@ -67,19 +67,19 @@ describe('AutofixEvidence', () => {
   describe('null rendering', () => {
     it('returns null when toolLink is missing', () => {
       const toolCall = makeToolCall('telemetry_live_search');
-      expect(resolveProps({ toolCall })).toBeNull();
+      expect(resolveProps({toolCall})).toBeNull();
     });
 
     it('returns null when toolLink kind is unknown', () => {
       const toolCall = makeToolCall('telemetry_live_search');
       const toolLink = makeToolLink('unknown_kind');
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null for unknown toolCall function with valid toolLink', () => {
       const toolCall = makeToolCall('unknown_function');
-      const toolLink = makeToolLink('telemetry_live_search', { query: 'test' });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      const toolLink = makeToolLink('telemetry_live_search', {query: 'test'});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 
@@ -90,14 +90,14 @@ describe('AutofixEvidence', () => {
         dataset: 'spans',
         query: 'test',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Query: Spans')).toBeInTheDocument();
     });
@@ -108,14 +108,14 @@ describe('AutofixEvidence', () => {
         dataset: 'issues',
         query: 'test',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Query: Issues')).toBeInTheDocument();
     });
@@ -126,14 +126,14 @@ describe('AutofixEvidence', () => {
         dataset: 'errors',
         query: 'test',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Query: Errors')).toBeInTheDocument();
     });
@@ -144,14 +144,14 @@ describe('AutofixEvidence', () => {
         dataset: 'logs',
         query: 'test',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Query: Logs')).toBeInTheDocument();
     });
@@ -161,16 +161,16 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('telemetry_live_search', {
         dataset: 'metrics',
         query: 'test',
-        trace_metric: { name: 'tool.duration', type: 'distribution', unit: 'second' },
+        trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Query: Metrics')).toBeInTheDocument();
     });
@@ -180,31 +180,31 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('telemetry_live_search', {
         dataset: 'tracemetrics',
         query: 'test',
-        trace_metric: { name: 'tool.duration', type: 'distribution', unit: 'second' },
+        trace_metric: {name: 'tool.duration', type: 'distribution', unit: 'second'},
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Query: Metrics')).toBeInTheDocument();
     });
 
     it('defaults to "Query: Spans" when dataset is undefined', () => {
       const toolCall = makeToolCall('telemetry_live_search');
-      const toolLink = makeToolLink('telemetry_live_search', { query: 'test' });
-      const props = resolveProps({ toolCall, toolLink });
+      const toolLink = makeToolLink('telemetry_live_search', {query: 'test'});
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Query: Spans')).toBeInTheDocument();
     });
@@ -217,14 +217,14 @@ describe('AutofixEvidence', () => {
         trace_id: 'abc123def4567890',
         span_id: '11223344aabbccdd',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Span: 11223344')).toBeInTheDocument();
     });
@@ -234,14 +234,14 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('get_trace_waterfall', {
         trace_id: 'abc123def4567890',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Trace: abc123de')).toBeInTheDocument();
     });
@@ -254,14 +254,14 @@ describe('AutofixEvidence', () => {
         event_id: 'abcd1234efgh5678',
         issue_id: '12345',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Error: abcd1234')).toBeInTheDocument();
     });
@@ -272,22 +272,22 @@ describe('AutofixEvidence', () => {
         issue_id: '12345',
         event_id: 'abcd1234efgh5678',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Error: abcd1234')).toBeInTheDocument();
     });
 
     it('returns null when event_id is missing for get_issue_details', () => {
       const toolCall = makeToolCall('get_issue_details');
-      const toolLink = makeToolLink('get_issue_details', { issue_id: '12345' });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      const toolLink = makeToolLink('get_issue_details', {issue_id: '12345'});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 
@@ -297,14 +297,14 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('get_replay_details', {
         replay_id: 'aabbccdd11223344',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Replay: aabbccdd')).toBeInTheDocument();
     });
@@ -317,14 +317,14 @@ describe('AutofixEvidence', () => {
         profile_id: 'prof1234abcd5678',
         project_id: '1',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Profile: prof1234')).toBeInTheDocument();
     });
@@ -339,14 +339,14 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('File: bar.py')).toBeInTheDocument();
       expect(screen.getByText('File: bar.py').closest('a')).toHaveAttribute(
@@ -363,14 +363,14 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('File: thisisal\u2026ename.py')).toBeInTheDocument();
       expect(
@@ -382,19 +382,19 @@ describe('AutofixEvidence', () => {
     });
 
     it('returns null when mode is not read_file', () => {
-      const toolCall = makeToolCall('code_search', { mode: 'search', query: 'foo' });
+      const toolCall = makeToolCall('code_search', {mode: 'search', query: 'foo'});
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo',
       });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when mode is missing', () => {
-      const toolCall = makeToolCall('code_search', { path: 'src/foo/bar.py' });
+      const toolCall = makeToolCall('code_search', {path: 'src/foo/bar.py'});
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
       });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when toolLink is missing', () => {
@@ -402,7 +402,7 @@ describe('AutofixEvidence', () => {
         mode: 'read_file',
         path: 'src/foo/bar.py',
       });
-      expect(resolveProps({ toolCall })).toBeNull();
+      expect(resolveProps({toolCall})).toBeNull();
     });
 
     it('returns null when code_url is missing from toolLink params', () => {
@@ -411,23 +411,23 @@ describe('AutofixEvidence', () => {
         path: 'src/foo/bar.py',
       });
       const toolLink = makeToolLink('code_search', {});
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when path is missing from args', () => {
-      const toolCall = makeToolCall('code_search', { mode: 'read_file' });
+      const toolCall = makeToolCall('code_search', {mode: 'read_file'});
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
       });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when args is invalid JSON', () => {
-      const toolCall = { id: 'tc-1', function: 'code_search', args: '{invalid json' };
+      const toolCall = {id: 'tc-1', function: 'code_search', args: '{invalid json'};
       const toolLink = makeToolLink('code_search', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/bar.py',
       });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 
@@ -435,16 +435,16 @@ describe('AutofixEvidence', () => {
     const CODE_URL = 'https://github.com/org/repo/blob/main/src/foo/bar.py';
 
     it('renders filename with code_url link', () => {
-      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
-      const toolLink = makeToolLink('read_file', { code_url: CODE_URL });
-      const props = resolveProps({ toolCall, toolLink });
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('File: bar.py')).toBeInTheDocument();
       expect(screen.getByText('File: bar.py').closest('a')).toHaveAttribute(
@@ -454,20 +454,20 @@ describe('AutofixEvidence', () => {
     });
 
     it('renders single line anchor when start_line equals end_line', () => {
-      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
       const toolLink = makeToolLink('read_file', {
         code_url: CODE_URL,
         start_line: 10,
         end_line: 10,
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('File: bar.py L10')).toBeInTheDocument();
       expect(screen.getByText('File: bar.py L10').closest('a')).toHaveAttribute(
@@ -477,20 +477,20 @@ describe('AutofixEvidence', () => {
     });
 
     it('renders line range anchor when start_line and end_line differ', () => {
-      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
       const toolLink = makeToolLink('read_file', {
         code_url: CODE_URL,
         start_line: 10,
         end_line: 20,
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('File: bar.py L10-L20')).toBeInTheDocument();
       expect(screen.getByText('File: bar.py L10-L20').closest('a')).toHaveAttribute(
@@ -506,45 +506,45 @@ describe('AutofixEvidence', () => {
       const toolLink = makeToolLink('read_file', {
         code_url: 'https://github.com/org/repo/blob/main/src/foo/thisisalongfilename.py',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('File: thisisal\u2026ename.py')).toBeInTheDocument();
     });
 
     it('returns null when toolLink is missing', () => {
-      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
-      expect(resolveProps({ toolCall })).toBeNull();
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
+      expect(resolveProps({toolCall})).toBeNull();
     });
 
     it('returns null when path is missing from args', () => {
       const toolCall = makeToolCall('read_file', {});
-      const toolLink = makeToolLink('read_file', { code_url: CODE_URL });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when path is not a string', () => {
-      const toolCall = makeToolCall('read_file', { path: 123 });
-      const toolLink = makeToolLink('read_file', { code_url: CODE_URL });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      const toolCall = makeToolCall('read_file', {path: 123});
+      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when code_url is missing from toolLink params', () => {
-      const toolCall = makeToolCall('read_file', { path: 'src/foo/bar.py' });
+      const toolCall = makeToolCall('read_file', {path: 'src/foo/bar.py'});
       const toolLink = makeToolLink('read_file', {});
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when args is invalid JSON', () => {
-      const toolCall = { id: 'tc-1', function: 'read_file', args: '{invalid json' };
-      const toolLink = makeToolLink('read_file', { code_url: CODE_URL });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      const toolCall = {id: 'tc-1', function: 'read_file', args: '{invalid json'};
+      const toolLink = makeToolLink('read_file', {code_url: CODE_URL});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 
@@ -554,14 +554,14 @@ describe('AutofixEvidence', () => {
         description: 'Run tests',
         command: 'pytest tests/ -q',
       });
-      const props = resolveProps({ toolCall, isEmployee: true });
+      const props = resolveProps({toolCall, isEmployee: true});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Command: Run tests')).toBeInTheDocument();
     });
@@ -571,14 +571,14 @@ describe('AutofixEvidence', () => {
         description: 'Run tests',
         command: 'pytest tests/ -q',
       });
-      const props = resolveProps({ toolCall, isEmployee: true });
+      const props = resolveProps({toolCall, isEmployee: true});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       const chip = screen.queryByText('Command: Run tests');
       expect(chip).toBeInTheDocument();
@@ -586,15 +586,15 @@ describe('AutofixEvidence', () => {
     });
 
     it('falls back to the command when description is absent', () => {
-      const toolCall = makeToolCall('bash', { command: 'pytest -q' });
-      const props = resolveProps({ toolCall, isEmployee: true });
+      const toolCall = makeToolCall('bash', {command: 'pytest -q'});
+      const props = resolveProps({toolCall, isEmployee: true});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Command: pytest -q')).toBeInTheDocument();
     });
@@ -603,26 +603,26 @@ describe('AutofixEvidence', () => {
       const toolCall = makeToolCall('bash', {
         description: 'this is a very long description that should be truncated',
       });
-      const props = resolveProps({ toolCall, isEmployee: true });
+      const props = resolveProps({toolCall, isEmployee: true});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Command: this is \u2026runcated')).toBeInTheDocument();
     });
 
     it('returns null when neither description nor command is present', () => {
       const toolCall = makeToolCall('bash');
-      expect(resolveProps({ toolCall, isEmployee: true })).toBeNull();
+      expect(resolveProps({toolCall, isEmployee: true})).toBeNull();
     });
 
     it('returns null when args is invalid JSON', () => {
-      const toolCall = { id: 'tc-1', function: 'bash', args: '{invalid json' };
-      expect(resolveProps({ toolCall, isEmployee: true })).toBeNull();
+      const toolCall = {id: 'tc-1', function: 'bash', args: '{invalid json'};
+      expect(resolveProps({toolCall, isEmployee: true})).toBeNull();
     });
 
     it('renders null when not employee', () => {
@@ -630,7 +630,7 @@ describe('AutofixEvidence', () => {
         description: 'Run tests',
         command: 'pytest tests/ -q',
       });
-      expect(resolveProps({ toolCall })).toBeNull();
+      expect(resolveProps({toolCall})).toBeNull();
     });
   });
 
@@ -649,14 +649,14 @@ describe('AutofixEvidence', () => {
         commit_url: COMMIT_URL,
         sha: FULL_SHA,
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Commit: a1b2c3d')).toBeInTheDocument();
       expect(screen.getByText('Commit: a1b2c3d').closest('a')).toHaveAttribute(
@@ -672,14 +672,14 @@ describe('AutofixEvidence', () => {
         commit_url: COMMIT_URL,
         sha: shortSha,
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Commit: abc1234')).toBeInTheDocument();
     });
@@ -692,14 +692,14 @@ describe('AutofixEvidence', () => {
         start_date: START_DATE,
         end_date: END_DATE,
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText(`Commits: ${REPO_NAME}`)).toBeInTheDocument();
       expect(screen.getByText(`Commits: ${REPO_NAME}`).closest('a')).toHaveAttribute(
@@ -717,14 +717,14 @@ describe('AutofixEvidence', () => {
         end_date: END_DATE,
         file_path: 'src/foo/bar.py',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Commits: bar.py')).toBeInTheDocument();
     });
@@ -738,14 +738,14 @@ describe('AutofixEvidence', () => {
         end_date: END_DATE,
         file_path: 'src/components/thisisalongfilename.tsx',
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Commits: thisisal\u2026name.tsx')).toBeInTheDocument();
     });
@@ -760,39 +760,39 @@ describe('AutofixEvidence', () => {
         start_date: START_DATE,
         end_date: END_DATE,
       });
-      const props = resolveProps({ toolCall, toolLink });
+      const props = resolveProps({toolCall, toolLink});
       render(
         <AutofixEvidence
           evidenceButtonProps={props!}
           groupId="123"
           toolCall={toolCall}
         />,
-        { organization }
+        {organization}
       );
       expect(screen.getByText('Commit: a1b2c3d')).toBeInTheDocument();
     });
 
     it('returns null when toolLink is missing', () => {
       const toolCall = makeToolCall('git_search');
-      expect(resolveProps({ toolCall })).toBeNull();
+      expect(resolveProps({toolCall})).toBeNull();
     });
 
     it('returns null when toolLink params are empty', () => {
       const toolCall = makeToolCall('git_search');
       const toolLink = makeToolLink('git_search', {});
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when commit_url is present but sha is missing', () => {
       const toolCall = makeToolCall('git_search');
-      const toolLink = makeToolLink('git_search', { commit_url: COMMIT_URL });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      const toolLink = makeToolLink('git_search', {commit_url: COMMIT_URL});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when sha is present but commit_url is missing', () => {
       const toolCall = makeToolCall('git_search');
-      const toolLink = makeToolLink('git_search', { sha: FULL_SHA });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      const toolLink = makeToolLink('git_search', {sha: FULL_SHA});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when commits_url path is missing end_date', () => {
@@ -802,7 +802,7 @@ describe('AutofixEvidence', () => {
         repo_name: REPO_NAME,
         start_date: START_DATE,
       });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when commits_url path is missing repo_name', () => {
@@ -812,13 +812,13 @@ describe('AutofixEvidence', () => {
         start_date: START_DATE,
         end_date: END_DATE,
       });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
 
     it('returns null when commit_url is not a string', () => {
       const toolCall = makeToolCall('git_search');
-      const toolLink = makeToolLink('git_search', { commit_url: 123, sha: FULL_SHA });
-      expect(resolveProps({ toolCall, toolLink })).toBeNull();
+      const toolLink = makeToolLink('git_search', {commit_url: 123, sha: FULL_SHA});
+      expect(resolveProps({toolCall, toolLink})).toBeNull();
     });
   });
 });
@@ -839,11 +839,11 @@ describe('useAutofixSectionEvidence', () => {
             content: 'results',
           },
         ],
-        tool_links: [makeToolLink('telemetry_live_search', { dataset: 'spans' })],
+        tool_links: [makeToolLink('telemetry_live_search', {dataset: 'spans'})],
       }),
     ]);
 
-    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toHaveLength(1);
     expect(result.current[0]!.toolCall.id).toBe('tc-1');
@@ -875,13 +875,13 @@ describe('useAutofixSectionEvidence', () => {
           },
         ],
         tool_links: [
-          makeToolLink('telemetry_live_search', { dataset: 'spans' }),
-          makeToolLink('get_trace_waterfall', { trace_id: 'abc' }),
+          makeToolLink('telemetry_live_search', {dataset: 'spans'}),
+          makeToolLink('get_trace_waterfall', {trace_id: 'abc'}),
         ],
       }),
     ]);
 
-    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toHaveLength(2);
     expect(result.current[0]!.toolCall.id).toBe('tc-1');
@@ -904,7 +904,7 @@ describe('useAutofixSectionEvidence', () => {
             content: 'r1',
           },
         ],
-        tool_links: [makeToolLink('telemetry_live_search', { dataset: 'spans' })],
+        tool_links: [makeToolLink('telemetry_live_search', {dataset: 'spans'})],
       }),
       makeBlock({
         id: 'b2',
@@ -920,11 +920,11 @@ describe('useAutofixSectionEvidence', () => {
             content: 'r2',
           },
         ],
-        tool_links: [makeToolLink('get_trace_waterfall', { trace_id: 'abc' })],
+        tool_links: [makeToolLink('get_trace_waterfall', {trace_id: 'abc'})],
       }),
     ]);
 
-    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toHaveLength(2);
   });
@@ -932,15 +932,15 @@ describe('useAutofixSectionEvidence', () => {
   it('returns empty array for empty blocks', () => {
     const section = makeSection([]);
 
-    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toEqual([]);
   });
 
   it('returns empty array when blocks have no tool_calls', () => {
-    const section = makeSection([makeBlock({ message: { content: '', role: 'assistant' } })]);
+    const section = makeSection([makeBlock({message: {content: '', role: 'assistant'}})]);
 
-    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toEqual([]);
   });
@@ -956,7 +956,7 @@ describe('useAutofixSectionEvidence', () => {
       }),
     ]);
 
-    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toEqual([]);
   });
@@ -979,7 +979,7 @@ describe('useAutofixSectionEvidence', () => {
       }),
     ]);
 
-    const { result } = renderHookWithProviders(() => useAutofixSectionEvidence({ section }));
+    const {result} = renderHookWithProviders(() => useAutofixSectionEvidence({section}));
 
     expect(result.current).toEqual([]);
   });

--- a/static/app/components/events/autofix/v3/autofixEvidence.tsx
+++ b/static/app/components/events/autofix/v3/autofixEvidence.tsx
@@ -131,6 +131,7 @@ export type EvidenceButtonProps =
   | EvidenceButtonPlainProps;
 
 interface GetEvidencePropsPayload {
+  isEmployee: boolean;
   organization: Organization;
   projects: Project[];
   toolCall: ToolCall;
@@ -413,7 +414,12 @@ function getReadFileEvidenceProps({
 
 function getBashEvidenceProps({
   toolCall,
+  isEmployee,
 }: GetEvidencePropsPayload): EvidenceButtonProps | null {
+  if (!isEmployee) {
+    return null;
+  }
+
   // The bash tool emits no navigable resource — its tool link only carries a
   // description — so evidence is the command itself, rendered as a plain chip
   // with the full command in the tooltip.

--- a/static/app/components/events/autofix/v3/useAutofixSectionEvidence.tsx
+++ b/static/app/components/events/autofix/v3/useAutofixSectionEvidence.tsx
@@ -59,5 +59,5 @@ export function useAutofixSectionEvidence({section}: UseAutofixSectionEvidence) 
 
       return evidence;
     });
-  }, [organization, projects, section.blocks]);
+  }, [organization, projects, section.blocks, isEmployee]);
 }

--- a/static/app/components/events/autofix/v3/useAutofixSectionEvidence.tsx
+++ b/static/app/components/events/autofix/v3/useAutofixSectionEvidence.tsx
@@ -6,6 +6,7 @@ import {
   type EvidenceButtonProps,
 } from 'sentry/components/events/autofix/v3/autofixEvidence';
 import {defined} from 'sentry/utils/defined';
+import {useIsSentryEmployee} from 'sentry/utils/useIsSentryEmployee';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import type {ToolCall, ToolLink, ToolResult} from 'sentry/views/seerExplorer/types';
@@ -24,6 +25,7 @@ interface UseAutofixSectionEvidence {
 export function useAutofixSectionEvidence({section}: UseAutofixSectionEvidence) {
   const organization = useOrganization();
   const {projects} = useProjects();
+  const isEmployee = useIsSentryEmployee();
 
   return useMemo(() => {
     return section.blocks.flatMap(block => {
@@ -41,7 +43,7 @@ export function useAutofixSectionEvidence({section}: UseAutofixSectionEvidence) 
 
         const resolver = AUTOFIX_EVIDENCE_PROPS_RESOLVER[toolCall.function];
         const evidenceButtonProps =
-          resolver?.({organization, projects, toolCall, toolLink}) ?? null;
+          resolver?.({organization, projects, toolCall, toolLink, isEmployee}) ?? null;
 
         if (!defined(evidenceButtonProps)) {
           continue;


### PR DESCRIPTION
The bash evidence is not clickable to view the details so if there are too many of them, it gets rather noisy. It's not particularly useful in most situations so only render it internally for debugging.