### PR TITLE
fix(github): Scope installation lookups to the GitHub provider

### DIFF
--- a/src/sentry/integrations/github/installation.py
+++ b/src/sentry/integrations/github/installation.py
@@ -14,6 +14,7 @@ from sentry.api.permissions import SentryIsAuthenticated
 from sentry.constants import ObjectStatus
 from sentry.integrations.models.integration import Integration
 from sentry.integrations.models.organization_integration import OrganizationIntegration
+from sentry.integrations.types import IntegrationProviderSlug
 
 logger = logging.getLogger("sentry.webhooks")
 
@@ -32,7 +33,9 @@ class GitHubIntegrationsInstallationEndpoint(Endpoint):
     def get(self, request: Request, installation_id):
         try:
             integration = Integration.objects.get(
-                external_id=installation_id, status=ObjectStatus.ACTIVE
+                provider=IntegrationProviderSlug.GITHUB.value,
+                external_id=installation_id,
+                status=ObjectStatus.ACTIVE,
             )
             OrganizationIntegration.objects.get(integration_id=integration.id)
             return HttpResponse(status=404)

--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -1024,7 +1024,9 @@ def validate_github_installation(
 
     try:
         integration = Integration.objects.get(
-            external_id=installation_id, status=ObjectStatus.ACTIVE
+            provider=GitHubIntegrationProvider.key,
+            external_id=installation_id,
+            status=ObjectStatus.ACTIVE,
         )
     except Integration.DoesNotExist:
         # The installation.created webhook from GitHub normally creates the

--- a/tests/sentry/integrations/github/test_installation.py
+++ b/tests/sentry/integrations/github/test_installation.py
@@ -64,3 +64,31 @@ class InstallationEndpointTest(APITestCase):
         installation_url = reverse("sentry-integration-github-installation", args=[888])
         response = self.client.get(installation_url)
         assert response.status_code == 404
+
+    @responses.activate
+    @patch("sentry.integrations.github.client.get_jwt", return_value="jwt_token_1")
+    def test_ignores_other_provider_with_same_external_id(self, get_jwt: MagicMock) -> None:
+        # Installation ids are only unique per provider.
+        self.create_provider_integration(provider="gcp", external_id="2", name="Other")
+
+        responses.add(
+            method=responses.GET,
+            url="https://api.github.com/app/installations/2",
+            body=INSTALLATION_API_RESPONSE,
+            status=200,
+            content_type="application/json",
+        )
+        response = self.client.post(
+            path=self.url,
+            data=INSTALLATION_EVENT_EXAMPLE,
+            content_type="application/json",
+            HTTP_X_GITHUB_EVENT="installation",
+            HTTP_X_HUB_SIGNATURE="sha1=348e46312df2901e8cb945616ee84ce30d9987c9",
+            HTTP_X_GITHUB_DELIVERY=str(uuid4()),
+        )
+        assert response.status_code == 204
+
+        installation_url = reverse("sentry-integration-github-installation", args=[2])
+        response = self.client.get(installation_url)
+        assert response.status_code == 200
+        assert response.json()["account"]["login"] == "octocat"

--- a/tests/sentry/integrations/github/test_integration.py
+++ b/tests/sentry/integrations/github/test_integration.py
@@ -2140,6 +2140,19 @@ class GitHubIntegrationApiPipelineTest(APITestCase):
         assert resp.data["status"] == "complete"
 
     @responses.activate
+    def test_org_selection_ignores_other_provider_with_same_external_id(self) -> None:
+        """Installation ids are only unique per provider; another provider's row with the
+        same external_id carries no GitHub sender metadata and must not be consulted."""
+        self.create_provider_integration(
+            provider="gcp", external_id=self.installation_id, name="Other"
+        )
+        self._advance_to_org_selection()
+
+        resp = self._advance_step({"installation_id": self.installation_id})
+        assert resp.status_code == 200
+        assert resp.data["status"] == "complete"
+
+    @responses.activate
     def test_full_api_pipeline_flow_new_installation(self) -> None:
         """End-to-end: initialize -> OAuth -> skip org selection -> complete."""
         resp = self._initialize_pipeline()


### PR DESCRIPTION
An `Integration.external_id` is the id the provider gave us, so it is only unique together with `provider` (`unique_together = (("provider", "external_id"),)`). The GitHub installation endpoint and the install pipeline looked an installation id up across all providers. A GCP or Discord integration whose id happened to match made `.get()` raise `MultipleObjectsReturned` (a 500), or fed the other provider's metadata into the GitHub sender check. Both lookups now filter on `provider="github"`.

Regression tests create a colliding non-GitHub integration alongside the GitHub one.

One of a series scoping `external_id` lookups to their provider; the lint that catches this class is #123801 (draft).
