### PR TITLE
fix(msteams): Scope identity lookups to the provider

### DIFF
--- a/src/sentry/integrations/messaging/linkage.py
+++ b/src/sentry/integrations/messaging/linkage.py
@@ -314,7 +314,11 @@ class UnlinkIdentityView(IdentityLinkageView, ABC):
         if isinstance(request.user, AnonymousUser):
             raise TypeError("Cannot link identity without a logged-in user")
         try:
-            identities = Identity.objects.filter(external_id=external_id)
+            # The signed link may predate idp resolution (MS Teams signs no integration_id),
+            # so the provider type is the narrowest scope every caller can guarantee.
+            identities = Identity.objects.filter(
+                external_id=external_id, idp__type=self.provider_slug
+            )
             if idp is not None:
                 identities = identities.filter(idp=idp)
             if self.filter_by_user_id:

--- a/src/sentry/integrations/messaging/linkage.py
+++ b/src/sentry/integrations/messaging/linkage.py
@@ -314,13 +314,15 @@ class UnlinkIdentityView(IdentityLinkageView, ABC):
         if isinstance(request.user, AnonymousUser):
             raise TypeError("Cannot link identity without a logged-in user")
         try:
-            # The signed link may predate idp resolution (MS Teams signs no integration_id),
-            # so the provider type is the narrowest scope every caller can guarantee.
-            identities = Identity.objects.filter(
-                external_id=external_id, idp__type=self.provider_slug
-            )
             if idp is not None:
-                identities = identities.filter(idp=idp)
+                identities = Identity.objects.filter(external_id=external_id, idp=idp)
+            else:
+                # MS Teams signs no integration_id, so the provider type is the narrowest
+                # scope left. Only here: a resolved idp may be a variant such as
+                # `slack_staging`, which the view's spec slug would not match.
+                identities = Identity.objects.filter(
+                    external_id=external_id, idp__type=self.provider_slug
+                )
             if self.filter_by_user_id:
                 identities = identities.filter(user_id=request.user.id)
             if self.no_identity_template and not identities:

