### PR TITLE
feat(explore): Add data-fidelity annotations to the timeseries endpoint

### DIFF
--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -23,6 +23,7 @@ from sentry.api.endpoints.timeseries import (
     StatsResponse,
     TimeSeries,
 )
+from sentry.api.helpers.data_annotations import get_dropped_data_annotations
 from sentry.api.utils import handle_query_errors
 from sentry.apidocs import constants as api_constants
 from sentry.apidocs.examples.discover_performance_examples import DiscoverAndPerformanceExamples
@@ -220,7 +221,9 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 additional_queries,
             )
             return Response(
-                self.serialize_stats_data(events_stats, axes, snuba_params, rollup, dataset),
+                self.serialize_stats_data(
+                    events_stats, axes, snuba_params, rollup, dataset, organization
+                ),
                 status=200,
             )
 
@@ -401,6 +404,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         snuba_params: SnubaParams,
         rollup: int,
         dataset,
+        organization: Organization,
     ) -> StatsResponse:
         # We need the current timestamp for the Ingestion Delay incomplete reason
         now = datetime.now().timestamp()
@@ -420,6 +424,15 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                         debug_info[key] = keyed_result.data["meta"]["debug_info"]
             # ignore typing here cause we don't want the openapi docs to include debug_info
             stats_meta["debug_info"] = debug_info  #  type: ignore[typeddict-unknown-key]
+        # Enrich meta with data-fidelity annotations (dropped-data outcomes)
+        if features.has("organizations:explore-data-fidelity-annotations", organization):
+            try:
+                stats_meta["annotations"] = get_dropped_data_annotations(
+                    dataset, snuba_params, rollup
+                )
+            except Exception:
+                sentry_sdk.capture_exception()
+                stats_meta["annotations"] = []
         response = StatsResponse(
             meta=stats_meta,
             timeSeries=self.serialize_result(result, axes, rollup, now),

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -220,9 +220,16 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 comparison_delta,
                 additional_queries,
             )
+            include_annotations = request.GET.get("includeAnnotations") is not None
             return Response(
                 self.serialize_stats_data(
-                    events_stats, axes, snuba_params, rollup, dataset, organization
+                    events_stats,
+                    axes,
+                    snuba_params,
+                    rollup,
+                    dataset,
+                    organization,
+                    include_annotations,
                 ),
                 status=200,
             )
@@ -405,6 +412,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         rollup: int,
         dataset,
         organization: Organization,
+        include_annotations: bool = False,
     ) -> StatsResponse:
         # We need the current timestamp for the Ingestion Delay incomplete reason
         now = datetime.now().timestamp()
@@ -424,8 +432,11 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                         debug_info[key] = keyed_result.data["meta"]["debug_info"]
             # ignore typing here cause we don't want the openapi docs to include debug_info
             stats_meta["debug_info"] = debug_info  #  type: ignore[typeddict-unknown-key]
