### PR TITLE
fix(integrations): Scope external_id lookups to their provider

### DIFF
--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -59,26 +59,28 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
         repo_name = request.query_params.get("repo_name")
 
         if repo_id or repo_name:
-            try:
-                if repo_id:
-                    repo = Repository.objects.get(
-                        organization_id=organization.id,
-                        external_id=repo_id,
-                        status=ObjectStatus.ACTIVE,
-                    )
-                else:
-                    repo = Repository.objects.get(
-                        organization_id=organization.id, name=repo_name, status=ObjectStatus.ACTIVE
-                    )
-
-                commit_ids_for_repo = list(
-                    Commit.objects.filter(
-                        id__in=release_commit_ids, repository_id=repo.id
-                    ).values_list("id", flat=True)
-                )
-                queryset = queryset.filter(commit_id__in=commit_ids_for_repo)
-            except Repository.DoesNotExist:
+            # Neither parameter names a provider, and an external id is only unique per
+            # provider, so resolve against the repositories that actually have commits in
+            # this release. Re-linking leaves duplicates that differ in provider or config;
+            # the newest one wins, as in ProjectReleaseCommitsEndpoint.
+            release_repos = Repository.objects.filter(
+                id__in=Commit.objects.filter(id__in=release_commit_ids).values("repository_id"),
+                status=ObjectStatus.ACTIVE,
+            )
+            if repo_id:
+                release_repos = release_repos.filter(external_id=repo_id)
+            else:
+                release_repos = release_repos.filter(name=repo_name)
+            repo = release_repos.order_by("-date_added").first()
+            if repo is None:
                 raise ResourceDoesNotExist
