### PR TITLE
ref(seer-infra-telemetry): Read GCP project IDs as an array

### DIFF
--- a/static/app/utils/seer/gcpConnection.ts
+++ b/static/app/utils/seer/gcpConnection.ts
@@ -109,27 +109,18 @@ export function describeService(service: GcpServiceResult): string {
   }`;
 }
 
-function parseGcpProjectIds(value: string): string[] {
-  return [
-    ...new Set(
-      value
-        .split(',')
-        .map(id => id.trim())
-        .filter(Boolean)
-    ),
-  ];
-}
-
 export function buildGcpVerifyPayload(
   configData: Record<string, unknown> | null | undefined
 ): {customerSaEmail: string; gcpProjectIds: string[]} | null {
   const customerSaEmail = configData?.customer_sa_email;
   const projectIds = configData?.projects;
-  if (typeof customerSaEmail !== 'string' || typeof projectIds !== 'string') {
+  if (typeof customerSaEmail !== 'string' || !Array.isArray(projectIds)) {
     return null;
   }
 
-  const gcpProjectIds = parseGcpProjectIds(projectIds);
+  const gcpProjectIds = [
+    ...new Set(projectIds.map(id => String(id).trim()).filter(Boolean)),
+  ];
   if (!customerSaEmail || !gcpProjectIds.length) {
     return null;
   }

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -439,7 +439,7 @@ describe('ConfigureIntegration GCP re-verification', () => {
       ],
       configData: {
         customer_sa_email: CUSTOMER_SA,
-        projects: 'project-prod, project-staging',
+        projects: ['project-prod', 'project-staging'],
         connection_status: connectionStatus,
         project_statuses: [],
         last_verified_at: '2026-08-30T00:00:00+00:00',
@@ -547,7 +547,7 @@ describe('ConfigureIntegration GCP re-verification', () => {
     const {verifyRequest, setStoredConfig} = setup();
 
     // A sibling field was saved elsewhere, so what this render closed over is stale.
-    setStoredConfig({projects: 'project-prod, project-staging, project-new'});
+    setStoredConfig({projects: ['project-prod', 'project-staging', 'project-new']});
 
     await saveNewSaEmail('new-sa@my-project.iam.gserviceaccount.com');
 

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
@@ -12,7 +12,7 @@ describe('GcpConnectionStatus', () => {
   const baseConfig = {
     sentry_sa_email: 'sentry-abc@sentry-connectors.iam.gserviceaccount.com',
     customer_sa_email: 'gcp-sentry@my-project.iam.gserviceaccount.com',
-    projects: 'project-prod, project-staging',
+    projects: ['project-prod', 'project-staging'],
   };
 
   function renderStatus({


### PR DESCRIPTION
https://linear.app/getsentry/issue/CW-1986/polish-the-gcp-integration-onboarding-flow-before-releasing-to-users

`buildGcpVerifyPayload` reads `projects` off the integration config, which is changing from a comma-separated string to an array when the settings field becomes a multi-select. Reads the array shape instead.