### PR TITLE
ref(seer): Extract the shared query embed block

### DIFF
--- a/static/app/components/seer/markdown/embeds/components/errorsQueryBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/errorsQueryBlock.tsx
@@ -1,26 +1,22 @@
-import {skipToken, useQuery} from '@tanstack/react-query';
-
-import {Alert} from '@sentry/scraps/alert';
 import {Tag} from '@sentry/scraps/badge';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
 
-import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
-import {ChartContent} from 'sentry/components/seer/markdown/embeds/components/chart';
-import {SimpleTable} from 'sentry/components/tables/simpleTable';
-import {t} from 'sentry/locale';
-import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
-import {apiOptions} from 'sentry/utils/api/apiOptions';
-import type {TableData} from 'sentry/utils/discover/discoverQuery';
-import {aggregateOutputType, getAggregateAlias} from 'sentry/utils/discover/fields';
-import {formatNumber} from 'sentry/utils/number/formatNumber';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import {QueryEmbedCard} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedCard';
 import {
-  isEventsStats,
-  isMultiSeriesEventsStats,
-} from 'sentry/views/dashboards/utils/isEventsStats';
-import {transformEventsStatsToSeries} from 'sentry/views/dashboards/utils/transformEventsStatsToSeries';
+  QueryEmbedChart,
+  seriesFromEventsStats,
+  toChartUnit,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedChart';
+import {
+  useQueryEmbedEventsStats,
+  useQueryEmbedEventsTable,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedQueries';
+import {
+  eventColumns,
+  eventRowKey,
+  QueryEmbedTable,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedTable';
+import {t} from 'sentry/locale';
+import {aggregateOutputType} from 'sentry/utils/discover/fields';
 
 import {ErrorsQueryLink} from './errorsQueryLink';
 import {
@@ -28,59 +24,8 @@ import {
   buildErrorsEventView,
   hasNoGroupBy,
   resolveChartYAxes,
-  toChartUnit,
   type ErrorsQueryData,
 } from './errorsQueryUtils';
-
-const ROW_LIMIT = 5;
-
-// Matches the height `ChartContent` renders into, so the chart's loading state
-// holds the block's shape instead of collapsing it.
-const CHART_HEIGHT = '220px';
-
-interface ErrorsQueryBlockProps {
-  data: ErrorsQueryData;
-}
-
-function formatCellValue(value: unknown): string {
-  if (value === undefined || value === null || value === '') {
-    return '—';
-  }
-
-  if (typeof value === 'number') {
-    return String(formatNumber(value));
-  }
-
-  if (typeof value === 'string') {
-    return value;
-  }
-
-  if (typeof value === 'boolean' || typeof value === 'bigint') {
-    return value.toString();
-  }
-
-  return JSON.stringify(value) ?? '—';
-}
-
-function chartSeriesFromStatsResponse(
-  responseData: EventsStats | MultiSeriesEventsStats,
-  yAxisFields: string[]
-) {
-  if (isEventsStats(responseData)) {
-    const field = yAxisFields[0] ?? t('Count');
-    return [transformEventsStatsToSeries(responseData, field, field)];
-  }
-
-  if (isMultiSeriesEventsStats(responseData)) {
-    return Object.entries(responseData)
-      .filter(([key]) => key !== 'order')
-      .map(([seriesName, stats]) =>
-        transformEventsStatsToSeries(stats, seriesName, seriesName)
-      );
-  }
-
-  return [];
-}
 
 function ErrorsQueryChart({
   data,
@@ -93,74 +38,25 @@ function ErrorsQueryChart({
   fields: string[];
   hasTable: boolean;
 }) {
-  const organization = useOrganization();
-
   // The chart is the total across the period, never a per-group breakdown —
   // the table below is what breaks the results out by group.
   const yAxisFields = resolveChartYAxes(data, fields);
-
-  const query = useQuery({
-    ...apiOptions.as<EventsStats | MultiSeriesEventsStats>()(
-      '/organizations/$organizationIdOrSlug/events-stats/',
-      {
-        path: {organizationIdOrSlug: organization.slug},
-        query: buildErrorsChartQuery(eventView, yAxisFields),
-        staleTime: 30_000,
-      }
-    ),
-    retry: false,
-  });
-
-  if (query.isPending) {
-    return (
-      <Flex align="center" height={CHART_HEIGHT} justify="center" width="100%">
-        <LoadingIndicator />
-      </Flex>
-    );
-  }
-
-  if (query.isError) {
-    return (
-      <Alert role="alert" variant="danger">
-        {t('Unable to load chart data')}
-      </Alert>
-    );
-  }
-
-  const series = chartSeriesFromStatsResponse(query.data, yAxisFields).map(item => ({
-    label: item.seriesName,
-    data: item.data.map(point => ({
-      x: new Date(point.name).toISOString(),
-      y: point.value,
-    })),
-  }));
-
-  if (series.every(item => item.data.length === 0)) {
-    // When a table follows, its own empty state already says this — drop the
-    // chart rather than repeat the message.
-    return hasTable ? null : (
-      <Alert role="alert" variant="muted">
-        {t('No matching errors')}
-      </Alert>
-    );
-  }
+  const query = useQueryEmbedEventsStats(buildErrorsChartQuery(eventView, yAxisFields));
 
   return (
-    <ChartContent
-      data={{
-        title: data.title ?? t('Errors over time'),
-        visualization: 'line',
-        x_axis: 'time',
-        y_axis_unit: toChartUnit(aggregateOutputType(yAxisFields[0])),
-        series,
-      }}
-      showHeader={false}
+    <QueryEmbedChart
+      emptyMessage={t('No matching errors')}
+      hasTable={hasTable}
+      isError={query.isError}
+      isPending={query.isPending}
+      series={query.data ? seriesFromEventsStats(query.data, yAxisFields) : []}
+      title={data.title ?? t('Errors over time')}
+      unit={toChartUnit(aggregateOutputType(yAxisFields[0]))}
     />
   );
 }
 
-export default function ErrorsQueryBlock({data}: ErrorsQueryBlockProps) {
-  const organization = useOrganization();
+export default function ErrorsQueryBlock({data}: {data: ErrorsQueryData}) {
   const eventView = buildErrorsEventView(data);
   const fields = eventView.getFields();
   const isAggregate = data.mode === 'aggregate';
@@ -169,82 +65,36 @@ export default function ErrorsQueryBlock({data}: ErrorsQueryBlockProps) {
   // table and gains the chart above it.
   const isChartOnly = isAggregate && hasNoGroupBy(fields);
 
-  const tableQuery = useQuery({
-    ...apiOptions.as<TableData>()('/organizations/$organizationIdOrSlug/events/', {
-      path: isChartOnly ? skipToken : {organizationIdOrSlug: organization.slug},
-      query: {
-        ...eventView.generateQueryStringObject(),
-        per_page: ROW_LIMIT,
-        referrer: 'seer-errors-query-embed',
-      },
-      staleTime: 30_000,
-    }),
-    retry: false,
+  const tableQuery = useQueryEmbedEventsTable({
+    enabled: !isChartOnly,
+    eventView,
+    referrer: 'seer-errors-query-embed',
   });
 
-  const columns = fields.map((field, index) => ({
-    key: field,
-    width: index === 0 ? 'minmax(0, 2fr)' : 'minmax(0, 1fr)',
-  }));
-
   return (
-    <Container
-      as="section"
-      background="primary"
-      border="primary"
-      data-test-id={`seer-errors-query-${data.mode}-embed`}
-      margin="lg 0"
-      padding="lg"
-      radius="md"
-      width="100%"
+    <QueryEmbedCard
+      badge={<Tag variant="muted">{isAggregate ? t('Aggregate') : t('Events')}</Tag>}
+      link={<ErrorsQueryLink data={data} />}
+      query={data.query}
+      testId={`seer-errors-query-${data.mode}-embed`}
     >
-      <Stack gap="md">
-        <Flex align="center" gap="md" justify="between">
-          <ErrorsQueryLink data={data} />
-          <Tag variant="muted">{isAggregate ? t('Aggregate') : t('Events')}</Tag>
-        </Flex>
-        {data.query ? <ProvidedFormattedQuery query={data.query} /> : null}
-        <ErrorsQueryChart
-          data={data}
-          eventView={eventView}
-          fields={fields}
-          hasTable={!isChartOnly}
+      <ErrorsQueryChart
+        data={data}
+        eventView={eventView}
+        fields={fields}
+        hasTable={!isChartOnly}
+      />
+      {isChartOnly ? null : (
+        <QueryEmbedTable
+          columns={eventColumns(fields)}
+          emptyMessage={t('No matching errors')}
+          errorMessage={t('Unable to load errors')}
+          isError={tableQuery.isError}
+          isPending={tableQuery.isPending}
+          rowKey={eventRowKey}
+          rows={tableQuery.data?.data ?? []}
         />
-        {isChartOnly ? null : (
-          <SimpleTable
-            columns={columns}
-            header={
-              <SimpleTable.HeaderRow>
-                {fields.map(field => (
-                  <SimpleTable.HeaderCell key={field}>
-                    <Text ellipsis>{field}</Text>
-                  </SimpleTable.HeaderCell>
-                ))}
-              </SimpleTable.HeaderRow>
-            }
-          >
-            {tableQuery.isPending ? (
-              <SimpleTable.Loading />
-            ) : tableQuery.isError ? (
-              <SimpleTable.Empty>{t('Unable to load errors')}</SimpleTable.Empty>
-            ) : tableQuery.data.data.length === 0 ? (
-              <SimpleTable.Empty>{t('No matching errors')}</SimpleTable.Empty>
-            ) : (
-              tableQuery.data.data.slice(0, ROW_LIMIT).map((row, rowIndex) => (
-                <SimpleTable.Row key={row.id ?? rowIndex}>
-                  {fields.map(field => (
-                    <SimpleTable.RowCell key={field}>
-                      <Text ellipsis>
-                        {formatCellValue(row[field] ?? row[getAggregateAlias(field)])}
-                      </Text>
-                    </SimpleTable.RowCell>
-                  ))}
-                </SimpleTable.Row>
-              ))
-            )}
-          </SimpleTable>
-        )}
-      </Stack>
-    </Container>
+      )}
+    </QueryEmbedCard>
   );
 }

--- a/static/app/components/seer/markdown/embeds/components/errorsQueryUtils.ts
+++ b/static/app/components/seer/markdown/embeds/components/errorsQueryUtils.ts
@@ -1,12 +1,10 @@
 import type {Query} from 'history';
 import * as qs from 'query-string';
 
-import type {ChartUnit} from 'sentry/components/seer/markdown/embeds/components/chartTypes';
 import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
 import {EventView} from 'sentry/utils/discover/eventView';
-import type {AggregationOutputType} from 'sentry/utils/discover/fields';
 import {SavedQueryDatasets} from 'sentry/utils/discover/types';
 
 export type ErrorsQueryData = EmbedOutput<'errorsQuery'>;
@@ -121,17 +119,4 @@ export function buildErrorsChartQuery(eventView: EventView, yAxis: string[]): Qu
   } = eventView.generateQueryStringObject();
 
   return {...rest, yAxis};
-}
-
-export function toChartUnit(outputType: AggregationOutputType): ChartUnit {
-  switch (outputType) {
-    case 'duration':
-      return 'duration';
-    case 'percentage':
-      return 'percentage';
-    case 'size':
-      return 'bytes';
-    default:
-      return 'number';
-  }
 }

--- a/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedCard.tsx
+++ b/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedCard.tsx
@@ -1,0 +1,57 @@
+import type {ReactNode} from 'react';
+
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+
+import {ProvidedFormattedQuery} from 'sentry/components/searchQueryBuilder/formattedQuery';
+
+interface QueryEmbedCardProps {
+  /**
+   * The chart and/or table this card frames. A query type with neither — a
+   * plain list preview — passes its rows straight through.
+   */
+  children: ReactNode;
+  /** The embed's own inline link component, rendered as the card's heading. */
+  link: ReactNode;
+  testId: string;
+  /** Right-aligned label for the query's mode, e.g. "Aggregate" or "Spans". */
+  badge?: ReactNode;
+  /**
+   * The search string, rendered as formatted tokens. Omitted when the query is
+   * empty, so an unfiltered preview doesn't show an empty token row.
+   */
+  query?: string;
+}
+
+/**
+ * The chrome every query-embed block shares: a bordered card holding the
+ * resource link, the formatted query, and whatever preview the embed renders.
+ */
+export function QueryEmbedCard({
+  badge,
+  children,
+  link,
+  query,
+  testId,
+}: QueryEmbedCardProps) {
+  return (
+    <Container
+      as="section"
+      background="primary"
+      border="primary"
+      data-test-id={testId}
+      margin="lg 0"
+      padding="lg"
+      radius="md"
+      width="100%"
+    >
+      <Stack gap="md">
+        <Flex align="center" gap="md" justify="between">
+          {link}
+          {badge}
+        </Flex>
+        {query ? <ProvidedFormattedQuery query={query} /> : null}
+        {children}
+      </Stack>
+    </Container>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedChart.tsx
+++ b/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedChart.tsx
@@ -1,0 +1,134 @@
+import {Alert} from '@sentry/scraps/alert';
+import {Flex} from '@sentry/scraps/layout';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {ChartContent} from 'sentry/components/seer/markdown/embeds/components/chart';
+import type {ChartUnit} from 'sentry/components/seer/markdown/embeds/components/chartTypes';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import {t} from 'sentry/locale';
+import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
+import type {AggregationOutputType} from 'sentry/utils/discover/fields';
+import {
+  isEventsStats,
+  isMultiSeriesEventsStats,
+} from 'sentry/views/dashboards/utils/isEventsStats';
+import {transformEventsStatsToSeries} from 'sentry/views/dashboards/utils/transformEventsStatsToSeries';
+
+/**
+ * Matches the height `ChartContent` renders into, so the chart's loading state
+ * holds the block's shape instead of collapsing it.
+ */
+const CHART_HEIGHT = '220px';
+
+type ChartSeries = EmbedOutput<'chart'>['series'];
+
+export function toChartUnit(outputType: AggregationOutputType): ChartUnit {
+  switch (outputType) {
+    case 'duration':
+      return 'duration';
+    case 'percentage':
+      return 'percentage';
+    case 'size':
+      return 'bytes';
+    default:
+      return 'number';
+  }
+}
+
+/**
+ * Adapts an `/organizations/$org/events-stats/` response, whose series arrive
+ * as raw count tuples that still need transforming.
+ */
+export function seriesFromEventsStats(
+  responseData: EventsStats | MultiSeriesEventsStats,
+  yAxisFields: string[]
+): ChartSeries {
+  const transformed = isEventsStats(responseData)
+    ? [
+        transformEventsStatsToSeries(
+          responseData,
+          yAxisFields[0] ?? t('Count'),
+          yAxisFields[0] ?? t('Count')
+        ),
+      ]
+    : isMultiSeriesEventsStats(responseData)
+      ? // A grouped query comes back keyed by group name — one entry per top
+        // group — and a multi-axis query keyed by aggregate. Either way the
+        // key is the label.
+        Object.entries(responseData)
+          .filter(([key]) => key !== 'order')
+          .map(([seriesName, stats]) =>
+            transformEventsStatsToSeries(stats, seriesName, seriesName)
+          )
+      : [];
+
+  return transformed.map(item => ({
+    label: item.seriesName,
+    data: item.data.map(point => ({
+      x: new Date(point.name).toISOString(),
+      y: point.value,
+    })),
+  }));
+}
+
+interface QueryEmbedChartProps {
+  emptyMessage: string;
+  /**
+   * Whether a table follows. Its own empty state already says there were no
+   * results, so an empty chart drops out rather than repeating the message.
+   */
+  hasTable: boolean;
+  isError: boolean;
+  isPending: boolean;
+  series: ChartSeries;
+  title: string;
+  unit: ChartUnit;
+}
+
+/** The timeseries preview every charting query embed shares. */
+export function QueryEmbedChart({
+  emptyMessage,
+  hasTable,
+  isError,
+  isPending,
+  series,
+  title,
+  unit,
+}: QueryEmbedChartProps) {
+  if (isPending) {
+    return (
+      <Flex align="center" height={CHART_HEIGHT} justify="center" width="100%">
+        <LoadingIndicator />
+      </Flex>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert role="alert" variant="danger">
+        {t('Unable to load chart data')}
+      </Alert>
+    );
+  }
+
+  if (series.every(item => item.data.length === 0)) {
+    return hasTable ? null : (
+      <Alert role="alert" variant="muted">
+        {emptyMessage}
+      </Alert>
+    );
+  }
+
+  return (
+    <ChartContent
+      data={{
+        title,
+        visualization: 'line',
+        x_axis: 'time',
+        y_axis_unit: unit,
+        series,
+      }}
+      showHeader={false}
+    />
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedConstants.ts
+++ b/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedConstants.ts
@@ -1,0 +1,2 @@
+/** How many rows every query embed previews before sending you to the full view. */
+export const QUERY_EMBED_ROW_LIMIT = 5;

--- a/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedQueries.ts
+++ b/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedQueries.ts
@@ -1,0 +1,64 @@
+import {skipToken, useQuery} from '@tanstack/react-query';
+import type {Query} from 'history';
+
+import {QUERY_EMBED_ROW_LIMIT} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedConstants';
+import type {EventsStats, MultiSeriesEventsStats} from 'sentry/types/organization';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {TableData} from 'sentry/utils/discover/discoverQuery';
+import type {EventView} from 'sentry/utils/discover/eventView';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+/** Previews are cheap and short-lived; don't refetch one the reader just saw. */
+const STALE_TIME = 30_000;
+
+/**
+ * The row preview behind `/organizations/$org/events/`. Every Discover-backed
+ * query embed — errors, spans, logs, metrics — differs only in the dataset its
+ * `EventView` carries.
+ */
+export function useQueryEmbedEventsTable({
+  enabled,
+  eventView,
+  referrer,
+}: {
+  /** False for a query whose results collapse to a single row. */
+  enabled: boolean;
+  eventView: EventView;
+  referrer: string;
+}) {
+  const organization = useOrganization();
+
+  return useQuery({
+    ...apiOptions.as<TableData>()('/organizations/$organizationIdOrSlug/events/', {
+      path: enabled ? {organizationIdOrSlug: organization.slug} : skipToken,
+      query: {
+        ...eventView.generateQueryStringObject(),
+        per_page: QUERY_EMBED_ROW_LIMIT,
+        referrer,
+      },
+      staleTime: STALE_TIME,
+    }),
+    retry: false,
+  });
+}
+
+/**
+ * The timeseries behind `/organizations/$org/events-stats/`. Callers build the
+ * query themselves — whether the chart splits into a series per group is the
+ * one thing that genuinely differs between datasets.
+ */
+export function useQueryEmbedEventsStats(query: Query) {
+  const organization = useOrganization();
+
+  return useQuery({
+    ...apiOptions.as<EventsStats | MultiSeriesEventsStats>()(
+      '/organizations/$organizationIdOrSlug/events-stats/',
+      {
+        path: {organizationIdOrSlug: organization.slug},
+        query,
+        staleTime: STALE_TIME,
+      }
+    ),
+    retry: false,
+  });
+}

--- a/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedTable.tsx
+++ b/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedTable.tsx
@@ -1,0 +1,123 @@
+import type {ReactNode} from 'react';
+
+import {Text} from '@sentry/scraps/text';
+
+import {QUERY_EMBED_ROW_LIMIT} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedConstants';
+import {SimpleTable} from 'sentry/components/tables/simpleTable';
+import {getAggregateAlias} from 'sentry/utils/discover/fields';
+import {formatNumber} from 'sentry/utils/number/formatNumber';
+
+function formatCellValue(value: unknown): string {
+  if (value === undefined || value === null || value === '') {
+    return '—';
+  }
+
+  if (typeof value === 'number') {
+    return String(formatNumber(value));
+  }
+
+  if (typeof value === 'string') {
+    return value;
+  }
+
+  if (typeof value === 'boolean' || typeof value === 'bigint') {
+    return value.toString();
+  }
+
+  return JSON.stringify(value) ?? '—';
+}
+
+export interface QueryEmbedColumn<Row> {
+  key: string;
+  /**
+   * Rendered into the cell as-is. A column of plain values is responsible for
+   * its own truncation — see `eventColumns` — so that a column of rich content
+   * isn't forced into a text context that would mangle it.
+   */
+  render: (row: Row) => ReactNode;
+}
+
+/**
+ * Columns for a table backed by `/organizations/$org/events/`, whose rows are
+ * keyed by field name. The aggregate alias fallback is what lets a column
+ * named `count_unique(user)` read the `count_unique_user` key the API returns.
+ */
+export function eventColumns<Row extends Record<string, unknown>>(
+  fields: string[]
+): Array<QueryEmbedColumn<Row>> {
+  return fields.map(field => ({
+    key: field,
+    render: (row: Row) => (
+      <Text ellipsis>{formatCellValue(row[field] ?? row[getAggregateAlias(field)])}</Text>
+    ),
+  }));
+}
+
+/** Rows from `/events/` carry an `id`; fall back to position for aggregates. */
+export function eventRowKey(row: {id?: string | number}, index: number): string {
+  return String(row.id ?? index);
+}
+
+interface QueryEmbedTableProps<Row> {
+  columns: Array<QueryEmbedColumn<Row>>;
+  emptyMessage: string;
+  errorMessage: string;
+  isError: boolean;
+  isPending: boolean;
+  rows: Row[];
+  rowKey?: (row: Row, index: number) => string;
+}
+
+/**
+ * The preview table every query embed shares: fixed column widths, ellipsised
+ * cells, and the three async states. Rows are read-only by construction —
+ * cells render values, never controls, so an interaction here can't reach the
+ * host page (see the embeds README).
+ */
+export function QueryEmbedTable<Row>({
+  columns,
+  emptyMessage,
+  errorMessage,
+  isError,
+  isPending,
+  rowKey,
+  rows,
+}: QueryEmbedTableProps<Row>) {
+  const columnConfig = columns.map((column, index) => ({
+    key: column.key,
+    width: index === 0 ? 'minmax(0, 2fr)' : 'minmax(0, 1fr)',
+  }));
+
+  return (
+    <SimpleTable
+      columns={columnConfig}
+      header={
+        <SimpleTable.HeaderRow>
+          {columns.map(column => (
+            <SimpleTable.HeaderCell key={column.key}>
+              <Text ellipsis>{column.key}</Text>
+            </SimpleTable.HeaderCell>
+          ))}
+        </SimpleTable.HeaderRow>
+      }
+    >
+      {isPending ? (
+        <SimpleTable.Loading />
+      ) : isError ? (
+        <SimpleTable.Empty>{errorMessage}</SimpleTable.Empty>
+      ) : rows.length === 0 ? (
+        <SimpleTable.Empty>{emptyMessage}</SimpleTable.Empty>
+      ) : (
+        rows.slice(0, QUERY_EMBED_ROW_LIMIT).map((row, index) => (
+          <SimpleTable.Row key={rowKey?.(row, index) ?? index}>
+            {columns.map(column => (
+              <SimpleTable.RowCell key={column.key}>
+                {column.render(row)}
+              </SimpleTable.RowCell>
+            ))}
+          </SimpleTable.Row>
+        ))
+      )}
+    </SimpleTable>
+  );
+}


### PR DESCRIPTION
This abstracts the query-based embeds as they are all fairly similar (errors, spans, metrics, logs).


## Slop

`errorsQueryBlock` and `spansQueryBlock` (#123012) had grown near-identical: the same card chrome, the same `SimpleTable` rendering, the same cell formatter, the same three async states around a chart. Four more query embeds are queued behind them — logs (CW-1950), metrics (CW-1953), replays (CW-1952), saved queries (CW-1940) — which would have made this the third through sixth copy.

### What's shared

Only the chrome, and the two fetches that are byte-identical:

| Module | Owns |
| --- | --- |
| `queryEmbedCard` | the bordered card, its link/badge header, the formatted query |
| `queryEmbedTable` | column widths, truncation, loading/error/empty states |
| `queryEmbedChart` | the chart's three states, plus the `events-stats` series adapter |
| `queryEmbedQueries` | the `/events/` and `/events-stats/` requests |

### What's deliberately *not* shared

Everything a `*QueryUtils.ts` knows about its own dataset. Building the `EventView`, choosing default fields, resolving y-axes, and deciding whether grouping splits the chart all differ per surface — spans ranks top groups with `topEvents`/`excludeOther` and normalizes its sort's spelling for each of its two consumers; errors derives its y-axes from the resolved table fields. Turning those into config on a shared component is where the seam would start to leak, so they stay per-embed.

Two seams were checked against the embeds still to come rather than only against the two that exist:

- `QueryEmbedChart` takes `series`/`isPending`/`isError` rather than a query, because Logs and Metrics chart through `/events-timeseries/` (a `{timeSeries: TimeSeries[]}` shape) rather than `/events-stats/`. A second adapter lands next to `seriesFromEventsStats` when that embed does.
- `QueryEmbedTable` renders each cell exactly as its column returns it, with truncation living in `eventColumns`. Replays needs a rich cell (`ReplayBadge`), which a text-ellipsis wrapper in the table would have mangled.

### Cost

This costs lines with one consumer and repays them from the second on — `spansQueryBlock` collapses from ~240 lines to ~60 against these modules, with no new props or escape hatches on any of them.

### Testing

No behaviour change. `errorsQuery`'s existing tests pass untouched, including their assertions on the `events` and `events-stats` request params. `typecheck`, `oxlint`, `knip` and `prek` all clean.

https://claude.ai/code/session_019ggTyhE8XgKwUezTEKg7t9