+
+            commit_ids_for_repo = list(
+                Commit.objects.filter(id__in=release_commit_ids, repository_id=repo.id).values_list(
+                    "id", flat=True
+                )
+            )
+            queryset = queryset.filter(commit_id__in=commit_ids_for_repo)
 
         return self.paginate(
             request=request,

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import datetime
+import operator
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
+from functools import reduce
 from typing import Any, NotRequired, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
-from django.db.models import Sum
+from django.db.models import Q, Sum
 
 from sentry import release_health, tagstore
 from sentry.api.serializers import Serializer, register, serialize
@@ -17,6 +19,7 @@ from sentry.api.serializers.types import (
     ReleaseSerializerResponse,
 )
 from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import EXTERNAL_PROVIDERS_REVERSE_VALUES
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.deploy import Deploy
@@ -231,25 +234,37 @@ def get_author_users_by_external_actors(
 ) -> tuple[dict[CommitAuthor, str], list[CommitAuthor]]:
     found: dict[CommitAuthor, str] = {}
 
-    usernames_to_authors: dict[str, CommitAuthor] = {}
+    # An ExternalActor's "@login" is only unique within its provider, and a CommitAuthor's
+    # external_id is "<provider>:<login>", so a mapping only counts for the same provider.
+    authors_by_mapping: dict[tuple[int, str], CommitAuthor] = {}
     for author in authors:
+        provider = EXTERNAL_PROVIDERS_REVERSE_VALUES.get(author.get_provider_from_external_id())
         username = author.get_username_from_external_id()
-        if username:
-            # ExternalActor.external_name includes @ prefix
-            # (e.g., "@username") for GitHub and GitLab
-            usernames_to_authors[f"@{username}"] = author
+        if provider is not None and username:
+            authors_by_mapping[(provider.value, f"@{username}")] = author
 
-    if not usernames_to_authors:
+    if not authors_by_mapping:
         return found, authors
+
+    names_by_provider: dict[int, list[str]] = defaultdict(list)
+    for provider_value, external_name in authors_by_mapping:
+        names_by_provider[provider_value].append(external_name)
+    mapping_filter = reduce(
+        operator.or_,
+        (
+            Q(provider=provider_value, external_name__in=names)
+            for provider_value, names in names_by_provider.items()
+        ),
+    )
 
     external_actors = (
         ExternalActor.objects.filter(
-            external_name__in=list(usernames_to_authors.keys()),
+            mapping_filter,
             organization_id=organization_id,
             user_id__isnull=False,  # excludes team mappings
         )
         .order_by("id")
-        .values_list("user_id", "external_name")
+        .values_list("user_id", "external_name", "provider")
     )
 
     if not external_actors:
@@ -257,9 +272,9 @@ def get_author_users_by_external_actors(
 
     missed: dict[int, CommitAuthor] = {a.id: a for a in authors}
 
-    for user_id, external_name in external_actors:
-        if external_name in usernames_to_authors:
-            found_author = usernames_to_authors[external_name]
+    for user_id, external_name, provider_value in external_actors:
+        found_author = authors_by_mapping.get((provider_value, external_name))
+        if found_author is not None:
             found[found_author] = str(user_id)
             missed.pop(found_author.id, None)
 

--- a/src/sentry/integrations/github/installation.py
+++ b/src/sentry/integrations/github/installation.py
@@ -14,6 +14,7 @@ from sentry.api.permissions import SentryIsAuthenticated
 from sentry.constants import ObjectStatus
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 
 logger = logging.getLogger("sentry.webhooks")
 
@@ -32,7 +33,9 @@ class GitHubIntegrationsInstallationEndpoint(Endpoint):
     def get(self, request: Request, installation_id):
         try:
             integration = Integration.objects.get(
-                external_id=installation_id, status=ObjectStatus.ACTIVE
+                provider=IntegrationProviderSlug.GITHUB.value,
+                external_id=installation_id,
+                status=ObjectStatus.ACTIVE,
             )
             OrganizationIntegration.objects.get(integration_id=integration.id)
             return HttpResponse(status=404)

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1024,7 +1024,9 @@ def validate_github_installation(
 
     try:
         integration = Integration.objects.get(
-            external_id=installation_id, status=ObjectStatus.ACTIVE
+            provider=GitHubIntegrationProvider.key,
+            external_id=installation_id,
+            status=ObjectStatus.ACTIVE,
         )
     except Integration.DoesNotExist:
         # The installation.created webhook from GitHub normally creates the

--- a/src/sentry/integrations/messaging/linkage.py
+++ b/src/sentry/integrations/messaging/linkage.py
@@ -314,7 +314,11 @@ class UnlinkIdentityView(IdentityLinkageView, ABC):
         if isinstance(request.user, AnonymousUser):
             raise TypeError("Cannot link identity without a logged-in user")
         try:
-            identities = Identity.objects.filter(external_id=external_id)
+            # The signed link may predate idp resolution (MS Teams signs no integration_id),
+            # so the provider type is the narrowest scope every caller can guarantee.
+            identities = Identity.objects.filter(
+                external_id=external_id, idp__type=self.provider_slug
+            )
             if idp is not None:
                 identities = identities.filter(idp=idp)
             if self.filter_by_user_id:

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -720,7 +720,10 @@ class MsTeamsCommandDispatcher(MessagingIntegrationCommandDispatcher[AdaptiveCar
 
     def link_user_handler(self, input: CommandInput) -> IntegrationResponse[AdaptiveCard]:
         linked_identity = identity_service.get_identity(
-            filter={"identity_ext_id": self.teams_user_id}
+            filter={
+                "identity_ext_id": self.teams_user_id,
+                "provider_type": IntegrationProviderSlug.MSTEAMS.value,
+            }
         )
         has_linked_identity = linked_identity is not None
 

--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 class VstsRepositoryProvider(IntegrationRepositoryProvider["VstsIntegrationType"]):
     name = "Azure DevOps"
     repo_provider = IntegrationProviderSlug.AZURE_DEVOPS.value
+    legacy_provider_ids = ("visualstudio",)
 
     def get_repository_data(
         self, organization: Organization, config: MutableMapping[str, Any]

--- a/src/sentry/models/commitauthor.py
+++ b/src/sentry/models/commitauthor.py
@@ -84,3 +84,11 @@ class CommitAuthor(Model):
             if self.external_id and ":" in self.external_id
             else None
         )
+
+    def get_provider_from_external_id(self) -> str | None:
+        """The provider that issued the login in ``external_id`` (``github:login`` -> ``github``)."""
+        return (
+            self.external_id.split(":", 1)[0]
+            if self.external_id and ":" in self.external_id
+            else None
+        )

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -86,6 +86,10 @@ class IntegrationRepositoryProvider(Generic[InstT]):
 
     name: ClassVar[str]
     repo_provider: ClassVar[str]
+    # ``Repository.provider`` values written by the plugin that preceded this integration,
+    # where they differ from ``repo_provider``. Plugin-era rows have no integration_id and
+    # are adopted on install rather than duplicated.
+    legacy_provider_ids: ClassVar[tuple[str, ...]] = ()
 
     def __init__(self, id: str) -> None:
         self.id = id
@@ -113,6 +117,39 @@ class IntegrationRepositoryProvider(Generic[InstT]):
 
         return cast(InstT, rpc_integration.get_installation(organization_id=organization_id))
 
+    @property
+    def owned_provider_ids(self) -> list[str]:
+        """Every ``Repository.provider`` value that belongs to this provider.
+
+        An external id is only unique per provider, so lookups by external id must be
+        restricted to these or they match another provider's repository with the same id.
+        """
+        return [self.id, self.repo_provider, *self.legacy_provider_ids]
+
+    def _adoptable_repositories(
+        self, organization_id: int, external_id: str, **filters: Any
+    ) -> list[RpcRepository]:
+        """Repositories this provider may take over for ``external_id``.
+
+        Its own rows (including plugin-era ones) and rows that never had a provider. A
+        row belonging to another provider is a different repository that happens to share
+        the id, and is left alone.
+        """
+        return [
+            *repository_service.get_repositories(
+                organization_id=organization_id,
+                providers=self.owned_provider_ids,
+                external_id=external_id,
+                **filters,
+            ),
+            *repository_service.get_repositories(
+                organization_id=organization_id,
+                has_provider=False,
+                external_id=external_id,
+                **filters,
+            ),
+        ]
+
     def create_repository(
         self,
         repo_config: Mapping[str, Any],
@@ -126,10 +163,8 @@ class IntegrationRepositoryProvider(Generic[InstT]):
         url = result["url"]
 
         # first check if there is an existing hidden repository for the organization and external id
-        repositories = repository_service.get_repositories(
-            organization_id=organization.id,
-            external_id=external_id,
-            status=ObjectStatus.HIDDEN,
+        repositories = self._adoptable_repositories(
+            organization.id, external_id, status=ObjectStatus.HIDDEN
         )
         existing_repo = repositories[0] if repositories else None
         if existing_repo:
@@ -146,10 +181,8 @@ class IntegrationRepositoryProvider(Generic[InstT]):
             return result, existing_repo
 
         # then check if there is a repository without an integration that matches
-        repositories = repository_service.get_repositories(
-            organization_id=organization.id,
-            has_integration=False,
-            external_id=external_id,
+        repositories = self._adoptable_repositories(
+            organization.id, external_id, has_integration=False
         )
         repo = repositories[0] if repositories else None
 

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -126,27 +126,19 @@ class IntegrationRepositoryProvider(Generic[InstT]):
         """
         return [self.id, self.repo_provider, *self.legacy_provider_ids]
 
-    def _adoptable_repositories(
-        self, organization_id: int, external_id: str, **filters: Any
-    ) -> list[RpcRepository]:
-        """Repositories this provider may take over for ``external_id``.
+    def _adoptable_repositories(self, organization_id: int, **filters: Any) -> list[RpcRepository]:
+        """Repositories this provider may take over, narrowed by ``filters``.
 
-        Its own rows (including plugin-era ones) and rows that never had a provider. A
-        row belonging to another provider is a different repository that happens to share
-        the id, and is left alone.
+        Its own rows (including plugin-era ones) and rows that never had a provider. A row
+        belonging to another provider is a different repository that happens to share an
+        external id, and is left alone.
         """
         return [
             *repository_service.get_repositories(
-                organization_id=organization_id,
-                providers=self.owned_provider_ids,
-                external_id=external_id,
-                **filters,
+                organization_id=organization_id, providers=self.owned_provider_ids, **filters
             ),
             *repository_service.get_repositories(
-                organization_id=organization_id,
-                has_provider=False,
-                external_id=external_id,
-                **filters,
+                organization_id=organization_id, has_provider=False, **filters
             ),
         ]
 
@@ -164,12 +156,13 @@ class IntegrationRepositoryProvider(Generic[InstT]):
 
         # first check if there is an existing hidden repository for the organization and external id
         repositories = self._adoptable_repositories(
-            organization.id, external_id, status=ObjectStatus.HIDDEN
+            organization.id, external_id=external_id, status=ObjectStatus.HIDDEN
         )
         existing_repo = repositories[0] if repositories else None
         if existing_repo:
             existing_repo.status = ObjectStatus.ACTIVE
             existing_repo.name = name
+            existing_repo.provider = self.id  # a plugin-era or provider-less row is ours now
             existing_repo.integration_id = integration_id
             existing_repo.url = url
             existing_repo.config = {**existing_repo.config, **(result.get("config") or {})}
@@ -182,7 +175,7 @@ class IntegrationRepositoryProvider(Generic[InstT]):
 
         # then check if there is a repository without an integration that matches
         repositories = self._adoptable_repositories(
-            organization.id, external_id, has_integration=False
+            organization.id, external_id=external_id, has_integration=False
         )
         repo = repositories[0] if repositories else None
 
@@ -256,6 +249,7 @@ class IntegrationRepositoryProvider(Generic[InstT]):
 
     def _update_repository(self, repo: RpcRepository, config: RepositoryConfig) -> RpcRepository:
         repo.status = ObjectStatus.ACTIVE
+        repo.provider = self.id  # a plugin-era or provider-less row is ours now
 
         new_config = config.get("config") or {}
         repo.config = {**repo.config, **new_config}
@@ -297,17 +291,11 @@ class IntegrationRepositoryProvider(Generic[InstT]):
         repos_to_update: list[RpcRepository] = []
         created_repos: list[RpcRepository] = []
 
-        hidden_repos = repository_service.get_repositories(
-            organization_id=organization.id,
-            status=ObjectStatus.HIDDEN,
-        )
+        hidden_repos = self._adoptable_repositories(organization.id, status=ObjectStatus.HIDDEN)
         repos_to_update.extend(self._update_repositories(hidden_repos, external_id_to_repo_config))
 
         # then check if there are repositories without an integration that matches
-        repositories = repository_service.get_repositories(
-            organization_id=organization.id,
-            has_integration=False,
-        )
+        repositories = self._adoptable_repositories(organization.id, has_integration=False)
         repos_to_update.extend(self._update_repositories(repositories, external_id_to_repo_config))
 
         # create remaining repositories

--- a/src/sentry/releases/endpoints/project_release_commits.py
+++ b/src/sentry/releases/endpoints/project_release_commits.py
@@ -70,30 +70,21 @@ class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
         repo_id = request.query_params.get("repo_id")
         repo_name = request.query_params.get("repo_name")
 
-        # prefer repo external ID to name
-        # NOTE: We filter on Repository here instead of using get b/c sometimes,
-        # we have have multiple repos for the same external_id/name that differ
-        # in other fields that differ such as 'provider' or 'config'.
+        # Neither parameter names a provider, and an external id is only unique per
+        # provider, so resolve against the repositories that actually have commits in
+        # this release. Re-linking leaves duplicates that differ in provider or config;
+        # prefer the newest.
+        release_repos = Repository.objects.filter(
+            id__in=queryset.values("commit__repository_id"), status=ObjectStatus.ACTIVE
+        )
         if repo_id:
-            repos = Repository.objects.filter(
-                organization_id=organization_id, external_id=repo_id, status=ObjectStatus.ACTIVE
-            ).order_by("-date_added")
-
-            latest_repo = repos.first()
+            release_repos = release_repos.filter(external_id=repo_id)
+        elif repo_name:
+            release_repos = release_repos.filter(name=repo_name)
+        if repo_id or repo_name:
+            latest_repo = release_repos.order_by("-date_added").first()
             if latest_repo is None:
                 raise ResourceDoesNotExist
-
-            queryset = queryset.filter(commit__repository_id=latest_repo.id)
-
-        if repo_name:
-            repos = Repository.objects.filter(
-                organization_id=organization_id, name=repo_name, status=ObjectStatus.ACTIVE
-            ).order_by("-date_added")
-
-            latest_repo = repos.first()
-            if latest_repo is None:
-                raise ResourceDoesNotExist
-
             queryset = queryset.filter(commit__repository_id=latest_repo.id)
 
         return self.paginate(

--- a/tests/sentry/api/endpoints/test_commit_filechange.py
+++ b/tests/sentry/api/endpoints/test_commit_filechange.py
@@ -101,3 +101,48 @@ class CommitFileChangeTest(APITestCase):
             status_code=404,
             qs_params={"repo_id": "0"},
         )
+
+    def test_query_external_id_ignores_other_provider(self) -> None:
+        # External ids are only unique per provider: another provider's repo with the same
+        # id has no commits in this release and must not shadow the release's repo.
+        self.create_repo(
+            project=self.project,
+            name="other/repo",
+            provider="integrations:gitlab",
+            external_id="123",
+        )
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.release.version,
+            qs_params={"repo_id": "123"},
+        )
+
+        assert len(response.data) == 2
+
+    def test_query_external_id_with_duplicate_repos(self) -> None:
+        newest_repo = self.create_repo(
+            project=self.project,
+            name="relinked/repo",
+            provider="integrations:gitlab",
+            external_id="123",
+        )
+        commit = self.create_commit(repo=newest_repo, key="c" * 40)
+        self.create_release_commit(release=self.release, commit=commit, order=2)
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.release.version,
+            qs_params={"repo_id": "123"},
+        )
+
+        assert {change["filename"] for change in response.data} == set(
+            CommitFileChange.objects.filter(commit_id=commit.id).values_list("filename", flat=True)
+        )
+
+    def test_query_external_id_repo_without_release_commits(self) -> None:
+        self.create_repo(project=self.project, name="other/repo", external_id="456")
+        self.get_error_response(
+            self.project.organization.slug,
+            self.release.version,
+            status_code=404,
+            qs_params={"repo_id": "456"},
+        )

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -12,6 +12,7 @@ from sentry.api.endpoints.organization_releases import ReleaseSerializerWithProj
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.release import GroupEventReleaseSerializer, get_users_for_authors
 from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import ExternalProviders
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.deploy import Deploy
@@ -975,6 +976,67 @@ class GetUsersForAuthorsUserMappingsTest(TestCase):
         assert users[str(author.id)].get("id", "not present") == str(user.id)
         assert users[str(author.id)]["email"] == "john@company.com"
         assert users[str(author.id)]["name"] == "John Smith"
+
+    def test_get_users_for_authors_ignores_mapping_of_other_provider(self) -> None:
+        """An @login is only unique per provider: a GitLab mapping must not claim a GitHub author."""
+        gitlab_user = self.create_user(email="gl-octocat@company.com", name="GitLab Octocat")
+        project = self.create_project()
+        self.create_member(user=gitlab_user, organization=project.organization)
+        gitlab = self.create_provider_integration(provider="gitlab")
+        self.create_organization_integration(
+            organization_id=project.organization_id, integration_id=gitlab.id
+        )
+        self.create_external_user(
+            user=gitlab_user,
+            organization=project.organization,
+            integration=gitlab,
+            external_name="@octocat",
+            provider=ExternalProviders.GITLAB.value,
+        )
+        author = self.create_commit_author(
+            organization_id=project.organization_id, email="1+octocat@users.noreply.github.com"
+        )
+        author.update(name="Octocat", external_id="github:octocat")
+
+        users = get_users_for_authors(organization_id=project.organization_id, authors=[author])
+
+        assert users[str(author.id)].get("id", "not present") == "not present"
+        assert users[str(author.id)]["email"] == author.email
+
+    def test_get_users_for_authors_picks_mapping_of_same_provider(self) -> None:
+        github_user = self.create_user(email="gh-hubot@company.com", name="GitHub Hubot")
+        gitlab_user = self.create_user(email="gl-hubot@company.com", name="GitLab Hubot")
+        project = self.create_project()
+        github = self.create_provider_integration(provider="github")
+        gitlab = self.create_provider_integration(provider="gitlab")
+        for user in (github_user, gitlab_user):
+            self.create_member(user=user, organization=project.organization)
+        for integration in (github, gitlab):
+            self.create_organization_integration(
+                organization_id=project.organization_id, integration_id=integration.id
+            )
+        self.create_external_user(
+            user=gitlab_user,
+            organization=project.organization,
+            integration=gitlab,
+            external_name="@hubot",
+            provider=ExternalProviders.GITLAB.value,
+        )
+        self.create_external_user(
+            user=github_user,
+            organization=project.organization,
+            integration=github,
+            external_name="@hubot",
+            provider=ExternalProviders.GITHUB.value,
+        )
+        author = self.create_commit_author(
+            organization_id=project.organization_id, email="2+hubot@users.noreply.github.com"
+        )
+        author.update(name="Hubot", external_id="github:hubot")
+
+        users = get_users_for_authors(organization_id=project.organization_id, authors=[author])
+
+        assert users[str(author.id)]["id"] == str(github_user.id)
 
     def test_get_users_for_authors_by_external_actor_no_user_id(self) -> None:
         """CommitAuthor has an ExternalActor but it's a team mapping"""

--- a/tests/sentry/integrations/github/test_installation.py
+++ b/tests/sentry/integrations/github/test_installation.py
@@ -64,3 +64,31 @@ class InstallationEndpointTest(APITestCase):
         installation_url = reverse("sentry-integration-github-installation", args=[888])
         response = self.client.get(installation_url)
         assert response.status_code == 404
+
+    @responses.activate
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def test_ignores_other_provider_with_same_external_id(self, get_jwt: MagicMock) -> None:
+        # Installation ids are only unique per provider.
+        self.create_provider_integration(provider="gcp", external_id="2", name="Other")
+
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/app/installations/2",
+            body=INSTALLATION_API_RESPONSE,
+            status=200,
+            content_type="application/json",
+        )
+        response = self.client.post(
+            path=self.url,
+            data=INSTALLATION_EVENT_EXAMPLE,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="installation",
+            HTTP_X_HUB_SIGNATURE="sha1=348e46312df2901e8cb945616ee84ce30d9987c9",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+        assert response.status_code == 204
+
+        installation_url = reverse("sentry-integration-github-installation", args=[2])
+        response = self.client.get(installation_url)
+        assert response.status_code == 200
+        assert response.json()["account"]["login"] == "octocat"

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -2140,6 +2140,19 @@ class GitHubIntegrationApiPipelineTest(APITestCase):
         assert resp.data["status"] == "complete"
 
     @responses.activate
+    def test_org_selection_ignores_other_provider_with_same_external_id(self) -> None:
+        """Installation ids are only unique per provider; another provider's row with the
+        same external_id carries no GitHub sender metadata and must not be consulted."""
+        self.create_provider_integration(
+            provider="gcp", external_id=self.installation_id, name="Other"
+        )
+        self._advance_to_org_selection()
+
+        resp = self._advance_step({"installation_id": self.installation_id})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+    @responses.activate
     def test_full_api_pipeline_flow_new_installation(self) -> None:
         """End-to-end: initialize -> OAuth -> skip org selection -> complete."""
         resp = self._initialize_pipeline()

--- a/tests/sentry/integrations/msteams/test_unlink_identity.py
+++ b/tests/sentry/integrations/msteams/test_unlink_identity.py
@@ -118,3 +118,23 @@ class MsTeamsIntegrationUnlinkIdentityTest(TestCase):
 
         assert len(identity) == 1
         assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_keeps_identity_of_other_provider(self) -> None:
+        # Identity external ids are only unique per provider.
+        teams_user_id = "my-teams-user-id"
+        self.create_identity(user=self.user1, identity_provider=self.idp, external_id=teams_user_id)
+        slack_idp = self.create_identity_provider(type="slack", external_id="TXXXXXXXX")
+        slack_identity = self.create_identity(
+            user=self.user1, identity_provider=slack_idp, external_id=teams_user_id
+        )
+
+        unlink_url = build_unlinking_url(
+            self.conversation_id, "https://smba.trafficmanager.net/amer", teams_user_id
+        )
+        resp = self.client.post(unlink_url)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/integrations/msteams/unlinked.html")
+        assert not Identity.objects.filter(idp=self.idp, external_id=teams_user_id).exists()
+        assert Identity.objects.filter(id=slack_identity.id).exists()

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -557,6 +557,51 @@ class MsTeamsWebhookTest(APITestCase):
         assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
 
     @responses.activate
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch("sentry.utils.jwt.decode")
+    @mock.patch("time.time")
+    def test_link_command_identity_under_other_provider(
+        self, mock_time: MagicMock, mock_decode: MagicMock, mock_record: MagicMock
+    ) -> None:
+        """Identity external ids are only unique per provider: a Slack identity with the
+        same id is not an existing MS Teams link."""
+        other_command = deepcopy(EXAMPLE_UNLINK_COMMAND)
+        other_command["text"] = "link"
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            idp = self.create_identity_provider(type="slack", external_id="TXXXXXXXX")
+            self.create_identity(
+                user=self.user, identity_provider=idp, external_id=other_command["from"]["id"]
+            )
+        access_json = {"expires_in": 86399, "access_token": "my_token"}
+        responses.add(
+            responses.POST,
+            "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+            json=access_json,
+        )
+        responses.add(
+            responses.POST,
+            "https://smba.trafficmanager.net/amer/v3/conversations/%s/activities"
+            % other_command["conversation"]["id"],
+            json={},
+        )
+        mock_time.return_value = 1594839999 + 60
+        mock_decode.return_value = DECODED_TOKEN
+        resp = self.client.post(
+            path=webhook_url,
+            data=other_command,
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {TOKEN}",
+        )
+
+        assert resp.status_code == 204
+        assert (
+            "Your Microsoft Teams identity will be linked to your Sentry account"
+            in responses.calls[3].request.body.decode("utf-8")
+        )
+
+        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+
+    @responses.activate
     @mock.patch("sentry.utils.jwt.decode")
     @mock.patch("time.time")
     def test_other_command(self, mock_time: MagicMock, mock_decode: MagicMock) -> None:

--- a/tests/sentry/models/test_commitauthor.py
+++ b/tests/sentry/models/test_commitauthor.py
@@ -23,3 +23,17 @@ class CommitAuthorUsernameExtractionTest(SimpleTestCase):
     def test_get_username_from_external_id_multiple_colons(self) -> None:
         author = CommitAuthor(external_id="provider:user:with:colons")
         assert author.get_username_from_external_id() == "user:with:colons"
+
+
+class CommitAuthorProviderExtractionTest(SimpleTestCase):
+    def test_get_provider_from_external_id(self) -> None:
+        author = CommitAuthor(external_id="github_enterprise:baxterthehacker")
+        assert author.get_provider_from_external_id() == "github_enterprise"
+
+    def test_get_provider_from_external_id_no_external_id(self) -> None:
+        author = CommitAuthor(external_id=None)
+        assert author.get_provider_from_external_id() is None
+
+    def test_get_provider_from_external_id_no_colon(self) -> None:
+        author = CommitAuthor(external_id="justausername")
+        assert author.get_provider_from_external_id() is None

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -200,7 +200,63 @@ class IntegrationRepositoryTestCase(TestCase):
         assert repo.id == orphan.id
         orphan.refresh_from_db()
         assert orphan.status == ObjectStatus.ACTIVE
+        assert orphan.provider == "integrations:github"
         assert orphan.integration_id == self.integration.id
+
+    def test_create_repositories__ignores_rows_of_other_provider(self, get_jwt: MagicMock) -> None:
+        # The bulk path (link_all_repos, install-change sync) matches by external id too.
+        hidden = self.create_repo(
+            project=self.project,
+            name="group/hidden",
+            provider="integrations:gitlab",
+            external_id=self.config["external_id"],
+        )
+        hidden.update(status=ObjectStatus.HIDDEN)
+        unlinked = self.create_repo(
+            project=self.project,
+            name="group/unlinked",
+            provider="gitlab",
+            external_id="999",
+        )
+        other_config = {**self.config, "external_id": "999", "identifier": "getsentry/other"}
+
+        created, reactivated, missing = self.provider.create_repositories(
+            [self.config, other_config], self.organization
+        )
+
+        assert {repo.external_id for repo in created} == {self.config["external_id"], "999"}
+        assert reactivated == []
+        assert missing == []
+        hidden.refresh_from_db()
+        unlinked.refresh_from_db()
+        assert (hidden.status, hidden.provider) == (ObjectStatus.HIDDEN, "integrations:gitlab")
+        assert (unlinked.integration_id, unlinked.provider) == (None, "gitlab")
+
+    def test_create_repositories__adopts_own_and_provider_less_rows(
+        self, get_jwt: MagicMock
+    ) -> None:
+        hidden = self.create_repo(
+            project=self.project,
+            name=self.repo_name,
+            provider="integrations:github",
+            external_id=self.config["external_id"],
+        )
+        hidden.update(status=ObjectStatus.HIDDEN)
+        orphan = self.create_repo(project=self.project, name="getsentry/other", external_id="999")
+        other_config = {**self.config, "external_id": "999", "identifier": "getsentry/other"}
+
+        created, reactivated, missing = self.provider.create_repositories(
+            [self.config, other_config], self.organization
+        )
+
+        assert created == []
+        assert {repo.id for repo in reactivated} == {hidden.id, orphan.id}
+        assert missing == []
+        for repo in (hidden, orphan):
+            repo.refresh_from_db()
+            assert repo.status == ObjectStatus.ACTIVE
+            assert repo.provider == "integrations:github"
+            assert repo.integration_id == self.integration.id
 
     def test_create_repository__ignores_unlinked_repo_of_other_provider(
         self, get_jwt: MagicMock

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -168,6 +168,72 @@ class IntegrationRepositoryTestCase(TestCase):
         assert repo.status == ObjectStatus.ACTIVE
         mock_metrics.incr.assert_called_with("sentry.integration_repo_provider.repo_relink")
 
+    def test_create_repository__ignores_hidden_repo_of_other_provider(
+        self, get_jwt: MagicMock
+    ) -> None:
+        # External ids are only unique per provider.
+        other = self.create_repo(
+            project=self.project,
+            name="group/project",
+            provider="integrations:gitlab",
+            external_id=self.config["external_id"],
+        )
+        other.update(status=ObjectStatus.HIDDEN)
+
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.id != other.id
+        assert repo.provider == "integrations:github"
+        other.refresh_from_db()
+        assert other.status == ObjectStatus.HIDDEN
+
+    def test_create_repository__activates_hidden_repo_without_provider(
+        self, get_jwt: MagicMock
+    ) -> None:
+        orphan = self.create_repo(
+            project=self.project, name=self.repo_name, external_id=self.config["external_id"]
+        )
+        orphan.update(status=ObjectStatus.HIDDEN)
+
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.id == orphan.id
+        orphan.refresh_from_db()
+        assert orphan.status == ObjectStatus.ACTIVE
+        assert orphan.integration_id == self.integration.id
+
+    def test_create_repository__ignores_unlinked_repo_of_other_provider(
+        self, get_jwt: MagicMock
+    ) -> None:
+        other = self.create_repo(
+            project=self.project,
+            name="group/project",
+            provider="gitlab",
+            external_id=self.config["external_id"],
+        )
+
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.id != other.id
+        other.refresh_from_db()
+        assert other.provider == "gitlab"
+        assert other.integration_id is None
+
+    def test_create_repository__adopts_plugin_era_repo(self, get_jwt: MagicMock) -> None:
+        legacy = self.create_repo(
+            project=self.project,
+            name=self.repo_name,
+            provider="github",
+            external_id=self.config["external_id"],
+        )
+
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.id == legacy.id
+        legacy.refresh_from_db()
+        assert legacy.provider == "integrations:github"
+        assert legacy.integration_id == self.integration.id
+
     def test_create_repository__only_activates_hidden_repo(self, get_jwt: MagicMock) -> None:
         repo = self._create_repo(external_id=self.config["external_id"])
         repo.status = ObjectStatus.PENDING_DELETION

--- a/tests/sentry/releases/endpoints/test_project_release_commits.py
+++ b/tests/sentry/releases/endpoints/test_project_release_commits.py
@@ -123,3 +123,31 @@ class ReleaseCommitsListTest(APITestCase):
             status_code=404,
             qs_params={"repo_id": "0"},
         )
+
+    def test_query_external_id_ignores_other_provider(self) -> None:
+        # External ids are only unique per provider: another provider's repo with the same
+        # id has no commits in this release and must not shadow the release's repo.
+        self.create_repo(
+            project=self.project,
+            name="other/repo",
+            provider="integrations:gitlab",
+            external_id="123",
+        )
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.release.version,
+            qs_params={"repo_id": "123"},
+        )
+
+        assert len(response.data) == 2
+
+    def test_query_external_id_repo_without_release_commits(self) -> None:
+        self.create_repo(project=self.project, name="other/repo", external_id="456")
+        self.get_error_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.release.version,
+            status_code=404,
+            qs_params={"repo_id": "456"},
+        )


### PR DESCRIPTION
An `external_id` is the id another system gave us: a GitHub installation id, a repo id, a Slack user id. It is only unique together with the column that says *which* system, and `Meta.unique_together` records exactly that on every model that has one. Several lookups filtered on the id alone, so when two providers happen to hand out the same id they matched each other's rows.

- **GitHub installation endpoint and install pipeline** looked an installation id up across all providers. A GCP or Discord integration with the same numeric id made `.get()` raise `MultipleObjectsReturned` (a 500), or fed another provider's metadata into the GitHub sender check. Both now filter on `provider="github"`.
- **Release commits and file-changes endpoints** resolved `repo_id` across providers and took the newest row; the file-changes one used `.get()` and 500'd on duplicates. Both now resolve `repo_id`/`repo_name` against the repositories that actually have commits in the release. One visible change: a repo that exists but has no commits in the release now 404s instead of returning `[]`. Neither parameter is in the OpenAPI schema.
- **Repository relink/adoption** (`IntegrationRepositoryProvider.create_repository` and the bulk `create_repositories` behind `link_all_repos` and the install-change sync) reactivated a hidden repo, or adopted an integration-less one, by external id alone, so installing GitHub could rewrite a GitLab row with the same id into a GitHub one. Both paths now only touch rows of their own provider (including the plugin-era id, e.g. `visualstudio` for VSTS) or rows that have no provider at all, and an adopted row takes the adopting provider.
- **MS Teams unlink** deleted every identity sharing the external id, whatever its provider. The signed unlink link carries no idp, so the delete is now scoped by provider type. The **MS Teams `link` command** treated a Slack identity with the same id as an existing Teams link; it now asks for MS Teams identities only.
- **Release author resolution** (`get_users_for_authors`) matched a commit author's `@login` against `ExternalActor` mappings of every provider, so a GitHub author could be attributed to whoever had the same login mapped on GitLab. A `CommitAuthor.external_id` is `<provider>:<login>`, so the lookup is now scoped to that provider.

Each site has a regression test with a colliding row from another provider.

#123801 adds a lint (S025) that fails CI on this class of query; its red flake8 job lists exactly these sites.
