### PR TITLE
fix(analytics): Initialize Amplitude for logged-out users

### DIFF
--- a/static/app/types/overrides.tsx
+++ b/static/app/types/overrides.tsx
@@ -407,7 +407,7 @@ type SuperuserWarningExcluded = (organization: Organization | null) => boolean;
 /**
  * Called when the app is mounted.
  */
-type AnalyticsInitUser = (user: User) => void;
+type AnalyticsInitUser = (user: User | null) => void;
 
 /**
  * Trigger analytics tracking in the override registry.

--- a/static/app/views/app/index.tsx
+++ b/static/app/views/app/index.tsx
@@ -130,6 +130,8 @@ export function App() {
   useEffect(() => GuideStore.onURLChange(), [location]);
 
   useEffect(() => {
+    getOverride('analytics:init-user')?.(user);
+
     // Skip loading organization-related data before the user is logged in,
     // because it triggers a 401 error in the UI.
     if (!preloadData) {
@@ -137,12 +139,6 @@ export function App() {
     }
 
     loadOrganizations();
-
-    // Set the user for analytics
-    if (user) {
-      getOverride('analytics:init-user')?.(user);
-    }
-
     fetchGuides();
 
     // When the app is unloaded clear the organizationst list

--- a/static/gsApp/overrides/analyticsInitUser.spec.tsx
+++ b/static/gsApp/overrides/analyticsInitUser.spec.tsx
@@ -25,6 +25,8 @@ describe('analyticsInitUser', () => {
   afterEach(() => {
     sessionStorageWrapper.removeItem('marketing_event_recorded');
     jest.mocked(trackMarketingEvent).mockClear();
+    jest.mocked(Amplitude.init).mockClear();
+    jest.mocked(Amplitude.identify).mockClear();
     jest.mocked(Amplitude.setUserId).mockClear();
     jest.mocked(Amplitude.track).mockClear();
     jest.mocked(Amplitude.Identify).mockClear();
@@ -34,6 +36,12 @@ describe('analyticsInitUser', () => {
     expect(Amplitude.Identify).toHaveBeenCalledWith();
     expect(_identifyInstance.set).toHaveBeenCalledWith('user_id', user.id);
     expect(_identifyInstance.set).toHaveBeenCalledWith('isInternalUser', false);
+  });
+  it('initializes Amplitude without identifying an anonymous user', () => {
+    analyticsInitUser(null);
+
+    expect(Amplitude.init).toHaveBeenCalledTimes(1);
+    expect(Amplitude.identify).not.toHaveBeenCalled();
   });
   it('calls user properties and sets isInternalUser with organization', () => {
     const internalUser = UserFixture({});

--- a/static/gsApp/overrides/analyticsInitUser.tsx
+++ b/static/gsApp/overrides/analyticsInitUser.tsx
@@ -16,12 +16,32 @@ type MarketingEventSchema = {
   event_label?: unknown;
 };
 
+function identifyAmplitudeUser(user: User) {
+  // Most of our in-app amplitude logging happens on the backend, whereas anonymous user tracking
+  // happens in the JS SDK. This means when a user signs up, we need to somehow link their
+  // anonymous activity with their in-app activity. Logging a dummy event from the JS SDK in-app
+  // accomplishes that.
+  const identify = new Amplitude.Identify();
+  const identifyObj = identify
+    .set('user_id', user.id)
+    .set('lastAppPageLoad', new Date().toISOString())
+    .set(
+      'isInternalUser',
+      user.identities.some(ident => ident.organization?.slug === 'sentry') ||
+        user.emails.some(email => email.email?.endsWith('sentry.io')) ||
+        user.isSuperuser
+    );
+
+  // pass in timestamp from this moment instead of letting Amplitude determine it
+  // which is roughly 100 ms later
+  Amplitude.identify(identifyObj, {time: Date.now()});
+}
+
 /**
- * This function initializes the user for analytics (Amplitude)
- * It also handles other initialization logic for analytics like sending
- * events to Google Analytics and storing the previous_referrer into local storage
+ * Initializes browser analytics and identifies the authenticated user when available.
+ * It also sends marketing events and stores the previous referrer.
  */
-export function analyticsInitUser(user: User) {
+export function analyticsInitUser(user: User | null) {
   const {frontend_events, referrer} = qs.parse(window.location.search) || {};
   // store the referrer in sessionStorage so we know what it was when the user
   // navigates to another page
@@ -51,24 +71,9 @@ export function analyticsInitUser(user: User) {
     },
   });
 
-  // Most of our in-app amplitude logging happens on the backend, whereas anonymous user tracking
-  // happens in the JS SDK. This means when a user signs up, we need to somehow link their
-  // anonymous activity with their in-app activity. Logging a dummy event from the JS SDK in-app
-  // accomplishes that.
-  const identify = new Amplitude.Identify();
-  const identifyObj = identify
-    .set('user_id', user.id)
-    .set('lastAppPageLoad', new Date().toISOString())
-    .set(
-      'isInternalUser',
-      user.identities.some(ident => ident.organization?.slug === 'sentry') ||
-        user.emails.some(email => email.email?.endsWith('sentry.io')) || // Has a sentry.io email
-        user.isSuperuser // Has an identity for the Sentry organization.
-    );
-
-  // pass in timestamp from this moment instead of letting Amplitude determine it
-  // which is roughly 100 ms later
-  Amplitude.identify(identifyObj, {time: Date.now()});
+  if (user) {
+    identifyAmplitudeUser(user);
+  }
 
   // the backend can send any arbitrary marketing events
   if (frontend_events && typeof frontend_events === 'string') {


### PR DESCRIPTION
## Summary

- initialize browser analytics on public routes without an authenticated user
- identify Amplitude users only when authentication data is available
- cover anonymous initialization without emitting an identify call

## Testing

- `pnpm test-ci static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx static/gsApp/overrides/analyticsInitUser.spec.tsx static/app/views/app/index.spec.tsx`
- `pnpm run lint:js static/app/types/overrides.tsx static/app/views/app/index.tsx static/gsApp/overrides/analyticsInitUser.tsx static/gsApp/overrides/analyticsInitUser.spec.tsx static/gsApp/utils/rawTrackAnalyticsEvent.tsx static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx`
- `pnpm run typecheck`
- `.venv/bin/prek run -q --files static/app/types/overrides.tsx static/app/views/app/index.tsx static/gsApp/overrides/analyticsInitUser.tsx static/gsApp/overrides/analyticsInitUser.spec.tsx static/gsApp/utils/rawTrackAnalyticsEvent.tsx static/gsApp/utils/rawTrackAnalyticsEvent.spec.tsx`