### PR TITLE
fix(releases): Resolve repo_id against the release's repositories

### DIFF
--- a/src/sentry/api/endpoints/filechange.py
+++ b/src/sentry/api/endpoints/filechange.py
@@ -59,26 +59,29 @@ class CommitFileChangeEndpoint(OrganizationReleasesBaseEndpoint):
         repo_name = request.query_params.get("repo_name")
 
         if repo_id or repo_name:
-            try:
-                if repo_id:
-                    repo = Repository.objects.get(
-                        organization_id=organization.id,
-                        external_id=repo_id,
-                        status=ObjectStatus.ACTIVE,
-                    )
-                else:
-                    repo = Repository.objects.get(
-                        organization_id=organization.id, name=repo_name, status=ObjectStatus.ACTIVE
-                    )
-
-                commit_ids_for_repo = list(
-                    Commit.objects.filter(
-                        id__in=release_commit_ids, repository_id=repo.id
-                    ).values_list("id", flat=True)
-                )
-                queryset = queryset.filter(commit_id__in=commit_ids_for_repo)
-            except Repository.DoesNotExist:
+            # Neither parameter names a provider, and an external id is only unique per
+            # provider, so resolve against the repositories that actually have commits in
+            # this release. Re-linking leaves duplicates that differ in provider or config;
+            # every match contributes its commits rather than guessing which was meant.
+            release_repos = Repository.objects.filter(
+                organization_id=organization.id,
+                id__in=Commit.objects.filter(id__in=release_commit_ids).values("repository_id"),
+                status=ObjectStatus.ACTIVE,
+            )
+            if repo_id:
+                release_repos = release_repos.filter(external_id=repo_id)
+            else:
+                release_repos = release_repos.filter(name=repo_name)
+            repo_ids = list(release_repos.values_list("id", flat=True))
+            if not repo_ids:
                 raise ResourceDoesNotExist
+
+            commit_ids_for_repos = list(
+                Commit.objects.filter(
+                    id__in=release_commit_ids, repository_id__in=repo_ids
+                ).values_list("id", flat=True)
+            )
+            queryset = queryset.filter(commit_id__in=commit_ids_for_repos)
 
         return self.paginate(
             request=request,

--- a/src/sentry/releases/endpoints/project_release_commits.py
+++ b/src/sentry/releases/endpoints/project_release_commits.py
@@ -70,30 +70,23 @@ class ProjectReleaseCommitsEndpoint(ProjectEndpoint):
         repo_id = request.query_params.get("repo_id")
         repo_name = request.query_params.get("repo_name")
 
-        # prefer repo external ID to name
-        # NOTE: We filter on Repository here instead of using get b/c sometimes,
-        # we have have multiple repos for the same external_id/name that differ
-        # in other fields that differ such as 'provider' or 'config'.
+        # Neither parameter names a provider, and an external id is only unique per
+        # provider, so resolve against the repositories that actually have commits in
+        # this release. Re-linking leaves duplicates that differ in provider or config;
+        # prefer the newest.
+        release_repos = Repository.objects.filter(
+            organization_id=organization_id,
+            id__in=queryset.values("commit__repository_id"),
+            status=ObjectStatus.ACTIVE,
+        )
         if repo_id:
-            repos = Repository.objects.filter(
-                organization_id=organization_id, external_id=repo_id, status=ObjectStatus.ACTIVE
-            ).order_by("-date_added")
-
-            latest_repo = repos.first()
+            release_repos = release_repos.filter(external_id=repo_id)
+        elif repo_name:
+            release_repos = release_repos.filter(name=repo_name)
+        if repo_id or repo_name:
+            latest_repo = release_repos.order_by("-date_added").first()
             if latest_repo is None:
                 raise ResourceDoesNotExist
-
-            queryset = queryset.filter(commit__repository_id=latest_repo.id)
-
-        if repo_name:
-            repos = Repository.objects.filter(
-                organization_id=organization_id, name=repo_name, status=ObjectStatus.ACTIVE
-            ).order_by("-date_added")
-
-            latest_repo = repos.first()
-            if latest_repo is None:
-                raise ResourceDoesNotExist
-
             queryset = queryset.filter(commit__repository_id=latest_repo.id)
 
         return self.paginate(

--- a/tests/sentry/api/endpoints/test_commit_filechange.py
+++ b/tests/sentry/api/endpoints/test_commit_filechange.py
@@ -101,3 +101,52 @@ class CommitFileChangeTest(APITestCase):
             status_code=404,
             qs_params={"repo_id": "0"},
         )
+
+    def test_query_external_id_ignores_other_provider(self) -> None:
+        # External ids are only unique per provider: another provider's repo with the same
+        # id has no commits in this release and must not shadow the release's repo.
+        self.create_repo(
+            project=self.project,
+            name="other/repo",
+            provider="integrations:gitlab",
+            external_id="123",
+        )
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.release.version,
+            qs_params={"repo_id": "123"},
+        )
+
+        assert len(response.data) == 2
+
+    def test_query_external_id_with_duplicate_repos(self) -> None:
+        newest_repo = self.create_repo(
+            project=self.project,
+            name="relinked/repo",
+            provider="integrations:gitlab",
+            external_id="123",
+        )
+        commit = self.create_commit(repo=newest_repo, key="c" * 40)
+        self.create_release_commit(release=self.release, commit=commit, order=2)
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.release.version,
+            qs_params={"repo_id": "123"},
+        )
+
+        newest_repo_files = set(
+            CommitFileChange.objects.filter(commit_id=commit.id).values_list("filename", flat=True)
+        )
+        assert {change["filename"] for change in response.data} == newest_repo_files | {
+            ".gitignore",
+            "/static/js/widget.js",
+        }
+
+    def test_query_external_id_repo_without_release_commits(self) -> None:
+        self.create_repo(project=self.project, name="other/repo", external_id="456")
+        self.get_error_response(
+            self.project.organization.slug,
+            self.release.version,
+            status_code=404,
+            qs_params={"repo_id": "456"},
+        )

