### PR TITLE
feat(seer): Add the metrics query block embed

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -1162,7 +1162,7 @@
   },
   {
     "name": "metricsQuery",
-    "description": "Link to an Explore > Metrics query for a single trace metric. Requires the metric `name` and `type` exactly as the metrics API returns them. Use mode \"aggregate\" with `groupBy`/`yAxes` to chart the metric, or \"samples\" to list raw points.",
+    "description": "Preview an Explore > Metrics query for a single trace metric. Requires the metric `name` and `type` exactly as the metrics API returns them. Use mode \"aggregate\" with `groupBy`/`yAxes` to chart the metric, or \"samples\" to list raw points. Name `yAxes` the short way, e.g. \"p95(value)\" — the embed qualifies them with the metric itself. Omit `yAxes` to use the default aggregate for the metric's type. Inline renders a link; block renders a timeseries chart with the first five matching rows beneath it. An aggregate that groups by nothing collapses to a single row, so there the chart replaces the table.",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/static/app/components/seer/markdown/embeds/components/metricsQuery.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/metricsQuery.spec.tsx
@@ -1,33 +1,175 @@
-import {getEmbedLinkHref} from './resourceEmbedTestUtils';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+
+jest.mock('sentry/components/charts/baseChart', () => ({
+  BaseChart: jest.fn(() => null),
+}));
+
+const METRIC = {
+  name: 'checkout.latency',
+  type: 'distribution',
+  unit: 'millisecond',
+};
+
+/** The fully qualified spelling Explore recognises for the metric above. */
+const QUALIFIED_P95 = 'p95(value,checkout.latency,distribution,millisecond)';
+const QUALIFIED_DEFAULT = 'sum(value,checkout.latency,distribution,millisecond)';
+
+const TIME_SERIES = [
+  {
+    yAxis: QUALIFIED_P95,
+    meta: {interval: 3_600_000, valueType: 'duration', valueUnit: 'millisecond'},
+    values: [
+      {timestamp: 1_700_000_000_000, value: 120},
+      {timestamp: 1_700_003_600_000, value: null},
+      {timestamp: 1_700_007_200_000, value: 180},
+    ],
+  },
+];
+
+function renderEmbed({
+  data,
+  level = 'block',
+}: {
+  data: Record<string, unknown>;
+  level?: 'block' | 'inline';
+}) {
+  const tag = `{% metricsQuery %}${JSON.stringify(data)}{% /metricsQuery %}`;
+  return render(<SeerMarkdown raw={level === 'inline' ? `See ${tag}` : tag} />);
+}
 
 describe('metrics query embed', () => {
-  it('encodes the metric as a single JSON param', () => {
-    const href = getEmbedLinkHref('metricsQuery', 'checkout.latency', {
-      name: 'checkout.latency',
-      type: 'distribution',
-      unit: 'millisecond',
-      mode: 'aggregate',
-      yAxes: ['p95(value)'],
+  it('qualifies a bare y-axis with the metric it measures', () => {
+    renderEmbed({
+      data: {...METRIC, mode: 'aggregate', query: '', yAxes: ['p95(value)']},
+      level: 'inline',
     });
 
-    expect(href).toContain('/organizations/org-slug/explore/metrics/');
+    // Seer emits `p95(value)`; Explore only decodes the qualified spelling, and
+    // refuses a query that charts nothing.
+    const href = screen
+      .getByRole('link', {name: METRIC.name})
+      .getAttribute('href')
+      ?.toString();
+    expect(decodeURIComponent(href ?? '')).toContain(QUALIFIED_P95);
+    expect(decodeURIComponent(href ?? '')).not.toContain('"p95(value)"');
+  });
 
-    const metric = new URL(href, 'https://sentry.io').searchParams.get('metric');
-    expect(JSON.parse(metric ?? '{}')).toEqual({
-      metric: {name: 'checkout.latency', type: 'distribution', unit: 'millisecond'},
-      query: '',
-      aggregateFields: [{yAxes: ['p95(value)']}],
-      mode: 'aggregate',
+  it('falls back to the default aggregate for the metric type', () => {
+    renderEmbed({
+      data: {...METRIC, mode: 'aggregate', query: ''},
+      level: 'inline',
+    });
+
+    // `distribution` defaults to `sum`, not a blanket `sum(value)`.
+    const href = screen
+      .getByRole('link', {name: METRIC.name})
+      .getAttribute('href')
+      ?.toString();
+    expect(decodeURIComponent(href ?? '')).toContain(QUALIFIED_DEFAULT);
+  });
+
+  it('charts a grouped aggregate above its table', async () => {
+    const timeseries = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {timeSeries: TIME_SERIES},
+    });
+    const table = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {
+        data: [
+          {'service.name': 'checkout', [QUALIFIED_P95]: 180},
+          {'service.name': 'cart', [QUALIFIED_P95]: 120},
+        ],
+      },
+    });
+
+    renderEmbed({
+      data: {
+        ...METRIC,
+        mode: 'aggregate',
+        query: 'release:1.0',
+        groupBy: ['service.name'],
+        yAxes: ['p95(value)'],
+        statsPeriod: '24h',
+      },
+    });
+
+    expect(await screen.findByTestId('seer-chart-content')).toBeInTheDocument();
+    expect(await screen.findByText('checkout')).toBeInTheDocument();
+    expect(screen.getByRole('table')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(timeseries).toHaveBeenCalledWith(
+        '/organizations/org-slug/events-timeseries/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'tracemetrics',
+            yAxis: [QUALIFIED_P95],
+            groupBy: ['service.name'],
+            // The identity lives in the y-axis, so the search stays the
+            // user's own predicate.
+            query: 'release:1.0',
+          }),
+        })
+      );
+    });
+
+    await waitFor(() => {
+      expect(table).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            dataset: 'tracemetrics',
+            field: ['service.name', QUALIFIED_P95],
+            per_page: 5,
+          }),
+        })
+      );
     });
   });
 
