### PR TITLE
feat(seer): Add the replays query block embed

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -1094,7 +1094,7 @@
   },
   {
     "name": "replaysQuery",
-    "description": "Link to the Session Replay list filtered by a search query. Use this when pointing the user at a SET of replays — if you have a specific replay ID, use the `replay` embed instead. `query` uses replay search syntax, e.g. \"user.email:user@example.com\".",
+    "description": "Preview the Session Replay list filtered by a search query. Use this when pointing the user at a SET of replays — if you have a specific replay ID, use the `replay` embed instead. `query` uses replay search syntax, e.g. \"user.email:user@example.com\". Inline renders a link; block renders the first five matching replays with their duration, error count and rage clicks.",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedTable.tsx
+++ b/static/app/components/seer/markdown/embeds/components/queryEmbed/queryEmbedTable.tsx
@@ -35,6 +35,8 @@ export interface QueryEmbedColumn<Row> {
    * isn't forced into a text context that would mangle it.
    */
   render: (row: Row) => ReactNode;
+  /** Header text. Defaults to `key`, which is what a field-named column wants. */
+  label?: ReactNode;
 }
 
 /**
@@ -95,7 +97,7 @@ export function QueryEmbedTable<Row>({
         <SimpleTable.HeaderRow>
           {columns.map(column => (
             <SimpleTable.HeaderCell key={column.key}>
-              <Text ellipsis>{column.key}</Text>
+              <Text ellipsis>{column.label ?? column.key}</Text>
             </SimpleTable.HeaderCell>
           ))}
         </SimpleTable.HeaderRow>

--- a/static/app/components/seer/markdown/embeds/components/replaysQuery.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replaysQuery.spec.tsx
@@ -1,6 +1,42 @@
-import {getEmbedLinkHref} from './resourceEmbedTestUtils';
+import {ProjectFixture} from 'sentry-fixture/project';
+
+import {screen, waitFor, within} from 'sentry-test/reactTestingLibrary';
+
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+
+import {getEmbedLinkHref, renderEmbed} from './resourceEmbedTestUtils';
+
+/** Shaped as the list endpoint returns it: seconds, and timestamps as strings. */
+function rawReplay(overrides: Record<string, unknown> = {}) {
+  return {
+    id: '346789a703f6454384f1de473b8b9fcc',
+    project_id: '2',
+    duration: 30,
+    started_at: '2022-09-15T06:50:00+00:00',
+    finished_at: '2022-09-15T06:54:00+00:00',
+    is_archived: false,
+    activity: 1,
+    count_errors: 4,
+    count_dead_clicks: 0,
+    count_rage_clicks: 7,
+    user: {
+      id: '1',
+      display_name: 'Test User',
+      email: 'user@example.com',
+      ip: '127.0.0.1',
+      username: 'testuser',
+    },
+    tags: {},
+    urls: [],
+    ...overrides,
+  };
+}
 
 describe('replays query embed', () => {
+  beforeEach(() => {
+    ProjectsStore.loadInitialData([ProjectFixture({id: '2', slug: 'web'})]);
+  });
+
   it('builds a replays query', () => {
     const href = getEmbedLinkHref('replaysQuery', 'Replay search', {
       query: 'count_rage_clicks:>0',
@@ -10,5 +46,77 @@ describe('replays query embed', () => {
     expect(href).toContain('/organizations/org-slug/explore/replays/');
     expect(href).toContain('query=count_rage_clicks%3A%3E0');
     expect(href).toContain('statsPeriod=7d');
+  });
+
+  it('previews matching replays, hydrating the raw response', async () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/replays/',
+      body: {data: [rawReplay()]},
+    });
+
+    renderEmbed({
+      name: 'replaysQuery',
+      data: {query: 'count_rage_clicks:>0', statsPeriod: '7d'},
+    });
+
+    expect(await screen.findByText('Test User')).toBeInTheDocument();
+
+    const row = screen.getByRole('row', {name: /Test User/});
+    // `duration` arrives as the number 30 (seconds) and only becomes
+    // renderable after `mapResponseToReplayRecord` turns it into a Duration.
+    expect(within(row).getByText('00:30')).toBeInTheDocument();
+    expect(within(row).getByText('4')).toBeInTheDocument();
+    expect(within(row).getByText('7')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith(
+        '/organizations/org-slug/replays/',
+        expect.objectContaining({
+          query: expect.objectContaining({
+            query: 'count_rage_clicks:>0',
+            statsPeriod: '7d',
+            // A plain search, not the issue/transaction referrers that force
+            // an all-projects override.
+            queryReferrer: 'replayList',
+            per_page: 5,
+          }),
+        })
+      );
+    });
+  });
+
+  it('renders an archived replay without its measurements', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/replays/',
+      body: {
+        data: [
+          rawReplay({
+            is_archived: true,
+            duration: undefined,
+            count_errors: null,
+            count_rage_clicks: null,
+            user: null,
+          }),
+        ],
+      },
+    });
+
+    renderEmbed({name: 'replaysQuery', data: {query: ''}});
+
+    // An archived replay keeps its id but loses everything measured about it.
+    expect(await screen.findByText('Deleted Replay')).toBeInTheDocument();
+    const row = screen.getByRole('row', {name: /Deleted Replay/});
+    expect(within(row).getAllByText('—').length).toBeGreaterThan(0);
+  });
+
+  it('shows an empty state when nothing matches', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/replays/',
+      body: {data: []},
+    });
+
+    renderEmbed({name: 'replaysQuery', data: {query: 'count_errors:>999'}});
+
+    expect(await screen.findByText('No matching replays')).toBeInTheDocument();
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/replaysQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replaysQuery.tsx
@@ -1,45 +1,18 @@
-import queryString from 'query-string';
+import {lazy} from 'react';
 
