### PR TITLE
feat(seer): Add find_referenced_fix_statements RPC for PR descriptions

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -982,12 +982,26 @@ AUTOMATED_AUTOFIX_REFERRERS = frozenset(
 )
 
 
+# Wraps the "Fixes <issue>" line so downstream readers (seer's duplicate-Fixes
+# check, PR-description parsers) can find it without regexing free text.
+SEER_FIXES_SENTRY_ISSUE_MARKER = "SEER_FIXES_SENTRY_ISSUE"
+
+
 def build_pr_description_suffix(group: Group, run_id: int) -> str | None:
     lines = []
 
     if group.qualified_short_id:
         issue_url = group.get_absolute_url(params={"seerDrawer": "true"})
-        lines.append(f"Fixes [{group.qualified_short_id}]({issue_url})")
+        lines.append(
+            f"<!-- {SEER_FIXES_SENTRY_ISSUE_MARKER} -->\n"
+            f"Fixes [{group.qualified_short_id}]({issue_url})\n"
+            f"<!-- /{SEER_FIXES_SENTRY_ISSUE_MARKER} -->"
+        )
+    else:
+        logger.warning(
+            "autofix.pr_description.no_short_id",
+            extra={"group": group.id, "project": group.project_id, "run_id": run_id},
+        )
 
     for external_issue in PlatformExternalIssue.objects.filter(group_id=group.id):
         if external_issue.service_type == "linear":