-  it('charts a default aggregate so the query stays decodable', () => {
-    const href = getEmbedLinkHref('metricsQuery', 'checkout.latency', {
-      name: 'checkout.latency',
-      type: 'distribution',
+  it('drops the table when an aggregate groups by nothing', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {timeSeries: TIME_SERIES},
+    });
+    const table = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: []},
     });
 
-    const metric = new URL(href, 'https://sentry.io').searchParams.get('metric');
-    expect(JSON.parse(metric ?? '{}').aggregateFields).toEqual([{yAxes: ['sum(value)']}]);
+    renderEmbed({
+      data: {...METRIC, mode: 'aggregate', query: '', yAxes: ['p95(value)']},
+    });
+
+    expect(await screen.findByTestId('seer-chart-content')).toBeInTheDocument();
+    expect(screen.queryByRole('table')).not.toBeInTheDocument();
+    expect(table).not.toHaveBeenCalled();
+  });
+
+  it('filters samples down to the metric, which has no aggregate to name it', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events-timeseries/',
+      body: {timeSeries: TIME_SERIES},
+    });
+    const table = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/events/',
+      body: {data: [{id: '1', 'metric.value': 42, timestamp: '2026-08-27T12:00:00Z'}]},
+    });
+
+    renderEmbed({data: {...METRIC, mode: 'samples', query: 'release:1.0'}});
+
+    await waitFor(() => {
+      expect(table).toHaveBeenCalledWith(
+        '/organizations/org-slug/events/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: expect.stringContaining('metric.name:checkout.latency'),
+          }),
+        })
+      );
+    });
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/metricsQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/metricsQuery.tsx
@@ -1,58 +1,18 @@
-import * as qs from 'query-string';
+import {lazy} from 'react';
 
-import {
-  toAggregateFields,
-  toPageFilters,
-} from 'sentry/components/seer/markdown/embeds/components/queryEmbedParams';
-import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
-import {
-  defineSeerEmbed,
-  type EmbedOutput,
-} from 'sentry/components/seer/markdown/embeds/utils';
-import {IconGraph} from 'sentry/icons';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
+import {LazyLoad} from 'sentry/components/lazyLoad';
+import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 
-/**
- * Metrics refuses to decode a query that charts nothing, so fall back to the
- * same aggregate the metrics UI opens with.
- */
-const DEFAULT_Y_AXES = ['sum(value)'];
+import {MetricsQueryLink} from './metricsQueryLink';
 