--- a/tests/sentry/releases/endpoints/test_project_release_commits.py
+++ b/tests/sentry/releases/endpoints/test_project_release_commits.py
@@ -123,3 +123,31 @@ class ReleaseCommitsListTest(APITestCase):
             status_code=404,
             qs_params={"repo_id": "0"},
         )
+
+    def test_query_external_id_ignores_other_provider(self) -> None:
+        # External ids are only unique per provider: another provider's repo with the same
+        # id has no commits in this release and must not shadow the release's repo.
+        self.create_repo(
+            project=self.project,
+            name="other/repo",
+            provider="integrations:gitlab",
+            external_id="123",
+        )
+        response = self.get_success_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.release.version,
+            qs_params={"repo_id": "123"},
+        )
+
+        assert len(response.data) == 2
+
+    def test_query_external_id_repo_without_release_commits(self) -> None:
+        self.create_repo(project=self.project, name="other/repo", external_id="456")
+        self.get_error_response(
+            self.project.organization.slug,
+            self.project.slug,
+            self.release.version,
+            status_code=404,
+            qs_params={"repo_id": "456"},
+        )


### PR DESCRIPTION
`Repository.external_id` is the provider's repo id, so it is only unique together with `provider`. The release commits and file-changes endpoints resolved the `repo_id` (and `repo_name`) query parameter across the whole organization: the commits endpoint took the newest matching row, and the file-changes endpoint used `.get()` and 500'd whenever two active repos shared the id or name, which re-linking a repository routinely produces.

Both now resolve the parameter against the repositories that have commits in the release, still scoped to the organization. The commits endpoint keeps its documented newest-wins rule; the file-changes endpoint includes every matching repository instead of guessing which one was meant.

One visible change: a repository that exists in the organization but has no commits in the release now 404s instead of returning `[]`. Neither parameter is in the OpenAPI schema.

One of a series scoping `external_id` lookups to their provider; the lint that catches this class is #123801 (draft).
