### PR TITLE
chore(ci): Add a flake8 rule for usage of .first()

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -70,9 +70,9 @@ per-file-ignores =
     tools/*: S
     # testing the options manager itself
     src/sentry/testutils/helpers/options.py, tests/sentry/options/test_manager.py: S011
-    # S021-S028 lint the shipped API surface and its lint infrastructure; test
+    # S021-S029 lint the shipped API surface and its lint infrastructure; test
     # modules deliberately contain the shapes they exercise
-    tests/*: S021, S022, S023, S024, S025, S026, S027, S028
+    tests/*: S021, S022, S023, S024, S025, S026, S027, S028, S029
 
 [flake8:local-plugins]
 paths = .

--- a/tests/tools/test_flake8_plugin.py
+++ b/tests/tools/test_flake8_plugin.py
@@ -1610,3 +1610,36 @@ class E(Endpoint):
         return options.get("key", request.GET)
 """
     assert _run_input(src, SHAPED) == []
+
+
+def test_S029() -> None:
+    from tools.flake8_plugin import S029_msg
+
+    error = f"t.py:1:9: {S029_msg}"
+    assert _run("result = Model.objects.filter(id=1).first()") == [error]
+    assert _run("result = Model.objects.exclude(status='deleted').first()") == [error]
+    assert _run("result = Model.objects.first()") == [error]
+    assert _run("result = queryset.first()") == [error]
+    assert _run("result = get_queryset().first()") == [error]
+    assert _run("result = Model.objects.filter(id=1).select_related('owner').first()") == [error]
+    assert _run("result = Model.objects.filter(id=1).values('id').first()") == [error]
+    assert _run("result = Model.objects.filter(id=1).values_list('id').first()") == [error]
+    assert _run("result = Model.objects.filter(id=1).only('id').first()") == [error]
+    assert _run("result = Model.objects.order_by().first()") == [error]
+    assert _run("result = Model.objects.order_by().filter(id=1).first()") == [error]
+    assert _run(
+        "result = Model.objects.order_by('name').filter(active=True).order_by().first()"
+    ) == [error]
+
+    assert _run("result = Model.objects.order_by('id').first()") == []
+    assert (
+        _run(
+            "result = Model.objects.order_by('id').filter(active=True).select_related('owner').first()"
+        )
+        == []
+    )
+    assert (
+        _run("result = Model.objects.order_by().filter(active=True).order_by('id').first()") == []
+    )
+    assert _run("result = Model.objects.get_or_none(id=1)") == []
+    assert _run("result = value.first") == []

--- a/tools/flake8_plugin.py
+++ b/tools/flake8_plugin.py
@@ -187,6 +187,24 @@ S025_body_msg = (
     "endpoint accepts. Add it as request=."
 )
 
+S029_msg = (
+    "S029 Use .get_or_none() instead of .first() when querying "
+    "for a single unique row. If multiple similar rows exist, use an explicit "
+    ".order_by(...) before .first() to fetch a specific row."
+)
+
+
+def _is_unordered_first(node: ast.Call) -> bool:
+    if not isinstance(node.func, ast.Attribute) or node.func.attr != "first":
+        return False
+
+    current = node.func.value
+    while isinstance(current, ast.Call) and isinstance(current.func, ast.Attribute):
+        if current.func.attr == "order_by":
+            return not current.args
+        current = current.func.value
+    return True
+
 
 def _s015_msg() -> str:
     return (
@@ -1135,6 +1153,9 @@ class SentryVisitor(ast.NodeVisitor):
             and node.func.value.value.id == "self"
         ):
             self.errors.append((node.lineno, node.col_offset, S020_msg))
+
+        if _is_unordered_first(node):
+            self.errors.append((node.lineno, node.col_offset, S029_msg))
 
         self.generic_visit(node)
 


### PR DESCRIPTION
Adds S025 to prevent using `.first()` after `.filter()` without an explicit `.order_by()`.

This makes it more explicit to the dev that `.first()` will add ordering, and to include that if its relevant to the code, or suggest just using `.get_or_none()` if it was only added to avoid handling a DoesNotExist exception.

I added the script to generate the current exception list + the list itself, which uses fingerprints instead of line numbers since there are a lot of files in it and I figured it'd be annoying to raise on unrelated changes in the same file. I don't know if this is preferred to `# noqa` comments instead, but it avoided making changes to like 180 locations.