-function MetricsQueryLink(props: EmbedOutput<'metricsQuery'>) {
-  const organization = useOrganization();
-  const {name, type, unit, query, mode, sort, groupBy, yAxes, title} = props;
-  const {projects, environments, datetime} = toPageFilters(props);
-
-  const metric = JSON.stringify({
-    metric: {name, type, unit},
-    query,
-    aggregateFields: toAggregateFields({
-      groupBy,
-      yAxes: yAxes?.length ? yAxes : DEFAULT_Y_AXES,
-    }),
-    aggregateSortBys: sort ? [sort] : undefined,
-    mode,
-  });
-
-  const href = `${makeMetricsPathname({organizationSlug: organization.slug, path: '/'})}?${qs.stringify(
-    {
-      project: projects.length === 0 ? '' : projects,
-      environment: environments,
-      statsPeriod: datetime.period,
-      start: datetime.start,
-      end: datetime.end,
-      metric,
-    },
-    {skipNull: true}
-  )}`;
-
-  return <ResourceLink icon={IconGraph} href={href} title={title ?? name} />;
-}
+const LazyMetricsQueryBlock = lazy(() => import('./metricsQueryBlock'));
 
 export const MetricsQuery = defineSeerEmbed({
   name: 'metricsQuery',
-  render(props) {
-    return <MetricsQueryLink {...props} />;
+  render(props, level) {
+    if (level === 'block') {
+      return <LazyLoad LazyComponent={LazyMetricsQueryBlock} data={props} />;
+    }
+    return <MetricsQueryLink data={props} />;
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/metricsQueryBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/metricsQueryBlock.tsx
@@ -1,0 +1,108 @@
+import {Tag} from '@sentry/scraps/badge';
+
+import {QueryEmbedCard} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedCard';
+import {
+  chartUnitFromTimeSeries,
+  QueryEmbedChart,
+  seriesFromTimeSeries,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedChart';
+import {QUERY_EMBED_ROW_LIMIT} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedConstants';
+import {useQueryEmbedEventsTable} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedQueries';
+import {
+  eventColumns,
+  eventRowKey,
+  QueryEmbedTable,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedTable';
+import {toPageFilters} from 'sentry/components/seer/markdown/embeds/components/queryEmbedParams';
+import {t} from 'sentry/locale';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {useFetchEventsTimeSeries} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
+
+import {MetricsQueryLink} from './metricsQueryLink';
+import {
+  buildMetricsEventView,
+  getMetricsQueryFields,
+  resolveMetricYAxes,
+  type MetricsQueryData,
+} from './metricsQueryUtils';
+
+/** An aggregate that groups by nothing collapses to one row per y-axis. */
+function hasNoGroupBy(data: MetricsQueryData): boolean {
+  return data.mode === 'aggregate' && !(data.groupBy ?? []).some(Boolean);
+}
+
+function MetricsQueryChart({
+  data,
+  hasTable,
+}: {
+  data: MetricsQueryData;
+  hasTable: boolean;
+}) {
+  const groupBy = (data.groupBy ?? []).filter(Boolean);
+
+  // The metric's identity rides in the y-axis arguments, so the search string
+  // stays the user's own predicate — unlike the samples table, which has no
+  // aggregate to carry it.
+  const query = useFetchEventsTimeSeries(
+    DiscoverDatasets.TRACEMETRICS,
+    {
+      yAxis: resolveMetricYAxes(data),
+      query: data.query,
+      groupBy: groupBy.length > 0 ? groupBy : undefined,
+      topEvents: groupBy.length > 0 ? QUERY_EMBED_ROW_LIMIT : undefined,
+      pageFilters: toPageFilters(data),
+    },
+    'seer-metrics-query-embed'
+  );
+
+  const timeSeries = query.data?.timeSeries ?? [];
+
+  return (
+    <QueryEmbedChart
+      emptyMessage={t('No matching metric values')}
+      hasTable={hasTable}
+      isError={query.isError}
+      isPending={query.isPending}
+      series={seriesFromTimeSeries(timeSeries)}
+      title={data.title ?? data.name}
+      unit={chartUnitFromTimeSeries(timeSeries)}
+    />
+  );
+}
+
+export default function MetricsQueryBlock({data}: {data: MetricsQueryData}) {
+  const eventView = buildMetricsEventView(data);
+  const isChartOnly = hasNoGroupBy(data);
+
+  const tableQuery = useQueryEmbedEventsTable({
+    enabled: !isChartOnly,
+    eventView,
+    referrer: 'seer-metrics-query-embed',
+  });
+
+  return (
+    <QueryEmbedCard
+      badge={
+        <Tag variant="muted">
+          {data.mode === 'aggregate' ? t('Aggregate') : t('Samples')}
+        </Tag>
+      }
+      link={<MetricsQueryLink data={data} />}
+      query={data.query}
+      testId={`seer-metrics-query-${data.mode}-embed`}
+    >
+      <MetricsQueryChart data={data} hasTable={!isChartOnly} />
+      {isChartOnly ? null : (
+        <QueryEmbedTable
+          columns={eventColumns(getMetricsQueryFields(data))}
+          emptyMessage={t('No matching metric values')}
+          errorMessage={t('Unable to load metric values')}
+          isError={tableQuery.isError}
+          isPending={tableQuery.isPending}
+          rowKey={eventRowKey}
+          rows={tableQuery.data?.data ?? []}
+        />
+      )}
+    </QueryEmbedCard>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/metricsQueryLink.tsx
+++ b/static/app/components/seer/markdown/embeds/components/metricsQueryLink.tsx
@@ -1,0 +1,17 @@
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {IconGraph} from 'sentry/icons';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {getMetricsQueryHref, type MetricsQueryData} from './metricsQueryUtils';
+
+export function MetricsQueryLink({data}: {data: MetricsQueryData}) {
+  const organization = useOrganization();
+
+  return (
+    <ResourceLink
+      icon={IconGraph}
+      href={getMetricsQueryHref(data, organization)}
+      title={data.title ?? data.name}
+    />
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/metricsQueryUtils.ts
+++ b/static/app/components/seer/markdown/embeds/components/metricsQueryUtils.ts
@@ -1,0 +1,131 @@
+import {
+  toAggregateFields,
+  toMode,
+  toPageFilters,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbedParams';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import type {NewQuery, Organization} from 'sentry/types/organization';
+import {EventView} from 'sentry/utils/discover/eventView';
+import {DiscoverDatasets} from 'sentry/utils/discover/types';
+import {
+  AlwaysPresentTraceMetricFields,
+  TraceSamplesTableColumns,
+} from 'sentry/views/explore/metrics/constants';
+import {getTraceSamplesTableFields} from 'sentry/views/explore/metrics/constants';
+import type {TraceMetric} from 'sentry/views/explore/metrics/metricQuery';
+import {
+  createTraceMetricEventsFilter,
+  getDefaultMetricYAxis,
+  getMetricYAxis,
+  makeMetricsPathname,
+} from 'sentry/views/explore/metrics/utils';
+
+export type MetricsQueryData = EmbedOutput<'metricsQuery'>;
+
+/** The metric this embed describes, in the shape the Metrics helpers expect. */
+function toTraceMetric({name, type, unit}: MetricsQueryData): TraceMetric {
+  return unit ? {name, type, unit} : {name, type};
+}
+
+/**
+ * Explore identifies a metric inside the aggregate's own arguments rather than
+ * as a separate parameter, so a bare `p95(value)` from Seer means nothing on
+ * its own. Qualify whatever arrived, and fall back to the aggregate the
+ * Metrics UI would have opened with for this metric's type.
+ */
+export function resolveMetricYAxes(data: MetricsQueryData): string[] {
+  const traceMetric = toTraceMetric(data);
+
+  return data.yAxes?.length
+    ? data.yAxes.map(yAxis => getMetricYAxis(yAxis, traceMetric))
+    : [getDefaultMetricYAxis(traceMetric)];
+}
+
+/**
+ * Samples have no aggregate to carry the metric's identity, so it moves into
+ * the search string instead — the same filter the Metrics samples table adds.
+ */
+function buildMetricsQuery(data: MetricsQueryData): string {
+  if (data.mode === 'aggregate') {
+    return data.query;
+  }
+
+  const identity = createTraceMetricEventsFilter([toTraceMetric(data)]);
+  return data.query ? `${data.query} ${identity}` : identity;
+}
+
+export function getMetricsQueryFields(data: MetricsQueryData): string[] {
+  if (data.mode === 'aggregate') {
+    return Array.from(
+      new Set([...(data.groupBy ?? []).filter(Boolean), ...resolveMetricYAxes(data)])
+    );
+  }
+
+  return data.fields?.length
+    ? data.fields
+    : Array.from(
+        new Set([
+          ...getTraceSamplesTableFields(TraceSamplesTableColumns),
+          ...AlwaysPresentTraceMetricFields,
+        ])
+      );
+}
+
+export function buildMetricsEventView(data: MetricsQueryData): EventView {
+  const fields = getMetricsQueryFields(data);
+  const query: NewQuery = {
+    id: undefined,
+    name: data.title ?? data.name,
+    fields,
+    orderby: [data.sort ?? (data.mode === 'aggregate' ? `-${fields[0]}` : '-timestamp')],
+    query: buildMetricsQuery(data),
+    version: 2,
+    dataset: DiscoverDatasets.TRACEMETRICS,
+  };
+
+  return EventView.fromNewQueryWithPageFilters(query, toPageFilters(data));
+}
+
+/**
+ * Metrics keeps each panel's whole query in one repeated `metric` param, as a
+ * JSON blob. Explore refuses to decode one that charts nothing, so the
+ * aggregate fields always carry a resolved y-axis.
+ */
+export function getMetricsQueryHref(
+  data: MetricsQueryData,
+  organization: Organization
+): string {
+  const {name, type, unit, query, mode, sort, groupBy} = data;
+  const {projects, environments, datetime} = toPageFilters(data);
+
+  const metric = JSON.stringify({
+    metric: {name, type, unit},
+    query,
+    aggregateFields: toAggregateFields({
+      groupBy,
+      yAxes: resolveMetricYAxes(data),
+    }),
+    aggregateSortBys: sort ? [sort] : undefined,
+    mode: toMode(mode),
+  });
+
+  const params = new URLSearchParams();
+  for (const project of projects) {
+    params.append('project', String(project));
+  }
+  for (const environment of environments) {
+    params.append('environment', environment);
+  }
+  if (datetime.period) {
+    params.set('statsPeriod', datetime.period);
+  }
+  if (datetime.start) {
+    params.set('start', String(datetime.start));
+  }
+  if (datetime.end) {
+    params.set('end', String(datetime.end));
+  }
+  params.append('metric', metric);
+
+  return `${makeMetricsPathname({organizationSlug: organization.slug, path: '/'})}?${params}`;
+}

--- a/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedChart.tsx
+++ b/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedChart.tsx
@@ -13,6 +13,8 @@ import {
   isMultiSeriesEventsStats,
 } from 'sentry/views/dashboards/utils/isEventsStats';
 import {transformEventsStatsToSeries} from 'sentry/views/dashboards/utils/transformEventsStatsToSeries';
+import type {TimeSeries} from 'sentry/views/dashboards/widgets/common/types';
+import {formatTimeSeriesName} from 'sentry/views/dashboards/widgets/timeSeriesWidget/formatters/formatTimeSeriesName';
 
 /**
  * Matches the height `ChartContent` renders into, so the chart's loading state
@@ -69,6 +71,48 @@ export function seriesFromEventsStats(
       y: point.value,
     })),
   }));
+}
+
+/**
+ * Adapts an `/organizations/$org/events-timeseries/` response, which the Logs
+ * and Metrics surfaces chart through. Its values arrive already normalized, so
+ * the only work is dropping the gaps: a null means the interval had no data
+ * rather than a zero, and plotting it as zero would draw a dip that never
+ * happened. A series left with no points is dropped entirely, since the chart
+ * schema requires at least one.
+ */
+export function seriesFromTimeSeries(timeSeries: TimeSeries[]): ChartSeries {
+  return timeSeries
+    .map(series => ({
+      label: formatTimeSeriesName(series),
+      data: series.values
+        .filter(item => item.value !== null)
+        .map(item => ({
+          // The chart schema wants an offset-bearing ISO 8601 string here, not
+          // the epoch milliseconds the endpoint returns.
+          x: new Date(item.timestamp).toISOString(),
+          y: item.value!,
+        })),
+    }))
+    .filter(series => series.data.length > 0);
+}
+
+/**
+ * The endpoint reports what it measured, so take the unit from the response
+ * rather than re-deriving it from the aggregate's name.
+ */
+export function chartUnitFromTimeSeries(timeSeries: TimeSeries[]): ChartUnit {
+  switch (timeSeries[0]?.meta.valueType) {
+    case 'duration':
+      return 'duration';
+    case 'percentage':
+    case 'percent_change':
+      return 'percentage';
+    case 'size':
+      return 'bytes';
+    default:
+      return 'number';
+  }
 }
 
 interface QueryEmbedChartProps {

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -655,10 +655,16 @@ export const SEER_EMBED_SCHEMAS = {
   },
   metricsQuery: {
     description:
-      'Link to an Explore > Metrics query for a single trace metric. ' +
+      'Preview an Explore > Metrics query for a single trace metric. ' +
       'Requires the metric `name` and `type` exactly as the metrics API returns ' +
       'them. Use mode "aggregate" with `groupBy`/`yAxes` to chart the metric, or ' +
-      '"samples" to list raw points.',
+      '"samples" to list raw points. ' +
+      'Name `yAxes` the short way, e.g. "p95(value)" — the embed qualifies them ' +
+      'with the metric itself. Omit `yAxes` to use the default aggregate for the ' +
+      "metric's type. " +
+      'Inline renders a link; block renders a timeseries chart with the first ' +
+      'five matching rows beneath it. An aggregate that groups by nothing ' +
+      'collapses to a single row, so there the chart replaces the table.',
     level: ['inline', 'block'],
     schema: z.object({
       ...exploreQueryFields,

--- a/static/app/views/explore/metrics/utils.tsx
+++ b/static/app/views/explore/metrics/utils.tsx
@@ -22,7 +22,7 @@ import type {
   SavedQuery,
 } from 'sentry/views/explore/hooks/useGetSavedQueries';
 import {isRawVisualize} from 'sentry/views/explore/hooks/useGetSavedQueries';
-import {NONE_UNIT} from 'sentry/views/explore/metrics/constants';
+import {DEFAULT_YAXIS_BY_TYPE, NONE_UNIT} from 'sentry/views/explore/metrics/constants';
 import {
   defaultMetricQuery,
   encodeMetricQueryParams,
@@ -37,8 +37,7 @@ import {
   type SampleTableColumnKey,
 } from 'sentry/views/explore/metrics/types';
 import {isGroupBy, type GroupBy} from 'sentry/views/explore/queryParams/groupBy';
-import type {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
-import {Visualize} from 'sentry/views/explore/queryParams/visualize';
+import {Visualize, VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
 
 export function makeMetricsPathname({
   organizationSlug,
@@ -306,6 +305,31 @@ export function makeMetricsAggregate({
     traceMetric.unit ?? NONE_UNIT,
   ];
   return `${aggregate}(${args.join(',')})`;
+}
+
+/**
+ * Qualifies a bare aggregate with the metric it measures. Callers outside the
+ * Metrics UI -- Seer, in particular -- name a y-axis the short way, as
+ * `p95(value)`; Explore only recognises the fully qualified spelling that
+ * carries the metric's name, type and unit. An unparseable y-axis is left
+ * alone rather than guessed at.
+ */
+export function getMetricYAxis(yAxis: string, traceMetric: TraceMetric): string {
+  const visualize = new VisualizeFunction(yAxis);
+  const aggregate = visualize.parsedFunction?.name;
+  if (!aggregate) {
+    return yAxis;
+  }
+
+  return makeMetricsAggregate({aggregate, traceMetric});
+}
+
+/** The aggregate the Metrics UI opens with, which varies by metric type. */
+export function getDefaultMetricYAxis(traceMetric: TraceMetric): string {
+  return makeMetricsAggregate({
+    aggregate: DEFAULT_YAXIS_BY_TYPE[traceMetric.type] ?? 'sum',
+    traceMetric,
+  });
 }
 
 export function updateVisualizeYAxis(

--- a/static/app/views/seerExplorer/links.tsx
+++ b/static/app/views/seerExplorer/links.tsx
@@ -15,14 +15,13 @@ import {
   LOGS_QUERY_KEY,
 } from 'sentry/views/explore/contexts/logs/logsPageParams';
 import {LOGS_SORT_BYS_KEY} from 'sentry/views/explore/contexts/logs/sortBys';
-import {DEFAULT_YAXIS_BY_TYPE} from 'sentry/views/explore/metrics/constants';
 import {
   defaultAggregateSortBys,
   defaultMetricQuery,
   encodeMetricQueryParams,
   type TraceMetric,
 } from 'sentry/views/explore/metrics/metricQuery';
-import {makeMetricsAggregate} from 'sentry/views/explore/metrics/utils';
+import {getDefaultMetricYAxis, getMetricYAxis} from 'sentry/views/explore/metrics/utils';
 import type {AggregateField} from 'sentry/views/explore/queryParams/aggregateField';
 import {Mode} from 'sentry/views/explore/queryParams/mode';
 import {VisualizeFunction} from 'sentry/views/explore/queryParams/visualize';
@@ -940,23 +939,6 @@ function getTraceMetricFromParams(params: Record<string, any>): TraceMetric | nu
     traceMetric.unit = rawTraceMetric.unit;
   }
   return traceMetric;
-}
-
-function getMetricYAxis(yAxis: string, traceMetric: TraceMetric): string {
-  const visualize = new VisualizeFunction(yAxis);
-  const aggregate = visualize.parsedFunction?.name;
-  if (!aggregate) {
-    return yAxis;
-  }
-
-  return makeMetricsAggregate({aggregate, traceMetric});
-}
-
-function getDefaultMetricYAxis(traceMetric: TraceMetric): string {
-  return makeMetricsAggregate({
-    aggregate: DEFAULT_YAXIS_BY_TYPE[traceMetric.type] ?? 'sum',
-    traceMetric,
-  });
 }
 
 function parseMetricsSort(


### PR DESCRIPTION
Closes CW-1953.

> [!NOTE]
> Based on #123789, which extracts the shared query embed block. Review that one first; this PR's diff is only the metrics embed. GitHub will retarget it to `master` when #123789 merges.

Renders a `metricsQuery` at block level — a timeseries chart with the first five matching rows beneath it, or the chart alone when an aggregate groups by nothing and so collapses to a single row.

### It also fixes the link this embed has been producing

Explore identifies a metric **inside the aggregate's own arguments**:

```
p95(value,checkout.latency,distribution,millisecond)
```

and `decodeMetricsQueryParams` returns `null` unless the aggregate fields parse into at least one visualize. The embed was passing Seer's short spelling (`p95(value)`) straight through, and defaulting to a blanket `sum(value)` — so the link landed on a metrics page that charted the wrong thing, or nothing at all. That's the behaviour the file's own `DEFAULT_Y_AXES` comment was describing without quite diagnosing.

It now qualifies each y-axis with the metric, and falls back to the default aggregate for the metric's *type* — `avg` for a gauge, `sum` for a counter or distribution — rather than a blanket `sum`.

That normalization already existed, module-private, in `seerExplorer/links.tsx`. It moves to `explore/metrics/utils.tsx` beside `makeMetricsAggregate`, and `links.tsx` imports it, so the rule has one home instead of two.

### Two dataset facts, not new abstractions

Worth calling out for anyone judging whether the shared block holds up:

- **Metrics charts through `/events-timeseries/`, not `/events-stats/`.** That response is already normalized, so it gets its own adapter — `seriesFromTimeSeries` — which drops null intervals rather than plotting them as zero (that would draw a dip that never happened) and reads the unit off the response instead of re-deriving it from the aggregate's name. `QueryEmbedChart` itself is untouched: it takes series, not a query, which is exactly the seam that made this possible.
- **Where the metric's identity goes depends on the mode.** Aggregate requests carry it in the y-axis, so their search string stays the user's own predicate. Samples have no aggregate to carry it, so it moves into the query as a filter — the same one the Metrics samples table adds.

The chart fetch reuses `useFetchEventsTimeSeries` directly. It accepts explicit `pageFilters` and skips the page-filter readiness wait when given them, so an embed can use it without depending on the host page's filter context.

### Testing

Five new tests, including two regression tests for the y-axis bug (a bare `p95(value)` is qualified; an omitted `yAxes` picks the type's default rather than `sum(value)`), plus coverage for the grouped chart-and-table case, the chart-only case, and the samples-mode identity filter.

`typecheck`, `oxlint`, `knip`, `prek` clean; `embed_widgets.generated.json` regenerated.

https://claude.ai/code/session_019ggTyhE8XgKwUezTEKg7t9