### PR TITLE
feat(seer): Derive PR iteration outcomes in sentry

### DIFF
--- a/src/sentry/seer/agent/client_models.py
+++ b/src/sentry/seer/agent/client_models.py
@@ -178,6 +178,20 @@ class MemoryBlock(BaseModel):
     class Config:
         extra = "ignore"
 
+    def has_file_patches(self) -> bool:
+        """Whether this block edited code, on either channel seer delivers patches on.
+
+        Classic editing tools write ``file_patches``; a Code Mode edit only ever
+        returns them on its tool result's ``structuredContent["file_patches"]``.
+        """
+        if self.file_patches:
+            return True
+        for result in self.tool_results or []:
+            structured = result.structuredContent if result is not None else None
+            if structured and structured.get("file_patches"):
+                return True
+        return False
+
 
 class PendingUserInput(BaseModel):
     """A pending user input request from the agent."""

--- a/src/sentry/seer/autofix/pr_iteration/outcomes.py
+++ b/src/sentry/seer/autofix/pr_iteration/outcomes.py
@@ -9,13 +9,11 @@ that ran before this existed still resolve.
 
 from __future__ import annotations
 
-import logging
 from enum import StrEnum
 
 from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.autofix_agent import Iteration, get_iterations
-
-logger = logging.getLogger(__name__)
+from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
 
 
 class IterationOutcome(StrEnum):
@@ -34,7 +32,9 @@ def _made_changes(iteration: Iteration) -> bool:
     return any(block.file_patches for block in iteration.blocks)
 
 
-def get_iteration_outcomes(state: SeerRunState) -> dict[str, str]:
+def get_iteration_outcomes(
+    state: SeerRunState, *, log_ctx: PrIterationLogContext
+) -> dict[str, str]:
     """Outcome per iteration, keyed by iteration index as a string so it survives
     JSON.
 
@@ -45,7 +45,7 @@ def get_iteration_outcomes(state: SeerRunState) -> dict[str, str]:
     try:
         iterations = get_iterations(state)
     except Exception:
-        logger.exception("autofix.pr_iteration.get_iteration_outcomes.failed")
+        log_ctx.error("autofix.pr_iteration.iteration_outcomes.failed")
         return {}
 
     if not iterations:

--- a/src/sentry/seer/autofix/pr_iteration/outcomes.py
+++ b/src/sentry/seer/autofix/pr_iteration/outcomes.py
@@ -1,0 +1,69 @@
+"""What each PR iteration did about the feedback that drove it.
+
+The feedback list shows the outcome next to the feedback, so a reader can tell
+whether Seer is still working on a CI failure or made no changes for it without
+opening the PR. Outcomes are derived from the run state on read — an iteration's
+blocks carry the edits it made — so nothing extra is persisted and iterations
+that ran before this existed still resolve.
+"""
+
+from __future__ import annotations
+
+import logging
+from enum import StrEnum
+
+from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.autofix.autofix_agent import Iteration, get_iterations
+
+logger = logging.getLogger(__name__)
+
+
+class IterationOutcome(StrEnum):
+    IN_PROGRESS = "in_progress"
+    CHANGES_PUSHED = "changes_pushed"
+    # Edits were made but the run ended without them reaching the PR.
+    PUSH_FAILED = "push_failed"
+    # The iteration ran to completion and edited nothing: Seer had no fix for
+    # this feedback.
+    NO_CHANGES = "no_changes"
+
+
+def _made_changes(iteration: Iteration) -> bool:
+    """`file_patches` are the edits made in that block, so any of them means this
+    iteration (not an earlier one) touched code."""
+    return any(block.file_patches for block in iteration.blocks)
+
+
+def get_iteration_outcomes(state: SeerRunState) -> dict[str, str]:
+    """Outcome per iteration, keyed by iteration index as a string so it survives
+    JSON.
+
+    Only the newest iteration can be unfinished, and only its changes can still
+    be waiting on a push: everything older is settled by the fact that another
+    iteration started after it.
+    """
+    try:
+        iterations = get_iterations(state)
+    except Exception:
+        logger.exception("autofix.pr_iteration.get_iteration_outcomes.failed")
+        return {}
+
+    if not iterations:
+        return {}
+
+    _, is_synced = state.has_code_changes()
+    outcomes: dict[str, str] = {}
+    for iteration in iterations:
+        is_latest = iteration is iterations[-1]
+        outcome: IterationOutcome
+        if is_latest and state.status == "processing":
+            outcome = IterationOutcome.IN_PROGRESS
+        elif not _made_changes(iteration):
+            outcome = IterationOutcome.NO_CHANGES
+        elif is_latest and not is_synced:
+            outcome = IterationOutcome.PUSH_FAILED
+        else:
+            outcome = IterationOutcome.CHANGES_PUSHED
+        outcomes[str(iteration.index)] = outcome.value
+
+    return outcomes

--- a/src/sentry/seer/autofix/pr_iteration/outcomes.py
+++ b/src/sentry/seer/autofix/pr_iteration/outcomes.py
@@ -1,10 +1,11 @@
-"""What each PR iteration did about the feedback that drove it.
+"""What each PR iteration did about the feedback that started it.
 
-The feedback list shows the outcome next to the feedback, so a reader can tell
-whether Seer is still working on a CI failure or made no changes for it without
-opening the PR. Outcomes are derived from the run state on read — an iteration's
-blocks carry the edits it made — so nothing extra is persisted and iterations
-that ran before this existed still resolve.
+The feedback list shows this outcome next to the feedback. A reader can then see
+that Seer works on a CI failure, or that Seer made no changes for it.
+
+Each outcome comes from the run state at read time. The blocks of an iteration
+hold the edits that the iteration made. This module stores nothing, so an
+iteration that ran before this code also gets an outcome.
 """
 
 from __future__ import annotations