-        # Enrich meta with data-fidelity annotations (dropped-data outcomes)
-        if features.has("organizations:explore-data-fidelity-annotations", organization):
+        # Opt-in and flag-gated; enrichment must never break the primary response.
+        should_annotate = include_annotations and features.has(
+            "organizations:explore-data-fidelity-annotations", organization
+        )
+        if should_annotate:
             try:
                 stats_meta["annotations"] = get_dropped_data_annotations(
                     dataset, snuba_params, rollup

--- a/src/sentry/api/endpoints/timeseries.py
+++ b/src/sentry/api/endpoints/timeseries.py
@@ -5,10 +5,24 @@ INGESTION_DELAY = 90
 INGESTION_DELAY_MESSAGE = "INCOMPLETE_BUCKET"
 
 
+class Annotation(TypedDict):
+    """A system annotation explaining that data over a time range was affected by
+    an external factor."""
+
+    type: Literal["system"]
+    category: str
+    reason: str
+    start: float
+    end: float
+    droppedCount: float
+    label: str
+
+
 class StatsMeta(TypedDict):
     dataset: str
     start: float
     end: float
+    annotations: NotRequired[list[Annotation]]
 
 
 class Row(TypedDict):

--- a/src/sentry/api/helpers/data_annotations.py
+++ b/src/sentry/api/helpers/data_annotations.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from sentry.api.endpoints.timeseries import Annotation
+from sentry.constants import DataCategory
+from sentry.search.events.types import SnubaParams
+from sentry.snuba.ourlogs import OurLogs
+from sentry.snuba.outcomes import QueryDefinition, run_outcomes_query_timeseries
+from sentry.snuba.spans_rpc import Spans
+from sentry.snuba.trace_metrics import TraceMetrics
+from sentry.utils.outcomes import Outcome
+from sentry.utils.snuba import parse_snuba_datetime
+
+DROPPED_OUTCOMES: tuple[Outcome, ...] = (
+    Outcome.FILTERED,
+    Outcome.RATE_LIMITED,
+    Outcome.INVALID,
+    Outcome.ABUSE,
+    Outcome.CLIENT_DISCARD,
+    Outcome.CARDINALITY_LIMITED,
+)
+
+
+DEFAULT_DROP_THRESHOLD = 1
+
+DATASET_TO_CATEGORY: dict[object, DataCategory] = {
+    Spans: DataCategory.SPAN,
+    OurLogs: DataCategory.LOG_ITEM,
+    TraceMetrics: DataCategory.TRACE_METRIC,
+}
+
+_REASON_LABELS: dict[str, str] = {
+    "over_quota": "Quota exceeded",
+    "grace_period": "Quota grace period",
+    "smart_rate_limit": "Spike protection",
+    "spike_protection": "Spike protection",
+}
+_OUTCOME_LABELS: dict[str, str] = {
+    Outcome.FILTERED.api_name(): "Inbound filter",
+    Outcome.RATE_LIMITED.api_name(): "Rate limited",
+    Outcome.INVALID.api_name(): "Invalid or malformed",
+    Outcome.ABUSE.api_name(): "Abuse limit",
+    Outcome.CLIENT_DISCARD.api_name(): "Client discard",
+    Outcome.CARDINALITY_LIMITED.api_name(): "Cardinality limited",
+}
+
+
+def _label_for(outcome: str, reason: str | None) -> str:
+    if reason and reason in _REASON_LABELS:
+        return _REASON_LABELS[reason]
+    return _OUTCOME_LABELS.get(outcome, outcome)
+
+
+def get_dropped_data_annotations(
+    dataset: object,
+    snuba_params: SnubaParams,
+    rollup: int,
+    *,
+    threshold: int = DEFAULT_DROP_THRESHOLD,
+) -> list[Annotation]:
+    """Build dropped-data annotations for a timeseries query.
+
+    Buckets align to the chart because ``rollup`` is the interval the endpoint
+    already resolved for the series.
+    """
+    category = DATASET_TO_CATEGORY.get(dataset)
+    if category is None or snuba_params.organization_id is None:
+        return []
+
+    query = QueryDefinition(
+        fields=["sum(quantity)"],
+        start=snuba_params.start_date.isoformat(),
+        end=snuba_params.end_date.isoformat(),
+        organization_id=snuba_params.organization_id,
+        project_ids=list(snuba_params.project_ids),
+        interval=f"{rollup}s",
+        outcome=[o.api_name() for o in DROPPED_OUTCOMES],
+        group_by=["outcome", "reason"],
+        category=[category.api_name()],
+    )
+
+    rows = run_outcomes_query_timeseries(
+        query, tenant_ids={"organization_id": snuba_params.organization_id}
+    )
+
+    annotations: list[Annotation] = []
+    for row in rows:
+        dropped = int(row.get("quantity", 0) or 0)
+        if dropped < threshold:
+            continue
+        raw_time = row.get("time")
+        if not raw_time:
+            continue
+        start_ms = parse_snuba_datetime(raw_time).timestamp() * 1000
+        outcome = str(row.get("outcome", ""))
+        reason = row.get("reason")
+        annotations.append(
+            Annotation(
+                type="system",
+                category=category.api_name(),
+                reason=str(reason) if reason is not None else outcome,
+                start=start_ms,
+                end=start_ms + rollup * 1000,
+                droppedCount=dropped,
+                label=_label_for(outcome, reason if isinstance(reason, str) else None),
+            )
+        )
+    return annotations

--- a/src/sentry/api/helpers/data_annotations.py
+++ b/src/sentry/api/helpers/data_annotations.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import logging
+
+import sentry_sdk
+
 from sentry.api.endpoints.timeseries import Annotation
 from sentry.constants import DataCategory
 from sentry.search.events.types import SnubaParams
@@ -9,6 +13,8 @@ from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.utils.outcomes import Outcome
 from sentry.utils.snuba import parse_snuba_datetime
+
+logger = logging.getLogger(__name__)
 
 DROPPED_OUTCOMES: tuple[Outcome, ...] = (
     Outcome.FILTERED,
@@ -62,46 +68,55 @@ def get_dropped_data_annotations(
     Buckets align to the chart because ``rollup`` is the interval the endpoint
     already resolved for the series.
     """
+    # Unsupported dataset is the normal v0 (EAP-only) path; a missing org is not.
     category = DATASET_TO_CATEGORY.get(dataset)
-    if category is None or snuba_params.organization_id is None:
+    if category is None:
+        return []
+    if snuba_params.organization_id is None:
+        logger.warning("data_annotations.missing_organization", extra={"dataset": str(dataset)})
         return []
 
-    query = QueryDefinition(
-        fields=["sum(quantity)"],
-        start=snuba_params.start_date.isoformat(),
-        end=snuba_params.end_date.isoformat(),
-        organization_id=snuba_params.organization_id,
-        project_ids=list(snuba_params.project_ids),
-        interval=f"{rollup}s",
-        outcome=[o.api_name() for o in DROPPED_OUTCOMES],
-        group_by=["outcome", "reason"],
-        category=[category.api_name()],
-    )
+    with sentry_sdk.start_span(op="data_annotations.get_dropped_data") as span:
+        span.set_data("category", category.api_name())
 
-    rows = run_outcomes_query_timeseries(
-        query, tenant_ids={"organization_id": snuba_params.organization_id}
-    )
-
-    annotations: list[Annotation] = []
-    for row in rows:
-        dropped = int(row.get("quantity", 0) or 0)
-        if dropped < threshold:
-            continue
-        raw_time = row.get("time")
-        if not raw_time:
-            continue
-        start_ms = parse_snuba_datetime(raw_time).timestamp() * 1000
-        outcome = str(row.get("outcome", ""))
-        reason = row.get("reason")
-        annotations.append(
-            Annotation(
-                type="system",
-                category=category.api_name(),
-                reason=str(reason) if reason is not None else outcome,
-                start=start_ms,
-                end=start_ms + rollup * 1000,
-                droppedCount=dropped,
-                label=_label_for(outcome, reason if isinstance(reason, str) else None),
-            )
+        query = QueryDefinition(
+            fields=["sum(quantity)"],
+            start=snuba_params.start_date.isoformat(),
+            end=snuba_params.end_date.isoformat(),
+            organization_id=snuba_params.organization_id,
+            project_ids=snuba_params.project_ids,
+            interval=f"{rollup}s",
+            outcome=[o.api_name() for o in DROPPED_OUTCOMES],
+            group_by=["outcome", "reason"],
+            category=[category.api_name()],
         )
-    return annotations
+
+        rows = run_outcomes_query_timeseries(
+            query, tenant_ids={"organization_id": snuba_params.organization_id}
+        )
+
+        annotations: list[Annotation] = []
+        for row in rows:
+            dropped = int(row.get("quantity", 0) or 0)
+            if dropped < threshold:
+                continue
+            raw_time = row.get("time")
+            if not raw_time:
+                continue
+            # Each row is a distinct time bucket; this is that bucket's start.
+            bucket_start_ms = parse_snuba_datetime(raw_time).timestamp() * 1000
+            outcome = str(row.get("outcome", ""))
+            reason = row.get("reason")
+            annotations.append(
+                Annotation(
+                    type="system",
+                    category=category.api_name(),
+                    reason=str(reason) if reason is not None else outcome,
+                    start=bucket_start_ms,
+                    end=bucket_start_ms + rollup * 1000,
+                    droppedCount=dropped,
+                    label=_label_for(outcome, reason if isinstance(reason, str) else None),
+                )
+            )
+        span.set_data("annotation_count", len(annotations))
+        return annotations

--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -107,6 +107,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:dynamic-sampling-custom", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable dynamic sampling minimum sample rate
     manager.add("organizations:dynamic-sampling-minimum-sample-rate", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable data-fidelity annotations (dropped-data outcomes) on the explore timeseries endpoint
+    manager.add("organizations:explore-data-fidelity-annotations", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable explore -> errors ui
     manager.add("organizations:explore-errors", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable returning the migrated discover queries in explore saved queries

--- a/tests/sentry/api/helpers/test_data_annotations.py
+++ b/tests/sentry/api/helpers/test_data_annotations.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from sentry.api.helpers.data_annotations import get_dropped_data_annotations
+from sentry.constants import DataCategory
+from sentry.search.events.types import SnubaParams
+from sentry.snuba import errors
+from sentry.snuba.ourlogs import OurLogs
+from sentry.snuba.spans_rpc import Spans
+from sentry.snuba.trace_metrics import TraceMetrics
+from sentry.testutils.cases import OutcomesSnubaTest
+from sentry.testutils.helpers.datetime import before_now
+from sentry.utils.outcomes import Outcome
+
+ONE_HOUR = 3600
+
+
+class GetDroppedDataAnnotationsTest(OutcomesSnubaTest):
+    def setUp(self) -> None:
+        super().setUp()
+        # Align to an hour boundary so the hourly Outcomes rollup buckets cleanly.
+        self.end = before_now(days=1).replace(minute=0, second=0, microsecond=0)
+        self.start = self.end - timedelta(hours=3)
+
+    def _snuba_params(self) -> SnubaParams:
+        return SnubaParams(
+            start=self.start,
+            end=self.end,
+            projects=[self.project],
+            organization=self.organization,
+        )
+
+    def _store_drop(
+        self,
+        outcome: Outcome,
+        category: DataCategory,
+        when: datetime,
+        reason: str = "none",
+        quantity: int = 1,
+        num_times: int = 1,
+    ) -> None:
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "project_id": self.project.id,
+                "outcome": outcome,
+                "reason": reason,
+                "category": category,
+                "timestamp": when,
+                "quantity": quantity,
+            },
+            num_times=num_times,
+        )
+
+    def test_returns_dropped_span_outcomes(self) -> None:
+        drop_at = self.start + timedelta(minutes=30)
+        self._store_drop(
+            Outcome.RATE_LIMITED, DataCategory.SPAN, drop_at, reason="over_quota", quantity=2000
+        )
+
+        annotations = get_dropped_data_annotations(Spans, self._snuba_params(), ONE_HOUR)
+
+        assert len(annotations) == 1
+        annotation = annotations[0]
+        assert annotation["type"] == "system"
+        assert annotation["category"] == DataCategory.SPAN.api_name()
+        assert annotation["reason"] == "over_quota"
+        assert annotation["droppedCount"] == 2000
+        assert annotation["label"] == "Quota exceeded"
+        # The bucket spans exactly one rollup interval.
+        assert annotation["end"] - annotation["start"] == ONE_HOUR * 1000
+
+    def test_accepted_outcomes_are_not_annotations(self) -> None:
+        when = self.start + timedelta(minutes=30)
+        self._store_drop(Outcome.ACCEPTED, DataCategory.SPAN, when, reason="none", quantity=5000)
+
+        annotations = get_dropped_data_annotations(Spans, self._snuba_params(), ONE_HOUR)
+
+        assert annotations == []
+
+    def test_threshold_filters_small_drops(self) -> None:
+        when = self.start + timedelta(minutes=30)
+        self._store_drop(Outcome.INVALID, DataCategory.SPAN, when, quantity=3)
+
+        annotations = get_dropped_data_annotations(
+            Spans, self._snuba_params(), ONE_HOUR, threshold=100
+        )
+
+        assert annotations == []
+
+    def test_category_scoped_to_dataset(self) -> None:
+        # A dropped log should not surface on a spans chart.
+        when = self.start + timedelta(minutes=30)
+        self._store_drop(Outcome.RATE_LIMITED, DataCategory.LOG_ITEM, when, quantity=500)
+
+        span_annotations = get_dropped_data_annotations(Spans, self._snuba_params(), ONE_HOUR)
+        log_annotations = get_dropped_data_annotations(OurLogs, self._snuba_params(), ONE_HOUR)
+
+        assert span_annotations == []
+        assert len(log_annotations) == 1
+        assert log_annotations[0]["category"] == DataCategory.LOG_ITEM.api_name()
+
+    def test_trace_metrics_dataset_supported(self) -> None:
+        when = self.start + timedelta(minutes=30)
+        self._store_drop(Outcome.INVALID, DataCategory.TRACE_METRIC, when, quantity=750)
+
+        annotations = get_dropped_data_annotations(TraceMetrics, self._snuba_params(), ONE_HOUR)
+
+        assert len(annotations) == 1
+        assert annotations[0]["category"] == DataCategory.TRACE_METRIC.api_name()
+        assert annotations[0]["droppedCount"] == 750
+
+    def test_unsupported_dataset_returns_empty(self) -> None:
+        when = self.start + timedelta(minutes=30)
+        self._store_drop(Outcome.RATE_LIMITED, DataCategory.SPAN, when, quantity=500)
+
+        # An object with no category mapping yields no annotations rather than
+        # raising. v0 is EAP-only, so non-EAP datasets (e.g. errors) map to nothing.
+        assert get_dropped_data_annotations(object(), self._snuba_params(), ONE_HOUR) == []
+        assert get_dropped_data_annotations(errors, self._snuba_params(), ONE_HOUR) == []

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import timedelta
+from typing import Any
 from unittest import mock
 
 import pytest
@@ -542,8 +543,8 @@ class OrganizationEventsTimeseriesAnnotationsTest(APITestCase, OutcomesSnubaTest
             }
         )
 
-    def _do_request(self, features):
-        data = {
+    def _do_request(self, features: dict[str, bool]):
+        data: dict[str, Any] = {
             "start": self.start,
             "end": self.end,
             "interval": "1h",

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -530,7 +530,7 @@ class OrganizationEventsTimeseriesAnnotationsTest(APITestCase, OutcomesSnubaTest
             kwargs={"organization_id_or_slug": self.organization.slug},
         )
 
-    def _store_span_drop(self, quantity: int) -> None:
+    def _store_span_drop(self, quantity: int, minutes: int = 30) -> None:
         self.store_outcomes(
             {
                 "org_id": self.organization.id,
@@ -538,12 +538,12 @@ class OrganizationEventsTimeseriesAnnotationsTest(APITestCase, OutcomesSnubaTest
                 "outcome": Outcome.RATE_LIMITED,
                 "reason": "over_quota",
                 "category": DataCategory.SPAN,
-                "timestamp": self.start + timedelta(minutes=30),
+                "timestamp": self.start + timedelta(minutes=minutes),
                 "quantity": quantity,
             }
         )
 
-    def _do_request(self, features: dict[str, bool]):
+    def _do_request(self, features: dict[str, bool], annotations: bool = True):
         data: dict[str, Any] = {
             "start": self.start,
             "end": self.end,
@@ -551,6 +551,8 @@ class OrganizationEventsTimeseriesAnnotationsTest(APITestCase, OutcomesSnubaTest
             "project": [self.project.id],
             "dataset": "spans",
         }
+        if annotations:
+            data["includeAnnotations"] = ""
         with self.feature(features):
             return self.client.get(self.url, data=data, format="json")
 
@@ -560,8 +562,24 @@ class OrganizationEventsTimeseriesAnnotationsTest(APITestCase, OutcomesSnubaTest
         assert response.status_code == 200, response.content
         assert "annotations" not in response.data["meta"]
 
-    def test_annotations_present_with_flag(self) -> None:
+    def test_annotations_absent_without_query_param(self) -> None:
+        # Flag on, but the endpoint must not enrich unless the caller opts in.
         self._store_span_drop(2000)
+        response = self._do_request(
+            {
+                "organizations:visibility-explore-view": True,
+                "organizations:explore-data-fidelity-annotations": True,
+            },
+            annotations=False,
+        )
+        assert response.status_code == 200, response.content
+        assert "annotations" not in response.data["meta"]
+
+    def test_annotations_present_with_flag(self) -> None:
+        # Two drops in different hourly buckets: annotations are per-bucket, so
+        # each carries its own start/end rather than the whole query's range.
+        self._store_span_drop(2000, minutes=30)
+        self._store_span_drop(1500, minutes=90)
         response = self._do_request(
             {
                 "organizations:visibility-explore-view": True,
@@ -571,10 +589,12 @@ class OrganizationEventsTimeseriesAnnotationsTest(APITestCase, OutcomesSnubaTest
         assert response.status_code == 200, response.content
         assert "annotations" in response.data["meta"]
         annotations = response.data["meta"]["annotations"]
-        assert len(annotations) == 1
-        assert annotations[0]["category"] == DataCategory.SPAN.api_name()
-        assert annotations[0]["droppedCount"] == 2000
-        assert annotations[0]["reason"] == "over_quota"
+        assert len(annotations) == 2
+        assert {a["droppedCount"] for a in annotations} == {2000, 1500}
+        assert {a["category"] for a in annotations} == {DataCategory.SPAN.api_name()}
+        # Distinct buckets => distinct start times, one interval apart.
+        starts = sorted(a["start"] for a in annotations)
+        assert starts[1] - starts[0] == 3_600_000
 
     def test_annotations_empty_when_no_drops(self) -> None:
         response = self._do_request(

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -7,8 +7,10 @@ import pytest
 from django.urls import reverse
 
 from sentry.api.endpoints.timeseries import INGESTION_DELAY_MESSAGE
-from sentry.testutils.cases import APITestCase, SnubaTestCase
+from sentry.constants import DataCategory
+from sentry.testutils.cases import APITestCase, OutcomesSnubaTest, SnubaTestCase
 from sentry.testutils.helpers.datetime import before_now, freeze_time
+from sentry.utils.outcomes import Outcome
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import SearchIssueTestMixin
 
@@ -511,3 +513,74 @@ class OrganizationEventsTimeseriesEndpointTest(APITestCase, SnubaTestCase, Searc
         )
 
         mock_sdk_logger.warning.assert_not_called()
+
+
+class OrganizationEventsTimeseriesAnnotationsTest(APITestCase, OutcomesSnubaTest):
+    endpoint = "sentry-api-0-organization-events-timeseries"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        # Align to an hour boundary so the hourly Outcomes rollup buckets cleanly.
+        self.end = before_now(days=1).replace(minute=0, second=0, microsecond=0)
+        self.start = self.end - timedelta(hours=2)
+        self.url = reverse(
+            self.endpoint,
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    def _store_span_drop(self, quantity: int) -> None:
+        self.store_outcomes(
+            {
+                "org_id": self.organization.id,
+                "project_id": self.project.id,
+                "outcome": Outcome.RATE_LIMITED,
+                "reason": "over_quota",
+                "category": DataCategory.SPAN,
+                "timestamp": self.start + timedelta(minutes=30),
+                "quantity": quantity,
+            }
+        )
+
+    def _do_request(self, features):
+        data = {
+            "start": self.start,
+            "end": self.end,
+            "interval": "1h",
+            "project": [self.project.id],
+            "dataset": "spans",
+        }
+        with self.feature(features):
+            return self.client.get(self.url, data=data, format="json")
+
+    def test_annotations_absent_without_flag(self) -> None:
+        self._store_span_drop(2000)
+        response = self._do_request({"organizations:visibility-explore-view": True})
+        assert response.status_code == 200, response.content
+        assert "annotations" not in response.data["meta"]
+
+    def test_annotations_present_with_flag(self) -> None:
+        self._store_span_drop(2000)
+        response = self._do_request(
+            {
+                "organizations:visibility-explore-view": True,
+                "organizations:explore-data-fidelity-annotations": True,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert "annotations" in response.data["meta"]
+        annotations = response.data["meta"]["annotations"]
+        assert len(annotations) == 1
+        assert annotations[0]["category"] == DataCategory.SPAN.api_name()
+        assert annotations[0]["droppedCount"] == 2000
+        assert annotations[0]["reason"] == "over_quota"
+
+    def test_annotations_empty_when_no_drops(self) -> None:
+        response = self._do_request(
+            {
+                "organizations:visibility-explore-view": True,
+                "organizations:explore-data-fidelity-annotations": True,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"]["annotations"] == []


### PR DESCRIPTION
Enriches the Explore timeseries endpoint (`OrganizationEventsTimeseriesEndpoint`) with **system annotations** that explain dropped data. 

### What changed

- **New `annotations` on `StatsMeta`** (`src/sentry/api/endpoints/timeseries.py`). Annotations live on `meta` because they describe the timeseries rather than being series data, next to `dataset`/`start`/`end`. They're chart-wide, so they sit on the response-level meta, not per-series.
- **New helper `sentry/api/helpers/data_annotations.py`.** Runs one bucketed query against the existing `outcomes` dataset over the same projects, time range, and interval as the chart, and returns one annotation per bucket where dropped-data outcomes exceed a threshold.
- **Endpoint enrichment**, gated behind `organizations:explore-data-fidelity-annotations`. Any failure building annotations is captured and swallowed so it can never break the primary chart response.

Refs DAIN-1848
