### PR TITLE
fix(event formatter): stop json field types depending on item count

### DIFF
--- a/src/sentry/issues/formatting/adapter.py
+++ b/src/sentry/issues/formatting/adapter.py
@@ -136,7 +136,9 @@ def _metric_alert_threshold(conditions: Any) -> str | None:
         if not isinstance(condition, dict):
             continue
         comparison = condition.get("comparison")
-        if comparison is None:
+        # anomaly detection stores a config object here rather than a number. There is no
+        # threshold to state in that case, and str() would leak a python repr into the output.
+        if not isinstance(comparison, str | int | float) or isinstance(comparison, bool):
             continue
         condition_type = condition.get("type")
         label = _COMPARISON_LABELS.get(condition_type) if isinstance(condition_type, str) else None

--- a/src/sentry/issues/formatting/adapter.py
+++ b/src/sentry/issues/formatting/adapter.py
@@ -136,8 +136,7 @@ def _metric_alert_threshold(conditions: Any) -> str | None:
         if not isinstance(condition, dict):
             continue
         comparison = condition.get("comparison")
-        # anomaly detection stores a config object here rather than a number. There is no
-        # threshold to state in that case, and str() would leak a python repr into the output.
+        # anomaly detection puts a config object here, not a number
         if not isinstance(comparison, str | int | float) or isinstance(comparison, bool):
             continue
         condition_type = condition.get("type")

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -84,6 +84,18 @@ def _keep_within(items: Sequence[Any], costs: Sequence[int], max_chars: int | No
     return kept
 
 
+def _merge_groups(groups: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Flatten a non-repeating section's groups into one object, concatenating the lists."""
+    merged: dict[str, Any] = {}
+    for group in groups:
+        for key, value in group.items():
+            if isinstance(value, list) and isinstance(merged.get(key), list):
+                merged[key] = merged[key] + value
+            else:
+                merged.setdefault(key, value)
+    return merged
+
+
 @dataclass(frozen=True)
 class Field:
     """A key/value pair. ``**Key:** value`` in markdown, ``<key>value</key>`` in xml."""
@@ -133,6 +145,10 @@ class Section:
 
     title: str
     groups: tuple[Group, ...] = ()
+    # whether groups are repetitions of one kind of thing (exceptions, threads) rather than
+    # different parts of one body. Only json cares: it emits a list for a repeating section and
+    # an object otherwise, so a consumer's field type does not change with the item count.
+    repeating: bool = False
     max_chars: int | None = None  # cut the joined body here
     max_group_chars: int | None = None  # drop whole groups instead
 
@@ -272,7 +288,10 @@ class JsonFormatter(Formatter):
         if not groups:
             return ""
 
-        payload: Any = groups[0] if len(groups) == 1 else groups
+        # a repeating section is always a list; a non-repeating one is always a single object,
+        # merging its groups rather than dropping them (autofix builds a root cause out of
+        # several)
+        payload: Any = groups if section.repeating else _merge_groups(groups)
         return _ENCODER.encode({slug(section.title): payload})
 
     def render_group_object(self, group: Group) -> dict[str, Any]:
@@ -294,11 +313,13 @@ class JsonFormatter(Formatter):
             else:
                 text.append(item.text)
 
+        # always lists, for the same reason: reading one breadcrumb and reading ten should not
+        # differ in shape
         obj: dict[str, Any] = dict(fields)
         if text:
-            obj["text"] = text[0] if len(text) == 1 else text
+            obj["text"] = text
         if code:
-            obj["code"] = code[0] if len(code) == 1 else code
+            obj["code"] = code
         return obj
 
 

--- a/src/sentry/issues/formatting/formatter.py
+++ b/src/sentry/issues/formatting/formatter.py
@@ -145,9 +145,8 @@ class Section:
 
     title: str
     groups: tuple[Group, ...] = ()
-    # whether groups are repetitions of one kind of thing (exceptions, threads) rather than
-    # different parts of one body. Only json cares: it emits a list for a repeating section and
-    # an object otherwise, so a consumer's field type does not change with the item count.
+    # repetitions of one thing (exceptions, threads), not parts of one body. Only json reads
+    # this: a repeating section is always a list, so field types don't shift with the count.
     repeating: bool = False
     max_chars: int | None = None  # cut the joined body here
     max_group_chars: int | None = None  # drop whole groups instead
@@ -288,9 +287,7 @@ class JsonFormatter(Formatter):
         if not groups:
             return ""
 
-        # a repeating section is always a list; a non-repeating one is always a single object,
-        # merging its groups rather than dropping them (autofix builds a root cause out of
-        # several)
+        # merge rather than take the first: autofix builds a root cause out of several groups
         payload: Any = groups if section.repeating else _merge_groups(groups)
         return _ENCODER.encode({slug(section.title): payload})
 
@@ -313,8 +310,7 @@ class JsonFormatter(Formatter):
             else:
                 text.append(item.text)
 
-        # always lists, for the same reason: reading one breadcrumb and reading ten should not
-        # differ in shape
+        # always lists, so one item and ten read the same
         obj: dict[str, Any] = dict(fields)
         if text:
             obj["text"] = text

--- a/src/sentry/issues/formatting/sections.py
+++ b/src/sentry/issues/formatting/sections.py
@@ -109,6 +109,7 @@ def exceptions_section(model: EventObject, limits: Limits) -> Section | None:
 
     return Section(
         title="Exception",
+        repeating=True,
         groups=tuple(groups),
         max_group_chars=limits.max_exceptions_chars,
     )
@@ -267,7 +268,7 @@ def threads_section(model: EventObject, limits: Limits) -> Section | None:
 
     if not groups:
         return None
-    return Section(title="Threads", groups=tuple(groups))
+    return Section(title="Threads", repeating=True, groups=tuple(groups))
 
 
 def spans_section(model: EventObject, limits: Limits) -> Section | None:
@@ -321,6 +322,7 @@ def contexts_section(model: EventObject, limits: Limits) -> Section | None:
         return None
     return Section(
         title="Contexts",
+        repeating=True,
         groups=tuple(groups),
         max_chars=limits.max_contexts_chars,
     )

--- a/tests/sentry/issues/formatting/test_adapter.py
+++ b/tests/sentry/issues/formatting/test_adapter.py
@@ -472,9 +472,8 @@ def test_metric_alert_renders_in_the_output() -> None:
 
 
 def test_metric_alert_skips_an_anomaly_detection_threshold() -> None:
-    # anomaly detection puts a config object in `comparison`. Seen in production rendering as
-    # "{'seasonality': 'auto', 'sensitivity': 'low', 'thresholdType': 2}"; the MCP's own
-    # formatter skips the condition instead, and a python repr is not a threshold.
+    # seen in production rendering as "{'seasonality': 'auto', ...}". The MCP skips the
+    # condition instead; a python repr is not a threshold.
     model = event_response_to_model(
         _metric_issue(
             conditions=[
@@ -490,5 +489,4 @@ def test_metric_alert_skips_an_anomaly_detection_threshold() -> None:
         )
     )
     assert not [label for label, _ in model.metric_alert if label == "Threshold"]
-    # the rest of the alert still renders
     assert ("Dataset", "events_analytics_platform") in model.metric_alert

--- a/tests/sentry/issues/formatting/test_adapter.py
+++ b/tests/sentry/issues/formatting/test_adapter.py
@@ -469,3 +469,26 @@ def test_metric_alert_renders_in_the_output() -> None:
     assert "## Metric Alert Details" in out
     assert "**Aggregate:** p95(span.duration)" in out
     assert "**Threshold:** above 500" in out
+
+
+def test_metric_alert_skips_an_anomaly_detection_threshold() -> None:
+    # anomaly detection puts a config object in `comparison`. Seen in production rendering as
+    # "{'seasonality': 'auto', 'sensitivity': 'low', 'thresholdType': 2}"; the MCP's own
+    # formatter skips the condition instead, and a python repr is not a threshold.
+    model = event_response_to_model(
+        _metric_issue(
+            conditions=[
+                {
+                    "type": "anomaly_detection",
+                    "comparison": {
+                        "seasonality": "auto",
+                        "sensitivity": "low",
+                        "thresholdType": 2,
+                    },
+                }
+            ]
+        )
+    )
+    assert not [label for label, _ in model.metric_alert if label == "Threshold"]
+    # the rest of the alert still renders
+    assert ("Dataset", "events_analytics_platform") in model.metric_alert

--- a/tests/sentry/issues/formatting/test_formatter.py
+++ b/tests/sentry/issues/formatting/test_formatter.py
@@ -274,9 +274,7 @@ def _two_contexts(model: EventObject, limits: object) -> Section | None:
 
 
 def test_json_types_do_not_depend_on_how_many_items_an_event_has() -> None:
-    # a consumer cannot read a field whose type changes with the count. Seen in production:
-    # span_evidence.text was a string on one issue and a list on another, and contexts was an
-    # object on one and a list on another.
+    # seen in production: span_evidence.text was a string on one issue and a list on another
     event = EventObject(title="t")
     one = json.loads(JsonFormatter().render(event, [_one_context], LIMITS_DEFAULT))
     two = json.loads(JsonFormatter().render(event, [_two_contexts], LIMITS_DEFAULT))
@@ -288,7 +286,7 @@ def test_json_types_do_not_depend_on_how_many_items_an_event_has() -> None:
 
 
 def _multi_group_body(model: EventObject, limits: object) -> Section | None:
-    # what autofix builds: several groups that are parts of one body, not repetitions
+    # what autofix builds: parts of one body, not repetitions
     return Section(
         title="Root Cause",
         groups=(

--- a/tests/sentry/issues/formatting/test_formatter.py
+++ b/tests/sentry/issues/formatting/test_formatter.py
@@ -129,6 +129,7 @@ def _fields_section(model: EventObject, limits: object) -> Section | None:
 def _repeating_section(model: EventObject, limits: object) -> Section | None:
     return Section(
         title="Exception",
+        repeating=True,
         groups=(
             Group(items=(Text("ValueError: a"),)),
             Group(items=(Text("KeyError: b"),)),
@@ -138,14 +139,18 @@ def _repeating_section(model: EventObject, limits: object) -> Section | None:
 
 def test_json_renders_a_section_as_an_object() -> None:
     out = JsonFormatter().render(EventObject(title="t"), [_fields_section], LIMITS_DEFAULT)
-    assert json.loads(out) == {"http_request": {"method": "GET", "text": "GET /x", "code": "body"}}
+    assert json.loads(out) == {
+        "http_request": {"method": "GET", "text": ["GET /x"], "code": ["body"]}
+    }
 
 
 def test_json_renders_repeating_groups_as_a_list() -> None:
     # the shape a consumer keys off has to be visible, not implied by blank lines the way it is
     # in the text formats
     out = JsonFormatter().render(EventObject(title="t"), [_repeating_section], LIMITS_DEFAULT)
-    assert json.loads(out) == {"exception": [{"text": "ValueError: a"}, {"text": "KeyError: b"}]}
+    assert json.loads(out) == {
+        "exception": [{"text": ["ValueError: a"]}, {"text": ["KeyError: b"]}]
+    }
 
 
 def test_json_merges_sections_into_one_object() -> None:
@@ -160,7 +165,7 @@ def test_json_skips_empty_and_failing_sections() -> None:
     out = JsonFormatter().render(
         EventObject(title="t"), [empty_section, boom_section, title_section], LIMITS_DEFAULT
     )
-    assert json.loads(out) == {"title": {"text": "t"}}
+    assert json.loads(out) == {"title": {"text": ["t"]}}
 
 
 def test_json_output_is_always_parseable() -> None:
@@ -254,3 +259,46 @@ def test_unicode_costs_the_same_against_the_cap_as_ascii() -> None:
         json.loads(JsonFormatter().render(event, [section("é")], LIMITS_DEFAULT))["evidence"]
     )
     assert ascii_kept == accented_kept
+
+
+def _one_context(model: EventObject, limits: object) -> Section | None:
+    return Section(title="Contexts", repeating=True, groups=(Group(items=(Text("browser"),)),))
+
+
+def _two_contexts(model: EventObject, limits: object) -> Section | None:
+    return Section(
+        title="Contexts",
+        repeating=True,
+        groups=(Group(items=(Text("browser"),)), Group(items=(Text("os"),))),
+    )
+
+
+def test_json_types_do_not_depend_on_how_many_items_an_event_has() -> None:
+    # a consumer cannot read a field whose type changes with the count. Seen in production:
+    # span_evidence.text was a string on one issue and a list on another, and contexts was an
+    # object on one and a list on another.
+    event = EventObject(title="t")
+    one = json.loads(JsonFormatter().render(event, [_one_context], LIMITS_DEFAULT))
+    two = json.loads(JsonFormatter().render(event, [_two_contexts], LIMITS_DEFAULT))
+
+    assert isinstance(one["contexts"], list)
+    assert isinstance(two["contexts"], list)
+    assert isinstance(one["contexts"][0]["text"], list)
+    assert isinstance(two["contexts"][0]["text"], list)
+
+
+def _multi_group_body(model: EventObject, limits: object) -> Section | None:
+    # what autofix builds: several groups that are parts of one body, not repetitions
+    return Section(
+        title="Root Cause",
+        groups=(
+            Group(items=(Text("the description"),)),
+            Group(items=(Text("1. why"),)),
+            Group(items=(Text("- step"),)),
+        ),
+    )
+
+
+def test_json_merges_a_non_repeating_section_rather_than_dropping_groups() -> None:
+    out = JsonFormatter().render(EventObject(title="t"), [_multi_group_body], LIMITS_DEFAULT)
+    assert json.loads(out) == {"root_cause": {"text": ["the description", "1. why", "- step"]}}


### PR DESCRIPTION
Calling the tool against real issues turned up fields whose type changed with the data: span_evidence.text was a string on one issue and a list on another, and contexts was an object on one and a list on another. A consumer cannot read that, and it would make event.body impossible to describe in an outputSchema.

Two causes, both here. Sections emitted their single group as an object and several as a list, and groups did the same for their text and code runs. Sections now declare whether their groups repeat: a repeating one (exceptions, threads, contexts) is always a list, a non-repeating one is always a single object, and text and code are always lists.

Non-repeating sections merge their groups rather than taking the first, since autofix builds a root cause out of several and dropping them would lose the whys and the reproduction steps.

Markdown and xml are untouched: only JsonFormatter reads any of this.