@@ -19,28 +20,24 @@ from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
 class IterationOutcome(StrEnum):
     IN_PROGRESS = "in_progress"
     CHANGES_PUSHED = "changes_pushed"
-    # Edits were made but the run ended without them reaching the PR.
     PUSH_FAILED = "push_failed"
-    # The iteration ran to completion and edited nothing: Seer had no fix for
-    # this feedback.
     NO_CHANGES = "no_changes"
 
 
 def _made_changes(iteration: Iteration) -> bool:
-    """`file_patches` are the edits made in that block, so any of them means this
-    iteration (not an earlier one) touched code."""
+    """`file_patches` hold the edits of one block, so they show only the work of
+    this iteration."""
     return any(block.file_patches for block in iteration.blocks)
 
 
 def get_iteration_outcomes(
     state: SeerRunState, *, log_ctx: PrIterationLogContext
 ) -> dict[str, str]:
-    """Outcome per iteration, keyed by iteration index as a string so it survives
-    JSON.
+    """The outcome of each iteration, keyed by the iteration index as a string.
 
-    Only the newest iteration can be unfinished, and only its changes can still
-    be waiting on a push: everything older is settled by the fact that another
-    iteration started after it.
+    Only the newest iteration can be incomplete. Only the edits of the newest
+    iteration can wait for a push. An older iteration is complete, because a
+    later iteration started after it.
     """
     try:
         iterations = get_iterations(state)

--- a/src/sentry/seer/autofix/pr_iteration/outcomes.py
+++ b/src/sentry/seer/autofix/pr_iteration/outcomes.py
@@ -25,9 +25,9 @@ class IterationOutcome(StrEnum):
 
 
 def _made_changes(iteration: Iteration) -> bool:
-    """`file_patches` hold the edits of one block, so they show only the work of
-    this iteration."""
-    return any(block.file_patches for block in iteration.blocks)
+    """A block's patches are the edits of that block alone, so they show only the
+    work of this iteration."""
+    return any(block.has_file_patches() for block in iteration.blocks)
 
 
 def get_iteration_outcomes(

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -602,6 +602,7 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
             for repo_name, info in missing_perms.items()
         ]
         queued_feedback = [item.feedback.dict() for item in queued_items]
+        log_ctx = PrIterationLogContext.for_run(logger, state, group.organization.id, group.id)
         # Off the fetched row, not is_pr_iteration_paused: polled every second.
         paused_marker = get_run_extra(run, PAUSED_EXTRA) if run is not None else None
         pause_reason = pause_reason_from_marker(paused_marker)
@@ -629,7 +630,7 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
                         "organizations:autofix-pr-iteration-manual", group.organization
                     ),
                     "queued_feedback": queued_feedback,
-                    "pr_iteration_outcomes": get_iteration_outcomes(state),
+                    "pr_iteration_outcomes": get_iteration_outcomes(state, log_ctx=log_ctx),
                     "pr_iteration_paused": paused_marker is not None,
                     "pr_iteration_pause_reason": pause_reason.value if pause_reason else None,
                     "warnings": warnings,

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -62,6 +62,7 @@ from sentry.seer.autofix.github_perms import (
 )
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
+from sentry.seer.autofix.pr_iteration.outcomes import get_iteration_outcomes
 from sentry.seer.autofix.pr_iteration.pause import (
     PAUSED_EXTRA,
     PauseReason,
@@ -628,6 +629,7 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
                         "organizations:autofix-pr-iteration-manual", group.organization
                     ),
                     "queued_feedback": queued_feedback,
+                    "pr_iteration_outcomes": get_iteration_outcomes(state),
                     "pr_iteration_paused": paused_marker is not None,
                     "pr_iteration_pause_reason": pause_reason.value if pause_reason else None,
                     "warnings": warnings,

--- a/tests/sentry/seer/autofix/pr_iteration/test_outcomes.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_outcomes.py
@@ -1,4 +1,5 @@
-from unittest.mock import MagicMock, patch
+import logging
+from unittest.mock import patch
 
 from sentry.seer.agent.client_models import (
     AgentFilePatch,
@@ -9,6 +10,7 @@ from sentry.seer.agent.client_models import (
     SeerRunState,
 )
 from sentry.seer.autofix.autofix_agent import AutofixStep
+from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
 from sentry.seer.autofix.pr_iteration.outcomes import IterationOutcome, get_iteration_outcomes
 from sentry.testutils.cases import TestCase
 
@@ -64,13 +66,20 @@ def _synced_pr_states(commit_sha: str) -> dict[str, RepoPRState]:
 
 
 class TestGetIterationOutcomes(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.log_ctx = PrIterationLogContext(logging.getLogger(__name__))
+
+    def _outcomes(self, state: SeerRunState) -> dict[str, str]:
+        return get_iteration_outcomes(state, log_ctx=self.log_ctx)
+
     def test_no_iterations(self) -> None:
-        assert get_iteration_outcomes(_state([_plain_block("a")])) == {}
+        assert self._outcomes(_state([_plain_block("a")])) == {}
 
     def test_iteration_that_edited_nothing_made_no_changes(self) -> None:
         state = _state([_iteration_block(0), _plain_block("a")])
 
-        assert get_iteration_outcomes(state) == {"0": IterationOutcome.NO_CHANGES}
+        assert self._outcomes(state) == {"0": IterationOutcome.NO_CHANGES}
 
     def test_edits_pushed_to_the_pr(self) -> None:
         state = _state(
@@ -78,7 +87,7 @@ class TestGetIterationOutcomes(TestCase):
             repo_pr_states=_synced_pr_states("abc"),
         )
 
-        assert get_iteration_outcomes(state) == {"0": IterationOutcome.CHANGES_PUSHED}
+        assert self._outcomes(state) == {"0": IterationOutcome.CHANGES_PUSHED}
 
     def test_edits_that_never_reached_the_pr(self) -> None:
         state = _state(
@@ -86,12 +95,12 @@ class TestGetIterationOutcomes(TestCase):
             repo_pr_states=_synced_pr_states("abc"),
         )
 
-        assert get_iteration_outcomes(state) == {"0": IterationOutcome.PUSH_FAILED}
+        assert self._outcomes(state) == {"0": IterationOutcome.PUSH_FAILED}
 
     def test_latest_iteration_is_in_progress_while_the_run_processes(self) -> None:
         state = _state([_iteration_block(0)], status="processing")
 
-        assert get_iteration_outcomes(state) == {"0": IterationOutcome.IN_PROGRESS}
+        assert self._outcomes(state) == {"0": IterationOutcome.IN_PROGRESS}
 
     def test_only_the_latest_iteration_is_in_progress(self) -> None:
         # The older iteration edited nothing and is settled; the newest is still running.
@@ -100,7 +109,7 @@ class TestGetIterationOutcomes(TestCase):
             status="processing",
         )
 
-        assert get_iteration_outcomes(state) == {
+        assert self._outcomes(state) == {
             "0": IterationOutcome.NO_CHANGES,
             "1": IterationOutcome.IN_PROGRESS,
         }
@@ -116,7 +125,7 @@ class TestGetIterationOutcomes(TestCase):
             repo_pr_states=_synced_pr_states("abc"),
         )
 
-        assert get_iteration_outcomes(state) == {
+        assert self._outcomes(state) == {
             "0": IterationOutcome.CHANGES_PUSHED,
             "1": IterationOutcome.NO_CHANGES,
         }
@@ -127,10 +136,11 @@ class TestGetIterationOutcomes(TestCase):
             repo_pr_states=_synced_pr_states("abc"),
         )
 
-        assert get_iteration_outcomes(state) == {"0": IterationOutcome.CHANGES_PUSHED}
+        assert self._outcomes(state) == {"0": IterationOutcome.CHANGES_PUSHED}
 
-    @patch("sentry.seer.autofix.pr_iteration.outcomes.logger")
-    def test_unparseable_iterations_report_and_return_nothing(self, mock_logger: MagicMock) -> None:
+    def test_unparseable_iterations_report_and_return_nothing(self) -> None:
         # A PR_ITERATION block without an iteration_index makes get_iterations raise.
-        assert get_iteration_outcomes(_state([_iteration_block(None)])) == {}
-        mock_logger.exception.assert_called_once()
+        with patch.object(self.log_ctx, "error") as mock_error:
+            assert self._outcomes(_state([_iteration_block(None)])) == {}
+
+        assert mock_error.call_args.args == ("autofix.pr_iteration.iteration_outcomes.failed",)

--- a/tests/sentry/seer/autofix/pr_iteration/test_outcomes.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_outcomes.py
@@ -103,7 +103,7 @@ class TestGetIterationOutcomes(TestCase):
         assert self._outcomes(state) == {"0": IterationOutcome.IN_PROGRESS}
 
     def test_only_the_latest_iteration_is_in_progress(self) -> None:
-        # The older iteration edited nothing and is settled; the newest is still running.
+        # The older iteration edited nothing, and the newest one still runs.
         state = _state(
             [_iteration_block(0), _iteration_block(1)],
             status="processing",
@@ -139,7 +139,7 @@ class TestGetIterationOutcomes(TestCase):
         assert self._outcomes(state) == {"0": IterationOutcome.CHANGES_PUSHED}
 
     def test_unparseable_iterations_report_and_return_nothing(self) -> None:
-        # A PR_ITERATION block without an iteration_index makes get_iterations raise.
+        # `get_iterations` raises when a PR_ITERATION block has no iteration_index.
         with patch.object(self.log_ctx, "error") as mock_error:
             assert self._outcomes(_state([_iteration_block(None)])) == {}
 

--- a/tests/sentry/seer/autofix/pr_iteration/test_outcomes.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_outcomes.py
@@ -1,0 +1,136 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.seer.agent.client_models import (
+    AgentFilePatch,
+    FilePatch,
+    MemoryBlock,
+    Message,
+    RepoPRState,
+    SeerRunState,
+)
+from sentry.seer.autofix.autofix_agent import AutofixStep
+from sentry.seer.autofix.pr_iteration.outcomes import IterationOutcome, get_iteration_outcomes
+from sentry.testutils.cases import TestCase
+
+
+def _patch() -> AgentFilePatch:
+    return AgentFilePatch(
+        repo_name="test-repo",
+        diff="diff --git a/test.py b/test.py",
+        patch=FilePatch(path="test.py", type="M", added=1, removed=0),
+    )
+
+
+def _iteration_block(index: int | None = 0, *, edited: bool = False) -> MemoryBlock:
+    metadata = {"step": AutofixStep.PR_ITERATION.value, "feedback": "[]"}
+    if index is not None:
+        metadata["iteration_index"] = str(index)
+    return MemoryBlock(
+        id=f"iter-{index}",
+        message=Message(role="assistant", content="", metadata=metadata),
+        timestamp="2023-07-18T12:00:00Z",
+        file_patches=[_patch()] if edited else None,
+    )
+
+
+def _plain_block(id: str, *, edited: bool = False, commit_sha: str | None = None) -> MemoryBlock:
+    return MemoryBlock(
+        id=id,
+        message=Message(role="assistant", content=""),
+        timestamp="2023-07-18T12:00:00Z",
+        file_patches=[_patch()] if edited else None,
+        merged_file_patches=[_patch()] if edited else None,
+        pr_commit_shas={"test-repo": commit_sha} if commit_sha is not None else None,
+    )
+
+
+def _state(
+    blocks: list[MemoryBlock],
+    *,
+    status: str = "completed",
+    repo_pr_states: dict[str, RepoPRState] | None = None,
+) -> SeerRunState:
+    return SeerRunState(
+        run_id=1,
+        blocks=blocks,
+        status=status,
+        updated_at="2023-07-18T12:00:00Z",
+        repo_pr_states=repo_pr_states or {},
+    )
+
+
+def _synced_pr_states(commit_sha: str) -> dict[str, RepoPRState]:
+    return {"test-repo": RepoPRState(repo_name="test-repo", commit_sha=commit_sha)}
+
+
+class TestGetIterationOutcomes(TestCase):
+    def test_no_iterations(self) -> None:
+        assert get_iteration_outcomes(_state([_plain_block("a")])) == {}
+
+    def test_iteration_that_edited_nothing_made_no_changes(self) -> None:
+        state = _state([_iteration_block(0), _plain_block("a")])
+
+        assert get_iteration_outcomes(state) == {"0": IterationOutcome.NO_CHANGES}
+
+    def test_edits_pushed_to_the_pr(self) -> None:
+        state = _state(
+            [_iteration_block(0), _plain_block("a", edited=True, commit_sha="abc")],
+            repo_pr_states=_synced_pr_states("abc"),
+        )
+
+        assert get_iteration_outcomes(state) == {"0": IterationOutcome.CHANGES_PUSHED}
+
+    def test_edits_that_never_reached_the_pr(self) -> None:
+        state = _state(
+            [_iteration_block(0), _plain_block("a", edited=True, commit_sha="stale")],
+            repo_pr_states=_synced_pr_states("abc"),
+        )
+
+        assert get_iteration_outcomes(state) == {"0": IterationOutcome.PUSH_FAILED}
+
+    def test_latest_iteration_is_in_progress_while_the_run_processes(self) -> None:
+        state = _state([_iteration_block(0)], status="processing")
+
+        assert get_iteration_outcomes(state) == {"0": IterationOutcome.IN_PROGRESS}
+
+    def test_only_the_latest_iteration_is_in_progress(self) -> None:
+        # The older iteration edited nothing and is settled; the newest is still running.
+        state = _state(
+            [_iteration_block(0), _iteration_block(1)],
+            status="processing",
+        )
+
+        assert get_iteration_outcomes(state) == {
+            "0": IterationOutcome.NO_CHANGES,
+            "1": IterationOutcome.IN_PROGRESS,
+        }
+
+    def test_an_earlier_iterations_edits_do_not_count_for_a_later_one(self) -> None:
+        state = _state(
+            [
+                _iteration_block(0),
+                _plain_block("a", edited=True, commit_sha="abc"),
+                _iteration_block(1),
+                _plain_block("b"),
+            ],
+            repo_pr_states=_synced_pr_states("abc"),
+        )
+
+        assert get_iteration_outcomes(state) == {
+            "0": IterationOutcome.CHANGES_PUSHED,
+            "1": IterationOutcome.NO_CHANGES,
+        }
+
+    def test_edits_on_the_opening_block_count(self) -> None:
+        state = _state(
+            [_iteration_block(0, edited=True)],
+            repo_pr_states=_synced_pr_states("abc"),
+        )
+
+        assert get_iteration_outcomes(state) == {"0": IterationOutcome.CHANGES_PUSHED}
+
+    @patch("sentry.seer.autofix.pr_iteration.outcomes.logger")
+    def test_unparseable_iterations_report_and_return_nothing(self, mock_logger: MagicMock) -> None:
+        # A PR_ITERATION block without an iteration_index makes get_iterations raise.
+        assert get_iteration_outcomes(_state([_iteration_block(None)])) == {}
+        mock_logger.exception.assert_called_once()

--- a/tests/sentry/seer/autofix/pr_iteration/test_outcomes.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_outcomes.py
@@ -8,6 +8,7 @@ from sentry.seer.agent.client_models import (
     Message,
     RepoPRState,
     SeerRunState,
+    ToolResult,
 )
 from sentry.seer.autofix.autofix_agent import AutofixStep
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
@@ -35,14 +36,34 @@ def _iteration_block(index: int | None = 0, *, edited: bool = False) -> MemoryBl
     )
 
 
-def _plain_block(id: str, *, edited: bool = False, commit_sha: str | None = None) -> MemoryBlock:
+def _tool_result(*, patches: bool) -> ToolResult:
+    return ToolResult(
+        tool_call_id="call-1",
+        tool_call_function="execute",
+        structuredContent=({"file_patches": [_patch().dict()]} if patches else {"logs": []}),
+    )
+
+
+def _plain_block(
+    id: str,
+    *,
+    edited: bool = False,
+    # A Code Mode edit puts its patches on a tool result instead of `file_patches`;
+    # the merged view is written to the block field either way.
+    code_mode_edited: bool = False,
+    tool_result: ToolResult | None = None,
+    commit_sha: str | None = None,
+) -> MemoryBlock:
+    if code_mode_edited:
+        tool_result = _tool_result(patches=True)
     return MemoryBlock(
         id=id,
         message=Message(role="assistant", content=""),
         timestamp="2023-07-18T12:00:00Z",
         file_patches=[_patch()] if edited else None,
-        merged_file_patches=[_patch()] if edited else None,
+        merged_file_patches=[_patch()] if edited or code_mode_edited else None,
         pr_commit_shas={"test-repo": commit_sha} if commit_sha is not None else None,
+        tool_results=[tool_result] if tool_result is not None else None,
     )
 
 
@@ -88,6 +109,21 @@ class TestGetIterationOutcomes(TestCase):
         )
 
         assert self._outcomes(state) == {"0": IterationOutcome.CHANGES_PUSHED}
+
+    def test_code_mode_edits_pushed_to_the_pr(self) -> None:
+        state = _state(
+            [_iteration_block(0), _plain_block("a", code_mode_edited=True, commit_sha="abc")],
+            repo_pr_states=_synced_pr_states("abc"),
+        )
+
+        assert self._outcomes(state) == {"0": IterationOutcome.CHANGES_PUSHED}
+
+    def test_a_tool_result_without_patches_is_not_an_edit(self) -> None:
+        state = _state(
+            [_iteration_block(0), _plain_block("a", tool_result=_tool_result(patches=False))]
+        )
+
+        assert self._outcomes(state) == {"0": IterationOutcome.NO_CHANGES}
 
     def test_edits_that_never_reached_the_pr(self) -> None:
         state = _state(

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -21,6 +21,7 @@ from sentry.seer.autofix.github_perms import MissingGithubPermissions
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import Decision
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
+from sentry.seer.autofix.pr_iteration.outcomes import IterationOutcome
 from sentry.seer.autofix.pr_iteration.pause import (
     PAUSED_EXTRA,
     PauseReason,
@@ -83,6 +84,38 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert response.status_code == 200, response.data
         assert response.data["autofix"]["run_id"] == 888
         assert response.data["autofix"]["sentry_run_id"] == str(run.uuid)
+
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
+    def test_get_reports_pr_iteration_outcomes(self, mock_get_explorer_state):
+        group = self.create_group()
+        mock_get_explorer_state.return_value = SeerRunState(
+            run_id=888,
+            blocks=[
+                MemoryBlock(
+                    id="iter-0",
+                    message=Message(
+                        role="assistant",
+                        content="",
+                        metadata={
+                            "step": AutofixStep.PR_ITERATION.value,
+                            "iteration_index": "0",
+                            "feedback": "[]",
+                        },
+                    ),
+                    timestamp="2023-07-18T12:00:00Z",
+                )
+            ],
+            status="completed",
+            updated_at="2023-07-18T12:00:00Z",
+        )
+        self.login_as(user=self.user)
+
+        response = self.client.get(self._get_url(group.id), format="json")
+
+        assert response.status_code == 200, response.data
+        assert response.data["autofix"]["pr_iteration_outcomes"] == {
+            "0": IterationOutcome.NO_CHANGES
+        }
 
     @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_agent_state")
     def test_get_reports_pr_iteration_paused(self, mock_get_explorer_state):


### PR DESCRIPTION
Reopens [#123609](https://github.com/getsentry/sentry/pull/123609), which GitHub would not reopen after the branch was rebased.

## Why

The feedback list in the PR-iteration UI can say only that an iteration finished. A reader cannot tell whether Seer changed any code for a round of feedback.

The first attempt at this had Seer write the outcome onto the block that opens an iteration ([getsentry/seer#8053](https://github.com/getsentry/seer/pull/8053)). Review found two defects in that approach, and both came from Seer recording the value at a fixed moment: an iteration that pauses for user input writes its outcome before the pending edits exist, and the resume request carries no metadata to correct it later.

Sentry has every input the value needs, and two that Seer does not: the push state of each repository, and the iteration boundaries of the whole run. Deriving the value at read time removes the class of defect above — each poll recomputes it from the blocks that exist then. The Seer pull request will be closed unmerged; nothing from it is deployed.

## What

`get_iteration_outcomes()` maps the run state to `{iteration_index: outcome}`, and the autofix `GET` endpoint serves it as `pr_iteration_outcomes`. Nothing is stored.

Per iteration, in order:

1. The newest iteration of a `processing` run is `in_progress`.
2. An iteration whose blocks carry no file patch is `no_changes`.
3. The newest iteration whose repositories are not synced is `push_failed`.
4. Anything else is `changes_pushed`.

Only the newest iteration can be incomplete, and only its edits can wait for a push, because a later iteration starts after an earlier one ends.

Patches reach a block on either of two channels: a classic editing tool writes `file_patches`, while Code Mode returns them on its tool result's `structuredContent["file_patches"]`. `MemoryBlock.has_file_patches()` reads both, so a Code Mode edit counts as a change.

The frontend change that consumes this field is [#123635](https://github.com/getsentry/sentry/pull/123635), stacked on this branch.

## Testing

`pytest tests/sentry/seer/autofix/pr_iteration/test_outcomes.py tests/sentry/seer/endpoints/test_group_ai_autofix.py` — 66 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrPWpEMBRcZnbsxP353ib5