### PR TITLE
feat(api): Record client_kind on a per-dispatch attribution span

### DIFF
--- a/src/sentry/api/client_kind.py
+++ b/src/sentry/api/client_kind.py
@@ -24,8 +24,12 @@ from sentry.middleware import is_frontend_request
 from sentry.models.organization import Organization
 from sentry.seer.agent_token import is_agent_auth
 from sentry.utils.http import SEER_REFERRER_HEADER, get_mcp_client_family, is_mcp_request
+from sentry.utils.sdk import get_transaction_name_from_request
+from sentry.utils.tracing import set_span_data, start_span
 
 FEATURE_FLAG = "organizations:api-client-kind-check"
+
+ATTRIBUTION_SPAN_OP = "api.attribution"
 
 
 class ClientKind(StrEnum):
@@ -156,12 +160,21 @@ def get_client_kind(request: Request, organization: Organization) -> ClientKind 
 
 
 def set_client_kind_attributes(request: Request, organization: Organization) -> None:
-    """Tag the current transaction with who called the endpoint.
+    """Record who called the endpoint, on a span and on the enclosing transaction.
 
     A no-op when the org has not opted into ``client_kind``. Wired into
     ``OrganizationEventsEndpointBase.convert_args`` so every events endpoint
     reports the same set of attributes without hand-wiring them per handler.
     """
+    client_kind = get_client_kind(request, organization)
+    if client_kind is None:
+        return
+
+    client_host = get_client_host(request)
+    user_agent = get_user_agent(request)
+
+    _record_attribution_span(request, client_kind, client_host, user_agent)
+
     # `sentry.api.client.ApiClient` dispatches endpoints in-process with a synthetic
     # request that carries no user agent, cookies or token, so it classifies as
     # UNKNOWN. These attributes are isolation-scoped, so recording that would overwrite
@@ -170,23 +183,39 @@ def set_client_kind_attributes(request: Request, organization: Organization) -> 
     if getattr(request, "__from_api_client__", False):
         return
 
-    client_kind = get_client_kind(request, organization)
-    if client_kind is None:
-        return
-
     # `_test` suffix while this is a POC, to keep it out of the way of a
     # real `client_kind` attribute later.
     sentry_sdk.set_tag("client_kind_test", client_kind.value)
     sentry_sdk.set_attribute("client_kind_test", client_kind.value)
 
-    client_host = get_client_host(request)
     if client_host is not None:
         sentry_sdk.set_tag("client_host_test", client_host)
         sentry_sdk.set_attribute("client_host_test", client_host)
 
-    user_agent = get_user_agent(request)
     if user_agent is not None:
         sentry_sdk.set_attribute(ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, user_agent)
+
+
+def _record_attribution_span(
+    request: Request,
+    client_kind: ClientKind,
+    client_host: str | None,
+    user_agent: str | None,
+) -> None:
+    """Emit a span pairing the route served with the caller that asked for it.
+
+    Scoped to the dispatch, unlike the isolation-scoped attributes above, so an
+    endpoint reached in-process through `sentry.api.client.ApiClient` reports the
+    route it served rather than its caller's.
+    """
+    route = get_transaction_name_from_request(request)
+    with start_span(op=ATTRIBUTION_SPAN_OP, name=route) as span:
+        set_span_data(span, ATTRIBUTE_NAMES.HTTP_ROUTE, route)
+        set_span_data(span, "client_kind_test", client_kind.value)
+        if client_host is not None:
+            set_span_data(span, "client_host_test", client_host)
+        if user_agent is not None:
+            set_span_data(span, ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, user_agent)
 
 
 def get_user_agent(request: Request) -> str | None:

--- a/tests/sentry/api/test_client_kind.py
+++ b/tests/sentry/api/test_client_kind.py
@@ -5,9 +5,11 @@ from unittest import mock
 from django.contrib.auth.models import AnonymousUser
 from django.test import RequestFactory
 from rest_framework.request import Request
+from rest_framework.test import APIRequestFactory
 from sentry_conventions.attributes import ATTRIBUTE_NAMES
 
 from sentry.api.client_kind import (
+    ATTRIBUTION_SPAN_OP,
     FEATURE_FLAG,
     ClientKind,
     get_client_host,
@@ -20,6 +22,10 @@ from sentry.auth.system import SystemToken
 from sentry.seer.agent_token import AGENT_TOKEN_KIND
 from sentry.seer.endpoints.seer_rpc import SeerRpcSignatureAuthentication
 from sentry.testutils.cases import TestCase
+from sentry.utils.sdk import get_transaction_name_from_request
+
+EVENTS_PATH = "/api/0/organizations/my-org/events/"
+EVENTS_ROUTE = "/api/0/organizations/{organization_id_or_slug}/events/"
 
 
 def make_request(
@@ -29,8 +35,9 @@ def make_request(
     user_agent: str | None = None,
     headers: dict[str, str] | None = None,
     cookies: bool = True,
+    path: str = EVENTS_PATH,
 ) -> Request:
-    request = Request(RequestFactory().get("/", headers=headers or {}))
+    request = Request(RequestFactory().get(path, headers=headers or {}))
     if user_agent is not None:
         request.META["HTTP_USER_AGENT"] = user_agent
     if cookies:
@@ -255,10 +262,12 @@ class SetClientKindAttributesTest(TestCase):
         with (
             self.feature({FEATURE_FLAG: False}),
             mock.patch("sentry.api.client_kind.sentry_sdk") as sdk,
+            mock.patch("sentry.api.client_kind.start_span") as start_span,
         ):
             set_client_kind_attributes(request, self.organization)
         sdk.set_tag.assert_not_called()
         sdk.set_attribute.assert_not_called()
+        start_span.assert_not_called()
 
     def test_records_kind_and_user_agent(self) -> None:
         request = make_request(auth=api_token(), user_agent="curl/8.7.1")
@@ -300,7 +309,7 @@ class SetClientKindAttributesTest(TestCase):
         for call in sdk.set_attribute.call_args_list:
             assert call.args[0] != ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL
 
-    def test_skips_requests_from_the_internal_api_client(self) -> None:
+    def test_skips_transaction_attributes_from_the_internal_api_client(self) -> None:
         # `ApiClient` dispatches in-process with a synthetic request carrying no user
         # agent, cookies or token. Recording its UNKNOWN would clobber the enclosing
         # transaction's own attribution, since these attributes are isolation-scoped.
@@ -309,7 +318,77 @@ class SetClientKindAttributesTest(TestCase):
         with (
             self.feature(FEATURE_FLAG),
             mock.patch("sentry.api.client_kind.sentry_sdk") as sdk,
+            mock.patch("sentry.api.client_kind.start_span"),
         ):
             set_client_kind_attributes(request, self.organization)
         sdk.set_tag.assert_not_called()
         sdk.set_attribute.assert_not_called()
+
+
+class AttributionSpanTest(TestCase):
+    def record(self, request: Request) -> tuple[Any, list[tuple[str, Any]]]:
+        with (
+            self.feature(FEATURE_FLAG),
+            mock.patch("sentry.api.client_kind.start_span") as start_span,
+            mock.patch("sentry.api.client_kind.set_span_data") as set_span_data,
+        ):
+            set_client_kind_attributes(request, self.organization)
+        span = start_span.return_value.__enter__.return_value
+        return start_span, [
+            call.args[1:] for call in set_span_data.call_args_list if call.args[0] is span
+        ]
+
+    def test_pairs_the_route_with_the_caller(self) -> None:
+        start_span, attributes = self.record(
+            make_request(auth=api_token(), user_agent="curl/8.7.1")
+        )
+        assert start_span.call_args == mock.call(op=ATTRIBUTION_SPAN_OP, name=EVENTS_ROUTE)
+        assert attributes == [
+            (ATTRIBUTE_NAMES.HTTP_ROUTE, EVENTS_ROUTE),
+            ("client_kind_test", "script"),
+            (ATTRIBUTE_NAMES.USER_AGENT_ORIGINAL, "curl/8.7.1"),
+        ]
+
+    def test_records_the_route_for_an_internal_api_client_dispatch(self) -> None:
+        request = make_request(auth=api_token(), user_agent="curl/8.7.1")
+        mark_from_api_client(request)
+        start_span, attributes = self.record(request)
+        assert start_span.call_args == mock.call(op=ATTRIBUTION_SPAN_OP, name=EVENTS_ROUTE)
+        assert (ATTRIBUTE_NAMES.HTTP_ROUTE, EVENTS_ROUTE) in attributes
+
+    def test_carries_the_mcp_client_host(self) -> None:
+        _, attributes = self.record(
+            make_request(
+                auth=api_token(),
+                user_agent="sentry-mcp/1.0",
+                headers={
+                    "X-Sentry-MCP-Version": "1.0",
+                    "X-Sentry-MCP-Client-Family": "Claude-Code",
+                },
+            )
+        )
+        assert ("client_host_test", "claude-code") in attributes
+
+    def test_omits_user_agent_when_absent(self) -> None:
+        _, attributes = self.record(make_request(auth=api_token()))
+        assert [key for key, _ in attributes] == [
+            ATTRIBUTE_NAMES.HTTP_ROUTE,
+            "client_kind_test",
+        ]
+
+
+class SpanRouteTest(TestCase):
+    """Pin the route resolution `_record_attribution_span` names its span with."""
+
+    def test_parameterizes_the_url(self) -> None:
+        assert get_transaction_name_from_request(make_request()) == EVENTS_ROUTE
+
+    def test_an_internal_dispatch_resolves_to_the_same_route(self) -> None:
+        mock_request = APIRequestFactory().get(EVENTS_PATH, {})
+        request = Request(mock_request)
+        request.user = AnonymousUser()
+        assert get_transaction_name_from_request(request) == EVENTS_ROUTE
+
+    def test_an_unmatched_path_collapses_onto_a_catch_all(self) -> None:
+        request = make_request(path="/api/0/definitely/not/a/route/")
+        assert get_transaction_name_from_request(request) == "/api/0/"


### PR DESCRIPTION
Stacked on #123640 — review that one first; this PR's diff is the second commit.

## The problem

`client_kind` is isolation-scoped today, so it lands on the enclosing transaction. That works for a request arriving over HTTP, and not at all for one arriving through `sentry.api.client.ApiClient`: an in-process dispatch shares its caller's transaction, so the transaction names the caller's route rather than the endpoint that ran.

Seer's RPC handlers take that path. `get_attribute_names` reaches `/organizations/{slug}/trace-items/attributes/` via `ApiClient`, and the only thing recorded is `POST /api/0/internal/seer-rpc/{method_name}/`. Nothing says both which endpoint served the call and who asked for it, so RPC callers can't be filtered alongside direct HTTP ones.

In production over 7d, `OrganizationTraceItemAttributesEndpoint.get` runs under three different transactions:

| transaction | count |
|---|---|
| `/api/0/organizations/{organization_id_or_slug}/trace-items/attributes/` | 1,062,805 |
| `/api/0/organizations/{organization_id_or_slug}/seer-rpc/{method_name}/` | 33,182 |
| `/api/0/internal/seer-rpc/{method_name}/` | 5,059 |

## The change

Emit a span per dispatch carrying `http.route` alongside the caller. A span is scoped to the dispatch that produced it, so both ways of reaching an endpoint report the same route:

```
span.op:api.attribution http.route:"/api/0/organizations/{organization_id_or_slug}/trace-items/attributes/"
```
grouped by `client_kind_test`, and in-process and over-the-wire callers land in one result.

The route comes from `get_transaction_name_from_request`, which resolves the path rather than reading the scope, so the synthetic request resolves to the same string as the equivalent HTTP call. Both shapes are tested. It is always parameterized — an unrecognized path collapses onto a catch-all, so no customer slug reaches a span name.

The isolation-scoped attributes keep their existing guard: an internal dispatch still must not overwrite the enclosing transaction's own classification.

## Known gap, not addressed here

On the internal path `client_kind` still derives as `unknown`. The synthetic request carries no user agent, cookies or token, and `SeerRpcServiceEndpoint` isn't an `OrganizationEventsEndpointBase`, so nothing classifies the outer seer-rpc transaction either — the caller's identity doesn't cross the in-process dispatch boundary. Making those spans say `seer` needs the identity derived once at the edge and read back inside (`ViewerContextMiddleware` is the existing precedent and already wraps the seer-rpc request). This PR gets the route parity that is a prerequisite for it.