--- a/src/sentry/integrations/msteams/webhook.py
+++ b/src/sentry/integrations/msteams/webhook.py
@@ -720,7 +720,10 @@ class MsTeamsCommandDispatcher(MessagingIntegrationCommandDispatcher[AdaptiveCar
 
     def link_user_handler(self, input: CommandInput) -> IntegrationResponse[AdaptiveCard]:
         linked_identity = identity_service.get_identity(
-            filter={"identity_ext_id": self.teams_user_id}
+            filter={
+                "identity_ext_id": self.teams_user_id,
+                "provider_type": IntegrationProviderSlug.MSTEAMS.value,
+            }
         )
         has_linked_identity = linked_identity is not None
 

--- a/tests/sentry/integrations/msteams/test_unlink_identity.py
+++ b/tests/sentry/integrations/msteams/test_unlink_identity.py
@@ -118,3 +118,23 @@ class MsTeamsIntegrationUnlinkIdentityTest(TestCase):
 
         assert len(identity) == 1
         assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_keeps_identity_of_other_provider(self) -> None:
+        # Identity external ids are only unique per provider.
+        teams_user_id = "my-teams-user-id"
+        self.create_identity(user=self.user1, identity_provider=self.idp, external_id=teams_user_id)
+        slack_idp = self.create_identity_provider(type="slack", external_id="TXXXXXXXX")
+        slack_identity = self.create_identity(
+            user=self.user1, identity_provider=slack_idp, external_id=teams_user_id
+        )
+
+        unlink_url = build_unlinking_url(
+            self.conversation_id, "https://smba.trafficmanager.net/amer", teams_user_id
+        )
+        resp = self.client.post(unlink_url)
+
+        assert resp.status_code == 200
+        self.assertTemplateUsed(resp, "sentry/integrations/msteams/unlinked.html")
+        assert not Identity.objects.filter(idp=self.idp, external_id=teams_user_id).exists()
+        assert Identity.objects.filter(id=slack_identity.id).exists()

--- a/tests/sentry/integrations/msteams/test_webhook.py
+++ b/tests/sentry/integrations/msteams/test_webhook.py
@@ -557,6 +557,51 @@ class MsTeamsWebhookTest(APITestCase):
         assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
 
     @responses.activate
+    @mock.patch("sentry.integrations.utils.metrics.EventLifecycle.record_event")
+    @mock.patch("sentry.utils.jwt.decode")
+    @mock.patch("time.time")
+    def test_link_command_identity_under_other_provider(
+        self, mock_time: MagicMock, mock_decode: MagicMock, mock_record: MagicMock
+    ) -> None:
+        """Identity external ids are only unique per provider: a Slack identity with the
+        same id is not an existing MS Teams link."""
+        other_command = deepcopy(EXAMPLE_UNLINK_COMMAND)
+        other_command["text"] = "link"
+        with assume_test_silo_mode(SiloMode.CONTROL):
+            idp = self.create_identity_provider(type="slack", external_id="TXXXXXXXX")
+            self.create_identity(
+                user=self.user, identity_provider=idp, external_id=other_command["from"]["id"]
+            )
+        access_json = {"expires_in": 86399, "access_token": "my_token"}
+        responses.add(
+            responses.POST,
+            "https://login.microsoftonline.com/botframework.com/oauth2/v2.0/token",
+            json=access_json,
+        )
+        responses.add(
+            responses.POST,
+            "https://smba.trafficmanager.net/amer/v3/conversations/%s/activities"
+            % other_command["conversation"]["id"],
+            json={},
+        )
+        mock_time.return_value = 1594839999 + 60
+        mock_decode.return_value = DECODED_TOKEN
+        resp = self.client.post(
+            path=webhook_url,
+            data=other_command,
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {TOKEN}",
+        )
+
+        assert resp.status_code == 204
+        assert (
+            "Your Microsoft Teams identity will be linked to your Sentry account"
+            in responses.calls[3].request.body.decode("utf-8")
+        )
+
+        assert_slo_metric(mock_record, EventLifecycleOutcome.SUCCESS)
+
+    @responses.activate
     @mock.patch("sentry.utils.jwt.decode")
     @mock.patch("time.time")
     def test_other_command(self, mock_time: MagicMock, mock_decode: MagicMock) -> None:

--- a/tests/sentry/integrations/slack/test_link_identity.py
+++ b/tests/sentry/integrations/slack/test_link_identity.py
@@ -304,6 +304,28 @@ class SlackIntegrationUnlinkIdentityTest(SlackIntegrationLinkIdentityTestBase):
         assert not Identity.objects.filter(external_id="new-slack-id", user=self.user).exists()
         assert self.mock_webhook.call_count == 1
 
+    def test_unlinks_staging_identity(self) -> None:
+        # The Slack identity provider registers some identities as `slack_staging`; the
+        # resolved idp, not the view's `slack` slug, must scope the delete.
+        staging = self.create_provider_integration(
+            provider="slack_staging", external_id="TSTAGING", metadata=self.integration.metadata
+        )
+        self.create_organization_integration(
+            organization_id=self.organization.id, integration=staging
+        )
+        staging_idp = self.create_identity_provider(type="slack_staging", external_id="TSTAGING")
+        self.create_identity(
+            user=self.user, identity_provider=staging_idp, external_id="staging-slack-id"
+        )
+
+        response = self.client.post(
+            build_unlinking_url(staging.id, "staging-slack-id", self.channel_id, self.response_url)
+        )
+
+        assert response.status_code == 200
+        assert not Identity.objects.filter(idp=staging_idp, external_id="staging-slack-id").exists()
+        assert Identity.objects.filter(idp=self.idp, external_id=self.external_id).exists()
+
     def test_user_with_multiple_organizations(self) -> None:
         # Create a second organization where the user is _not_ a member.
         self.create_organization_integration(


### PR DESCRIPTION
`Identity.external_id` is the messaging provider's user id, so it is only unique together with the identity provider. Two MS Teams paths ignored that:

- The unlink view deleted every identity sharing the external id, whatever its provider. Its signed link carries no idp (Slack's and Discord's do), so the delete is now scoped by provider type, the narrowest scope every caller can guarantee.
- The `link` command treated a Slack identity with the same id as an existing Teams link and answered "already linked". It now asks for MS Teams identities only.

Tests add a Slack identity with the same external id and check it survives the unlink and does not count as a link.

One of a series scoping `external_id` lookups to their provider; the lint that catches this class is #123801 (draft).
