### PR TITLE
feat(onboarding): Update Bun onboarding for SDK v11

### DIFF
--- a/static/app/components/onboarding/productSelection.tsx
+++ b/static/app/components/onboarding/productSelection.tsx
@@ -93,7 +93,11 @@ export function getDisabledProducts(organization: Organization): DisabledProduct
 // NOTE: Please keep the prefix in alphabetical order
 export const platformProductAvailability = {
   'apple-macos': [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.PROFILING],
-  bun: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
+  bun: [
+    ProductSolution.PERFORMANCE_MONITORING,
+    ProductSolution.LOGS,
+    ProductSolution.METRICS,
+  ],
   capacitor: [ProductSolution.PERFORMANCE_MONITORING, ProductSolution.LOGS],
   dotnet: [
     ProductSolution.PERFORMANCE_MONITORING,

--- a/static/app/data/platformCategories.tsx
+++ b/static/app/data/platformCategories.tsx
@@ -416,6 +416,7 @@ export const withMetricsOnboarding = new Set<PlatformKey>([
   'apple',
   'apple-ios',
   'apple-macos',
+  'bun',
   'dotnet',
   'dotnet-aspnet',
   'dotnet-aspnetcore',
@@ -880,4 +881,5 @@ export const mcpMonitoringPlatforms: ReadonlySet<PlatformKey> = new Set([
   ...javascriptMetaFrameworks,
   ...platformKeys.filter(id => id.startsWith('node')),
   ...platformKeys.filter(id => id.startsWith('python')),
+  'bun',
 ]);

--- a/static/app/gettingStartedDocs/bun/index.tsx
+++ b/static/app/gettingStartedDocs/bun/index.tsx
@@ -5,10 +5,13 @@ import {
   replayOnboardingJsLoader,
 } from 'sentry/gettingStartedDocs/javascript/jsLoader';
 import {featureFlag} from 'sentry/gettingStartedDocs/node/featureFlag';
-import {getNodeLogsOnboarding} from 'sentry/gettingStartedDocs/node/utils';
 
 import {crashReport} from './crashReport';
+import {logs} from './logs';
+import {mcp} from './mcp';
+import {metrics} from './metrics';
 import {onboarding} from './onboarding';
+import {PACKAGE_NAME, sentryImport} from './utils';
 
 export const docs: Docs = {
   onboarding,
@@ -16,13 +19,13 @@ export const docs: Docs = {
   crashReportOnboarding: crashReport,
   feedbackOnboardingJsLoader,
   featureFlagOnboarding: featureFlag({
-    packageName: '@sentry/bun',
-  }),
-  logsOnboarding: getNodeLogsOnboarding({
-    docsPlatform: 'bun',
-    packageName: '@sentry/bun',
+    packageName: PACKAGE_NAME,
+    sentryImport,
   }),
   agentMonitoringOnboarding: agentMonitoring({
-    packageName: '@sentry/bun',
+    packageName: PACKAGE_NAME,
   }),
+  logsOnboarding: logs,
+  mcpOnboarding: mcp,
+  metricsOnboarding: metrics,
 };

--- a/static/app/gettingStartedDocs/bun/logs.tsx
+++ b/static/app/gettingStartedDocs/bun/logs.tsx
@@ -1,0 +1,87 @@
+import {ExternalLink} from '@sentry/scraps/link';
+
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+
+import {
+  getInstallContent,
+  getMigrationContent,
+  PACKAGE_NAME,
+  sentryImport,
+} from './utils';
+
+export const logs: OnboardingConfig = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        ...getInstallContent(
+          tct(
+            'Add the Sentry SDK as a dependency. The minimum version of [packageName] that supports logs is [code:9.41.0].',
+            {
+              code: <code />,
+              packageName: <code>{PACKAGE_NAME}</code>,
+            }
+          )
+        ),
+        getMigrationContent(),
+      ],
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Logs are enabled by default. To also capture your [code:console] logs, add the [code:consoleLoggingIntegration] to your [code:Sentry.init()] configuration.',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          language: 'typescript',
+          code: `${sentryImport}
+
+Sentry.init({
+  dsn: "${params.dsn.public}",
+  integrations: [
+    // send console.log, console.warn, and console.error calls as logs to Sentry
+    Sentry.consoleLoggingIntegration({ levels: ["log", "warn", "error"] }),
+  ],
+});`,
+        },
+        {
+          type: 'text',
+          text: tct('For more detailed information, see the [link:logs documentation].', {
+            link: (
+              <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/bun/logs/" />
+            ),
+          }),
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Send a test log from your app, then refresh this page to verify it arrived in Sentry.'
+          ),
+        },
+        {
+          type: 'code',
+          language: 'typescript',
+          code: `${sentryImport}
+
+Sentry.logger.info('User triggered test log', { action: 'test_log' })`,
+        },
+      ],
+    },
+  ],
+};

