### PR TITLE
test(ci): Exercise pull request scope reconciliation

### DIFF
--- a/.github/workflows/scripts/pr-scope-validation.js
+++ b/.github/workflows/scripts/pr-scope-validation.js
@@ -1,0 +1,1 @@
+// Temporary frontend marker used to validate pull request scope reconciliation.

--- a/.github/workflows/scripts/pr-scope-validation.js
+++ b/.github/workflows/scripts/pr-scope-validation.js
@@ -1,1 +1,0 @@
-// Temporary frontend marker used to validate pull request scope reconciliation.

--- a/src/sentry/pr_scope_validation.py
+++ b/src/sentry/pr_scope_validation.py
@@ -1,0 +1,1 @@
+"""Temporary backend marker used to validate pull request scope reconciliation."""

--- a/src/sentry/pr_scope_validation.py
+++ b/src/sentry/pr_scope_validation.py
@@ -1,1 +1,0 @@
-"""Temporary backend marker used to validate pull request scope reconciliation."""


### PR DESCRIPTION
This throwaway PR validates the deployed pull request scope reconciliation across three commits. The initial mixed frontend/backend state produced both scope labels and one warning; the frontend-only state removed the backend label and warning; and the current backend-only state removed the frontend label, restored the backend label, and kept the warning absent.
