### PR TITLE
ref(onboarding): Update the Hapi onboarding for v11

### DIFF
--- a/static/app/gettingStartedDocs/node-hapi/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-hapi/onboarding.spec.tsx
@@ -34,7 +34,7 @@ describe('hapi onboarding docs', () => {
 
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/node --import \.\/instrument\.mjs index\.mjs/)
+        textWithMarkupMatcher(/node --import \.\/instrument\.js index\.js/)
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/node-hapi/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-hapi/onboarding.spec.tsx
@@ -29,12 +29,22 @@ describe('hapi onboarding docs', () => {
     });
   });
 
-  it('includes error handler', () => {
+  it('starts the app with the --import flag', () => {
     renderWithOnboardingLayout(docs);
 
     expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry\.setupHapiErrorHandler\(server\)/))
+      screen.getByText(
+        textWithMarkupMatcher(/node --import \.\/instrument\.mjs index\.mjs/)
+      )
     ).toBeInTheDocument();
+  });
+
+  it('does not include the deprecated hapi error handler', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry\.setupHapiErrorHandler/))
+    ).not.toBeInTheDocument();
   });
 
   it('displays sample rates by default', () => {
@@ -115,7 +125,7 @@ describe('hapi onboarding docs', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+          /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
         )
       )
     ).toBeInTheDocument();
@@ -141,7 +151,7 @@ describe('hapi onboarding docs', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+          /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node-hapi/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-hapi/onboarding.tsx
@@ -7,19 +7,15 @@ import type {
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {
-  getImportInstrumentSnippet,
+  getImport,
   getInstallCodeBlock,
   getSdkInitSnippet,
-  getSentryImportSnippet,
 } from 'sentry/gettingStartedDocs/node/utils';
 import {t, tct} from 'sentry/locale';
 
 const getSdkSetupSnippet = () => `
-${getImportInstrumentSnippet()}
-
-// All other imports below
-${getSentryImportSnippet('@sentry/node')}
-const Hapi = require('@hapi/hapi');
+${getImport('@sentry/node', 'esm-only').join('\n')}
+import Hapi from "@hapi/hapi";
 
 const init = async () => {
   const server = Hapi.server({
@@ -29,7 +25,6 @@ const init = async () => {
 
   // All your routes live here
 
-  await Sentry.setupHapiErrorHandler(server);
   await server.start();
 };
 
@@ -90,7 +85,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.mjs].',
             {code: <code />}
           ),
         },
@@ -100,15 +95,15 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs)',
-              code: getSdkInitSnippet(params, 'node'),
+              filename: 'instrument.mjs',
+              code: getSdkInitSnippet(params, 'node', 'esm-only'),
             },
           ],
         },
         {
           type: 'text',
           text: tct(
-            "Make sure to import [code:instrument.js/mjs] at the top of your file. Set up the error handler. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)]. If you're running your application in ESM mode, or looking for alternative ways to set up Sentry, read about [docs:installation methods in our docs].",
+            'Start your application with the [code:--import] flag, so that [code:instrument.mjs] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
             {
               code: <code />,
               docs: (
@@ -119,14 +114,33 @@ export const onboarding: OnboardingConfig = {
         },
         {
           type: 'code',
+          language: 'bash',
+          code: 'node --import ./instrument.mjs index.mjs',
+        },
+        {
+          type: 'text',
+          text: tct(
+            'This is what your application entry point, usually [code:index.mjs], looks like:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           tabs: [
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'index.(js|mjs)',
+              filename: 'index.mjs',
               code: getSdkSetupSnippet(),
             },
           ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'The default [code:hapiIntegration] captures errors from your routes automatically. You do not have to add an error handler.',
+            {code: <code />}
+          ),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node-hapi/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-hapi/onboarding.tsx
@@ -85,7 +85,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.mjs].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.js]. These snippets use ESM syntax, so your [code:package.json] needs [code:"type": "module"].',
             {code: <code />}
           ),
         },
@@ -95,7 +95,7 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'instrument.mjs',
+              filename: 'instrument.js',
               code: getSdkInitSnippet(params, 'node', 'esm-only'),
             },
           ],
@@ -103,7 +103,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'Start your application with the [code:--import] flag, so that [code:instrument.mjs] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
+            'Start your application with the [code:--import] flag, so that [code:instrument.js] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
             {
               code: <code />,
               docs: (
@@ -115,12 +115,12 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'code',
           language: 'bash',
-          code: 'node --import ./instrument.mjs index.mjs',
+          code: 'node --import ./instrument.js index.js',
         },
         {
           type: 'text',
           text: tct(
-            'This is what your application entry point, usually [code:index.mjs], looks like:',
+            'This is what your application entry point, usually [code:index.js], looks like:',
             {code: <code />}
           ),
         },
@@ -130,7 +130,7 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'index.mjs',
+              filename: 'index.js',
               code: getSdkSetupSnippet(),
             },
           ],

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -102,8 +102,8 @@ export function getImport(
       ];
 }
 
-function getProfilingImport(defaultMode?: 'esm' | 'cjs'): string {
-  return defaultMode === 'esm'
+function getProfilingImport(defaultMode?: 'esm' | 'cjs' | 'esm-only'): string {
+  return defaultMode === 'esm' || defaultMode === 'esm-only'
     ? 'import { nodeProfilingIntegration } from "@sentry/profiling-node";'
     : 'const { nodeProfilingIntegration } = require("@sentry/profiling-node");';
 }
@@ -144,7 +144,7 @@ function getDefaultNodeImports({
 }: {
   params: DocsParams;
   sdkImport: 'node' | 'aws' | 'gpc' | 'nestjs' | null;
-  defaultMode?: 'esm' | 'cjs';
+  defaultMode?: 'esm' | 'cjs' | 'esm-only';
 }) {
   if (sdkImport === null || !libraryMap[sdkImport]) {
     return '';
@@ -579,7 +579,7 @@ Sentry.logger.info('User triggered test log', { action: 'test_log' })`,
 export const getSdkInitSnippet = (
   params: DocsParams,
   sdkImport: 'node' | 'aws' | 'gpc' | 'nestjs' | null,
-  defaultMode?: 'esm' | 'cjs'
+  defaultMode?: 'esm' | 'cjs' | 'esm-only'
 ) => `${getDefaultNodeImports({params, sdkImport, defaultMode})}
 
 Sentry.init({


### PR DESCRIPTION
## What

Switches the Hapi onboarding to ESM with a `node --import ./instrument.js` start command, and removes the `Sentry.setupHapiErrorHandler(server)` call.

## Why

v11 no longer supports `--require`, and the Hapi error handler is registered automatically when the server starts.