--- a/static/app/gettingStartedDocs/bun/mcp.tsx
+++ b/static/app/gettingStartedDocs/bun/mcp.tsx
@@ -1,0 +1,79 @@
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {t, tct} from 'sentry/locale';
+
+import {getInstallContent, sentryImport} from './utils';
+
+export const mcp: OnboardingConfig = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      content: getInstallContent(
+        tct(
+          'To enable MCP monitoring, you need to install the Sentry SDK with a minimum version of [code:9.44.0].',
+          {code: <code />}
+        )
+      ),
+    },
+  ],
+  configure: params => [
+    {
+      type: StepType.CONFIGURE,
+      content: [
+        {
+          type: 'text',
+          text: tct('Initialize the Sentry SDK by calling [code:Sentry.init()]:', {
+            code: <code />,
+          }),
+        },
+        {
+          type: 'code',
+          language: 'typescript',
+          code: `${sentryImport}
+
+Sentry.init({
+  dsn: "${params.dsn.public}",
+  // Tracing must be enabled for MCP monitoring to work
+  tracesSampleRate: 1.0,
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/bun/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+});`,
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Wrap your MCP server in a [code:Sentry.wrapMcpServerWithSentry()] call. This will automatically capture spans for all MCP server interactions.',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          language: 'typescript',
+          code: `import { McpServer } from "@modelcontextprotocol/sdk";
+
+const server = Sentry.wrapMcpServerWithSentry(new McpServer({
+  name: "my-mcp-server",
+  version: "1.0.0",
+}));`,
+        },
+      ],
+    },
+  ],
+  verify: () => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: t(
+            'Verify that MCP monitoring is working correctly by triggering some MCP server interactions in your application.'
+          ),
+        },
+      ],
+    },
+  ],
+};

--- a/static/app/gettingStartedDocs/bun/metrics.tsx
+++ b/static/app/gettingStartedDocs/bun/metrics.tsx
@@ -1,0 +1,82 @@
+import {ExternalLink} from '@sentry/scraps/link';
+
+import type {OnboardingConfig} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {tct} from 'sentry/locale';
+
+import {
+  getInstallContent,
+  getMigrationContent,
+  getSdkInitSnippet,
+  PACKAGE_NAME,
+} from './utils';
+
+export const metrics: OnboardingConfig = {
+  install: () => [
+    {
+      type: StepType.INSTALL,
+      content: [
+        ...getInstallContent(
+          tct(
+            'Add the Sentry SDK as a dependency. The minimum version of [packageName] that supports metrics is [code:10.25.0].',
+            {
+              code: <code />,
+              packageName: <code>{PACKAGE_NAME}</code>,
+            }
+          )
+        ),
+        getMigrationContent(),
+      ],
+    },
+  ],
+  configure: () => [],
+  verify: params => [
+    {
+      type: StepType.VERIFY,
+      content: [
+        {
+          type: 'text',
+          text: tct(
+            'Metrics are automatically enabled after Sentry is initialized. You can emit metrics using the [code:Sentry.metrics] API.',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          language: 'typescript',
+          code: `${getSdkInitSnippet(params)}
+
+Sentry.metrics.count('button_click', 1);
+Sentry.metrics.gauge('page_load_time', 150);
+Sentry.metrics.distribution('response_time', 200);`,
+        },
+        {
+          type: 'text',
+          text: tct(
+            'To also collect CPU, memory and event loop metrics of the Bun process, add the [code:bunRuntimeMetricsIntegration] to your [code:Sentry.init()] configuration. It needs [minVersion] or newer.',
+            {code: <code />, minVersion: <code>10.47.0</code>}
+          ),
+        },
+        {
+          type: 'code',
+          language: 'typescript',
+          code: `Sentry.init({
+  dsn: "${params.dsn.public}",
+  integrations: [Sentry.bunRuntimeMetricsIntegration()],
+});`,
+        },
+        {
+          type: 'text',
+          text: tct(
+            'For more detailed information, see the [link:metrics documentation].',
+            {
+              link: (
+                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/bun/metrics/" />
+              ),
+            }
+          ),
+        },
+      ],
+    },
+  ],
+};

--- a/static/app/gettingStartedDocs/bun/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/bun/onboarding.spec.tsx
@@ -15,10 +15,42 @@ describe('bun onboarding docs', () => {
     expect(screen.getByRole('heading', {name: 'Configure SDK'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Verify'})).toBeInTheDocument();
 
+    // Renders the instrument file and the entry point that imports it
+    expect(
+      screen.getAllByText(
+        textWithMarkupMatcher(/import \* as Sentry from "@sentry\/bun";/)
+      ).length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getByText(textWithMarkupMatcher(/import "\.\/instrument\.ts";/))
+    ).toBeInTheDocument();
+
+    // Renders the build step, which is what injects the library instrumentation
+    expect(
+      screen.getByText(textWithMarkupMatcher(/plugins: \[sentryBunPlugin\(\)\],/))
+    ).toBeInTheDocument();
+
+    // Renders the filename header above each snippet
+    expect(screen.getByText('build.ts')).toBeInTheDocument();
+
     // Renders config options
     expect(
       screen.getByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
     ).toBeInTheDocument();
+    expect(
+      screen.getByText(textWithMarkupMatcher(/dataCollection: \{/))
+    ).toBeInTheDocument();
+  });
+
+  it('renders the outgoing request note when tracing is selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.PERFORMANCE_MONITORING],
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/are not traced on Bun yet/))
+    ).toBeInTheDocument();
+    expect(screen.getByText('Tracing')).toBeInTheDocument();
   });
 
   it('renders without tracing', () => {
@@ -30,21 +62,53 @@ describe('bun onboarding docs', () => {
     expect(
       screen.queryByText(textWithMarkupMatcher(/tracesSampleRate: 1\.0,/))
     ).not.toBeInTheDocument();
+
+    // Does not render the outgoing request note
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/are not traced on Bun yet/))
+    ).not.toBeInTheDocument();
   });
 