-import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
-import {
-  defineSeerEmbed,
-  type EmbedOutput,
-} from 'sentry/components/seer/markdown/embeds/utils';
-import {IconPlay} from 'sentry/icons';
-import {t} from 'sentry/locale';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
+import {LazyLoad} from 'sentry/components/lazyLoad';
+import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 
-function ReplaysQueryLink({
-  query,
-  sort,
-  title,
-  projects,
-  environments,
-  statsPeriod,
-  start,
-  end,
-}: EmbedOutput<'replaysQuery'>) {
-  const organization = useOrganization();
-  const href = queryString.stringifyUrl({
-    url: makeReplaysPathname({organization, path: '/'}),
-    query: {
-      query,
-      sort,
-      project: projects,
-      environment: environments,
-      statsPeriod,
-      start,
-      end,
-    },
-  });
+import {ReplaysQueryLink} from './replaysQueryLink';
 
-  return <ResourceLink icon={IconPlay} href={href} title={title ?? t('Replay search')} />;
-}
+const LazyReplaysQueryBlock = lazy(() => import('./replaysQueryBlock'));
 
 export const ReplaysQuery = defineSeerEmbed({
   name: 'replaysQuery',
-  render(props) {
-    return <ReplaysQueryLink {...props} />;
+  render(props, level) {
+    if (level === 'block') {
+      return <LazyLoad LazyComponent={LazyReplaysQueryBlock} data={props} />;
+    }
+    return <ReplaysQueryLink data={props} />;
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/replaysQueryBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replaysQueryBlock.tsx
@@ -1,0 +1,119 @@
+import {useQuery} from '@tanstack/react-query';
+
+import {Text} from '@sentry/scraps/text';
+
+import {Duration} from 'sentry/components/duration/duration';
+import {ReplayBadge} from 'sentry/components/replays/replayBadge';
+import {QueryEmbedCard} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedCard';
+import {QUERY_EMBED_ROW_LIMIT} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedConstants';
+import {
+  QueryEmbedTable,
+  type QueryEmbedColumn,
+} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedTable';
+import {t} from 'sentry/locale';
+import {formatNumber} from 'sentry/utils/number/formatNumber';
+import {mapResponseToReplayRecord} from 'sentry/utils/replays/replayDataUtils';
+import {replayListApiOptions} from 'sentry/utils/replays/replayListApiOptions';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import type {ReplayListRecord} from 'sentry/views/explore/replays/types';
+
+import {ReplaysQueryLink} from './replaysQueryLink';
+import type {ReplaysQueryData} from './replaysQueryUtils';
+
+/**
+ * An archived replay keeps its id but loses everything measured about it, so
+ * every column but the badge has nothing to show.
+ */
+function archivedFallback() {
+  return (
+    <Text ellipsis variant="muted">
+      —
+    </Text>
+  );
+}
+
+const COLUMNS: Array<QueryEmbedColumn<ReplayListRecord>> = [
+  {
+    key: 'replay',
+    label: t('Replay'),
+    render: replay => <ReplayBadge replay={replay} />,
+  },
+  {
+    key: 'duration',
+    label: t('Duration'),
+    render: replay =>
+      replay.is_archived || !replay.duration ? (
+        archivedFallback()
+      ) : (
+        <Duration duration={[replay.duration.asMilliseconds(), 'ms']} precision="sec" />
+      ),
+  },
+  {
+    key: 'count_errors',
+    label: t('Errors'),
+    render: replay =>
+      replay.is_archived ? (
+        archivedFallback()
+      ) : (
+        <Text ellipsis>{formatNumber(replay.count_errors ?? 0)}</Text>
+      ),
+  },
+  {
+    key: 'count_rage_clicks',
+    label: t('Rage clicks'),
+    render: replay =>
+      replay.is_archived ? (
+        archivedFallback()
+      ) : (
+        <Text ellipsis>{formatNumber(replay.count_rage_clicks ?? 0)}</Text>
+      ),
+  },
+];
+
+export default function ReplaysQueryBlock({data}: {data: ReplaysQueryData}) {
+  const organization = useOrganization();
+
+  const replaysQuery = useQuery({
+    ...replayListApiOptions({
+      organization,
+      // `replayList` is the referrer for a plain search; the issue and
+      // transaction referrers force an all-projects override we don't want.
+      queryReferrer: 'replayList',
+      options: {
+        query: {
+          query: data.query,
+          sort: data.sort,
+          project: data.projects?.map(String),
+          environment: data.environments,
+          statsPeriod: data.statsPeriod,
+          start: data.start,
+          end: data.end,
+          per_page: QUERY_EMBED_ROW_LIMIT,
+        },
+      },
+    }),
+    retry: false,
+  });
+
+  // The list endpoint returns durations and timestamps raw; every row
+  // component below expects them hydrated.
+  const rows = (replaysQuery.data?.data ?? []).map(mapResponseToReplayRecord);
+
+  return (
+    <QueryEmbedCard
+      link={<ReplaysQueryLink data={data} />}
+      query={data.query}
+      testId="seer-replays-query-embed"
+    >
+      <QueryEmbedTable
+        columns={COLUMNS}
+        emptyMessage={t('No matching replays')}
+        errorMessage={t('Unable to load replays')}
+        isError={replaysQuery.isError}
+        isPending={replaysQuery.isPending}
+        rowKey={replay => replay.id}
+        rows={rows}
+      />
+    </QueryEmbedCard>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/replaysQueryLink.tsx
+++ b/static/app/components/seer/markdown/embeds/components/replaysQueryLink.tsx
@@ -1,0 +1,18 @@
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {IconPlay} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+import {getReplaysQueryHref, type ReplaysQueryData} from './replaysQueryUtils';
+
+export function ReplaysQueryLink({data}: {data: ReplaysQueryData}) {
+  const organization = useOrganization();
+
+  return (
+    <ResourceLink
+      icon={IconPlay}
+      href={getReplaysQueryHref(data, organization)}
+      title={data.title ?? t('Replay search')}
+    />
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/replaysQueryUtils.ts
+++ b/static/app/components/seer/markdown/embeds/components/replaysQueryUtils.ts
@@ -1,0 +1,31 @@
+import queryString from 'query-string';
+
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import type {Organization} from 'sentry/types/organization';
+import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
+
+export type ReplaysQueryData = EmbedOutput<'replaysQuery'>;
+
+/**
+ * The replays list takes its page filters as plain query params rather than
+ * through the Explore URL builders, so this doesn't go via `toPageFilters`.
+ */
+export function getReplaysQueryHref(
+  data: ReplaysQueryData,
+  organization: Organization
+): string {
+  const {query, sort, projects, environments, statsPeriod, start, end} = data;
+
+  return queryString.stringifyUrl({
+    url: makeReplaysPathname({organization, path: '/'}),
+    query: {
+      query,
+      sort,
+      project: projects,
+      environment: environments,
+      statsPeriod,
+      start,
+      end,
+    },
+  });
+}

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -635,10 +635,12 @@ export const SEER_EMBED_SCHEMAS = {
   },
   replaysQuery: {
     description:
-      'Link to the Session Replay list filtered by a search query. ' +
+      'Preview the Session Replay list filtered by a search query. ' +
       'Use this when pointing the user at a SET of replays — if you have a ' +
       'specific replay ID, use the `replay` embed instead. ' +
-      '`query` uses replay search syntax, e.g. "user.email:user@example.com".',
+      '`query` uses replay search syntax, e.g. "user.email:user@example.com". ' +
+      'Inline renders a link; block renders the first five matching replays ' +
+      'with their duration, error count and rage clicks.',
     level: ['inline', 'block'],
     schema: z.object({
       ...pageFilterFields,

--- a/static/app/utils/replays/replayListApiOptions.tsx
+++ b/static/app/utils/replays/replayListApiOptions.tsx
@@ -12,6 +12,7 @@ interface QueryOptions {
   cursor?: string;
   end?: string;
   environment?: string[];
+  per_page?: number;
   project?: string[];
   query?: string;
   sort?: string;


### PR DESCRIPTION
Closes CW-1952.

> [!NOTE]
> Based on #123789, which extracts the shared query embed block. This PR's diff is only the replays embed. GitHub will retarget it to `master` when #123789 merges.

Renders a `replaysQuery` at block level — the first five matching replays with their duration, error count and rage clicks.

### This embed deliberately uses less of the shared block

Replays is the query type that fits the "query block" mould least, and the shape here reflects that rather than fighting it:

| | Uses |
| --- | --- |
| `QueryEmbedCard` | ✅ |
| `QueryEmbedTable` | ✅ |
| `QueryEmbedChart` | ❌ — no timeseries exists |
| `useQueryEmbedEventsTable` / `…EventsStats` | ❌ — not an `EventView` |

**There is no chart because there is nothing to chart.** The Replays list page renders no chart anywhere, and there's no `events-stats` equivalent for replays (`/replay-count/` only maps issue/transaction ids to scalars). So the block renders no chart rather than an empty one.

It fetches through `/organizations/$org/replays/` using the existing `replayListApiOptions`, so it uses neither shared request hook. What it shares is the card chrome and the preview table — which is the useful half.

### Two things the list endpoint forces

- **Rows arrive raw.** `duration` is a number of seconds and the timestamps are strings; every replay row component expects them hydrated, so the response goes through `mapResponseToReplayRecord` first. There's a test that asserts this end-to-end — a raw `30` renders as `00:30`.
- **Archived replays keep their id but lose everything measured about them.** Every column but the badge renders an em dash for one, and there's a test for that too.

### Read-only, per the embeds README

`ReplayBadge` is the only piece reused from the Replays list, and it touches no router. The list's own table was left alone on purpose — `ReplayTable` calls `useNavigate`, `useReplayTableSort` pushes onto the host's history via nuqs, `ReplaySelectColumn` mutates through bulk delete/mark-viewed, and `ReplayPlayPauseColumn` / `ReplaySlowestTransactionColumn` write into the host URL. Adopting it wholesale would have meant defeating all of that.

### Shared-module change

Restores `label` on `QueryEmbedColumn`, which #123789 dropped for having no consumer. This is that consumer: a replay column's header is "Duration", not a field name. Note this is also the payoff from that PR's other table fix — cells render exactly what a column returns, so `ReplayBadge` isn't forced into a text-ellipsis context.

`per_page` is added to `replayListApiOptions`' query options so a 5-row preview doesn't fetch 50.

### Testing

Four tests: the inline link (pre-existing), the hydrated row preview with request assertions, the archived-replay case, and the empty state. All 19 embed suites / 75 tests pass. `typecheck`, `oxlint`, `knip`, `prek` clean; `embed_widgets.generated.json` regenerated.

https://claude.ai/code/session_019ggTyhE8XgKwUezTEKg7t9