### PR TITLE
feat(seer-infra-telemetry): Use a multi-select field for GCP project IDs in the setup wizard

### DIFF
--- a/static/app/components/pipeline/integrationGcp/index.spec.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.spec.tsx
@@ -74,29 +74,12 @@ describe('GcpSaGenerationStep', () => {
 });
 
 describe('GcpCustomerConfigStep', () => {
-  it('renders the config form with one empty project input', () => {
+  it('renders the config form', () => {
     render(<GcpCustomerConfigStep {...makeCustomerConfigStepProps({stepData: {}})} />);
 
     expect(screen.getByLabelText('Service Account Email')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('my-gcp-project')).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Add Project'})).toBeInTheDocument();
+    expect(screen.getByText('GCP Project IDs')).toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Continue'})).toBeInTheDocument();
-  });
-
-  it('adds and removes project inputs', async () => {
-    render(<GcpCustomerConfigStep {...makeCustomerConfigStepProps({stepData: {}})} />);
-
-    expect(screen.getAllByPlaceholderText('my-gcp-project')).toHaveLength(1);
-    expect(
-      screen.queryByRole('button', {name: 'Remove project'})
-    ).not.toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole('button', {name: 'Add Project'}));
-    expect(screen.getAllByPlaceholderText('my-gcp-project')).toHaveLength(2);
-    expect(screen.getAllByRole('button', {name: 'Remove project'})).toHaveLength(2);
-
-    await userEvent.click(screen.getAllByRole('button', {name: 'Remove project'})[0]!);
-    expect(screen.getAllByPlaceholderText('my-gcp-project')).toHaveLength(1);
   });
 
   it('calls advance with config on submit', async () => {
@@ -110,12 +93,9 @@ describe('GcpCustomerConfigStep', () => {
       'gcp-sentry@my-project.iam.gserviceaccount.com'
     );
 
-    const projectInputs = screen.getAllByPlaceholderText('my-gcp-project');
-    await userEvent.type(projectInputs[0]!, 'my-project-prod');
-
-    await userEvent.click(screen.getByRole('button', {name: 'Add Project'}));
-    const updatedInputs = screen.getAllByPlaceholderText('my-gcp-project');
-    await userEvent.type(updatedInputs[1]!, 'my-project-staging');
+    const projectIds = screen.getByRole('textbox', {name: 'GCP Project IDs'});
+    await userEvent.type(projectIds, 'my-project-prod{Enter}');
+    await userEvent.type(projectIds, 'my-project-staging{Enter}');
 
     await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 

--- a/static/app/components/pipeline/integrationGcp/index.spec.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.spec.tsx
@@ -107,6 +107,26 @@ describe('GcpCustomerConfigStep', () => {
     });
   });
 
+  it('shows an error for an invalid project ID', async () => {
+    render(<GcpCustomerConfigStep {...makeCustomerConfigStepProps({stepData: {}})} />);
+
+    await userEvent.type(
+      screen.getByLabelText('Service Account Email'),
+      'gcp-sentry@my-project.iam.gserviceaccount.com'
+    );
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'GCP Project IDs'}),
+      'INVALID{Enter}'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    expect(
+      await screen.findByText(
+        'Project IDs must be 6-30 characters using lowercase letters, digits, and hyphens, and must start with a letter.'
+      )
+    ).toBeInTheDocument();
+  });
+
   it('shows busy state when isAdvancing', () => {
     render(
       <GcpCustomerConfigStep

--- a/static/app/components/pipeline/integrationGcp/index.spec.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.spec.tsx
@@ -127,6 +127,30 @@ describe('GcpCustomerConfigStep', () => {
     ).toBeInTheDocument();
   });
 
+  it('accepts a project ID pasted with surrounding whitespace', async () => {
+    const advance = jest.fn();
+    render(
+      <GcpCustomerConfigStep {...makeCustomerConfigStepProps({stepData: {}, advance})} />
+    );
+
+    await userEvent.type(
+      screen.getByLabelText('Service Account Email'),
+      'gcp-sentry@my-project.iam.gserviceaccount.com'
+    );
+    await userEvent.type(
+      screen.getByRole('textbox', {name: 'GCP Project IDs'}),
+      'my-project-prod {Enter}'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
+
+    await waitFor(() => {
+      expect(advance).toHaveBeenCalledWith({
+        customerSaEmail: 'gcp-sentry@my-project.iam.gserviceaccount.com',
+        projects: ['my-project-prod'],
+      });
+    });
+  });
+
   it('shows busy state when isAdvancing', () => {
     render(
       <GcpCustomerConfigStep

--- a/static/app/components/pipeline/integrationGcp/index.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.tsx
@@ -158,7 +158,7 @@ function GcpCustomerConfigStep({
     onSubmit: ({value}) => {
       advance({
         customerSaEmail: value.customerSaEmail,
-        projects: value.projects.map(s => s.trim()).filter(Boolean),
+        projects: value.projects,
       });
     },
   });
@@ -196,7 +196,9 @@ function GcpCustomerConfigStep({
                 creatable
                 options={[]}
                 value={field.state.value}
-                onChange={field.handleChange}
+                onChange={ids =>
+                  field.handleChange(ids.map(id => id.trim()).filter(Boolean))
+                }
                 placeholder={t('Type a project ID and press enter')}
               />
             </field.Layout.Stack>

--- a/static/app/components/pipeline/integrationGcp/index.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.tsx
@@ -126,10 +126,21 @@ function GcpSaGenerationStep({
 const gcpCustomerConfigSchema = z.object({
   customerSaEmail: z.email(t('Must be a valid email address')),
   projects: z
-    .array(z.string().regex(GCP_PROJECT_ID_RE, t('Invalid project ID')))
+    .array(z.string())
     .min(1, t('At least one project ID is required'))
-    .max(MAX_PROJECTS, t('You can connect up to %s GCP projects', MAX_PROJECTS)),
+    .max(MAX_PROJECTS, t('You can connect up to %s GCP projects', MAX_PROJECTS))
+    .refine(
+      ids => ids.every(id => GCP_PROJECT_ID_RE.test(id)),
+      t(
+        'Project IDs must be 6-30 characters using lowercase letters, digits, and hyphens, and must start with a letter.'
+      )
+    ),
 });
+
+const emptyGcpCustomerConfig: z.infer<typeof gcpCustomerConfigSchema> = {
+  customerSaEmail: '',
+  projects: [],
+};
 
 function GcpCustomerConfigStep({
   advance,
@@ -142,7 +153,7 @@ function GcpCustomerConfigStep({
 >) {
   const form = useScrapsForm({
     ...defaultFormOptions,
-    defaultValues: {customerSaEmail: '', projects: [] as string[]},
+    defaultValues: emptyGcpCustomerConfig,
     validators: {onDynamic: gcpCustomerConfigSchema},
     onSubmit: ({value}) => {
       advance({

--- a/static/app/components/pipeline/integrationGcp/index.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.tsx
@@ -17,7 +17,7 @@ import type {
 } from 'sentry/components/pipeline/types';
 import {pipelineComplete} from 'sentry/components/pipeline/types';
 import {TextCopyInput} from 'sentry/components/textCopyInput';
-import {IconAdd, IconDelete, IconRefresh} from 'sentry/icons';
+import {IconRefresh} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 import type {IntegrationWithConfig} from 'sentry/types/integrations';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
@@ -128,7 +128,7 @@ const gcpCustomerConfigSchema = z.object({
   projects: z
     .array(z.string().regex(GCP_PROJECT_ID_RE, t('Invalid project ID')))
     .min(1, t('At least one project ID is required'))
-    .max(MAX_PROJECTS),
+    .max(MAX_PROJECTS, t('You can connect up to %s GCP projects', MAX_PROJECTS)),
 });
 
 function GcpCustomerConfigStep({
@@ -142,7 +142,7 @@ function GcpCustomerConfigStep({
 >) {
   const form = useScrapsForm({
     ...defaultFormOptions,
-    defaultValues: {customerSaEmail: '', projects: ['']},
+    defaultValues: {customerSaEmail: '', projects: [] as string[]},
     validators: {onDynamic: gcpCustomerConfigSchema},
     onSubmit: ({value}) => {
       advance({
@@ -177,48 +177,18 @@ function GcpCustomerConfigStep({
             </field.Layout.Stack>
           )}
         </form.AppField>
-        <form.AppField name="projects" mode="array">
+        <form.AppField name="projects">
           {field => (
-            <Fragment>
-              <Text bold>{t('GCP Project IDs')}</Text>
-              <Stack gap="sm">
-                {field.state.value.map((_, i) => (
-                  <Flex key={i} gap="sm" align="center">
-                    <form.AppField name={`projects[${i}]`}>
-                      {subField => (
-                        <subField.Input
-                          value={subField.state.value}
-                          onChange={subField.handleChange}
-                          placeholder="my-gcp-project"
-                          style={{flex: 1}}
-                        />
-                      )}
-                    </form.AppField>
-                    {field.state.value.length > 1 && (
-                      <Button
-                        aria-label={t('Remove project')}
-                        size="sm"
-                        variant="transparent"
-                        icon={<IconDelete size="xs" />}
-                        onClick={() => field.removeValue(i)}
-                      />
-                    )}
-                  </Flex>
-                ))}
-                {field.state.value.length < MAX_PROJECTS && (
-                  <Flex>
-                    <Button
-                      size="sm"
-                      icon={<IconAdd size="xs" />}
-                      onClick={() => field.pushValue('')}
-                    >
-                      {t('Add Project')}
-                    </Button>
-                  </Flex>
-                )}
-                <field.Meta.Status />
-              </Stack>
-            </Fragment>
+            <field.Layout.Stack label={t('GCP Project IDs')} required>
+              <field.Select
+                multiple
+                creatable
+                options={[]}
+                value={field.state.value}
+                onChange={field.handleChange}
+                placeholder={t('Type a project ID and press enter')}
+              />
+            </field.Layout.Stack>
           )}
         </form.AppField>
         <Flex>


### PR DESCRIPTION
https://linear.app/getsentry/issue/CW-1986/polish-the-gcp-integration-onboarding-flow-before-releasing-to-users

This PR switches the project IDs field in the GCP integration installation wizard to a creatable multi-select, rather than a list of text inputs with Add and Remove buttons.