-  it('displays logs integration next step when logs are selected', () => {
+  it('displays logging code in verify section when logs are selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.LOGS],
     });
 
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/Sentry\.logger\.info\('User triggered test error'/)
+      )
+    ).toBeInTheDocument();
     expect(screen.getByText('Logging Integrations')).toBeInTheDocument();
   });
 
-  it('does not display logs integration next step when logs are not selected', () => {
+  it('displays metrics code in verify section when metrics are selected', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedProducts: [ProductSolution.ERROR_MONITORING, ProductSolution.METRICS],
+    });
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/Sentry\.metrics\.count\('test_counter', 1\)/)
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByText('Application Metrics')).toBeInTheDocument();
+  });
+
+  it('does not display logs or metrics code when they are not selected', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [ProductSolution.ERROR_MONITORING],
     });
 
-    expect(screen.queryByText('Logging Integrations')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        textWithMarkupMatcher(/Sentry\.logger\.info\('User triggered test error'/)
+      )
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        textWithMarkupMatcher(/Sentry\.metrics\.count\('test_counter', 1\)/)
+      )
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/gettingStartedDocs/bun/onboarding.tsx
+++ b/static/app/gettingStartedDocs/bun/onboarding.tsx
@@ -3,47 +3,81 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 
-type Params = DocsParams;
+import {getInstallContent, getSdkInitSnippet, PACKAGE_NAME, sentryImport} from './utils';
 
-const getConfigureSnippet = (params: Params) => `
-//...
-import * as Sentry from "@sentry/bun";
+const INSTRUMENT_FILENAME = 'instrument.ts';
+const ENTRY_POINT_FILENAME = 'index.ts';
+const BUILD_FILENAME = 'build.ts';
 
-Sentry.init({
-  dsn: "${params.dsn.public}",${
-    params.isPerformanceSelected
-      ? `
-  // Tracing
-  tracesSampleRate: 1.0, // Capture 100% of the transactions`
-      : ''
-  }
+const getEntryPointSnippet = () => `import "./${INSTRUMENT_FILENAME}";
+
+// All other imports below
+Bun.serve({
+  fetch: () => new Response("Hello World!"),
 });`;
 
