### PR TITLE
feat(ui): Support multiple and creatable select fields in the auto-save form

### DIFF
--- a/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.spec.tsx
@@ -73,6 +73,60 @@ describe('BackendJsonAutoSaveForm', () => {
     expect(screen.getByText('Medium')).toBeInTheDocument();
   });
 
+  it('renders a multiple select with its selected values', () => {
+    render(
+      <BackendJsonAutoSaveForm
+        field={{
+          name: 'regions',
+          type: 'select',
+          label: 'Regions',
+          multiple: true,
+          choices: [
+            ['us', 'US'],
+            ['eu', 'EU'],
+          ],
+        }}
+        initialValue={['us', 'eu']}
+        mutationOptions={mutationOptions}
+      />,
+      {organization: org}
+    );
+
+    expect(screen.getByText('US')).toBeInTheDocument();
+    expect(screen.getByText('EU')).toBeInTheDocument();
+  });
+
+  it('accepts a value outside the choices when creatable', async () => {
+    const mutationFn = jest.fn().mockResolvedValue({});
+
+    render(
+      <BackendJsonAutoSaveForm
+        field={{
+          name: 'projects',
+          type: 'select',
+          label: 'Projects',
+          multiple: true,
+          creatable: true,
+          choices: [['suggested', 'Suggested project']],
+        }}
+        initialValue={[]}
+        mutationOptions={{mutationFn}}
+      />,
+      {organization: org}
+    );
+
+    await userEvent.type(screen.getByRole('textbox'), 'my-own-project');
+    await userEvent.keyboard('{Enter}');
+    await userEvent.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(mutationFn).toHaveBeenCalledWith(
+        {projects: ['my-own-project']},
+        expect.anything()
+      )
+    );
+  });
+
   it('renders table field with add button', () => {
     render(
       <BackendJsonAutoSaveForm

--- a/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.spec.tsx
@@ -127,6 +127,26 @@ describe('BackendJsonAutoSaveForm', () => {
     );
   });
 
+  it('displays a stored value that is not in the choices when creatable', () => {
+    render(
+      <BackendJsonAutoSaveForm
+        field={{
+          name: 'projects',
+          type: 'select',
+          label: 'Projects',
+          multiple: true,
+          creatable: true,
+          choices: [['suggested', 'Suggested project']],
+        }}
+        initialValue={['my-own-project']}
+        mutationOptions={mutationOptions}
+      />,
+      {organization: org}
+    );
+
+    expect(screen.getByText('my-own-project')).toBeInTheDocument();
+  });
+
   it('renders table field with add button', () => {
     render(
       <BackendJsonAutoSaveForm

--- a/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonAutoSaveForm.tsx
@@ -210,9 +210,12 @@ export function BackendJsonAutoSaveForm<
             return (
               <fieldApi.Layout.Row label={field.label} hintText={field.help}>
                 <fieldApi.Select
-                  value={fieldApi.state.value}
+                  {...(field.multiple
+                    ? {multiple: true as const, value: fieldApi.state.value ?? []}
+                    : {value: fieldApi.state.value})}
                   onChange={fieldApi.handleChange}
                   options={transformChoices(field.choices)}
+                  creatable={field.creatable}
                   disabled={getDisabledProp(field)}
                 />
               </fieldApi.Layout.Row>

--- a/static/app/components/backendJsonFormAdapter/types.ts
+++ b/static/app/components/backendJsonFormAdapter/types.ts
@@ -48,6 +48,10 @@ interface JsonFormAdapterSelect extends JsonFormAdapterBase {
   type: 'select' | 'choice';
   choices?: readonly JsonFormAdapterChoice[];
   /**
+   * When true, allows entering values that are not in `choices`.
+   */
+  creatable?: boolean;
+  /**
    * Field names that must have values before prefetched options can be fetched.
    */
   dependsOn?: string[];
@@ -163,7 +167,7 @@ export type FieldValue<T extends JsonFormAdapterFieldConfig> =
       : T extends JsonFormAdapterNumber
         ? number
         : T extends JsonFormAdapterSelect
-          ? JsonFormAdapterChoiceValue | null
+          ? JsonFormAdapterChoiceValue | JsonFormAdapterChoiceValue[] | null
           : T extends JsonFormAdapterChoiceMapper
             ? Record<string, Record<string, unknown>>
             : T extends JsonFormAdapterTable

--- a/static/app/components/core/form/field/selectField.tsx
+++ b/static/app/components/core/form/field/selectField.tsx
@@ -49,6 +49,10 @@ type BaseSelectFieldProps<TValue, IsMulti extends boolean> = Omit<
   BaseFieldProps<HTMLInputElement> & {
     options: ReadonlyArray<SelectValue<TValue>>;
     /**
+     * Allows entering values that are not in `options`.
+     */
+    creatable?: boolean;
+    /**
      * custom value comparator function
      * defaults to === comparison of the option values
      */

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -585,17 +585,25 @@ export function Select<OptionType extends GeneralSelectValue = GeneralSelectValu
       return a === b;
     };
 
+    const toOption = (val: OptionType['value']) =>
+      creatable && defined(val)
+        ? ({value: val, label: String(val)} as OptionType)
+        : undefined;
+
     if (props.multiple && Array.isArray(props.value)) {
       mappedValue = props.value
-        .map(val =>
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-          flatOptions.find(option => compare(option.value, val))
+        .map(
+          val =>
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            flatOptions.find(option => compare(option.value, val)) ?? toOption(val)
         )
         .filter(defined);
     } else {
       mappedValue =
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        flatOptions.find(option => compare(option.value, props.value)) ?? mappedValue;
+        flatOptions.find(option => compare(option.value, props.value)) ??
+        toOption(props.value as OptionType['value']) ??
+        mappedValue;
     }
   }
 

--- a/static/app/components/core/select/select.tsx
+++ b/static/app/components/core/select/select.tsx
@@ -602,7 +602,7 @@ export function Select<OptionType extends GeneralSelectValue = GeneralSelectValu
       mappedValue =
         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         flatOptions.find(option => compare(option.value, props.value)) ??
-        toOption(props.value as OptionType['value']) ??
+        toOption(props.value) ??
         mappedValue;
     }
   }


### PR DESCRIPTION
`multiple` was already part of the backend field config type, but the auto-save form never forwarded it and `FieldValue` didn't allow arrays. This PR wires it up and adds `creatable`, for fields whose valid values do not have to come from a preset list of choices.

The select props are a union discriminated on `multiple`, so the variant is narrowed in a spread rather than passed through as a boolean.