### PR TITLE
feat(seer-infra-telemetry): Make GCP project IDs a multi-select on configuration page

### DIFF
--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -247,9 +247,14 @@ class GcpIntegration(IntegrationInstallation):
             },
             {
                 "name": "projects",
-                "type": "string",
+                "type": "select",
                 "label": _("GCP Project IDs"),
-                "help": _("Comma-separated list of IDs for connected GCP projects."),
+                "help": _(
+                    "The GCP projects Sentry reads telemetry from. "
+                    "Type a project ID and press enter to add it."
+                ),
+                "multiple": True,
+                "creatable": True,
                 "required": True,
             },
         ]
@@ -261,7 +266,7 @@ class GcpIntegration(IntegrationInstallation):
         return {
             "sentry_sa_email": config.get("sentry_sa_email", ""),
             "customer_sa_email": config.get("customer_sa_email", ""),
-            "projects": ", ".join(config.get("projects", [])),
+            "projects": list(config.get("projects", [])),
             "connection_status": config.get("connection_status", GCP_STATUS_UNVERIFIED),
             "project_statuses": config.get("project_statuses", []),
             "last_verified_at": config.get("last_verified_at"),

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -249,10 +249,7 @@ class GcpIntegration(IntegrationInstallation):
                 "name": "projects",
                 "type": "select",
                 "label": _("GCP Project IDs"),
-                "help": _(
-                    "The GCP projects Sentry reads telemetry from. "
-                    "Type a project ID and press enter to add it."
-                ),
+                "help": _("The GCP projects Sentry reads telemetry from."),
                 "multiple": True,
                 "creatable": True,
                 "required": True,

--- a/src/sentry/integrations/gcp/utils.py
+++ b/src/sentry/integrations/gcp/utils.py
@@ -44,16 +44,10 @@ def validate_gcp_project_id(project_id: str) -> None:
 
 
 def parse_gcp_project_ids(value: Any) -> list[str]:
-    if isinstance(value, str):
-        raw: list[Any] = value.split(",")
-    elif isinstance(value, (list, tuple)):
-        raw = list(value)
-    else:
-        raise IntegrationConfigurationError(
-            "GCP project IDs must be a comma-separated list of project IDs."
-        )
+    if not isinstance(value, (list, tuple)):
+        raise IntegrationConfigurationError("GCP project IDs must be a list of project IDs.")
 
-    project_ids = list(dict.fromkeys(str(item).strip() for item in raw if str(item).strip()))
+    project_ids = list(dict.fromkeys(str(item).strip() for item in value if str(item).strip()))
     if not project_ids:
         raise IntegrationConfigurationError("At least one GCP project ID is required.")
 

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -593,7 +593,7 @@ class GcpIntegrationTest(TestCase):
         installation = self._create_installed_integration()
 
         installation.update_organization_config(
-            {"projects": " project-prod , project-staging ,project-prod"}
+            {"projects": [" project-prod ", "project-staging", "project-prod"]}
         )
 
         config = self._stored_config()
@@ -609,7 +609,7 @@ class GcpIntegrationTest(TestCase):
             projects=["project-prod", "project-staging"]
         )
 
-        installation.update_organization_config({"projects": "project-staging, project-prod"})
+        installation.update_organization_config({"projects": ["project-staging", "project-prod"]})
 
         config = self._stored_config()
         assert config["projects"] == ["project-prod", "project-staging"]
@@ -621,17 +621,23 @@ class GcpIntegrationTest(TestCase):
             projects=["project-prod", "project-staging"]
         )
 
-        installation.update_organization_config({"projects": "project-staging, project-new"})
+        installation.update_organization_config({"projects": ["project-staging", "project-new"]})
 
         config = self._stored_config()
         assert config["connection_status"] == GCP_STATUS_UNVERIFIED
         assert config["last_verified_at"] is None
 
+    def test_update_config_rejects_a_string_of_projects(self) -> None:
+        installation = self._create_installed_integration()
+
+        with pytest.raises(IntegrationConfigurationError, match="must be a list"):
+            installation.update_organization_config({"projects": "project-prod, project-staging"})
+
     def test_update_config_rejects_invalid_project_id(self) -> None:
         installation = self._create_installed_integration()
 
         with pytest.raises(IntegrationConfigurationError, match="Invalid GCP project ID"):
-            installation.update_organization_config({"projects": "INVALID"})
+            installation.update_organization_config({"projects": ["INVALID"]})
 
         assert self._stored_config()["projects"] == ["my-gcp-project"]
 
@@ -639,7 +645,7 @@ class GcpIntegrationTest(TestCase):
         installation = self._create_installed_integration()
 
         with pytest.raises(IntegrationConfigurationError, match="At least one GCP project ID"):
-            installation.update_organization_config({"projects": "  ,  "})
+            installation.update_organization_config({"projects": ["  ", ""]})
 
     def test_update_config_rejects_empty_customer_sa_email(self) -> None:
         installation = self._create_installed_integration()
@@ -662,7 +668,7 @@ class GcpIntegrationTest(TestCase):
     def test_update_config_noop_when_nothing_changed(self) -> None:
         installation = self._create_installed_integration()
         installation.update_organization_config(
-            {"customer_sa_email": _CUSTOMER_SA, "projects": "my-gcp-project"}
+            {"customer_sa_email": _CUSTOMER_SA, "projects": ["my-gcp-project"]}
         )
 
         config = self._stored_config()
@@ -689,7 +695,15 @@ class GcpIntegrationTest(TestCase):
         assert "disabled" not in fields["customer_sa_email"]
         assert "disabled" not in fields["projects"]
 
-    def test_get_config_data_flattens_projects(self) -> None:
+    def test_projects_field_is_a_creatable_multi_select(self) -> None:
+        installation = self._create_installed_integration()
+        fields = {f["name"]: f for f in installation.get_organization_config()}
+
+        assert fields["projects"]["type"] == "select"
+        assert fields["projects"]["multiple"] is True
+        assert fields["projects"]["creatable"] is True
+
+    def test_get_config_data_returns_projects_as_a_list(self) -> None:
         installation = self._create_installed_integration(
             projects=["project-a", "project-b", "project-c"]
         )
@@ -697,7 +711,7 @@ class GcpIntegrationTest(TestCase):
 
         assert data["sentry_sa_email"] == _SA_EMAIL
         assert data["customer_sa_email"] == _CUSTOMER_SA
-        assert data["projects"] == "project-a, project-b, project-c"
+        assert data["projects"] == ["project-a", "project-b", "project-c"]
 
     def test_get_config_data_exposes_the_connection_status(self) -> None:
         installation = self._create_installed_integration()
@@ -821,7 +835,7 @@ class GcpIntegrationTest(TestCase):
         assert parse_gcp_project_ids(["project-a", "project-b"]) == ["project-a", "project-b"]
 
     def test_parse_gcp_project_ids_rejects_unusable_input(self) -> None:
-        with pytest.raises(IntegrationConfigurationError, match="comma-separated list"):
+        with pytest.raises(IntegrationConfigurationError, match="must be a list"):
             parse_gcp_project_ids(42)
 
     def test_parse_customer_sa_email_trims(self) -> None:


### PR DESCRIPTION
https://linear.app/getsentry/issue/CW-1986/polish-the-gcp-integration-onboarding-flow-before-releasing-to-users

Make the GCP project IDs field on the integration settings configuration page a creatable multi-select field, instead of a text input. This way, each project is its own removable entry.