-const getVerifySnippet = () => `try {
-  throw new Error('Sentry Bun test');
-} catch (e) {
-  Sentry.captureException(e);
-}`;
+const getBuildSnippet = () => `import { sentryBunPlugin } from "${PACKAGE_NAME}/plugin";
+
+await Bun.build({
+  entrypoints: ["./${ENTRY_POINT_FILENAME}"],
+  target: "bun",
+  outdir: "./dist",
+  plugins: [sentryBunPlugin()],
+});`;
+
+/**
+ * The log and metric calls the verify snippet makes before it throws.
+ *
+ * @param indent The whitespace put in front of every line.
+ */
+const getVerifySignalsSnippet = (params: DocsParams, indent: string) =>
+  `${
+    params.isLogsSelected
+      ? `
+${indent}// Send a log before throwing the error
+${indent}Sentry.logger.info('User triggered test error', {
+${indent}  action: 'test_error',
+${indent}});`
+      : ''
+  }${
+    params.isMetricsSelected
+      ? `
+${indent}// Send a test metric before throwing the error
+${indent}Sentry.metrics.count('test_counter', 1);`
+      : ''
+  }`;
+
+const getVerifySnippet = (params: DocsParams) => {
+  if (!params.isPerformanceSelected) {
+    return `${sentryImport}
+${getVerifySignalsSnippet(params, '')}
+
+setTimeout(() => {
+  throw new Error();
+});`;
+  }
+
+  return `${sentryImport}
+
+Sentry.startSpan({
+  op: "test",
+  name: "My First Test Span",
+}, () => {${getVerifySignalsSnippet(params, '  ')}
+  throw new Error();
+});`;
+};
 
 export const onboarding: OnboardingConfig = {
+  introduction: () =>
+    t(
+      "In this quick guide you'll set up and configure the Sentry Bun SDK for the use in your Bun application."
+    ),
   install: () => [
     {
       type: StepType.INSTALL,
-      content: [
-        {
-          type: 'text',
-          text: t(
-            "Sentry captures data by using an SDK within your application's runtime."
-          ),
-        },
-        {
-          type: 'code',
-          language: 'bash',
-          code: 'bun add @sentry/bun',
-        },
-      ],
+      content: getInstallContent(t('Add the Sentry Bun SDK as a dependency:')),
     },
   ],
   configure: params => [
@@ -52,19 +86,75 @@ export const onboarding: OnboardingConfig = {
       content: [
         {
           type: 'text',
-          text: t(
-            "Initialize Sentry as early as possible in your application's lifecycle."
+          text: tct(
+            'Put the [code:Sentry.init()] call in its own [code:instrument.ts] file, so that it runs before the rest of your code.',
+            {code: <code />}
           ),
         },
         {
           type: 'code',
-          language: 'javascript',
-          code: getConfigureSnippet(params),
+          tabs: [
+            {
+              label: 'TypeScript',
+              language: 'typescript',
+              filename: INSTRUMENT_FILENAME,
+              code: getSdkInitSnippet(params),
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Import [code:instrument.ts] at the top of your entry point, before every other import. Incoming [code:Bun.serve] and [code:node:http] requests are then instrumented for you.',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'TypeScript',
+              language: 'typescript',
+              filename: ENTRY_POINT_FILENAME,
+              code: getEntryPointSnippet(),
+            },
+          ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'Libraries such as [code:express], [code:fastify], [code:mysql] and [code:postgres] are instrumented while your app is bundled. [code:bun run] cannot do this, so build your app with [code:sentryBunPlugin()] to get their spans and their errors.',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
+          tabs: [
+            {
+              label: 'TypeScript',
+              language: 'typescript',
+              filename: BUILD_FILENAME,
+              code: getBuildSnippet(),
+            },
+          ],
+        },
+        {
+          type: 'conditional',
+          condition: params.isPerformanceSelected,
+          content: [
+            {
+              type: 'text',
+              text: tct(
+                'Outgoing requests are traced when you send them with [code:fetch]. Clients that use [code:node:http], for example the [code:axios] HTTP adapter, are not traced on Bun yet.',
+                {code: <code />}
+              ),
+            },
+          ],
         },
       ],
     },
   ],
-  verify: () => [
+  verify: params => [
     {
       type: StepType.VERIFY,
       content: [
@@ -76,14 +166,25 @@ export const onboarding: OnboardingConfig = {
         },
         {
           type: 'code',
-          language: 'javascript',
-          code: getVerifySnippet(),
+          language: 'typescript',
+          code: getVerifySnippet(params),
         },
       ],
     },
   ],
-  nextSteps: (params: Params) => {
+  nextSteps: params => {
     const steps = [];
+
+    if (params.isPerformanceSelected) {
+      steps.push({
+        id: 'tracing',
+        name: t('Tracing'),
+        description: t(
+          'Learn which libraries the SDK instruments for you, and how to add your own spans.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/bun/tracing/',
+      });
+    }
 
     if (params.isLogsSelected) {
       steps.push({
@@ -93,6 +194,17 @@ export const onboarding: OnboardingConfig = {
           'Add logging integrations to automatically capture logs from your application.'
         ),
         link: 'https://docs.sentry.io/platforms/javascript/guides/bun/logs/#integrations',
+      });
+    }
+
+    if (params.isMetricsSelected) {
+      steps.push({
+        id: 'metrics',
+        name: t('Application Metrics'),
+        description: t(
+          'Learn how to track custom metrics to monitor your application performance and business KPIs.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/bun/metrics/',
       });
     }
 

--- a/static/app/gettingStartedDocs/bun/onboarding.tsx
+++ b/static/app/gettingStartedDocs/bun/onboarding.tsx
@@ -123,7 +123,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'Libraries such as [code:express], [code:fastify], [code:mysql] and [code:postgres] are instrumented while your app is bundled. [code:bun run] cannot do this, so build your app with [code:sentryBunPlugin()] to get their spans and their errors.',
+            'Libraries such as [code:express], [code:mysql] and [code:postgres] are instrumented while your app is bundled. [code:bun run] cannot do this, so build your app with [code:sentryBunPlugin()] to get their spans and their errors.',
             {code: <code />}
           ),
         },

--- a/static/app/gettingStartedDocs/bun/utils.tsx
+++ b/static/app/gettingStartedDocs/bun/utils.tsx
@@ -1,0 +1,68 @@
+import {ExternalLink} from '@sentry/scraps/link';
+
+import type {
+  ContentBlock,
+  DocsParams,
+} from 'sentry/components/onboarding/gettingStartedDoc/types';
+import {tct} from 'sentry/locale';
+
+export const PACKAGE_NAME = '@sentry/bun';
+
+export const sentryImport = `import * as Sentry from "${PACKAGE_NAME}";`;
+
+/**
+ * The install step content, shared by every onboarding on this platform.
+ *
+ * @param text The sentence above the code block.
+ */
+export function getInstallContent(text: React.ReactNode): ContentBlock[] {
+  return [
+    {type: 'text', text},
+    {
+      type: 'code',
+      language: 'bash',
+      code: `bun add ${PACKAGE_NAME}`,
+    },
+  ];
+}
+
+export function getMigrationContent(): ContentBlock {
+  return {
+    type: 'text',
+    text: tct(
+      'If you are on an older version of the SDK, follow our [link:migration guide] to upgrade.',
+      {
+        link: (
+          <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/bun/migration/" />
+        ),
+      }
+    ),
+  };
+}
+
+/**
+ * The `Sentry.init()` call, shared by every snippet on this platform so that
+ * they cannot drift apart.
+ */
+export function getSdkInitSnippet(params: DocsParams) {
+  return `${sentryImport}
+
+Sentry.init({
+  dsn: "${params.dsn.public}",${
+    params.isPerformanceSelected
+      ? `
+  // Set tracesSampleRate to 1.0 to capture 100% of spans for tracing.
+  // Learn more at
+  // https://docs.sentry.io/platforms/javascript/configuration/options/#traces-sample-rate
+  tracesSampleRate: 1.0,`
+      : ''
+  }
+
+  dataCollection: {
+    // To disable sending user data and HTTP bodies, uncomment the lines below. For more info visit:
+    // https://docs.sentry.io/platforms/javascript/guides/bun/configuration/options/#dataCollection
+    // userInfo: false,
+    // httpBodies: [],
+  },
+});`;
+}


### PR DESCRIPTION
closes SDK-1459

The Bun onboarding still described the v10 SDK: a single `Sentry.init()` call in an unnamed file, no `dataCollection` options, and no logs, metrics or MCP guides.

The configure step now splits the setup into an `instrument.ts` file and a `bun --preload` command that runs it before every other module, which is what the `Bun.serve` and `node:http` instrumentation needs. When tracing is selected, it documents `sentryBunPlugin()`, because libraries such as `mysql` and `postgres` are instrumented at build time on Bun.

Add logs, metrics and MCP onboarding. They share one install block and one `Sentry.init()` snippet from `utils.tsx`, so the snippets cannot drift apart. The install block uses `bun add` instead of the npm/yarn/pnpm tabs of the Node helpers. The metrics guide also documents `bunRuntimeMetricsIntegration` for CPU, memory and event loop metrics.