### PR TITLE
feat(seer): Add the saved query block embed

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -620,7 +620,14 @@
         },
         "dataset": {
           "type": "string",
-          "enum": ["spans", "logs", "metrics", "replays"]
+          "enum": [
+            "spans",
+            "segment_spans",
+            "logs",
+            "metrics",
+            "replays",
+            "ai_conversations"
+          ]
         },
         "name": {
           "type": "string",

--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -608,7 +608,7 @@
   },
   {
     "name": "savedQuery",
-    "description": "The ONLY way to reference a saved Explore query. Use the saved query ID exactly as the API returns it and set `dataset` to the dataset it was saved against. Include the API-provided name when available. Never use a markdown link for saved query references.",
+    "description": "The ONLY way to reference a saved Explore query. Use the saved query ID exactly as the API returns it and set `dataset` to the dataset it was saved against. Include the API-provided name when available. Never use a markdown link for saved query references. Inline renders a link; block fetches the saved query and shows its name, filter, group-by and visualize, linking to the query's own parameters rather than just its id.",
     "level": ["inline", "block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/static/app/components/seer/markdown/__stories__/savedQueryEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/savedQueryEmbedStory.tsx
@@ -1,0 +1,38 @@
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {useGetSavedQueries} from 'sentry/views/explore/hooks/useGetSavedQueries';
+
+import {EmbedStory, EmbedVariant} from './embedStory';
+
+export function SavedQueryEmbedStory() {
+  const {
+    data: savedQueries,
+    isLoading,
+    isError,
+  } = useGetSavedQueries({sortBy: ['-dateUpdated'], perPage: 1});
+
+  const savedQuery = savedQueries?.[0];
+
+  return (
+    <EmbedStory name="savedQuery">
+      {isLoading ? (
+        <LoadingIndicator />
+      ) : isError ? (
+        <Text variant="muted">Unable to load a saved query example.</Text>
+      ) : savedQuery ? (
+        <EmbedVariant
+          name="savedQuery"
+          label="Saved query"
+          data={{
+            id: String(savedQuery.id),
+            dataset: savedQuery.dataset,
+            name: savedQuery.name,
+          }}
+        />
+      ) : (
+        <Text variant="muted">No saved query is available for this organization.</Text>
+      )}
+    </EmbedStory>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/savedQuery.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedQuery.spec.tsx
@@ -1,14 +1,111 @@
-import {getEmbedLinkHref} from './resourceEmbedTestUtils';
+import {UserFixture} from 'sentry-fixture/user';
+
+import {screen} from 'sentry-test/reactTestingLibrary';
+
+import {getEmbedLinkHref, renderEmbed} from './resourceEmbedTestUtils';
+
+function savedQueryResponse(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 312,
+    name: 'Slow checkout spans',
+    dataset: 'spans',
+    projects: [1],
+    environment: ['prod'],
+    range: '7d',
+    interval: '1h',
+    starred: true,
+    position: null,
+    dateAdded: '2026-08-01T00:00:00Z',
+    dateUpdated: '2026-08-27T00:00:00Z',
+    lastVisited: '2026-08-27T00:00:00Z',
+    createdBy: UserFixture({name: 'A Teammate'}),
+    query: [
+      {
+        query: 'span.op:http.client',
+        fields: ['span.description', 'span.duration'],
+        mode: 'aggregate',
+        orderby: '-p95_span_duration',
+        groupby: ['span.op'],
+        visualize: [{yAxes: ['p95(span.duration)']}],
+        aggregateField: [{groupBy: 'span.op'}, {yAxes: ['p95(span.duration)']}],
+      },
+    ],
+    ...overrides,
+  };
+}
 
 describe('saved query embed', () => {
-  it.each([
-    ['spans', '/organizations/org-slug/explore/traces/?id=312'],
-    ['logs', '/organizations/org-slug/explore/logs/?id=312'],
-    ['metrics', '/organizations/org-slug/explore/metrics/?id=312'],
-    ['replays', '/organizations/org-slug/explore/replays/?id=312'],
-  ])('opens a saved %s query on its own explore surface', (dataset, expected) => {
-    expect(getEmbedLinkHref('savedQuery', 'Saved query 312', {id: '312', dataset})).toBe(
-      expected
-    );
+  it('links inline without fetching the saved query', () => {
+    const request = MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/explore/saved/312/',
+      body: savedQueryResponse(),
+    });
+
+    const href = getEmbedLinkHref('savedQuery', 'Slow checkout spans', {
+      id: '312',
+      dataset: 'spans',
+      name: 'Slow checkout spans',
+    });
+
+    expect(href).toContain('/organizations/org-slug/explore/traces/');
+    // An inline mention stays cheap; only the block level fetches.
+    expect(request).not.toHaveBeenCalled();
+  });
+
+  it('renders the saved query with a link that restores its parameters', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/explore/saved/312/',
+      body: savedQueryResponse(),
+    });
+
+    renderEmbed({name: 'savedQuery', data: {id: '312', dataset: 'spans'}});
+
+    const link = await screen.findByRole('link', {name: /Slow checkout spans/});
+    const href = decodeURIComponent(link.getAttribute('href') ?? '');
+
+    // The inline `?id=` link carries nothing but the id, which Explore reads
+    // only for the page title — so that page opens on the viewer's own
+    // defaults. The block has the definition, so its link restores the query
+    // itself. `id` rides along for the title, as the canonical builder emits.
+    expect(href).toContain('query=span.op:http.client');
+    expect(href).toContain('statsPeriod=7d');
+    expect(href).toContain('groupBy=span.op');
+    expect(href).toContain('p95(span.duration)');
+    expect(href).toContain('project=1');
+    expect(href).toContain('environment=prod');
+
+    expect(screen.getByText('Group by')).toBeInTheDocument();
+    // Also appears in the formatted query above it.
+    expect(screen.getAllByText('span.op').length).toBeGreaterThan(0);
+    expect(screen.getByText('Visualize')).toBeInTheDocument();
+    expect(screen.getByText('p95(span.duration)')).toBeInTheDocument();
+    expect(screen.getByText(/A Teammate/)).toBeInTheDocument();
+  });
+
+  it('trusts the dataset the API reports over the one the tag claimed', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/explore/saved/312/',
+      body: savedQueryResponse({dataset: 'logs'}),
+    });
+
+    // The model said spans; the saved query is actually a logs query.
+    renderEmbed({name: 'savedQuery', data: {id: '312', dataset: 'spans'}});
+
+    expect(await screen.findByText('Logs')).toBeInTheDocument();
+  });
+
+  it('falls back to the inline link when the saved query cannot be loaded', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/explore/saved/999/',
+      statusCode: 404,
+      body: {detail: 'Not found'},
+    });
+
+    renderEmbed({
+      name: 'savedQuery',
+      data: {id: '999', dataset: 'spans', name: 'Deleted query'},
+    });
+
+    expect(await screen.findByRole('link', {name: /Deleted query/})).toBeInTheDocument();
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/savedQuery.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedQuery.spec.tsx
@@ -94,6 +94,24 @@ describe('saved query embed', () => {
     expect(await screen.findByText('Logs')).toBeInTheDocument();
   });
 
