### PR TITLE
fix(onboarding): Make the SCM create project view an accessible form

### DIFF
--- a/static/app/components/onboarding/scm/scmCardButton.tsx
+++ b/static/app/components/onboarding/scm/scmCardButton.tsx
@@ -1,11 +1,6 @@
 import styled from '@emotion/styled';
 
-/**
- * A button with all default browser styling removed.
- * Use when wrapping a Container or other visual primitive that
- * provides its own appearance but needs click/keyboard semantics.
- */
-export const ScmCardButton = styled('button')`
+const CardButton = styled('button')`
   appearance: none;
   background: transparent;
   border: none;
@@ -17,3 +12,19 @@ export const ScmCardButton = styled('button')`
     cursor: not-allowed;
   }
 `;
+
+/**
+ * A button with all default browser styling removed.
+ * Use when wrapping a Container or other visual primitive that
+ * provides its own appearance but needs click/keyboard semantics.
+ *
+ * Defaults to `type="button"` so a card inside a form (see
+ * ScmCreateProject) neither submits it on click nor becomes the form's
+ * default button for Enter in a text field.
+ */
+export function ScmCardButton({
+  type = 'button',
+  ...props
+}: React.ComponentProps<typeof CardButton>) {
+  return <CardButton type={type} {...props} />;
+}

