### PR TITLE
fix(releases): Match commit authors to user mappings of the same provider

### DIFF
--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -238,9 +238,12 @@ def get_author_users_by_external_actors(
     # external_id is "<provider>:<login>", so a mapping only counts for the same provider.
     authors_by_mapping: dict[tuple[int, str], CommitAuthor] = {}
     for author in authors:
-        provider = EXTERNAL_PROVIDERS_REVERSE_VALUES.get(author.get_provider_from_external_id())
+        provider_slug = author.get_provider_from_external_id()
         username = author.get_username_from_external_id()
-        if provider is not None and username:
+        if provider_slug is None or not username:
+            continue
+        provider = EXTERNAL_PROVIDERS_REVERSE_VALUES.get(provider_slug)
+        if provider is not None:
             authors_by_mapping[(provider.value, f"@{username}")] = author
 
     if not authors_by_mapping:

--- a/src/sentry/api/serializers/models/release.py
+++ b/src/sentry/api/serializers/models/release.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
 import datetime
+import operator
 from collections import defaultdict
 from collections.abc import Mapping, Sequence
+from functools import reduce
 from typing import Any, NotRequired, TypedDict
 
 from django.contrib.auth.models import AnonymousUser
 from django.core.cache import cache
-from django.db.models import Sum
+from django.db.models import Q, Sum
 
 from sentry import release_health, tagstore
 from sentry.api.serializers import Serializer, register, serialize
@@ -17,6 +19,7 @@ from sentry.api.serializers.types import (
     ReleaseSerializerResponse,
 )
 from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import EXTERNAL_PROVIDERS_REVERSE_VALUES
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.deploy import Deploy
@@ -231,25 +234,37 @@ def get_author_users_by_external_actors(
 ) -> tuple[dict[CommitAuthor, str], list[CommitAuthor]]:
     found: dict[CommitAuthor, str] = {}
 
-    usernames_to_authors: dict[str, CommitAuthor] = {}
+    # An ExternalActor's "@login" is only unique within its provider, and a CommitAuthor's
+    # external_id is "<provider>:<login>", so a mapping only counts for the same provider.
+    authors_by_mapping: dict[tuple[int, str], CommitAuthor] = {}
     for author in authors:
+        provider = EXTERNAL_PROVIDERS_REVERSE_VALUES.get(author.get_provider_from_external_id())
         username = author.get_username_from_external_id()
-        if username:
-            # ExternalActor.external_name includes @ prefix
-            # (e.g., "@username") for GitHub and GitLab
-            usernames_to_authors[f"@{username}"] = author
+        if provider is not None and username:
+            authors_by_mapping[(provider.value, f"@{username}")] = author
 
-    if not usernames_to_authors:
+    if not authors_by_mapping:
         return found, authors
+
+    names_by_provider: dict[int, list[str]] = defaultdict(list)
+    for provider_value, external_name in authors_by_mapping:
+        names_by_provider[provider_value].append(external_name)
+    mapping_filter = reduce(
+        operator.or_,
+        (
+            Q(provider=provider_value, external_name__in=names)
+            for provider_value, names in names_by_provider.items()
+        ),
+    )
 
     external_actors = (
         ExternalActor.objects.filter(
-            external_name__in=list(usernames_to_authors.keys()),
+            mapping_filter,
             organization_id=organization_id,
             user_id__isnull=False,  # excludes team mappings
         )
         .order_by("id")
-        .values_list("user_id", "external_name")
+        .values_list("user_id", "external_name", "provider")
     )
 
     if not external_actors:
@@ -257,9 +272,9 @@ def get_author_users_by_external_actors(
 
     missed: dict[int, CommitAuthor] = {a.id: a for a in authors}
 
-    for user_id, external_name in external_actors:
-        if external_name in usernames_to_authors:
-            found_author = usernames_to_authors[external_name]
+    for user_id, external_name, provider_value in external_actors:
+        found_author = authors_by_mapping.get((provider_value, external_name))
+        if found_author is not None:
             found[found_author] = str(user_id)
             missed.pop(found_author.id, None)
 

--- a/src/sentry/models/commitauthor.py
+++ b/src/sentry/models/commitauthor.py
@@ -84,3 +84,11 @@ class CommitAuthor(Model):
             if self.external_id and ":" in self.external_id
             else None
         )
+
+    def get_provider_from_external_id(self) -> str | None:
+        """The provider that issued the login in ``external_id`` (``github:login`` -> ``github``)."""
+        return (
+            self.external_id.split(":", 1)[0]
+            if self.external_id and ":" in self.external_id
+            else None
+        )

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -12,6 +12,7 @@ from sentry.api.endpoints.organization_releases import ReleaseSerializerWithProj
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.release import GroupEventReleaseSerializer, get_users_for_authors
 from sentry.integrations.models.external_actor import ExternalActor
+from sentry.integrations.types import ExternalProviders
 from sentry.models.commit import Commit
 from sentry.models.commitauthor import CommitAuthor
 from sentry.models.deploy import Deploy
@@ -975,6 +976,67 @@ class GetUsersForAuthorsUserMappingsTest(TestCase):
         assert users[str(author.id)].get("id", "not present") == str(user.id)
         assert users[str(author.id)]["email"] == "john@company.com"
         assert users[str(author.id)]["name"] == "John Smith"
+
+    def test_get_users_for_authors_ignores_mapping_of_other_provider(self) -> None:
+        """An @login is only unique per provider: a GitLab mapping must not claim a GitHub author."""
+        gitlab_user = self.create_user(email="gl-octocat@company.com", name="GitLab Octocat")
+        project = self.create_project()
+        self.create_member(user=gitlab_user, organization=project.organization)
+        gitlab = self.create_provider_integration(provider="gitlab")
+        self.create_organization_integration(
+            organization_id=project.organization_id, integration_id=gitlab.id
+        )
+        self.create_external_user(
+            user=gitlab_user,
+            organization=project.organization,
+            integration=gitlab,
+            external_name="@octocat",
+            provider=ExternalProviders.GITLAB.value,
+        )
+        author = self.create_commit_author(
+            organization_id=project.organization_id, email="1+octocat@users.noreply.github.com"
+        )
+        author.update(name="Octocat", external_id="github:octocat")
+
+        users = get_users_for_authors(organization_id=project.organization_id, authors=[author])
+
+        assert users[str(author.id)].get("id", "not present") == "not present"
+        assert users[str(author.id)]["email"] == author.email
+
+    def test_get_users_for_authors_picks_mapping_of_same_provider(self) -> None:
+        github_user = self.create_user(email="gh-hubot@company.com", name="GitHub Hubot")
+        gitlab_user = self.create_user(email="gl-hubot@company.com", name="GitLab Hubot")
+        project = self.create_project()
+        github = self.create_provider_integration(provider="github")
+        gitlab = self.create_provider_integration(provider="gitlab")
+        for user in (github_user, gitlab_user):
+            self.create_member(user=user, organization=project.organization)
+        for integration in (github, gitlab):
+            self.create_organization_integration(
+                organization_id=project.organization_id, integration_id=integration.id
+            )
+        self.create_external_user(
+            user=gitlab_user,
+            organization=project.organization,
+            integration=gitlab,
+            external_name="@hubot",
+            provider=ExternalProviders.GITLAB.value,
+        )
+        self.create_external_user(
+            user=github_user,
+            organization=project.organization,
+            integration=github,
+            external_name="@hubot",
+            provider=ExternalProviders.GITHUB.value,
+        )
+        author = self.create_commit_author(
+            organization_id=project.organization_id, email="2+hubot@users.noreply.github.com"
+        )
+        author.update(name="Hubot", external_id="github:hubot")
+
+        users = get_users_for_authors(organization_id=project.organization_id, authors=[author])
+
+        assert users[str(author.id)]["id"] == str(github_user.id)
 
     def test_get_users_for_authors_by_external_actor_no_user_id(self) -> None:
         """CommitAuthor has an ExternalActor but it's a team mapping"""

--- a/tests/sentry/api/serializers/test_release.py
+++ b/tests/sentry/api/serializers/test_release.py
@@ -1036,7 +1036,7 @@ class GetUsersForAuthorsUserMappingsTest(TestCase):
 
         users = get_users_for_authors(organization_id=project.organization_id, authors=[author])
 
-        assert users[str(author.id)]["id"] == str(github_user.id)
+        assert users[str(author.id)].get("id") == str(github_user.id)
 
     def test_get_users_for_authors_by_external_actor_no_user_id(self) -> None:
         """CommitAuthor has an ExternalActor but it's a team mapping"""

--- a/tests/sentry/models/test_commitauthor.py
+++ b/tests/sentry/models/test_commitauthor.py
@@ -23,3 +23,17 @@ class CommitAuthorUsernameExtractionTest(SimpleTestCase):
     def test_get_username_from_external_id_multiple_colons(self) -> None:
         author = CommitAuthor(external_id="provider:user:with:colons")
         assert author.get_username_from_external_id() == "user:with:colons"
+
+
+class CommitAuthorProviderExtractionTest(SimpleTestCase):
+    def test_get_provider_from_external_id(self) -> None:
+        author = CommitAuthor(external_id="github_enterprise:baxterthehacker")
+        assert author.get_provider_from_external_id() == "github_enterprise"
+
+    def test_get_provider_from_external_id_no_external_id(self) -> None:
+        author = CommitAuthor(external_id=None)
+        assert author.get_provider_from_external_id() is None
+
+    def test_get_provider_from_external_id_no_colon(self) -> None:
+        author = CommitAuthor(external_id="justausername")
+        assert author.get_provider_from_external_id() is None


### PR DESCRIPTION
`ExternalActor.external_name` is an `@login`, unique only within its provider. Release author resolution (`get_users_for_authors`) matched a commit author's login against mappings of every provider, so a GitHub commit author could be attributed to whoever had the same login mapped on GitLab. A `CommitAuthor.external_id` is `<provider>:<login>`, so the lookup is now scoped to that provider, via a small `CommitAuthor.get_provider_from_external_id()` next to the existing username helper.

Tests: a GitLab mapping with the same login does not claim a GitHub author; with both mapped, the GitHub one wins.

One of a series scoping `external_id` lookups to their provider; the lint that catches this class is #123801 (draft).