+  // The saved query API reports `segment_spans` and `ai_conversations` for a
+  // real share of saved queries. An embed whose props fail to parse renders
+  // nothing at all, so the tag has to accept every dataset the API can name.
+  it.each([
+    ['segment_spans', '/organizations/org-slug/explore/traces/'],
+    ['ai_conversations', '/organizations/org-slug/explore/agents/'],
+    ['spans', '/organizations/org-slug/explore/traces/'],
+    ['logs', '/organizations/org-slug/explore/logs/'],
+  ])('links a %s saved query inline', (dataset, pathname) => {
+    const href = getEmbedLinkHref('savedQuery', 'Slow checkout spans', {
+      id: '312',
+      dataset,
+      name: 'Slow checkout spans',
+    });
+
+    expect(href).toContain(pathname);
+  });
+
   it('falls back to the inline link when the saved query cannot be loaded', async () => {
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/explore/saved/999/',

--- a/static/app/components/seer/markdown/embeds/components/savedQuery.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedQuery.tsx
@@ -1,56 +1,18 @@
-import queryString from 'query-string';
+import {lazy} from 'react';
 
-import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
-import {
-  defineSeerEmbed,
-  type EmbedOutput,
-} from 'sentry/components/seer/markdown/embeds/utils';
-import {IconStar} from 'sentry/icons';
-import {t} from 'sentry/locale';
-import type {Organization} from 'sentry/types/organization';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import {makeLogsPathname} from 'sentry/views/explore/logs/utils';
-import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
-import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
-import {makeTracesPathname} from 'sentry/views/traces/pathnames';
+import {LazyLoad} from 'sentry/components/lazyLoad';
+import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 
-type Dataset = EmbedOutput<'savedQuery'>['dataset'];
+import {SavedQueryLink} from './savedQueryLink';
 
-/**
- * Explore has no saved-query detail route. Opening one means loading the
- * dataset's own explore surface with the saved query's `id`.
- */
-function datasetPathname(dataset: Dataset, organization: Organization): string {
-  switch (dataset) {
-    case 'logs':
-      return makeLogsPathname({organizationSlug: organization.slug, path: '/'});
-    case 'metrics':
-      return makeMetricsPathname({organizationSlug: organization.slug, path: '/'});
-    case 'replays':
-      return makeReplaysPathname({organization, path: '/'});
-    case 'spans':
-      return makeTracesPathname({organization, path: '/'});
-    default:
-      dataset satisfies never;
-      return makeTracesPathname({organization, path: '/'});
-  }
-}
-
-function SavedQueryLink({id, dataset, name}: EmbedOutput<'savedQuery'>) {
-  const organization = useOrganization();
-  const href = queryString.stringifyUrl({
-    url: datasetPathname(dataset, organization),
-    query: {id},
-  });
-
-  return (
-    <ResourceLink icon={IconStar} href={href} title={name ?? t('Saved query %s', id)} />
-  );
-}
+const LazySavedQueryBlock = lazy(() => import('./savedQueryBlock'));
 
 export const SavedQuery = defineSeerEmbed({
   name: 'savedQuery',
-  render(props) {
-    return <SavedQueryLink {...props} />;
+  render(props, level) {
+    if (level === 'block') {
+      return <LazyLoad LazyComponent={LazySavedQueryBlock} data={props} />;
+    }
+    return <SavedQueryLink data={props} />;
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/savedQueryBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedQueryBlock.tsx
@@ -1,0 +1,101 @@
+import {Tag} from '@sentry/scraps/badge';
+import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {QueryEmbedCard} from 'sentry/components/seer/markdown/embeds/components/queryEmbed/queryEmbedCard';
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {TimeSince} from 'sentry/components/timeSince';
+import {IconStar} from 'sentry/icons';
+import {t, tct} from 'sentry/locale';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {
+  getSavedQueryDatasetLabel,
+  useGetSavedQuery,
+} from 'sentry/views/explore/hooks/useGetSavedQueries';
+import {getSavedQueryTraceItemUrl} from 'sentry/views/explore/utils';
+
+import {SavedQueryLink, type SavedQueryData} from './savedQueryLink';
+
+export default function SavedQueryBlock({data}: {data: SavedQueryData}) {
+  const organization = useOrganization();
+  const {data: savedQuery, isLoading} = useGetSavedQuery(data.id);
+
+  if (isLoading) {
+    return (
+      <Flex align="center" justify="center" padding="xl" width="100%">
+        <LoadingIndicator />
+      </Flex>
+    );
+  }
+
+  // A saved query that can't be loaded — deleted, or not visible to this
+  // viewer — still has a name and a dataset from the tag, so fall back to the
+  // inline link rather than rendering an empty card.
+  if (!savedQuery) {
+    return <SavedQueryLink data={data} />;
+  }
+
+  // Multi-query saved queries exist but only Explore's compare mode renders
+  // them; the saved-queries table shows the first and so does this. The link
+  // still resolves to the compare view, which is what the URL builder does.
+  const query = savedQuery.query[0];
+  const yAxes = query.visualize.flatMap(visualize => visualize.yAxes);
+
+  return (
+    <QueryEmbedCard
+      badge={
+        // Trust the dataset the API reports over the one the tag claimed.
+        <Tag variant="muted">{getSavedQueryDatasetLabel(savedQuery.dataset)}</Tag>
+      }
+      link={
+        <ResourceLink
+          icon={IconStar}
+          href={getSavedQueryTraceItemUrl({savedQuery, organization})}
+          title={savedQuery.name}
+        />
+      }
+      query={query.query}
+      testId="seer-saved-query-embed"
+    >
+      {query.groupby.length > 0 || yAxes.length > 0 ? (
+        <Flex align="center" gap="md" wrap="wrap">
+          {query.groupby.length > 0 ? (
+            <Flex align="center" gap="xs" wrap="wrap">
+              <Text size="sm" variant="muted">
+                {t('Group by')}
+              </Text>
+              {query.groupby.map(groupBy => (
+                <Tag key={groupBy} variant="info">
+                  {groupBy}
+                </Tag>
+              ))}
+            </Flex>
+          ) : null}
+          {yAxes.length > 0 ? (
+            <Flex align="center" gap="xs" wrap="wrap">
+              <Text size="sm" variant="muted">
+                {t('Visualize')}
+              </Text>
+              {yAxes.map(yAxis => (
+                <Tag key={yAxis} variant="info">
+                  {yAxis}
+                </Tag>
+              ))}
+            </Flex>
+          ) : null}
+        </Flex>
+      ) : null}
+      <Text size="sm" variant="muted">
+        {savedQuery.createdBy?.name
+          ? tct('Updated [time] by [name]', {
+              time: <TimeSince date={savedQuery.dateUpdated} />,
+              name: savedQuery.createdBy.name,
+            })
+          : tct('Updated [time]', {
+              time: <TimeSince date={savedQuery.dateUpdated} />,
+            })}
+      </Text>
+    </QueryEmbedCard>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/savedQueryLink.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedQueryLink.tsx
@@ -5,7 +5,9 @@ import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 import {IconStar} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Organization} from 'sentry/types/organization';
+import {normalizeUrl} from 'sentry/utils/url/normalizeUrl';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {EXPLORE_AGENTS_SUB_PATH} from 'sentry/views/explore/conversations/settings';
 import {makeLogsPathname} from 'sentry/views/explore/logs/utils';
 import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
 import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
@@ -27,7 +29,13 @@ function datasetPathname(dataset: Dataset, organization: Organization): string {
       return makeMetricsPathname({organizationSlug: organization.slug, path: '/'});
     case 'replays':
       return makeReplaysPathname({organization, path: '/'});
+    case 'ai_conversations':
+      return normalizeUrl(
+        `/organizations/${organization.slug}/explore/${EXPLORE_AGENTS_SUB_PATH}/`
+      );
+    // `segment_spans` is a saved-query-only distinction; both open Traces.
     case 'spans':
+    case 'segment_spans':
       return makeTracesPathname({organization, path: '/'});
     default:
       dataset satisfies never;

--- a/static/app/components/seer/markdown/embeds/components/savedQueryLink.tsx
+++ b/static/app/components/seer/markdown/embeds/components/savedQueryLink.tsx
@@ -1,0 +1,57 @@
+import queryString from 'query-string';
+
+import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconStar} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import type {Organization} from 'sentry/types/organization';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {makeLogsPathname} from 'sentry/views/explore/logs/utils';
+import {makeMetricsPathname} from 'sentry/views/explore/metrics/utils';
+import {makeReplaysPathname} from 'sentry/views/explore/replays/pathnames';
+import {makeTracesPathname} from 'sentry/views/traces/pathnames';
+
+export type SavedQueryData = EmbedOutput<'savedQuery'>;
+
+type Dataset = SavedQueryData['dataset'];
+
+/**
+ * Explore has no saved-query detail route. Opening one means loading the
+ * dataset's own explore surface with the saved query's `id`.
+ */
+function datasetPathname(dataset: Dataset, organization: Organization): string {
+  switch (dataset) {
+    case 'logs':
+      return makeLogsPathname({organizationSlug: organization.slug, path: '/'});
+    case 'metrics':
+      return makeMetricsPathname({organizationSlug: organization.slug, path: '/'});
+    case 'replays':
+      return makeReplaysPathname({organization, path: '/'});
+    case 'spans':
+      return makeTracesPathname({organization, path: '/'});
+    default:
+      dataset satisfies never;
+      return makeTracesPathname({organization, path: '/'});
+  }
+}
+
+/**
+ * The inline link, which knows only what the tag carried. Restoring the saved
+ * query's own filters would mean fetching it, and an inline mention shouldn't
+ * cost a request — the block level does that and links precisely.
+ */
+export function SavedQueryLink({data}: {data: SavedQueryData}) {
+  const organization = useOrganization();
+  const href = queryString.stringifyUrl({
+    url: datasetPathname(data.dataset, organization),
+    query: {id: data.id},
+  });
+
+  return (
+    <ResourceLink
+      icon={IconStar}
+      href={href}
+      title={data.name ?? t('Saved query %s', data.id)}
+    />
+  );
+}

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -442,7 +442,10 @@ export const SEER_EMBED_SCHEMAS = {
       'Use the saved query ID exactly as the API returns it and set `dataset` ' +
       'to the dataset it was saved against. ' +
       'Include the API-provided name when available. ' +
-      'Never use a markdown link for saved query references.',
+      'Never use a markdown link for saved query references. ' +
+      'Inline renders a link; block fetches the saved query and shows its ' +
+      "name, filter, group-by and visualize, linking to the query's own " +
+      'parameters rather than just its id.',
     level: ['inline', 'block'],
     schema: z.object({
       id: z.string().min(1),

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -449,7 +449,18 @@ export const SEER_EMBED_SCHEMAS = {
     level: ['inline', 'block'],
     schema: z.object({
       id: z.string().min(1),
-      dataset: z.enum(['spans', 'logs', 'metrics', 'replays']),
+      // Every value the saved query API can report, not just the four Explore
+      // surfaces. `segment_spans` and `ai_conversations` are what the API
+      // returns for a good share of real saved queries, and an embed whose
+      // props fail to parse renders nothing at all.
+      dataset: z.enum([
+        'spans',
+        'segment_spans',
+        'logs',
+        'metrics',
+        'replays',
+        'ai_conversations',
+      ]),
       name: z.string().min(1).optional(),
     }),
     examples: [

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -16,6 +16,7 @@ import {MonitorEmbedStory} from './__stories__/monitorEmbedStory';
 import {ReleaseEmbedStory} from './__stories__/releaseEmbedStory';
 import {ReplayEmbedStory} from './__stories__/replayEmbedStory';
 import {SavedIssueViewEmbedStory} from './__stories__/savedIssueViewEmbedStory';
+import {SavedQueryEmbedStory} from './__stories__/savedQueryEmbedStory';
 
 `<SeerMarkdown>` wraps the core [`<Markdown>`](/scraps/core/markdown/) component with Seer-specific overrides: issue short ID linkification, origin-relative links, flattened headings, and an **embed system** that renders structured widgets inline from tag syntax.
 
@@ -101,7 +102,7 @@ Tag syntax: `{% name %}{"key":"value"}{% /name %}`. The JSON body is validated a
 
 ### savedQuery
 
-<EmbedStory name="savedQuery" />
+<SavedQueryEmbedStory />
 
 ### trace
 


### PR DESCRIPTION
Closes CW-1940.

> [!NOTE]
> Based on #123789 for `QueryEmbedCard`. This PR's diff is only the saved query embed. GitHub will retarget it to `master` when #123789 merges.

The `savedQuery` schema has advertised `level: ['inline', 'block']` since it was added, but the component ignored the `level` argument and rendered the same one-line link either way — the model was being told a block existed that didn't. This delivers it.

### It also fixes a live bug in the link

The href was hand-rolled as `?id=<id>`. But Explore reads that param **only** for the document title, breadcrumb and analytics — no surface hydrates query state from it, because the URL params are the source of truth. (`droppedFieldsAlert.tsx` compares saved fields *against* URL fields, which confirms the direction.)

So opening a saved query from this embed showed its **name** over the viewer's **own default query** and **their current date range**. Filter, columns, group-by, visualize, projects and time range were all silently dropped. Metrics was worse — that page needs its `metrics=` param to know which metric to render at all.

The block builds its href with `getSavedQueryTraceItemUrl`, which restores all of it and routes multi-query saved queries to `/compare/`.

**The inline link keeps `?id=` deliberately.** Correcting it requires the fetched definition, and an inline mention shouldn't cost a request. The block already fetches for its own sake, so its link is correct for free. There's a test asserting the inline path makes no request.

### Deliberate limits, both matching what the product already does

- **Multi-query saved queries preview their first query** — exactly what `savedQueriesTable.tsx` does; there's no multi-query affordance on the landing page either. The *link* still resolves to the compare view.
- **A saved query that can't be loaded** — deleted, or not visible to this viewer — falls back to the inline link rather than an empty card.
- The **dataset shown comes from the API response**, not the tag, since the model supplies the latter and can get it wrong. There's a test for that.

### Scope note

This is the metadata block. A **results preview** — dispatching to the logs/metrics/spans blocks to render a real chart and table — is the natural follow-up, but it would stack this PR behind all three of those. Worth doing once they land.

Two known gaps left for that follow-up: the schema allows 4 datasets but the API returns 6 (`segment_spans`, `ai_conversations` are missing), and `crossEvents` saved queries have no representation.

`ExploreParams` was considered for the pills and rejected: it's embed-safe (no router, nothing writes the host URL) but its `+N` overflow uses ResizeObserver, and in jsdom only the first pill ever renders — untestable.

### Testing

Four tests: the inline link makes no request, the block's link restores the full query, the API dataset wins over the tag's, and the not-found fallback. All 19 embed suites / 72 tests pass. `typecheck`, `oxlint`, `knip`, `prek` clean; `embed_widgets.generated.json` regenerated.

https://claude.ai/code/session_019ggTyhE8XgKwUezTEKg7t9