### PR TITLE
fix(integrations): Adopt only the provider's own repositories on relink

### DIFF
--- a/src/sentry/integrations/vsts/repository.py
+++ b/src/sentry/integrations/vsts/repository.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 class VstsRepositoryProvider(IntegrationRepositoryProvider["VstsIntegrationType"]):
     name = "Azure DevOps"
     repo_provider = IntegrationProviderSlug.AZURE_DEVOPS.value
+    legacy_provider_ids = ("visualstudio",)
 
     def get_repository_data(
         self, organization: Organization, config: MutableMapping[str, Any]

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -132,14 +132,30 @@ class IntegrationRepositoryProvider(Generic[InstT]):
         Its own rows (including plugin-era ones) and rows that never had a provider. A row
         belonging to another provider is a different repository that happens to share an
         external id, and is left alone.
+
+        Adopting rewrites ``provider`` to this provider's id, so a plugin-era or
+        provider-less row is skipped when a row already holds ``(organization, provider,
+        external_id)`` for it — whatever that row's status. That row is the repository;
+        rewriting the other would violate the unique key.
         """
-        return [
+        candidates = [
             *repository_service.get_repositories(
                 organization_id=organization_id, providers=self.owned_provider_ids, **filters
             ),
             *repository_service.get_repositories(
                 organization_id=organization_id, has_provider=False, **filters
             ),
+        ]
+        taken = {
+            repo.external_id
+            for repo in repository_service.get_repositories(
+                organization_id=organization_id,
+                providers=[self.id],
+                external_id=filters.get("external_id"),
+            )
+        }
+        return [
+            repo for repo in candidates if repo.provider == self.id or repo.external_id not in taken
         ]
 
     def create_repository(

--- a/src/sentry/plugins/providers/integration_repository.py
+++ b/src/sentry/plugins/providers/integration_repository.py
@@ -86,6 +86,10 @@ class IntegrationRepositoryProvider(Generic[InstT]):
 
     name: ClassVar[str]
     repo_provider: ClassVar[str]
+    # ``Repository.provider`` values written by the plugin that preceded this integration,
+    # where they differ from ``repo_provider``. Plugin-era rows have no integration_id and
+    # are adopted on install rather than duplicated.
+    legacy_provider_ids: ClassVar[tuple[str, ...]] = ()
 
     def __init__(self, id: str) -> None:
         self.id = id
@@ -113,6 +117,31 @@ class IntegrationRepositoryProvider(Generic[InstT]):
 
         return cast(InstT, rpc_integration.get_installation(organization_id=organization_id))
 
+    @property
+    def owned_provider_ids(self) -> list[str]:
+        """Every ``Repository.provider`` value that belongs to this provider.
+
+        An external id is only unique per provider, so lookups by external id must be
+        restricted to these or they match another provider's repository with the same id.
+        """
+        return [self.id, self.repo_provider, *self.legacy_provider_ids]
+
+    def _adoptable_repositories(self, organization_id: int, **filters: Any) -> list[RpcRepository]:
+        """Repositories this provider may take over, narrowed by ``filters``.
+
+        Its own rows (including plugin-era ones) and rows that never had a provider. A row
+        belonging to another provider is a different repository that happens to share an
+        external id, and is left alone.
+        """
+        return [
+            *repository_service.get_repositories(
+                organization_id=organization_id, providers=self.owned_provider_ids, **filters
+            ),
+            *repository_service.get_repositories(
+                organization_id=organization_id, has_provider=False, **filters
+            ),
+        ]
+
     def create_repository(
         self,
         repo_config: Mapping[str, Any],
@@ -126,15 +155,14 @@ class IntegrationRepositoryProvider(Generic[InstT]):
         url = result["url"]
 
         # first check if there is an existing hidden repository for the organization and external id
-        repositories = repository_service.get_repositories(
-            organization_id=organization.id,
-            external_id=external_id,
-            status=ObjectStatus.HIDDEN,
+        repositories = self._adoptable_repositories(
+            organization.id, external_id=external_id, status=ObjectStatus.HIDDEN
         )
         existing_repo = repositories[0] if repositories else None
         if existing_repo:
             existing_repo.status = ObjectStatus.ACTIVE
             existing_repo.name = name
+            existing_repo.provider = self.id  # a plugin-era or provider-less row is ours now
             existing_repo.integration_id = integration_id
             existing_repo.url = url
             existing_repo.config = {**existing_repo.config, **(result.get("config") or {})}
@@ -146,10 +174,8 @@ class IntegrationRepositoryProvider(Generic[InstT]):
             return result, existing_repo
 
         # then check if there is a repository without an integration that matches
-        repositories = repository_service.get_repositories(
-            organization_id=organization.id,
-            has_integration=False,
-            external_id=external_id,
+        repositories = self._adoptable_repositories(
+            organization.id, external_id=external_id, has_integration=False
         )
         repo = repositories[0] if repositories else None
 
@@ -223,6 +249,7 @@ class IntegrationRepositoryProvider(Generic[InstT]):
 
     def _update_repository(self, repo: RpcRepository, config: RepositoryConfig) -> RpcRepository:
         repo.status = ObjectStatus.ACTIVE
+        repo.provider = self.id  # a plugin-era or provider-less row is ours now
 
         new_config = config.get("config") or {}
         repo.config = {**repo.config, **new_config}
@@ -264,17 +291,11 @@ class IntegrationRepositoryProvider(Generic[InstT]):
         repos_to_update: list[RpcRepository] = []
         created_repos: list[RpcRepository] = []
 
-        hidden_repos = repository_service.get_repositories(
-            organization_id=organization.id,
-            status=ObjectStatus.HIDDEN,
-        )
+        hidden_repos = self._adoptable_repositories(organization.id, status=ObjectStatus.HIDDEN)
         repos_to_update.extend(self._update_repositories(hidden_repos, external_id_to_repo_config))
 
         # then check if there are repositories without an integration that matches
-        repositories = repository_service.get_repositories(
-            organization_id=organization.id,
-            has_integration=False,
-        )
+        repositories = self._adoptable_repositories(organization.id, has_integration=False)
         repos_to_update.extend(self._update_repositories(repositories, external_id_to_repo_config))
 
         # create remaining repositories

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -258,6 +258,49 @@ class IntegrationRepositoryTestCase(TestCase):
             assert repo.provider == "integrations:github"
             assert repo.integration_id == self.integration.id
 
+    def test_create_repository__does_not_adopt_over_an_existing_row(
+        self, get_jwt: MagicMock
+    ) -> None:
+        # A plugin-era row and the integration's own row for the same repo: adopting the
+        # former would rewrite it onto the key the latter already holds.
+        legacy = self.create_repo(
+            project=self.project,
+            name=self.repo_name,
+            provider="github",
+            external_id=self.config["external_id"],
+        )
+        existing = self._create_repo(external_id=self.config["external_id"])
+
+        with pytest.raises(RepoExistsError) as exc_info:
+            self.provider.create_repository(self.config, self.organization)
+
+        assert exc_info.value.existing_repo is not None
+        assert exc_info.value.existing_repo.id == existing.id
+        legacy.refresh_from_db()
+        assert (legacy.provider, legacy.integration_id) == ("github", None)
+
+    def test_create_repositories__does_not_adopt_over_an_existing_row(
+        self, get_jwt: MagicMock
+    ) -> None:
+        legacy = self.create_repo(
+            project=self.project,
+            name=self.repo_name,
+            provider="github",
+            external_id=self.config["external_id"],
+        )
+        legacy.update(status=ObjectStatus.HIDDEN)
+        existing = self._create_repo(external_id=self.config["external_id"])
+
+        created, reactivated, missing = self.provider.create_repositories(
+            [self.config], self.organization
+        )
+
+        assert created == []
+        assert {repo.id for repo in reactivated} == {existing.id}
+        assert missing == [self.provider.build_repository_config(self.organization, self.config)]
+        legacy.refresh_from_db()
+        assert (legacy.status, legacy.provider) == (ObjectStatus.HIDDEN, "github")
+
     def test_create_repository__ignores_unlinked_repo_of_other_provider(
         self, get_jwt: MagicMock
     ) -> None:

--- a/tests/sentry/plugins/test_integration_repository.py
+++ b/tests/sentry/plugins/test_integration_repository.py
@@ -168,6 +168,128 @@ class IntegrationRepositoryTestCase(TestCase):
         assert repo.status == ObjectStatus.ACTIVE
         mock_metrics.incr.assert_called_with("sentry.integration_repo_provider.repo_relink")
 
+    def test_create_repository__ignores_hidden_repo_of_other_provider(
+        self, get_jwt: MagicMock
+    ) -> None:
+        # External ids are only unique per provider.
+        other = self.create_repo(
+            project=self.project,
+            name="group/project",
+            provider="integrations:gitlab",
+            external_id=self.config["external_id"],
+        )
+        other.update(status=ObjectStatus.HIDDEN)
+
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.id != other.id
+        assert repo.provider == "integrations:github"
+        other.refresh_from_db()
+        assert other.status == ObjectStatus.HIDDEN
+
+    def test_create_repository__activates_hidden_repo_without_provider(
+        self, get_jwt: MagicMock
+    ) -> None:
+        orphan = self.create_repo(
+            project=self.project, name=self.repo_name, external_id=self.config["external_id"]
+        )
+        orphan.update(status=ObjectStatus.HIDDEN)
+
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.id == orphan.id
+        orphan.refresh_from_db()
+        assert orphan.status == ObjectStatus.ACTIVE
+        assert orphan.provider == "integrations:github"
+        assert orphan.integration_id == self.integration.id
+
+    def test_create_repositories__ignores_rows_of_other_provider(self, get_jwt: MagicMock) -> None:
+        # The bulk path (link_all_repos, install-change sync) matches by external id too.
+        hidden = self.create_repo(
+            project=self.project,
+            name="group/hidden",
+            provider="integrations:gitlab",
+            external_id=self.config["external_id"],
+        )
+        hidden.update(status=ObjectStatus.HIDDEN)
+        unlinked = self.create_repo(
+            project=self.project,
+            name="group/unlinked",
+            provider="gitlab",
+            external_id="999",
+        )
+        other_config = {**self.config, "external_id": "999", "identifier": "getsentry/other"}
+
+        created, reactivated, missing = self.provider.create_repositories(
+            [self.config, other_config], self.organization
+        )
+
+        assert {repo.external_id for repo in created} == {self.config["external_id"], "999"}
+        assert reactivated == []
+        assert missing == []
+        hidden.refresh_from_db()
+        unlinked.refresh_from_db()
+        assert (hidden.status, hidden.provider) == (ObjectStatus.HIDDEN, "integrations:gitlab")
+        assert (unlinked.integration_id, unlinked.provider) == (None, "gitlab")
+
+    def test_create_repositories__adopts_own_and_provider_less_rows(
+        self, get_jwt: MagicMock
+    ) -> None:
+        hidden = self.create_repo(
+            project=self.project,
+            name=self.repo_name,
+            provider="integrations:github",
+            external_id=self.config["external_id"],
+        )
+        hidden.update(status=ObjectStatus.HIDDEN)
+        orphan = self.create_repo(project=self.project, name="getsentry/other", external_id="999")
+        other_config = {**self.config, "external_id": "999", "identifier": "getsentry/other"}
+
+        created, reactivated, missing = self.provider.create_repositories(
+            [self.config, other_config], self.organization
+        )
+
+        assert created == []
+        assert {repo.id for repo in reactivated} == {hidden.id, orphan.id}
+        assert missing == []
+        for repo in (hidden, orphan):
+            repo.refresh_from_db()
+            assert repo.status == ObjectStatus.ACTIVE
+            assert repo.provider == "integrations:github"
+            assert repo.integration_id == self.integration.id
+
+    def test_create_repository__ignores_unlinked_repo_of_other_provider(
+        self, get_jwt: MagicMock
+    ) -> None:
+        other = self.create_repo(
+            project=self.project,
+            name="group/project",
+            provider="gitlab",
+            external_id=self.config["external_id"],
+        )
+
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.id != other.id
+        other.refresh_from_db()
+        assert other.provider == "gitlab"
+        assert other.integration_id is None
+
+    def test_create_repository__adopts_plugin_era_repo(self, get_jwt: MagicMock) -> None:
+        legacy = self.create_repo(
+            project=self.project,
+            name=self.repo_name,
+            provider="github",
+            external_id=self.config["external_id"],
+        )
+
+        _, repo = self.provider.create_repository(self.config, self.organization)
+
+        assert repo.id == legacy.id
+        legacy.refresh_from_db()
+        assert legacy.provider == "integrations:github"
+        assert legacy.integration_id == self.integration.id
+
     def test_create_repository__only_activates_hidden_repo(self, get_jwt: MagicMock) -> None:
         repo = self._create_repo(external_id=self.config["external_id"])
         repo.status = ObjectStatus.PENDING_DELETION


### PR DESCRIPTION
`Repository.external_id` is only unique together with `provider`, but `IntegrationRepositoryProvider` reactivated a hidden repository, or adopted one without an integration, by external id alone. That happens in the single-repo path (`create_repository`) and in the bulk path behind `link_all_repos` and the install-change sync (`create_repositories`, which loaded every hidden or unlinked repo in the org and matched them in Python). Installing GitHub could therefore rewrite a GitLab row with the same id into a GitHub one, and the adopted row kept its old provider.

Both paths now consider only rows the provider owns (its `integrations:` id, the bare id, and the plugin-era id where it differs, e.g. `visualstudio` for VSTS) or rows that never had a provider, and an adopted row takes the adopting provider.

Tests cover the other-provider row being left alone, plugin-era and provider-less rows being adopted, and the bulk path.

One of a series scoping `external_id` lookups to their provider; the lint that catches this class is #123801 (draft).