--- a/src/sentry/seer/endpoints/seer_rpc.py
+++ b/src/sentry/seer/endpoints/seer_rpc.py
@@ -145,6 +145,7 @@ from sentry.seer.sentry_data_models import (
     OrganizationProjectDetail,
     OrganizationProjectsResponse,
     OrganizationSlugResponse,
+    ReferencedFixStatementsResponse,
     RefreshMonitoringProviderTokenErrorResponse,
     RefreshMonitoringProviderTokenSuccessResponse,
     SendSeerWebhookErrorResponse,
@@ -418,6 +419,16 @@ class SeerRpcServiceEndpoint(Endpoint):
 def get_organization_slug(*, org_id: int) -> OrganizationSlugResponse:
     org: Organization = Organization.objects.get(id=org_id)
     return OrganizationSlugResponse(slug=org.slug)
+
+
+def find_referenced_fix_statements(*, org_id: int, text: str) -> ReferencedFixStatementsResponse:
+    from sentry.utils.groupreference import find_fix_statements, find_referenced_groups
+
+    groups = find_referenced_groups(text, org_id)
+    return ReferencedFixStatementsResponse(
+        statements=find_fix_statements(text, org_id),
+        short_ids=sorted(g.qualified_short_id for g in groups if g.qualified_short_id),
+    )
 
 
 def deliver_investigation_event(
@@ -1028,6 +1039,7 @@ seer_method_registry: dict[str, SeerRpcMethod] = {  # return type must be serial
     #
     # Autofix
     "get_organization_slug": seer_rpc(get_organization_slug),
+    "find_referenced_fix_statements": seer_rpc(find_referenced_fix_statements),
     "get_organization_autofix_consent": seer_rpc(get_organization_autofix_consent),
     "get_error_event_details": seer_rpc(get_error_event_details),
     "get_profile_details": seer_rpc(get_profile_details),

--- a/src/sentry/seer/sentry_data_models.py
+++ b/src/sentry/seer/sentry_data_models.py
@@ -116,6 +116,11 @@ class OrganizationSlugResponse(BaseModel):
     slug: str
 
 
+class ReferencedFixStatementsResponse(BaseModel):
+    statements: list[str]
+    short_ids: list[str]
+
+
 class OrganizationProjectDetail(BaseModel):
     id: int
     slug: str

--- a/src/sentry/utils/groupreference.py
+++ b/src/sentry/utils/groupreference.py
@@ -107,35 +107,13 @@ def find_referenced_groups(text: str | None, org_id: int) -> set[Group]:
 
 
 def find_fix_statements(text: str | None, org_id: int) -> list[str]:
-    """Return the raw text of each "Fix/Fixes/.../Resolved ..." statement in
-    *text* that references a real Sentry issue in *org_id*.
+    """Return each whole line of *text* that fixes a real Sentry issue in
+    *org_id*, so a caller can strip the line from a description verbatim.
 
-    Only the "keyword + short id/URL" span is returned, not _fixes_re's full
-    (loosely-bounded, whitespace-swallowing) match: that match is meant only
-    for feeding _short_id_re, and using it verbatim here would strip
-    unrelated trailing text out of the caller's description.
+    Group detection is delegated to find_referenced_groups, line by line, so a
+    line listing several issues ("Fixes FOO-1, FOO-2") is one statement.
     """
-    from sentry.models.group import Group
-
     if not text:
         return []
 
-    statements = []
-
-    for fmatch in _fixes_re.finditer(text):
-        for smatch in _short_id_re.finditer(fmatch.group(1)):
-            short_id = smatch.group(1)
-            try:
-                Group.objects.by_qualified_short_id(
-                    organization_id=org_id, short_id=short_id, project_ids=None
-                )
-            except Group.DoesNotExist:
-                continue
-            statement_end = fmatch.start(1) + smatch.end(1)
-            statements.append(text[fmatch.start() : statement_end])
-
-    for fmatch in _fixes_url_re.finditer(text):
-        if find_referenced_groups(fmatch.group(0), org_id):
-            statements.append(fmatch.group(0))
-
-    return statements
+    return [line for line in text.splitlines() if find_referenced_groups(line, org_id)]

--- a/src/sentry/utils/groupreference.py
+++ b/src/sentry/utils/groupreference.py
@@ -9,15 +9,17 @@ if TYPE_CHECKING:
 
 _markdown_strip_re = re.compile(r"\[([^]]+)\]\([^)]+\)", re.I)
 
+_fix_keywords = r"(?:Fix|Fixes|Fixed|Close|Closes|Closed|Resolve|Resolves|Resolved)"
+
 _fixes_re = re.compile(
-    r"\b(?:Fix|Fixes|Fixed|Close|Closes|Closed|Resolve|Resolves|Resolved):?\s+([A-Za-z0-9_\-\s\,]+)\b",
+    rf"\b{_fix_keywords}:?\s+([A-Za-z0-9_\-\s\,]+)\b",
     re.I,
 )
 _short_id_re = re.compile(r"\b([A-Z0-9_-]+-[A-Z0-9]+)\b", re.I)
 
 # Matches fix keywords followed by a URL
 _fixes_url_re = re.compile(
-    r"\b(?:Fix|Fixes|Fixed|Close|Closes|Closed|Resolve|Resolves|Resolved):?\s+(https?://[^\s]+)",
+    rf"\b{_fix_keywords}:?\s+(https?://[^\s]+)",
     re.I,
 )
 # Extracts numeric group ID from /issues/{id} in URL path
@@ -102,3 +104,38 @@ def find_referenced_groups(text: str | None, org_id: int) -> set[Group]:
             results.add(group)
 
     return results
+
+
+def find_fix_statements(text: str | None, org_id: int) -> list[str]:
+    """Return the raw text of each "Fix/Fixes/.../Resolved ..." statement in
+    *text* that references a real Sentry issue in *org_id*.
+
+    Only the "keyword + short id/URL" span is returned, not _fixes_re's full
+    (loosely-bounded, whitespace-swallowing) match: that match is meant only
+    for feeding _short_id_re, and using it verbatim here would strip
+    unrelated trailing text out of the caller's description.
+    """
+    from sentry.models.group import Group
+
+    if not text:
+        return []
+
+    statements = []
+
+    for fmatch in _fixes_re.finditer(text):
+        for smatch in _short_id_re.finditer(fmatch.group(1)):
+            short_id = smatch.group(1)
+            try:
+                Group.objects.by_qualified_short_id(
+                    organization_id=org_id, short_id=short_id, project_ids=None
+                )
+            except Group.DoesNotExist:
+                continue
+            statement_end = fmatch.start(1) + smatch.end(1)
+            statements.append(text[fmatch.start() : statement_end])
+
+    for fmatch in _fixes_url_re.finditer(text):
+        if find_referenced_groups(fmatch.group(0), org_id):
+            statements.append(fmatch.group(0))
+
+    return statements

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -13,6 +13,7 @@ from sentry.seer.agent.client_models import (
     SeerRunState,
 )
 from sentry.seer.autofix.autofix_agent import (
+    SEER_FIXES_SENTRY_ISSUE_MARKER,
     STEP_CONFIGS,
     AutofixStep,
     NoSeerQuotaException,
@@ -1759,7 +1760,11 @@ class TestTriggerPushChanges(TestCase):
 
     def _fixes_line(self) -> str:
         issue_url = self.group.get_absolute_url(params={"seerDrawer": "true"})
-        return f"Fixes [{self.group.qualified_short_id}]({issue_url})"
+        return (
+            f"<!-- {SEER_FIXES_SENTRY_ISSUE_MARKER} -->\n"
+            f"Fixes [{self.group.qualified_short_id}]({issue_url})\n"
+            f"<!-- /{SEER_FIXES_SENTRY_ISSUE_MARKER} -->"
+        )
 
     def test_raises_permission_denied_when_coding_disabled(self):
         self.organization.update_option("sentry:enable_seer_coding", False)

--- a/tests/sentry/utils/test_groupreference.py
+++ b/tests/sentry/utils/test_groupreference.py
@@ -1,0 +1,129 @@
+from urllib.parse import urlparse
+
+from sentry import options
+from sentry.testutils.cases import TestCase
+from sentry.utils.groupreference import find_fix_statements
+
+
+class FindFixStatementsTest(TestCase):
+    def _url_prefix(self) -> str:
+        return options.get("system.url-prefix")
+
+    def _sentry_host(self) -> str:
+        return urlparse(self._url_prefix()).netloc
+
+    def _find(self, text: str | None) -> list[str]:
+        return find_fix_statements(text, self.organization.id)
+
+    def test_empty_text(self) -> None:
+        assert self._find(None) == []
+        assert self._find("") == []
+
+    def test_no_fix_statement(self) -> None:
+        group = self.create_group()
+
+        assert self._find(f"Mentions {group.qualified_short_id} without a keyword") == []
+
+    def test_bare_short_id(self) -> None:
+        group = self.create_group()
+
+        assert self._find(f"Fixes {group.qualified_short_id}") == [
+            f"Fixes {group.qualified_short_id}"
+        ]
+
+    def test_markdown_short_id_link(self) -> None:
+        group = self.create_group()
+        issue_url = group.get_absolute_url(params={"seerDrawer": "true"})
+        statement = f"Fixes [{group.qualified_short_id}]({issue_url})"
+
+        assert self._find(statement) == [statement]
+
+    def test_markdown_statement_returned_verbatim_for_removal(self) -> None:
+        group = self.create_group()
+        issue_url = group.get_absolute_url(params={"seerDrawer": "true"})
+        description = (
+            f"Some summary paragraph.\n\n"
+            f"Fixes [{group.qualified_short_id}]({issue_url})\n\n"
+            f"Trailing notes."
+        )
+
+        (statement,) = self._find(description)
+        assert statement in description
+        assert description.replace(statement, "") == (
+            "Some summary paragraph.\n\n\n\nTrailing notes."
+        )
+
+    def test_whole_line_is_returned(self) -> None:
+        group = self.create_group()
+        issue_url = group.get_absolute_url()
+        line = f"Fixes [{group.qualified_short_id}]({issue_url}) and more prose"
+
+        assert self._find(line) == [line]
+
+    def test_comma_separated_short_ids_are_one_statement(self) -> None:
+        group = self.create_group()
+        group2 = self.create_group()
+        line = f"Fixes {group.qualified_short_id}, {group2.qualified_short_id}"
+
+        assert self._find(line) == [line]
+
+    def test_only_the_matching_line_is_returned(self) -> None:
+        group = self.create_group()
+        line = f"Fixes {group.qualified_short_id}"
+        description = f"Intro paragraph.\n{line}\nOutro paragraph."
+
+        assert self._find(description) == [line]
+        assert description.replace(line, "") == "Intro paragraph.\n\nOutro paragraph."
+
+    def test_markdown_link_after_earlier_link(self) -> None:
+        group = self.create_group()
+        issue_url = group.get_absolute_url()
+        statement = f"Fixes [{group.qualified_short_id}]({issue_url})"
+
+        assert self._find(f"See [the docs](https://example.com/docs).\n{statement}") == [statement]
+
+    def test_all_keywords(self) -> None:
+        group = self.create_group()
+        issue_url = group.get_absolute_url()
+
+        for keyword in ("Fix", "Fixes", "Fixed", "Close", "Closes", "Closed", "Resolves"):
+            statement = f"{keyword} [{group.qualified_short_id}]({issue_url})"
+            assert self._find(statement) == [statement]
+
+    def test_keyword_with_colon(self) -> None:
+        group = self.create_group()
+
+        assert self._find(f"Fixes: {group.qualified_short_id}") == [
+            f"Fixes: {group.qualified_short_id}"
+        ]
+
+    def test_unknown_short_id_ignored(self) -> None:
+        assert self._find("Fixes [NOPE-999](https://example.com/nope)") == []
+
+    def test_short_id_from_other_org_ignored(self) -> None:
+        other_org = self.create_organization()
+        other_project = self.create_project(organization=other_org)
+        other_group = self.create_group(project=other_project)
+        issue_url = other_group.get_absolute_url()
+
+        assert self._find(f"Fixes [{other_group.qualified_short_id}]({issue_url})") == []
+
+    def test_bare_issue_url(self) -> None:
+        group = self.create_group()
+        statement = f"Fixes {self._url_prefix()}/issues/{group.id}/"
+
+        assert self._find(statement) == [statement]
+
+    def test_issue_url_wrong_domain_ignored(self) -> None:
+        group = self.create_group()
+
+        assert self._find(f"Fixes https://github.com/issues/{group.id}/") == []
+
+    def test_multiple_statements(self) -> None:
+        group = self.create_group()
+        group2 = self.create_group()
+        issue_url = group.get_absolute_url()
+        first = f"Fixes [{group.qualified_short_id}]({issue_url})"
+        second = f"Fixes {self._url_prefix()}/issues/{group2.id}/"
+
+        assert self._find(f"{first}\n{second}") == [first, second]


### PR DESCRIPTION
Seer's autofix PR descriptions can end up with a "Fixes ..." line the
LLM wrote itself, duplicating our own deterministic suffix line. Adds
find_fix_statements to groupreference.py to locate those statements
(short id or URL form) and a matching RPC method so seer can strip
them before appending its own suffix. Also wraps the suffix's line in
HTML comment markers so it's identifiable regardless.

