### PR TITLE
chore(locale): Remove underused helper `tctCode`

### DIFF
--- a/static/app/components/events/interfaces/csp/help/effectiveDirectives.tsx
+++ b/static/app/components/events/interfaces/csp/help/effectiveDirectives.tsx
@@ -1,81 +1,99 @@
-import {tctCode} from 'sentry/locale';
+import {tct} from 'sentry/locale';
+
+const code = {code: <code />};
 
 export const effectiveDirectives = {
-  'base-uri': tctCode(
+  'base-uri': tct(
     `The [code:base-uri] directive defines the URIs that a user agent
   may use as the document base URL. If this value is absent, then any URI
   is allowed. If this directive is absent, the user agent will use the
-  value in the [code:<base>] element.`
+  value in the [code:<base>] element.`,
+    code
   ),
-  'child-src': tctCode(
+  'child-src': tct(
     `The [code:child-src] directive defines the valid sources for
   web workers and nested browsing contexts loaded using elements such as
-  [code:<frame>] and [code:<iframe>].`
+  [code:<frame>] and [code:<iframe>].`,
+    code
   ),
-  'connect-src': tctCode(
+  'connect-src': tct(
     `The [code:connect-src] directive defines valid sources for fetch,
   [code:XMLHttpRequest], [code:WebSocket], and
-  [code:EventSource] connections.`
+  [code:EventSource] connections.`,
+    code
   ),
-  'font-src': tctCode(
+  'font-src': tct(
     `The [code:font-src] directive specifies valid sources for fonts
-  loaded using [code:@font-face].`
+  loaded using [code:@font-face].`,
+    code
   ),
-  'form-action': tctCode(
+  'form-action': tct(
     `The [code:form-action] directive specifies valid endpoints for
-  [code:<form>] submissions.`
+  [code:<form>] submissions.`,
+    code
   ),
-  'frame-ancestors': tctCode(
+  'frame-ancestors': tct(
     `The [code:frame-ancestors] directive specifies valid parents that
   may embed a page using the [code:<frame>] and
-  [code:<iframe>] elements.`
+  [code:<iframe>] elements.`,
+    code
   ),
-  'img-src': tctCode(
+  'img-src': tct(
     `The [code:img-src] directive specifies valid sources of images and
-  favicons.`
+  favicons.`,
+    code
   ),
-  'prefetch-src': tctCode(
+  'prefetch-src': tct(
     `The [code:prefetch-src] directive restricts the URLs
-      from which resources may be prefetched or prerendered.`
+      from which resources may be prefetched or prerendered.`,
+    code
   ),
-  'manifest-src': tctCode(
+  'manifest-src': tct(
     `The [code:manifest-src] directive specifies which manifest can be
-  applied to the resource.`
+  applied to the resource.`,
+    code
   ),
-  'media-src': tctCode(
+  'media-src': tct(
     `The [code:media-src] directive specifies valid sources for loading
   media using the [code:<audio>] and [code:<video>]
-  elements.`
+  elements.`,
+    code
   ),
-  'object-src': tctCode(
+  'object-src': tct(
     `The [code:object-src] directive specifies valid sources for the
   [code:<object>], [code:<embed>], and
-  [code:<applet>] elements.`
+  [code:<applet>] elements.`,
+    code
   ),
-  'plugin-types': tctCode(
+  'plugin-types': tct(
     `The [code:plugin-types] directive specifies the valid plugins that
-  the user agent may invoke.`
+  the user agent may invoke.`,
+    code
   ),
-  referrer: tctCode(
+  referrer: tct(
     `The [code:referrer] directive specifies information in the
-  [code:Referer] header for links away from a page.`
+  [code:Referer] header for links away from a page.`,
+    code
   ),
-  'script-src': tctCode(
+  'script-src': tct(
     `The [code:script-src] directive specifies valid sources
   for JavaScript. When either the [code:script-src] or the
   [code:default-src] directive is included, inline script and
   [code:eval()] are disabled unless you specify 'unsafe-inline'
-  and 'unsafe-eval', respectively.`
+  and 'unsafe-eval', respectively.`,
+    code
   ),
-  'script-src-elem': tctCode(
+  'script-src-elem': tct(
     `The [code:script-src-elem] directive applies to all script requests
-      and element contents. It does not apply to scripts defined in attributes.`
+      and element contents. It does not apply to scripts defined in attributes.`,
+    code
   ),
-  'script-src-attr': tctCode(
+  'script-src-attr': tct(
     `The [code:script-src-attr] directive applies to event handlers and, if present,
-      it will override the [code:script-src] directive for relevant checks.`
+      it will override the [code:script-src] directive for relevant checks.`,
+    code
   ),
-  'style-src': tctCode(
+  'style-src': tct(
     `The [code:style-src] directive specifies valid sources for
   stylesheets. This includes both externally-loaded stylesheets and inline
   use of the [code:<style>] element and HTML style attributes.
@@ -83,24 +101,29 @@ export const effectiveDirectives = {
   requested or loaded. When either the [code:style-src] or the
   [code:default-src] directive is included, inline use of the
   [code:<style>] element and HTML style attributes are disabled
-  unless you specify 'unsafe-inline'.`
+  unless you specify 'unsafe-inline'.`,
+    code
   ),
-  'style-src-elem': tctCode(
+  'style-src-elem': tct(
     `The [code:style-src-elem] directive applies to all styles except
-      those defined in inline attributes.`
+      those defined in inline attributes.`,
+    code
   ),
-  'style-src-attr': tctCode(
+  'style-src-attr': tct(
     `The [code:style-src-attr] directive applies to inline style attributes and, if present,
-      it will override the [code:style-src] directive for relevant checks.`
+      it will override the [code:style-src] directive for relevant checks.`,
+    code
   ),
-  'frame-src': tctCode(
+  'frame-src': tct(
     `The [code:frame-src] directive specifies valid sources for nested
   browsing contexts loading using elements such as
-  [code:<frame>] and [code:<iframe>].`
+  [code:<frame>] and [code:<iframe>].`,
+    code
   ),
-  'worker-src': tctCode(
+  'worker-src': tct(
     `The [code:worker-src] directive specifies valid sources for
   [code:Worker], [code:SharedWorker], or
-  [code:ServiceWorker] scripts.`
+  [code:ServiceWorker] scripts.`,
+    code
   ),
 };

--- a/static/app/gettingStartedDocs/javascript-nuxt/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-nuxt/onboarding.tsx
@@ -6,7 +6,7 @@ import type {
   OnboardingConfig,
 } from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
-import {t, tct, tctCode} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 
 import {getInstallContent} from './utils';
 
@@ -43,8 +43,9 @@ export const onboarding: OnboardingConfig = {
       content: [
         {
           type: 'text',
-          text: tctCode(
-            'Build and run your application and visit [code:/sentry-example-page] if you have set it up. Click the button to trigger a test error.'
+          text: tct(
+            'Build and run your application and visit [code:/sentry-example-page] if you have set it up. Click the button to trigger a test error.',
+            {code: <code />}
           ),
         },
         {

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -394,15 +394,11 @@ function gettextComponentTemplate(
   components: ComponentMap
 ): React.JSX.Element {
   const parsedTemplate = parseComponentTemplate(getClient().gettext(template));
-  return mark(renderTemplate(parsedTemplate, components));
-}
-
-/**
- * Helper over `gettextComponentTemplate` with a pre-populated `<code />` component that
- * is commonly used.
- */
-export function tctCode(template: string, components: ComponentMap = {}) {
-  return gettextComponentTemplate(template, {code: <code />, ...components});
+  return mark(
+    renderTemplate(parsedTemplate, {
+      ...components,
+    })
+  );
 }
 
 /**

--- a/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/datasetSelector.tsx
@@ -5,7 +5,7 @@ import * as Sentry from '@sentry/react';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 
 import {ExternalLink} from 'sentry/components/links/externalLink';
-import {t, tct, tctCode} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import {useOrganization} from 'sentry/utils/useOrganization';
@@ -41,8 +41,9 @@ export function WidgetBuilderDatasetSelector() {
     label: t('Transactions'),
     disabled: isTransactionsDeprecated,
     details: isTransactionsDeprecated
-      ? tctCode(
-          'No longer supported. Use the spans dataset with the [code:is_transaction:true] filter.'
+      ? tct(
+          'No longer supported. Use the spans dataset with the [code:is_transaction:true] filter.',
+          {code: <code />}
         )
       : t('Transactions from your application'),
   };

--- a/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetBuilderSlideout.tsx
@@ -23,7 +23,7 @@ import {openConfirmModal} from 'sentry/components/confirm';
 import {ErrorBoundary} from 'sentry/components/errorBoundary';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
-import {t, tctCode} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {WidgetBuilderVersion} from 'sentry/utils/analytics/dashboardsAnalyticsEvents';
 import {generateFieldAsString} from 'sentry/utils/discover/fields';
@@ -359,9 +359,10 @@ function WidgetBuilderSlideoutInner({
                     }
                   >
                     {disableTransactionWidget && isEditing
-                      ? tctCode(
+                      ? tct(
                           'Editing of transaction-based widgets is disabled, as we migrate to the span dataset. To expedite and re-enable edit functionality, switch to the [spans] dataset below with the [code:is_transaction:true] filter. Please read these [FAQLink:FAQs] for more information.',
                           {
+                            code: <code />,
                             spans: (
                               <Link
                                 // We need to do this otherwise the dashboard filters will change
@@ -389,9 +390,10 @@ function WidgetBuilderSlideoutInner({
                             ),
                           }
                         )
-                      : tctCode(
+                      : tct(
                           'The transactions dataset is being deprecated. Please use the Spans dataset with the [code:is_transaction:true] filter instead. Please read these [FAQLink:FAQs] for more information.',
                           {
+                            code: <code />,
                             FAQLink: (
                               <ExternalLink href="https://www.sentry.help/en/articles/13964151-faq-transactions-spans-migration" />
                             ),

--- a/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
+++ b/static/app/views/detectors/components/details/metric/transactionsDatasetWarning.tsx
@@ -1,15 +1,16 @@
 import {Alert} from '@sentry/scraps/alert';
 import {ExternalLink, Link} from '@sentry/scraps/link';
 
-import {tctCode} from 'sentry/locale';
+import {tct} from 'sentry/locale';
 import type {MetricDetector} from 'sentry/types/workflowEngine/detectors';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {makeMonitorDetailsPathname} from 'sentry/views/detectors/pathnames';
 import {useCanEditDetector} from 'sentry/views/detectors/utils/useCanEditDetector';
 
-export const TRANSACTIONS_DATASET_DEPRECATION_MESSAGE = tctCode(
+export const TRANSACTIONS_DATASET_DEPRECATION_MESSAGE = tct(
   'The transaction dataset is being deprecated. Please use Span alerts instead. Spans are a superset of transactions, you can isolate transactions by using the [code:is_transaction:true] filter. Please read these [FAQLink:FAQs] for more information.',
   {
+    code: <code />,
     FAQLink: (
       <ExternalLink href="https://www.sentry.help/en/articles/13964151-faq-transactions-spans-migration" />
     ),
@@ -40,9 +41,10 @@ export function MigratedAlertWarning({detector}: {detector: MetricDetector}) {
   return (
     <Alert.Container>
       <Alert variant="info">
-        {tctCode(
+        {tct(
           'To match the original behaviour, we’ve migrated this alert from a transaction-based alert to a span-based alert using a special compatibility mode. When you have a moment, please [editLink:edit] the alert updating its thresholds to account for [samplingLink:sampling].',
           {
+            code: <code />,
             editLink: <Link to={editLink} disabled={!canEdit} />,
             samplingLink: (
               <ExternalLink href="https://docs.sentry.io/product/explore/trace-explorer/#how-sampling-affects-queries-in-trace-explorer" />

--- a/static/app/views/discover/results.tsx
+++ b/static/app/views/discover/results.tsx
@@ -46,7 +46,7 @@ import {trackAiQueryOutcome} from 'sentry/components/searchQueryBuilder/askSeerC
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {IconEllipsis} from 'sentry/icons';
 import {IconClose} from 'sentry/icons/iconClose';
-import {t, tct, tctCode} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import {DataCategory, type PageFilters} from 'sentry/types/core';
 import {SavedSearchType} from 'sentry/types/group';
 import type {NewQuery, Organization, SavedQuery} from 'sentry/types/organization';
@@ -968,9 +968,10 @@ function TransactionsDatasetDeprecationBanner({
             />
           }
         >
-          {tctCode(
+          {tct(
             'The transactions dataset is being deprecated. Please use [traceLink:Explore / Traces] with the [code:is_transaction:true] filter instead. Please read these [FAQLink:FAQs] for more information.',
             {
+              code: <code />,
               traceLink: (
                 <Link
                   to={{


### PR DESCRIPTION
Seems silly to me for there to be one helper that helps with only one of these base html tags, when other tags like `<strong>` and `<em>` `<br/>` and `<pre>` are probably all used at the same rate.

If i change the `tct` signature to be this, then i can find ~250 files that are using these keys that likely represent the matching primitive html tags:
```
function gettextComponentTemplate(
  template: string,
  components: Omit<ComponentMap, 'br' | 'code' | 'em' | 'pre' | 'strong'> & {
    br?: never;
    code?: never;
    em?: never;
    pre?: never;
    strong?: never;
  }
): React.JSX.Element {
  const parsedTemplate = parseComponentTemplate(getClient().gettext(template));
  return mark(
    renderTemplate(parsedTemplate, {
      br: <br />,
      code: <code />,
      em: <em />,
      pre: <pre />,
      strong: <strong />,
      ...components,
    })
  );
}
```

That seems like a decent followup, and it'll touch these 6 files again.