### PR TITLE
chore(workflow-engine): More logging to diagnose missing detectors

### DIFF
--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -54,14 +54,6 @@ def connect_workflows_to_issue_stream(
     )
 
 
-def connect_workflows_to_detector(
-    detector: Detector,
-    workflows: list[Workflow],
-) -> Sequence[DetectorWorkflow]:
-    connections = [DetectorWorkflow(workflow=workflow, detector=detector) for workflow in workflows]
-    return DetectorWorkflow.objects.bulk_create(connections, ignore_conflicts=True)
-
-
 def create_priority_workflow(org: Organization) -> Workflow:
     with transaction.atomic(router.db_for_write(Workflow)):
         when_condition_group = DataConditionGroup.objects.create(

--- a/src/sentry/workflow_engine/receivers/organization_detectors.py
+++ b/src/sentry/workflow_engine/receivers/organization_detectors.py
@@ -15,22 +15,27 @@ logger = logging.getLogger(__name__)
 
 
 def create_organization_detectors(organization: Organization, **kwargs: Any) -> dict[str, Detector]:
-    log_name = "organization_created.create_organization_detectors"
-    log_extra = {"organization_id": organization.id}
-    logger.info(f"{log_name}.start", extra=log_extra)
+    logger.info(
+        "organization_created.create_organization_detectors.start",
+        extra={"organization_id": organization.id},
+    )
     try:
         results = ensure_default_organization_detectors(organization)
         logger.info(
-            f"{log_name}.success",
+            "organization_created.create_organization_detectors.success",
             extra={
-                **log_extra,
+                "organization_id": organization.id,
                 "detector_ids": [detector.id for detector in results.values()],
             },
         )
         return results
     except (UnableToAcquireLockApiError, Detector.MultipleObjectsReturned) as e:
         sentry_sdk.capture_exception(e)
-        logger.info(f"{log_name}.failure", extra=log_extra, exc_info=e)
+        logger.info(
+            "organization_created.create_organization_detectors.failure",
+            extra={"organization_id": organization.id},
+            exc_info=e,
+        )
     return {}
 
 

--- a/src/sentry/workflow_engine/receivers/organization_detectors.py
+++ b/src/sentry/workflow_engine/receivers/organization_detectors.py
@@ -15,22 +15,22 @@ logger = logging.getLogger(__name__)
 
 
 def create_organization_detectors(organization: Organization, **kwargs: Any) -> dict[str, Detector]:
-    logging_name = "organization_created.create_organization_detectors"
-    logging_extra = {"organization_id": organization.id}
-    logging.info(f"{logging_name}.start", extra=logging_extra)
+    log_name = "organization_created.create_organization_detectors"
+    log_extra = {"organization_id": organization.id}
+    logger.info(f"{log_name}.start", extra=log_extra)
     try:
         results = ensure_default_organization_detectors(organization)
-        logging.info(
-            f"{logging_name}.success",
+        logger.info(
+            f"{log_name}.success",
             extra={
-                **logging_extra,
+                **log_extra,
                 "detector_ids": [detector.id for detector in results.values()],
             },
         )
         return results
     except (UnableToAcquireLockApiError, Detector.MultipleObjectsReturned) as e:
         sentry_sdk.capture_exception(e)
-        logging.info(f"{logging_name}.failure", extra=logging_extra, exc_info=e)
+        logger.info(f"{log_name}.failure", extra=log_extra, exc_info=e)
     return {}
 
 

--- a/src/sentry/workflow_engine/receivers/organization_detectors.py
+++ b/src/sentry/workflow_engine/receivers/organization_detectors.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import sentry_sdk
@@ -10,12 +11,26 @@ from sentry.workflow_engine.defaults.detectors import (
 )
 from sentry.workflow_engine.models import Detector
 
+logger = logging.getLogger(__name__)
+
 
 def create_organization_detectors(organization: Organization, **kwargs: Any) -> dict[str, Detector]:
+    logging_name = "organization_created.create_organization_detectors"
+    logging_extra = {"organization_id": organization.id}
+    logging.info(f"{logging_name}.start", extra=logging_extra)
     try:
-        return ensure_default_organization_detectors(organization)
+        results = ensure_default_organization_detectors(organization)
+        logging.info(
+            f"{logging_name}.success",
+            extra={
+                **logging_extra,
+                "detector_ids": [detector.id for detector in results.values()],
+            },
+        )
+        return results
     except (UnableToAcquireLockApiError, Detector.MultipleObjectsReturned) as e:
         sentry_sdk.capture_exception(e)
+        logging.info(f"{logging_name}.failure", extra=logging_extra, exc_info=e)
     return {}
 
 

--- a/src/sentry/workflow_engine/receivers/organization_workflows.py
+++ b/src/sentry/workflow_engine/receivers/organization_workflows.py
@@ -15,14 +15,18 @@ logger = logging.getLogger(__name__)
 
 
 def create_organization_workflows(organization: Organization, **kwargs: Any) -> None:
-    log_name = "organization_created.create_organization_workflows"
-    log_extra = {"organization_id": organization.id}
-    logger.info(f"{log_name}.start", extra=log_extra)
+    logger.info(
+        "organization_created.create_organization_workflows.start",
+        extra={"organization_id": organization.id},
+    )
     try:
         workflows = ensure_default_organization_workflows(organization)
         logger.info(
-            f"{log_name}.success",
-            extra={**log_extra, "workflow_ids": [workflow.id for workflow in workflows]},
+            "organization_created.create_organization_workflows.success",
+            extra={
+                "organization_id": organization.id,
+                "workflow_ids": [workflow.id for workflow in workflows],
+            },
         )
     except (
         UnableToAcquireLockApiError,
@@ -30,7 +34,11 @@ def create_organization_workflows(organization: Organization, **kwargs: Any) -> 
         Workflow.MultipleObjectsReturned,
     ) as e:
         sentry_sdk.capture_exception(e)
-        logger.info(f"{log_name}.failure", extra=log_extra, exc_info=e)
+        logger.info(
+            "organization_created.create_organization_workflows.failure",
+            extra={"organization_id": organization.id},
+            exc_info=e,
+        )
 
 
 organization_created.connect(

--- a/src/sentry/workflow_engine/receivers/organization_workflows.py
+++ b/src/sentry/workflow_engine/receivers/organization_workflows.py
@@ -15,14 +15,14 @@ logger = logging.getLogger(__name__)
 
 
 def create_organization_workflows(organization: Organization, **kwargs: Any) -> None:
-    logging_name = "organization_created.create_organization_workflows"
-    logging_extra = {"organization_id": organization.id}
-    logging.info(f"{logging_name}.start", extra=logging_extra)
+    log_name = "organization_created.create_organization_workflows"
+    log_extra = {"organization_id": organization.id}
+    logger.info(f"{log_name}.start", extra=log_extra)
     try:
         workflows = ensure_default_organization_workflows(organization)
-        logging.info(
-            f"{logging_name}.success",
-            extra={**logging_extra, "workflow_ids": [workflow.id for workflow in workflows]},
+        logger.info(
+            f"{log_name}.success",
+            extra={**log_extra, "workflow_ids": [workflow.id for workflow in workflows]},
         )
     except (
         UnableToAcquireLockApiError,
@@ -30,7 +30,7 @@ def create_organization_workflows(organization: Organization, **kwargs: Any) -> 
         Workflow.MultipleObjectsReturned,
     ) as e:
         sentry_sdk.capture_exception(e)
-        logging.info(f"{logging_name}.success", extra=logging_extra, exc_info=e)
+        logger.info(f"{log_name}.failure", extra=log_extra, exc_info=e)
 
 
 organization_created.connect(

--- a/src/sentry/workflow_engine/receivers/organization_workflows.py
+++ b/src/sentry/workflow_engine/receivers/organization_workflows.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 import sentry_sdk
@@ -10,16 +11,26 @@ from sentry.workflow_engine.defaults.detectors import (
 from sentry.workflow_engine.defaults.workflows import ensure_default_organization_workflows
 from sentry.workflow_engine.models import Detector, Workflow
 
+logger = logging.getLogger(__name__)
+
 
 def create_organization_workflows(organization: Organization, **kwargs: Any) -> None:
+    logging_name = "organization_created.create_organization_workflows"
+    logging_extra = {"organization_id": organization.id}
+    logging.info(f"{logging_name}.start", extra=logging_extra)
     try:
-        ensure_default_organization_workflows(organization)
+        workflows = ensure_default_organization_workflows(organization)
+        logging.info(
+            f"{logging_name}.success",
+            extra={**logging_extra, "workflow_ids": [workflow.id for workflow in workflows]},
+        )
     except (
         UnableToAcquireLockApiError,
         Detector.MultipleObjectsReturned,
         Workflow.MultipleObjectsReturned,
     ) as e:
         sentry_sdk.capture_exception(e)
+        logging.info(f"{logging_name}.success", extra=logging_extra, exc_info=e)
 
 
 organization_created.connect(


### PR DESCRIPTION
Making sure these signals are firing in production, since quite a few orgs still lack detectors after the backfill even though these signals are hooked up. May follow up with a health check endpoint to create these easily for orgs who somehow lack them (would help self hosted as well)

also noticed some dead code (`connect_workflows_to_detector`)