### PR TITLE
fix(analytics): Send logged-out events to Amplitude

### DIFF
--- a/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx
@@ -5,6 +5,7 @@ import {setWindowLocation} from 'sentry-test/utils';
 
 import {CUSTOM_REFERRER_KEY} from 'sentry/constants';
 import {ConfigStore} from 'sentry/stores/configStore';
+import type {User} from 'sentry/types/user';
 import {uniqueId} from 'sentry/utils/guid';
 import {sessionStorageWrapper} from 'sentry/utils/sessionStorage';
 
@@ -29,6 +30,7 @@ describe('rawTrackAnalyticsEvent', () => {
   });
 
   afterEach(() => {
+    ConfigStore.set('user', user);
     jest.mocked(trackReloadEvent).mockClear();
     jest.mocked(trackAmplitudeEvent).mockClear();
     jest.mocked(trackMarketingEvent).mockClear();
@@ -279,6 +281,26 @@ describe('rawTrackAnalyticsEvent', () => {
     );
     expect(uniqueId).toHaveBeenCalledWith();
   });
+
+  it('tracks logged-out events in Amplitude but not Reload', () => {
+    ConfigStore.set('user', null as unknown as User);
+
+    rawTrackAnalyticsEvent({
+      eventKey: 'test_event',
+      eventName: 'Test Event',
+      organization: null,
+      someProp: 'value',
+    });
+
+    expect(trackReloadEvent).not.toHaveBeenCalled();
+    expect(trackAmplitudeEvent).toHaveBeenCalledWith(
+      'Test Event',
+      null,
+      expect.objectContaining({someProp: 'value', user_age: null}),
+      {time: undefined}
+    );
+  });
+
   it('accepts subscription and sets plan', () => {
     rawTrackAnalyticsEvent({
       eventKey: 'test_event',

--- a/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
+++ b/static/gsApp/utils/rawTrackAnalyticsEvent.tsx
@@ -127,7 +127,11 @@ const getOrganizationAge = (
   return null;
 };
 
-const getUserAge = (user: User): number => {
+const getUserAge = (user: User | null): number | null => {
+  if (!user) {
+    return null;
+  }
+
   return getDaysSinceDate(user.dateJoined);
 };
 type RawTrackEventHook = Overrides['analytics:raw-track-event'];
@@ -216,11 +220,14 @@ export function rawTrackAnalyticsEvent(
     // Prepare reloads data payload. If the organization_id is passed we include
     // that in the data payload.
     const user = ConfigStore.get('user');
+    const userId = coerceNumber(user?.id);
+    const reloadOrganizationId = data.organization_id ?? organization_id;
 
-    if (eventKey) {
+    if (eventKey && (userId || reloadOrganizationId)) {
       const reloadData = {
-        user_id: coerceNumber(user?.id),
+        user_id: userId,
         org_id: organization_id,
+        organization_id: reloadOrganizationId,
         allow_no_schema: true,
         sent_at: (time || Date.now()).toString(),
         ...data,


### PR DESCRIPTION
Logged-out analytics events currently send an invalid Reload request and then throw while calculating user age, preventing the independent Amplitude delivery. This skips Reload when neither an accepted user nor organization identity is available, sends the derived organization ID using Reload's accepted field, and records anonymous Amplitude events with a null user age.

A regression test covers the logged-out Auth V2 event path and verifies that Amplitude receives the event while Reload is skipped.