### PR TITLE
chore(hybridcloud): remove the deletion watermark cutover options

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2577,16 +2577,6 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
-register(
-    "hybrid_cloud.write_deletion_watermark_to_postgres",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
-    "hybrid_cloud.read_deletion_watermark_from_postgres",
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
 
 # List of event IDs to pass through
 register(


### PR DESCRIPTION
Blocked on https://github.com/getsentry/getsentry/pull/21873

Last of three PRs retiring `hybrid_cloud.write_deletion_watermark_to_postgres` and `hybrid_cloud.read_deletion_watermark_from_postgres`.

Refs INFRENG-589