--- a/static/app/components/onboarding/scm/scmProjectDetailsCore.spec.tsx
+++ b/static/app/components/onboarding/scm/scmProjectDetailsCore.spec.tsx
@@ -22,18 +22,17 @@ function renderCore(overrides: Partial<CoreProps> = {}) {
 }
 
 describe('ScmProjectDetailsCore', () => {
-  it('renders the project name and team fields', () => {
+  it('labels the project name and team fields', () => {
     renderCore();
 
-    expect(screen.getByText('Project name')).toBeInTheDocument();
-    expect(screen.getByText('Team')).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-project');
+    expect(screen.getByRole('textbox', {name: 'Project name'})).toHaveValue('my-project');
+    expect(screen.getByRole('textbox', {name: 'Team'})).toBeInTheDocument();
   });
 
   it('hides the team selector for a no-access member', () => {
     renderCore({isOrgMemberWithNoAccess: true});
 
-    expect(screen.getByText('Project name')).toBeInTheDocument();
-    expect(screen.queryByText('Team')).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Project name'})).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', {name: 'Team'})).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/onboarding/scm/scmProjectDetailsCore.tsx
+++ b/static/app/components/onboarding/scm/scmProjectDetailsCore.tsx
@@ -1,6 +1,8 @@
+import {useId} from 'react';
+
 import {Input} from '@sentry/scraps/input';
 import {Container, Grid, Stack} from '@sentry/scraps/layout';
-import {Heading, Text} from '@sentry/scraps/text';
+import {Text} from '@sentry/scraps/text';
 
 import {TeamSelector} from 'sentry/components/teamSelector';
 import {t} from 'sentry/locale';
@@ -29,15 +31,21 @@ export function ScmProjectDetailsCore({
   projectName,
   teamSlug,
 }: ScmProjectDetailsCoreProps) {
+  const projectNameId = useId();
+  const teamId = useId();
+
   return (
     <Grid width="100%" columns={{zero: '1fr', '3xl': '1fr 1fr'}} gap="xl">
       <Stack gap="md">
         <Container>
-          <Heading as="h4">{t('Project name')}</Heading>
+          <Text as="label" htmlFor={projectNameId} bold size="md">
+            {t('Project name')}
+          </Text>
         </Container>
 
         <Stack gap="xs">
           <Input
+            id={projectNameId}
             type="text"
             placeholder={t('project-name')}
             value={projectName}
@@ -55,14 +63,16 @@ export function ScmProjectDetailsCore({
       {!isOrgMemberWithNoAccess && (
         <Stack gap="md">
           <Container>
-            <Heading as="h4">{t('Team')}</Heading>
+            <Text as="label" htmlFor={teamId} bold size="md">
+              {t('Team')}
+            </Text>
           </Container>
 
           <Stack gap="xs">
             <TeamSelector
               allowCreate
+              inputId={teamId}
               name="team"
-              aria-label={t('Select a Team')}
               clearable={false}
               placeholder={t('Select a Team')}
               teamFilter={(tm: Team) => tm.access.includes('team:admin')}

--- a/static/app/views/projectInstall/scmCreateProject.spec.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.spec.tsx
@@ -322,7 +322,7 @@ describe('ScmCreateProject', () => {
     // platform, and project-details sections are all present at once.
     expect(await screen.findByRole('heading', {name: 'Repository'})).toBeInTheDocument();
     expect(screen.getByRole('heading', {name: 'Platform'})).toBeInTheDocument();
-    expect(screen.getByRole('heading', {name: 'Project name'})).toBeInTheDocument();
+    expect(screen.getByRole('textbox', {name: 'Project name'})).toBeInTheDocument();
 
     // Nothing is filled in yet, so the primary action stays disabled.
     expect(screen.getByRole('button', {name: 'Create project'})).toBeDisabled();
@@ -389,7 +389,7 @@ describe('ScmCreateProject', () => {
 
     const projectName = screen.getByPlaceholderText('project-name');
     expect(projectName).toHaveValue('python-django');
-    await userEvent.type(screen.getByLabelText('Select a Team'), '{keyDown}');
+    await userEvent.type(screen.getByLabelText('Team'), '{keyDown}');
     await userEvent.click(await screen.findByText('#selected-team'));
 
     await userEvent.click(screen.getByText('Django'));
@@ -437,10 +437,9 @@ describe('ScmCreateProject', () => {
       initialRouterConfig: returningRouterConfig,
     });
 
-    expect(
-      await screen.findByRole('heading', {name: 'Project name'})
-    ).toBeInTheDocument();
-    expect(screen.getByPlaceholderText('project-name')).toHaveValue('my-restored-name');
+    expect(await screen.findByRole('textbox', {name: 'Project name'})).toHaveValue(
+      'my-restored-name'
+    );
   });
 
   it('re-derives a restored untouched name on a platform change', async () => {
@@ -539,6 +538,25 @@ describe('ScmCreateProject', () => {
       expect(router.location.pathname).toContain('/python/getting-started/');
     });
     expect(router.location.query.projectCreationVariant).toBe('scm');
+  });
+
+  it('creates the project on Enter in the project name field', async () => {
+    persistWizardSession();
+    const {createRequest} = mockProjectCreation('python', 'python');
+
+    render(<ScmCreateProject />, {
+      organization,
+      initialRouterConfig: returningRouterConfig,
+    });
+
+    await userEvent.type(
+      await screen.findByRole('textbox', {name: 'Project name'}),
+      '{Enter}'
+    );
+
+    await waitFor(() => {
+      expect(createRequest).toHaveBeenCalled();
+    });
   });
 
   it('forwards the selected products to getting-started as the product query', async () => {

--- a/static/app/views/projectInstall/scmCreateProject.tsx
+++ b/static/app/views/projectInstall/scmCreateProject.tsx
@@ -252,141 +252,155 @@ function ScmCreateProjectWizard({initialState}: {initialState: WizardState}) {
 
   const submitTooltipText = form.submitTooltipText;
 
+  // A real form so Enter in the project name field submits through the
+  // Create project button (implicit submission), which stays a no-op while
+  // the button is disabled.
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    form.submit();
+  };
+
   return (
     <SentryDocumentTitle title={t('Create a new project')}>
       <Access access={canUserCreateProject ? ['project:read'] : ['project:admin']}>
-        <Stack padding="3xl" gap="2xl" align="center">
-          <LayoutGroup>
-            {/* Keep spacing inside each animated section so it collapses with it. */}
-            <MotionStack
-              flexGrow={1}
-              gap="0"
-              padding="2xl"
-              maxWidth={CREATE_PROJECT_MAX_WIDTH}
-              width="100%"
-              border="primary"
-              radius="lg"
-              layout
-            >
-              <Layout.Title>{t('Create a new project')}</Layout.Title>
+        <form onSubmit={handleSubmit}>
+          <Stack padding="3xl" gap="2xl" align="center">
+            <LayoutGroup>
+              {/* Keep spacing inside each animated section so it collapses with it. */}
+              <MotionStack
+                flexGrow={1}
+                gap="0"
+                padding="2xl"
+                maxWidth={CREATE_PROJECT_MAX_WIDTH}
+                width="100%"
+                border="primary"
+                radius="lg"
+                layout
+              >
+                <Layout.Title>{t('Create a new project')}</Layout.Title>
 
-              <MotionStack gap="md" paddingBottom="2xl" layout="position">
-                <Heading as="h1">{t('Create a project')}</Heading>
-                <Text variant="secondary" density="comfortable">
-                  {tct(
-                    'Set up a separate project for each part of your application (for example, your API server and frontend client), to quickly pinpoint which part of your application errors are coming from. [link: Read the docs].',
-                    {
-                      link: (
-                        <ExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/create-new-project/" />
-                      ),
-                    }
-                  )}
-                </Text>
-              </MotionStack>
-
-              {showRepositorySection && (
                 <MotionStack gap="md" paddingBottom="2xl" layout="position">
-                  <Flex justify="between" align="center">
-                    <Stack gap="sm">
-                      <Heading as="h4">{t('Repository')}</Heading>
-                      <Text variant="secondary" density="comfortable" size="sm">
-                        {t(
-                          'Source context in stack traces, suspect commits, and deploy tracking'
-                        )}
-                      </Text>
-                    </Stack>
-                    <Tag variant="muted">{t('Optional')}</Tag>
-                  </Flex>
-
-                  <ScmIntegrationConnect
-                    analyticsFlow="project-creation"
-                    allowIntegrationSwitching
-                    selectedIntegration={selectedIntegration}
-                    selectedRepository={selectedRepository}
-                    onIntegrationChange={handleIntegrationChange}
-                    onRepositoryChange={handleRepositoryChange}
-                    onClearDerivedState={handleClearDerivedState}
-                    maxWidth={CREATE_PROJECT_MAX_WIDTH}
-                  />
+                  <Heading as="h1">{t('Create a project')}</Heading>
+                  <Text variant="secondary" density="comfortable">
+                    {tct(
+                      'Set up a separate project for each part of your application (for example, your API server and frontend client), to quickly pinpoint which part of your application errors are coming from. [link: Read the docs].',
+                      {
+                        link: (
+                          <ExternalLink href="https://docs.sentry.io/product/sentry-basics/integrate-frontend/create-new-project/" />
+                        ),
+                      }
+                    )}
+                  </Text>
                 </MotionStack>
-              )}
 
-              <MotionContainer layout="position" paddingBottom="2xl">
-                <ScmPlatformFeaturesCore
+                {showRepositorySection && (
+                  <MotionStack gap="md" paddingBottom="2xl" layout="position">
+                    <Flex justify="between" align="center">
+                      <Stack gap="sm">
+                        <Heading as="h4">{t('Repository')}</Heading>
+                        <Text variant="secondary" density="comfortable" size="sm">
+                          {t(
+                            'Source context in stack traces, suspect commits, and deploy tracking'
+                          )}
+                        </Text>
+                      </Stack>
+                      <Tag variant="muted">{t('Optional')}</Tag>
+                    </Flex>
+
+                    <ScmIntegrationConnect
+                      analyticsFlow="project-creation"
+                      allowIntegrationSwitching
+                      selectedIntegration={selectedIntegration}
+                      selectedRepository={selectedRepository}
+                      onIntegrationChange={handleIntegrationChange}
+                      onRepositoryChange={handleRepositoryChange}
+                      onClearDerivedState={handleClearDerivedState}
+                      maxWidth={CREATE_PROJECT_MAX_WIDTH}
+                    />
+                  </MotionStack>
+                )}
+
+                <MotionContainer layout="position" paddingBottom="2xl">
+                  <ScmPlatformFeaturesCore
+                    analyticsFlow="project-creation"
+                    selectedRepository={selectedRepository}
+                    selectedPlatform={selectedPlatform}
+                    onPlatformChange={handlePlatformChange}
+                    onFeaturesChange={handleFeaturesChange}
+                  />
+                </MotionContainer>
+
+                <MotionContainer layout="position" paddingBottom="2xl">
+                  <Separator orientation="horizontal" />
+                </MotionContainer>
+
+                <ScmFeatureSelectionPanel
                   analyticsFlow="project-creation"
                   selectedRepository={selectedRepository}
                   selectedPlatform={selectedPlatform}
-                  onPlatformChange={handlePlatformChange}
+                  selectedFeatures={selectedFeatures}
                   onFeaturesChange={handleFeaturesChange}
+                  trailing={
+                    <MotionContainer
+                      layout="position"
+                      paddingTop="2xl"
+                      paddingBottom="2xl"
+                    >
+                      <Separator orientation="horizontal" />
+                    </MotionContainer>
+                  }
                 />
-              </MotionContainer>
 
-              <MotionContainer layout="position" paddingBottom="2xl">
-                <Separator orientation="horizontal" />
-              </MotionContainer>
+                <MotionContainer layout="position" paddingBottom="2xl">
+                  <ScmProjectDetailsCore
+                    projectName={form.projectName}
+                    onProjectNameChange={form.onProjectNameChange}
+                    onProjectNameBlur={form.onProjectNameBlur}
+                    teamSlug={form.teamSlug}
+                    onTeamChange={form.onTeamChange}
+                    isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
+                  />
+                </MotionContainer>
 
-              <ScmFeatureSelectionPanel
-                analyticsFlow="project-creation"
-                selectedRepository={selectedRepository}
-                selectedPlatform={selectedPlatform}
-                selectedFeatures={selectedFeatures}
-                onFeaturesChange={handleFeaturesChange}
-                trailing={
-                  <MotionContainer layout="position" paddingTop="2xl" paddingBottom="2xl">
-                    <Separator orientation="horizontal" />
-                  </MotionContainer>
-                }
-              />
+                <MotionContainer layout="position" paddingBottom="2xl">
+                  <Separator orientation="horizontal" />
+                </MotionContainer>
 
-              <MotionContainer layout="position" paddingBottom="2xl">
-                <ScmProjectDetailsCore
-                  projectName={form.projectName}
-                  onProjectNameChange={form.onProjectNameChange}
-                  onProjectNameBlur={form.onProjectNameBlur}
-                  teamSlug={form.teamSlug}
-                  onTeamChange={form.onTeamChange}
-                  isOrgMemberWithNoAccess={form.isOrgMemberWithNoAccess}
-                />
-              </MotionContainer>
-
-              <MotionContainer layout="position" paddingBottom="2xl">
-                <Separator orientation="horizontal" />
-              </MotionContainer>
-
-              <MotionContainer layout="position">
-                <ScmAlertFrequencySection
-                  analyticsFlow="project-creation"
-                  alertRuleConfig={form.alertRuleConfig}
-                  notificationProps={form.notificationProps}
-                  onAlertChange={form.onAlertChange}
-                />
-              </MotionContainer>
-            </MotionStack>
-            {/* Page-level CTA: disabled until a platform and project details are
+                <MotionContainer layout="position">
+                  <ScmAlertFrequencySection
+                    analyticsFlow="project-creation"
+                    alertRuleConfig={form.alertRuleConfig}
+                    notificationProps={form.notificationProps}
+                    onAlertChange={form.onAlertChange}
+                  />
+                </MotionContainer>
+              </MotionStack>
+              {/* Page-level CTA: disabled until a platform and project details are
               ready. */}
-            <MotionStack
-              gap="md"
-              maxWidth={CREATE_PROJECT_MAX_WIDTH}
-              width="100%"
-              layout="position"
-            >
-              <ProjectCreationErrorAlert error={form.error} />
-              <Flex justify="end">
-                <Tooltip title={submitTooltipText} disabled={!submitTooltipText}>
-                  <Button
-                    variant="primary"
-                    onClick={form.submit}
-                    disabled={!form.canSubmit}
-                    busy={form.isBusy}
-                    icon={<IconProject />}
-                  >
-                    {t('Create project')}
-                  </Button>
-                </Tooltip>
-              </Flex>
-            </MotionStack>
-          </LayoutGroup>
-        </Stack>
+              <MotionStack
+                gap="md"
+                maxWidth={CREATE_PROJECT_MAX_WIDTH}
+                width="100%"
+                layout="position"
+              >
+                <ProjectCreationErrorAlert error={form.error} />
+                <Flex justify="end">
+                  <Tooltip title={submitTooltipText} disabled={!submitTooltipText}>
+                    <Button
+                      type="submit"
+                      variant="primary"
+                      disabled={!form.canSubmit}
+                      busy={form.isBusy}
+                      icon={<IconProject />}
+                    >
+                      {t('Create project')}
+                    </Button>
+                  </Tooltip>
+                </Flex>
+              </MotionStack>
+            </LayoutGroup>
+          </Stack>
+        </form>
       </Access>
     </SentryDocumentTitle>
   );


### PR DESCRIPTION
The SCM create project view is now a real form. The Create project button is a submit button, so pressing Enter in the project name field creates the project, and stays a no-op while the button is disabled. The Project name and Team titles are labels tied to their inputs, so clicking a title focuses the field and screen readers get the field name from the visible text. The Team selector drops its aria-label because the label now names it.

The platform, product, and alert option cards use a raw button element with no type. Inside a form those default to submit, and the first one would take Enter instead of the Create project button, so `ScmCardButton` now defaults to `type="button"`. The new Enter test fails without that default.

Most of the diff in `scmCreateProject.tsx` is indentation from the form wrapper. Reviewing with whitespace hidden shows the three real changes.

Refs CORE-334
