### PR TITLE
test(auth): Drop redundant account settings assertion

### DIFF
--- a/static/app/views/authV2/authLogin/index.spec.tsx
+++ b/static/app/views/authV2/authLogin/index.spec.tsx
@@ -174,9 +174,6 @@ describe('AuthLogin', () => {
     expect(screen.queryByRole('textbox', {name: 'Email'})).not.toBeInTheDocument();
     expect(screen.queryByLabelText('Password')).not.toBeInTheDocument();
     expect(
-      screen.queryByRole('button', {name: 'Account Settings'})
-    ).not.toBeInTheDocument();
-    expect(
       screen.queryByRole('button', {name: 'Clear organization login context'})
     ).not.toBeInTheDocument();
     expect(testableWindowLocation.assign).not.toHaveBeenCalled();


### PR DESCRIPTION
The organization SSO test only needs to verify the authentication controls available in that state. Drop the redundant Account Settings absence assertion.