### PR TITLE
fix(ci): Reconcile pull request scope metadata

### DIFF
--- a/.github/workflows/development-environment.yml
+++ b/.github/workflows/development-environment.yml
@@ -35,6 +35,13 @@ jobs:
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
 
+      - uses: actions/setup-node@1e60f620b9541d16bece96c5465dc8ee9832be0b # v4
+        with:
+          node-version-file: '.node-version'
+
+      - name: Test workflow scripts
+        run: node --test .github/workflows/scripts/*.test.{js,ts}
+
       - uses: astral-sh/setup-uv@884ad927a57e558e7a70b92f2bccf9198a4be546 # v6
         with:
           version: '0.9.28'

--- a/.github/workflows/label-pullrequest.yml
+++ b/.github/workflows/label-pullrequest.yml
@@ -4,6 +4,10 @@ name: meta(labels)
 on:
   pull_request_target:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   label-pullrequest:
     permissions:
@@ -23,57 +27,16 @@ jobs:
           token: ${{ github.token }}
           filters: .github/file-filters.yml
 
-      - name: Add frontend label
-        uses: getsentry/action-add-labels@ca568508c6e91387909cb3661e4cd965aa2f3a89
-        if: steps.changes.outputs.frontend_all == 'true'
-        with:
-          labels: 'Scope: Frontend'
-
-      - name: Add backend label
-        uses: getsentry/action-add-labels@ca568508c6e91387909cb3661e4cd965aa2f3a89
-        if: steps.changes.outputs.backend_src == 'true'
-        with:
-          labels: 'Scope: Backend'
-
-      - name: Find previous frontend/backend warning comment
-        uses: peter-evans/find-comment@a54c31d7fa095754bfef525c0c8e5e5674c4b4b1 # v2.4.0
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: '<!-- FRONTEND_BACKEND_WARNING -->'
-
-      - name: Count backend warning exemptions
-        id: backend_exemptions
+      - name: Reconcile frontend/backend labels and warning
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         env:
-          EMBED_WIDGET_CODEGEN_COUNT: ${{ steps.changes.outputs.embed_widget_codegen_count }}
-          INTEGRATION_TEST_UTILS_COUNT: ${{ steps.changes.outputs.integration_test_utils_count }}
-        run: |
-          echo "count=$((${EMBED_WIDGET_CODEGEN_COUNT:-0} + ${INTEGRATION_TEST_UTILS_COUNT:-0}))" >> "$GITHUB_OUTPUT"
-
-      - name: Add frontend/backend warning comment
-        uses: peter-evans/create-or-update-comment@b95e16d2859ad843a14218d1028da5b2c4cbc4b4
-        if: >
-          fromJSON(steps.changes.outputs.frontend_all_count) >
-          fromJSON(steps.changes.outputs.api_url_codegen_count) &&
-          fromJSON(steps.changes.outputs.backend_src_count) >
-          fromJSON(steps.backend_exemptions.outputs.count || '0') &&
-          steps.fc.outputs.comment-id == 0
+          PATH_FILTER_OUTPUTS: ${{ toJSON(steps.changes.outputs) }}
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          body: >
-            <!-- FRONTEND_BACKEND_WARNING -->
-
-            🚨 **Warning:** This pull request contains Frontend and Backend changes!
-
-
-            It's discouraged to make changes to Sentry's Frontend and Backend
-            in a single pull request. The Frontend and Backend are **not**
-            atomically deployed. If the changes are interdependent of each
-            other, they **must** be separated into two pull requests and be made
-            forward or backwards compatible, such that the Backend or Frontend
-            can be safely deployed independently.
-
-
-            Have questions? Please ask in the [`#discuss-dev-infra`
-            channel](https://app.slack.com/client/T024ZCV9U/CTJL7358X).
+          script: |
+            const {reconcilePrScope} = await import(`${process.env.GITHUB_WORKSPACE}/.github/workflows/scripts/reconcile-pr-scope.js`);
+            await reconcilePrScope({
+              github,
+              context,
+              core,
+              pathFilterOutputs: JSON.parse(process.env.PATH_FILTER_OUTPUTS),
+            });

--- a/.github/workflows/scripts/reconcile-pr-scope.js
+++ b/.github/workflows/scripts/reconcile-pr-scope.js
@@ -1,0 +1,86 @@
+export const FRONTEND_LABEL = 'Scope: Frontend';
+export const BACKEND_LABEL = 'Scope: Backend';
+export const COMMENT_MARKER = '<!-- FRONTEND_BACKEND_WARNING -->';
+
+export const WARNING_BODY = `${COMMENT_MARKER}
+🚨 **Warning:** This pull request contains Frontend and Backend changes!
+
+It's discouraged to make changes to Sentry's Frontend and Backend in a single pull request. The Frontend and Backend are **not** atomically deployed. If the changes are interdependent of each other, they **must** be separated into two pull requests and be made forward or backwards compatible, such that the Backend or Frontend can be safely deployed independently.
+
+Have questions? Please ask in the [\`#discuss-dev-infra\` channel](https://app.slack.com/client/T024ZCV9U/CTJL7358X).`;
+
+function count(outputs, name) {
+  const value = outputs[name];
+  const parsed = Number(value);
+  if (value === undefined || value === '' || !Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`Expected ${name} to be a non-negative integer, got: ${value}`);
+  }
+  return parsed;
+}
+
+export function deriveScopeState(pathFilterOutputs) {
+  const frontendChanges = count(pathFilterOutputs, 'frontend_all_count');
+  const backendChanges = count(pathFilterOutputs, 'backend_src_count');
+  const frontendWarningExemptions = count(pathFilterOutputs, 'api_url_codegen_count');
+  const backendWarningExemptions =
+    count(pathFilterOutputs, 'embed_widget_codegen_count') +
+    count(pathFilterOutputs, 'integration_test_utils_count');
+
+  return {
+    frontend: frontendChanges > 0,
+    backend: backendChanges > 0,
+    shouldWarn:
+      frontendChanges > frontendWarningExemptions &&
+      backendChanges > backendWarningExemptions,
+  };
+}
+
+export async function reconcilePrScope({github, context, core, pathFilterOutputs}) {
+  const {owner, repo} = context.repo;
+  const issue_number = context.payload.pull_request.number;
+  const scopeState = deriveScopeState(pathFilterOutputs);
+
+  const {data: pullRequest} = await github.rest.issues.get({owner, repo, issue_number});
+  const currentLabels = new Set(pullRequest.labels.map(label => label.name));
+  const desiredLabels = new Map([
+    [FRONTEND_LABEL, scopeState.frontend],
+    [BACKEND_LABEL, scopeState.backend],
+  ]);
+
+  for (const [name, shouldExist] of desiredLabels) {
+    if (shouldExist && !currentLabels.has(name)) {
+      await github.rest.issues.addLabels({owner, repo, issue_number, labels: [name]});
+      core.info(`Added ${name} to #${issue_number}.`);
+    } else if (!shouldExist && currentLabels.has(name)) {
+      await github.rest.issues.removeLabel({owner, repo, issue_number, name});
+      core.info(`Removed stale ${name} from #${issue_number}.`);
+    }
+  }
+
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number,
+    per_page: 100,
+  });
+  const warning = comments.find(
+    comment =>
+      comment.user?.login === 'github-actions[bot]' &&
+      comment.body?.includes(COMMENT_MARKER)
+  );
+
+  if (scopeState.shouldWarn && !warning) {
+    await github.rest.issues.createComment({
+      owner,
+      repo,
+      issue_number,
+      body: WARNING_BODY,
+    });
+    core.info(`Posted frontend/backend warning on #${issue_number}.`);
+  } else if (!scopeState.shouldWarn && warning) {
+    await github.rest.issues.deleteComment({owner, repo, comment_id: warning.id});
+    core.info(`Deleted stale frontend/backend warning on #${issue_number}.`);
+  } else {
+    core.info(`Frontend/backend warning on #${issue_number} is already correct.`);
+  }
+}

--- a/.github/workflows/scripts/reconcile-pr-scope.test.js
+++ b/.github/workflows/scripts/reconcile-pr-scope.test.js
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import {describe, it} from 'node:test';
+
+import {
+  BACKEND_LABEL,
+  COMMENT_MARKER,
+  deriveScopeState,
+  FRONTEND_LABEL,
+  reconcilePrScope,
+} from './reconcile-pr-scope.js';
+
+function pathFilterOutputs(overrides = {}) {
+  return {
+    frontend_all_count: '0',
+    backend_src_count: '0',
+    api_url_codegen_count: '0',
+    embed_widget_codegen_count: '0',
+    integration_test_utils_count: '0',
+    ...overrides,
+  };
+}
+
+function setup({labels = [], comments = []} = {}) {
+  const calls = [];
+  const logs = [];
+  const github = {
+    paginate: async () => comments,
+    rest: {
+      issues: {
+        get: async () => ({data: {labels: labels.map(name => ({name}))}}),
+        addLabels: async params => calls.push({method: 'addLabels', params}),
+        removeLabel: async params => calls.push({method: 'removeLabel', params}),
+        listComments: () => {},
+        createComment: async params => calls.push({method: 'createComment', params}),
+        deleteComment: async params => calls.push({method: 'deleteComment', params}),
+      },
+    },
+  };
+  const context = {
+    repo: {owner: 'getsentry', repo: 'sentry'},
+    payload: {pull_request: {number: 123}},
+  };
+  const core = {info: message => logs.push(message)};
+
+  return {github, context, core, calls, logs};
+}
+
+describe('reconcilePrScope', () => {
+  it('derives semantic scope state from path-filter outputs', () => {
+    assert.deepEqual(
+      deriveScopeState(
+        pathFilterOutputs({
+          frontend_all_count: '2',
+          backend_src_count: '2',
+          api_url_codegen_count: '2',
+          embed_widget_codegen_count: '1',
+        })
+      ),
+      {frontend: true, backend: true, shouldWarn: false}
+    );
+  });
+
+  it('rejects missing path-filter outputs', () => {
+    assert.throws(
+      () => deriveScopeState({}),
+      /Expected frontend_all_count to be a non-negative integer/
+    );
+  });
+
+  it('removes stale backend metadata from a frontend-only pull request', async () => {
+    const warning = {
+      id: 456,
+      user: {login: 'github-actions[bot]'},
+      body: COMMENT_MARKER,
+    };
+    const {github, context, core, calls, logs} = setup({
+      labels: [FRONTEND_LABEL, BACKEND_LABEL],
+      comments: [warning],
+    });
+
+    await reconcilePrScope({
+      github,
+      context,
+      core,
+      pathFilterOutputs: pathFilterOutputs({frontend_all_count: '1'}),
+    });
+
+    assert.deepEqual(
+      calls.map(call => call.method),
+      ['removeLabel', 'deleteComment']
+    );
+    assert.equal(calls[0].params.name, BACKEND_LABEL);
+    assert.equal(calls[1].params.comment_id, warning.id);
+    assert.deepEqual(logs, [
+      'Removed stale Scope: Backend from #123.',
+      'Deleted stale frontend/backend warning on #123.',
+    ]);
+  });
+
+  it('replaces stale frontend metadata when a pull request becomes backend-only', async () => {
+    const {github, context, core, calls, logs} = setup({labels: [FRONTEND_LABEL]});
+
+    await reconcilePrScope({
+      github,
+      context,
+      core,
+      pathFilterOutputs: pathFilterOutputs({backend_src_count: '1'}),
+    });
+
+    assert.deepEqual(
+      calls.map(call => call.method),
+      ['removeLabel', 'addLabels']
+    );
+    assert.equal(calls[0].params.name, FRONTEND_LABEL);
+    assert.deepEqual(calls[1].params.labels, [BACKEND_LABEL]);
+    assert.deepEqual(logs, [
+      'Removed stale Scope: Frontend from #123.',
+      'Added Scope: Backend to #123.',
+      'Frontend/backend warning on #123 is already correct.',
+    ]);
+  });
+
+  it('adds both labels and the warning for a mixed pull request', async () => {
+    const {github, context, core, calls} = setup();
+
+    await reconcilePrScope({
+      github,
+      context,
+      core,
+      pathFilterOutputs: pathFilterOutputs({
+        frontend_all_count: '1',
+        backend_src_count: '1',
+      }),
+    });
+
+    assert.deepEqual(
+      calls.map(call => call.method),
+      ['addLabels', 'addLabels', 'createComment']
+    );
+    assert.deepEqual(
+      calls.slice(0, 2).map(call => call.params.labels[0]),
+      [FRONTEND_LABEL, BACKEND_LABEL]
+    );
+    assert.match(calls[2].params.body, /Frontend and Backend changes/);
+  });
+
+  it('does not warn when all matching files are warning exemptions', async () => {
+    const warning = {
+      id: 456,
+      user: {login: 'github-actions[bot]'},
+      body: COMMENT_MARKER,
+    };
+    const {github, context, core, calls} = setup({comments: [warning]});
+
+    await reconcilePrScope({
+      github,
+      context,
+      core,
+      pathFilterOutputs: pathFilterOutputs({
+        frontend_all_count: '1',
+        backend_src_count: '2',
+        api_url_codegen_count: '1',
+        embed_widget_codegen_count: '1',
+        integration_test_utils_count: '1',
+      }),
+    });
+
+    assert.deepEqual(
+      calls.map(call => call.method),
+      ['addLabels', 'addLabels', 'deleteComment']
+    );
+  });
+
+  it('leaves already-correct metadata unchanged', async () => {
+    const {github, context, core, calls, logs} = setup({labels: [BACKEND_LABEL]});
+
+    await reconcilePrScope({
+      github,
+      context,
+      core,
+      pathFilterOutputs: pathFilterOutputs({backend_src_count: '2'}),
+    });
+
+    assert.deepEqual(calls, []);
+    assert.deepEqual(logs, ['Frontend/backend warning on #123 is already correct.']);
+  });
+});


### PR DESCRIPTION
Frontend and backend scope metadata now reflects the current pull request diff after every push. The workflow removes stale scope labels, deletes the mixed-change warning when it is no longer applicable, and cancels superseded runs so older revisions cannot restore stale state.

The reconciliation policy is derived from the existing path-filter outputs, including warning exemptions. This also adds the workflow-script test suite to `dev env / test`, so existing workflow-helper tests and the new reconciliation tests run on pull requests.