### PR TITLE
feat(hybrid-cloud): dual-write backfill watermark to Postgres (behind option)

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -150,6 +150,13 @@ register(
 )
 
 register(
+    "hybrid_cloud.write_outbox_backfill_watermark_to_postgres",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "hybrid_cloud.authentication.disabled_organization_shards",
     type=Sequence,
     default=[],

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -17,12 +17,20 @@ from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
 from sentry import options
 from sentry.hybridcloud.models.outbox import outbox_context
+from sentry.hybridcloud.models.outboxbackfillwatermark import (
+    BaseOutboxBackfillWatermark,
+    CellOutboxBackfillWatermark,
+    ControlOutboxBackfillWatermark,
+)
 from sentry.hybridcloud.outbox.base import CellOutboxProducingModel, ControlOutboxProducingModel
 from sentry.silo.base import SiloMode
 from sentry.users.models.user import User
 from sentry.utils import json, metrics, redis
 
 logger = logging.getLogger(__name__)
+
+WRITE_WATERMARK_TO_POSTGRES_OPTION = "hybrid_cloud.write_outbox_backfill_watermark_to_postgres"
+WATERMARK_DUAL_WRITE_ERROR_METRIC = "backfill_outboxes.watermark_dual_write_error"
 
 
 def _get_redis_client() -> RedisCluster[str] | StrictRedis[str]:
@@ -63,6 +71,49 @@ def read_processing_state(table_name: str) -> tuple[int, int] | None:
     if not (isinstance(lower, int) and isinstance(version, int)):
         raise TypeError("Expected processing data to be a tuple of (int, int)")
     return lower, version
+
+
+def _watermark_model(
+    model: type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User],
+) -> type[BaseOutboxBackfillWatermark]:
+    current_mode = SiloMode.get_current_mode()
+    if current_mode == SiloMode.CONTROL:
+        return ControlOutboxBackfillWatermark
+    if current_mode == SiloMode.CELL:
+        return CellOutboxBackfillWatermark
+
+    # for monolith deployments, pick the table that would be written to in prod w/ split deployments
+    silo_limit = getattr(model._meta, "silo_limit", None)
+    if silo_limit is not None and silo_limit.modes == frozenset({SiloMode.CONTROL}):
+        return ControlOutboxBackfillWatermark
+    return CellOutboxBackfillWatermark
+
+
+def _write_postgres_watermark(
+    model: type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User],
+    value: int,
+    version: int,
+) -> None:
+    if not options.get(WRITE_WATERMARK_TO_POSTGRES_OPTION):
+        return
+
+    table_name = model._meta.db_table
+    try:
+        _watermark_model(model).objects.update_or_create(
+            table_name=table_name,
+            defaults={"low_bound": value, "version": version},
+        )
+    except Exception:
+        # Mask failures since Redis is the source of truth
+        #
+        # TODO: update this so that when Postgres becomes promoted to the read-path,
+        # we don't swallow exceptions here. It will be conditional on the read-from-postgres flag.
+        metrics.incr(
+            WATERMARK_DUAL_WRITE_ERROR_METRIC,
+            tags=dict(table_name=table_name),
+            skip_internal=True,
+            sample_rate=1.0,
+        )
 
 
 def get_processing_state(table_name: str) -> tuple[int, int]:
@@ -186,11 +237,14 @@ def process_outbox_backfill_batch(
                     outbox.save()
 
     if not processing_state.has_more:
-        set_processing_state(model._meta.db_table, 0, model.replication_version + 1)
+        low_bound, version = 0, model.replication_version + 1
     else:
-        set_processing_state(
-            model._meta.db_table, processing_state.up + 1, processing_state.version
-        )
+        low_bound, version = processing_state.up + 1, processing_state.version
+
+    set_processing_state(model._meta.db_table, low_bound, version)
+
+    # This is the write site we keep after the migration to Postgres is done
+    _write_postgres_watermark(model, low_bound, version)
 
     return processing_state
 
@@ -293,7 +347,11 @@ def report_backfill_watermarks(silo_mode: SiloMode, force_synchronous: bool = Fa
             if state is None:
                 continue
 
-            # TODO: we'll dual-write to Postgres here
+            # This write site is used only to guarantee full, consistent sync between
+            # Redis and PG during the migration period because it runs every cycle guaranteed
+            # TODO: Once everything is cut over to PG, we'll remove this
+            lower, version = state
+            _write_postgres_watermark(model, lower, version)
     except Exception:
         metrics.incr(WATERMARK_REPORT_ERROR_METRIC, skip_internal=True, sample_rate=1.0)
         logger.exception("backfill_outboxes.watermark_report_failed")

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -6,6 +6,7 @@ will produce new outboxes incrementally to replicate those models.
 
 from __future__ import annotations
 
+import functools
 import logging
 from dataclasses import dataclass
 
@@ -73,9 +74,23 @@ def read_processing_state(table_name: str) -> tuple[int, int] | None:
     return lower, version
 
 
-def _watermark_model(
-    model: type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User],
-) -> type[BaseOutboxBackfillWatermark]:
+@functools.lru_cache(maxsize=1)
+def _control_backfill_tables() -> frozenset[str]:
+    """
+    Backfill table names that live on the control silo under a split deployment.
+
+    The model registry does not change once the apps are loaded, so this is built once.
+    """
+    control_only = frozenset({SiloMode.CONTROL})
+    tables = set()
+    for model in _backfill_models(SiloMode.MONOLITH):
+        silo_limit = getattr(model._meta, "silo_limit", None)
+        if silo_limit is not None and silo_limit.modes == control_only:
+            tables.add(model._meta.db_table)
+    return frozenset(tables)
+
+
+def _watermark_model(table_name: str) -> type[BaseOutboxBackfillWatermark]:
     current_mode = SiloMode.get_current_mode()
     if current_mode == SiloMode.CONTROL:
         return ControlOutboxBackfillWatermark
@@ -83,23 +98,17 @@ def _watermark_model(
         return CellOutboxBackfillWatermark
 
     # for monolith deployments, pick the table that would be written to in prod w/ split deployments
-    silo_limit = getattr(model._meta, "silo_limit", None)
-    if silo_limit is not None and silo_limit.modes == frozenset({SiloMode.CONTROL}):
+    if table_name in _control_backfill_tables():
         return ControlOutboxBackfillWatermark
     return CellOutboxBackfillWatermark
 
 
-def _write_postgres_watermark(
-    model: type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User],
-    value: int,
-    version: int,
-) -> None:
+def _write_postgres_watermark(table_name: str, value: int, version: int) -> None:
     if not options.get(WRITE_WATERMARK_TO_POSTGRES_OPTION):
         return
 
-    table_name = model._meta.db_table
     try:
-        _watermark_model(model).objects.update_or_create(
+        _watermark_model(table_name).objects.update_or_create(
             table_name=table_name,
             defaults={"low_bound": value, "version": version},
         )
@@ -132,12 +141,7 @@ def get_processing_state(table_name: str) -> tuple[int, int]:
     return result
 
 
-def set_processing_state(
-    model: type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User],
-    value: int,
-    version: int,
-) -> None:
-    table_name = model._meta.db_table
+def set_processing_state(table_name: str, value: int, version: int) -> None:
     client = _get_redis_client()
     client.set(get_backfill_key(table_name), json.dumps((value, version)))
     metrics.gauge(
@@ -145,7 +149,7 @@ def set_processing_state(
         value,
         tags=dict(table_name=table_name, version=version),
     )
-    _write_postgres_watermark(model, value, version)
+    _write_postgres_watermark(table_name, value, version)
 
 
 def find_replication_version(
@@ -247,7 +251,7 @@ def process_outbox_backfill_batch(
     else:
         low_bound, version = processing_state.up + 1, processing_state.version
 
-    set_processing_state(model, low_bound, version)
+    set_processing_state(model._meta.db_table, low_bound, version)
 
     return processing_state
 
@@ -331,19 +335,20 @@ def report_backfill_watermarks(silo_mode: SiloMode, force_synchronous: bool = Fa
     """
     try:
         for model in _backfill_models(silo_mode):
+            table_name = model._meta.db_table
             try:
                 state = _report_watermark_for_model(model, force_synchronous=force_synchronous)
             except Exception:
                 # One bad table must not stop the rest of the walk.
                 metrics.incr(
                     WATERMARK_REPORT_ERROR_METRIC,
-                    tags=dict(table_name=model._meta.db_table),
+                    tags=dict(table_name=table_name),
                     skip_internal=True,
                     sample_rate=1.0,
                 )
                 logger.exception(
                     "backfill_outboxes.watermark_report_failed",
-                    extra={"table_name": model._meta.db_table},
+                    extra={"table_name": table_name},
                 )
                 continue
 
@@ -354,7 +359,7 @@ def report_backfill_watermarks(silo_mode: SiloMode, force_synchronous: bool = Fa
             # Redis and PG during the migration period because it runs every cycle guaranteed
             # TODO: Once everything is cut over to PG, we'll remove this
             lower, version = state
-            _write_postgres_watermark(model, lower, version)
+            _write_postgres_watermark(table_name, lower, version)
     except Exception:
         metrics.incr(WATERMARK_REPORT_ERROR_METRIC, skip_internal=True, sample_rate=1.0)
         logger.exception("backfill_outboxes.watermark_report_failed")

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -76,11 +76,6 @@ def read_processing_state(table_name: str) -> tuple[int, int] | None:
 
 @functools.lru_cache(maxsize=1)
 def _control_backfill_tables() -> frozenset[str]:
-    """
-    Backfill table names that live on the control silo under a split deployment.
-
-    The model registry does not change once the apps are loaded, so this is built once.
-    """
     control_only = frozenset({SiloMode.CONTROL})
     tables = set()
     for model in _backfill_models(SiloMode.MONOLITH):

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -132,7 +132,12 @@ def get_processing_state(table_name: str) -> tuple[int, int]:
     return result
 
 
-def set_processing_state(table_name: str, value: int, version: int) -> None:
+def set_processing_state(
+    model: type[ControlOutboxProducingModel] | type[CellOutboxProducingModel] | type[User],
+    value: int,
+    version: int,
+) -> None:
+    table_name = model._meta.db_table
     client = _get_redis_client()
     client.set(get_backfill_key(table_name), json.dumps((value, version)))
     metrics.gauge(
@@ -140,6 +145,7 @@ def set_processing_state(table_name: str, value: int, version: int) -> None:
         value,
         tags=dict(table_name=table_name, version=version),
     )
+    _write_postgres_watermark(model, value, version)
 
 
 def find_replication_version(
@@ -241,10 +247,7 @@ def process_outbox_backfill_batch(
     else:
         low_bound, version = processing_state.up + 1, processing_state.version
 
-    set_processing_state(model._meta.db_table, low_bound, version)
-
-    # This is the write site we keep after the migration to Postgres is done
-    _write_postgres_watermark(model, low_bound, version)
+    set_processing_state(model, low_bound, version)
 
     return processing_state
 

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -276,7 +276,7 @@ def _counter_calls(metrics_mock: Any, name: str) -> int:
 def test_watermark_report_runs_without_budget() -> None:
     """The pass sits above the budget branch, so a starved tick still reports."""
     reset_processing_state()
-    set_processing_state(AuthProvider._meta.db_table, 41, 1)
+    set_processing_state(AuthProvider, 41, 1)
 
     with patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock:
         # No budget at all, so the backfill loop itself does nothing.
@@ -292,7 +292,7 @@ def test_watermark_report_covers_a_finished_table() -> None:
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
     finished_version = AuthProvider.replication_version + 1
-    set_processing_state(table_name, 0, finished_version)
+    set_processing_state(AuthProvider, 0, finished_version)
 
     with patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock:
         # Budget of 1, so the loop really runs. Every control table is past its
@@ -321,7 +321,7 @@ def test_watermark_report_survives_a_failing_backfill_loop() -> None:
     """The loop above the report is unguarded. Its failure must not take the report away."""
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
-    set_processing_state(table_name, 41, 1)
+    set_processing_state(AuthProvider, 41, 1)
 
     def boom(model: Any, batch_size: int, force_synchronous: bool = False) -> Any:
         raise RuntimeError("the backfill loop is broken")
@@ -349,7 +349,7 @@ def test_watermark_report_carries_the_value_the_cycle_left() -> None:
     reset_processing_state()
     models = _backfill_models(SiloMode.CONTROL)
     for model in models:
-        set_processing_state(model._meta.db_table, 3, 1)
+        set_processing_state(model, 3, 1)
     with outbox_context(flush=False):
         for _ in range(5):
             Factories.create_user()
@@ -424,7 +424,7 @@ def test_watermark_report_leaves_a_stored_value_alone() -> None:
     """An existing key keeps its exact stored bytes after the pass."""
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
-    set_processing_state(table_name, 12345, 3)
+    set_processing_state(AuthProvider, 12345, 3)
     client = _get_redis_client()
     before = client.get(get_backfill_key(table_name))
 
@@ -441,7 +441,7 @@ def test_watermark_report_continues_when_one_table_raises() -> None:
     reset_processing_state()
     broken_table = AuthProvider._meta.db_table
     good_table = ApiToken._meta.db_table
-    set_processing_state(good_table, 7, 1)
+    set_processing_state(ApiToken, 7, 1)
 
     real_read = read_processing_state
 
@@ -523,8 +523,7 @@ def test_backfill_stops_at_the_budget() -> None:
 def test_watermark_report_hands_back_the_stored_pair() -> None:
     """The dual write mirrors this pair, so the report has to return it."""
     reset_processing_state()
-    table_name = AuthProvider._meta.db_table
-    set_processing_state(table_name, 8080, 2)
+    set_processing_state(AuthProvider, 8080, 2)
 
     assert _report_watermark_for_model(AuthProvider, force_synchronous=False) == (8080, 2)
     # An absent key reports itself and yields nothing to mirror.
@@ -538,18 +537,18 @@ def test_dual_write_mirrors_every_key_on_a_starved_tick() -> None:
 
     reset_processing_state()
     seeded = {
-        AuthProvider._meta.db_table: (41, 1),
-        ApiToken._meta.db_table: (77, 2),
+        AuthProvider: (41, 1),
+        ApiToken: (77, 2),
     }
-    for table_name, (lower, version) in seeded.items():
-        set_processing_state(table_name, lower, version)
+    for model, (lower, version) in seeded.items():
+        set_processing_state(model, lower, version)
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
         # No budget at all, so the backfill loop itself does nothing.
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
-    for table_name, pair in seeded.items():
-        row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
+    for model, pair in seeded.items():
+        row = ControlOutboxBackfillWatermark.objects.get(table_name=model._meta.db_table)
         assert (row.low_bound, row.version) == pair
 
     # A table with no Redis key has nothing to mirror, so it gets no row.
@@ -563,7 +562,7 @@ def test_dual_write_mirrors_a_finished_table() -> None:
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
     finished_version = AuthProvider.replication_version + 1
-    set_processing_state(table_name, 0, finished_version)
+    set_processing_state(AuthProvider, 0, finished_version)
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
         # Budget of 1, so the loop really runs and finds no work for this table.
@@ -657,12 +656,12 @@ def test_dual_write_off_leaves_the_redis_state_identical() -> None:
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
 
-    set_processing_state(table_name, 4242, 3)
+    set_processing_state(AuthProvider, 4242, 3)
     backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
     without_option = read_processing_state(table_name)
 
     reset_processing_state()
-    set_processing_state(table_name, 4242, 3)
+    set_processing_state(AuthProvider, 4242, 3)
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
         backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
 
@@ -687,7 +686,7 @@ def test_a_read_never_creates_a_postgres_row() -> None:
 def test_a_failed_postgres_write_does_not_break_the_pass() -> None:
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
-    set_processing_state(table_name, 99, 2)
+    set_processing_state(AuthProvider, 99, 2)
 
     with (
         override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}),
@@ -713,9 +712,9 @@ def test_dual_write_updates_the_row_in_place() -> None:
     table_name = AuthProvider._meta.db_table
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
-        set_processing_state(table_name, 10, 1)
+        set_processing_state(AuthProvider, 10, 1)
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
-        set_processing_state(table_name, 20, 2)
+        set_processing_state(AuthProvider, 20, 2)
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
     rows = list(ControlOutboxBackfillWatermark.objects.filter(table_name=table_name))

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -10,15 +10,22 @@ from django.test.utils import override_settings
 from sentry.db.models import BaseModel
 from sentry.hybridcloud.models.apitokenreplica import ApiTokenReplica
 from sentry.hybridcloud.models.outbox import CellOutbox, ControlOutbox, outbox_context
+from sentry.hybridcloud.models.outboxbackfillwatermark import (
+    CellOutboxBackfillWatermark,
+    ControlOutboxBackfillWatermark,
+)
 from sentry.hybridcloud.outbox.base import run_outbox_replications_for_self_hosted
 from sentry.hybridcloud.tasks.backfill_outboxes import (
+    WATERMARK_DUAL_WRITE_ERROR_METRIC,
     WATERMARK_REPORT_ERROR_METRIC,
     WATERMARK_STATE_METRIC,
     WATERMARK_TARGET_VERSION_METRIC,
     WATERMARK_VERSION_METRIC,
+    WRITE_WATERMARK_TO_POSTGRES_OPTION,
     _backfill_models,
     _get_redis_client,
     _report_watermark_for_model,
+    _write_postgres_watermark,
     backfill_outboxes_for,
     get_backfill_key,
     get_processing_state,
@@ -40,6 +47,7 @@ from sentry.testutils.outbox import outbox_runner
 from sentry.testutils.pytest.fixtures import django_db_all
 from sentry.testutils.silo import (
     assume_test_silo_mode,
+    cell_silo_test,
     control_silo_test,
     create_test_cells,
     no_silo_test,
@@ -521,3 +529,238 @@ def test_watermark_report_hands_back_the_stored_pair() -> None:
     assert _report_watermark_for_model(AuthProvider, force_synchronous=False) == (8080, 2)
     # An absent key reports itself and yields nothing to mirror.
     assert _report_watermark_for_model(ApiToken, force_synchronous=False) is None
+
+
+@django_db_all
+@no_silo_test
+def test_dual_write_mirrors_every_key_on_a_starved_tick() -> None:
+    """Guarantees that every cycle we mirror all Redis keys no matter the budget"""
+
+    reset_processing_state()
+    seeded = {
+        AuthProvider._meta.db_table: (41, 1),
+        ApiToken._meta.db_table: (77, 2),
+    }
+    for table_name, (lower, version) in seeded.items():
+        set_processing_state(table_name, lower, version)
+
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
+        # No budget at all, so the backfill loop itself does nothing.
+        assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    for table_name, pair in seeded.items():
+        row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
+        assert (row.low_bound, row.version) == pair
+
+    # A table with no Redis key has nothing to mirror, so it gets no row.
+    assert ControlOutboxBackfillWatermark.objects.count() == len(seeded)
+
+
+@django_db_all
+@no_silo_test
+def test_dual_write_mirrors_a_finished_table() -> None:
+    """A table past its target version is skipped by the loop, but still mirrored."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    finished_version = AuthProvider.replication_version + 1
+    set_processing_state(table_name, 0, finished_version)
+
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
+        # Budget of 1, so the loop really runs and finds no work for this table.
+        assert not backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
+
+    row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
+    assert (row.low_bound, row.version) == (0, finished_version)
+
+
+@django_db_all
+@no_silo_test
+def test_dual_write_mirrors_an_advancing_batch_into_postgres() -> None:
+    """Option on: a batch that moves the watermark leaves the same pair in both stores."""
+    reset_processing_state()
+    table_name = User._meta.db_table
+    with outbox_context(flush=False):
+        for _ in range(5):
+            Factories.create_user()
+
+    with override_options(
+        {
+            "outbox_replication.auth_user.replication_version": User.replication_version,
+            WRITE_WATERMARK_TO_POSTGRES_OPTION: True,
+        }
+    ):
+        # A budget of 2 against 5 users, so the loop advances auth_user and stops.
+        backfill_outboxes_for(SiloMode.CONTROL, 0, 2)
+
+    stored = read_processing_state(table_name)
+    assert stored is not None
+    assert stored[0] > 0, "the batch did not advance the watermark"
+
+    row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
+    assert (row.low_bound, row.version) == stored
+    assert CellOutboxBackfillWatermark.objects.count() == 0
+
+
+@django_db_all
+@no_silo_test
+def test_dual_write_mirrors_from_the_write_path_alone() -> None:
+    """Guarantees that the PG write path mirrors the Redis write path"""
+    reset_processing_state()
+    table_name = User._meta.db_table
+    with outbox_context(flush=False):
+        for _ in range(5):
+            Factories.create_user()
+
+    with override_options(
+        {
+            "outbox_replication.auth_user.replication_version": User.replication_version,
+            WRITE_WATERMARK_TO_POSTGRES_OPTION: True,
+        }
+    ):
+        # One batch, called directly, so report_backfill_watermarks never runs.
+        batch = process_outbox_backfill_batch(User, batch_size=2)
+
+    assert batch is not None
+    stored = read_processing_state(table_name)
+    assert stored is not None
+    row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
+    assert (row.low_bound, row.version) == stored
+
+
+@django_db_all
+@no_silo_test
+def test_dual_write_off_leaves_postgres_empty() -> None:
+    """Option off: the Redis path is what it is today and nothing reaches Postgres."""
+    reset_processing_state()
+    table_name = User._meta.db_table
+    with outbox_context(flush=False):
+        for _ in range(5):
+            Factories.create_user()
+
+    with override_options(
+        {"outbox_replication.auth_user.replication_version": User.replication_version}
+    ):
+        backfill_outboxes_for(SiloMode.CONTROL, 0, 2)
+
+    stored = read_processing_state(table_name)
+    assert stored is not None
+    assert stored[0] > 0, "the batch did not advance the watermark"
+
+    assert ControlOutboxBackfillWatermark.objects.count() == 0
+    assert CellOutboxBackfillWatermark.objects.count() == 0
+
+
+@django_db_all
+@no_silo_test
+def test_dual_write_off_leaves_the_redis_state_identical() -> None:
+    """The option must not change what a whole pass leaves in Redis."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+
+    set_processing_state(table_name, 4242, 3)
+    backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
+    without_option = read_processing_state(table_name)
+
+    reset_processing_state()
+    set_processing_state(table_name, 4242, 3)
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
+        backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
+
+    assert read_processing_state(table_name) == without_option
+
+
+@django_db_all
+@no_silo_test
+def test_a_read_never_creates_a_postgres_row() -> None:
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
+        assert get_processing_state(table_name) == (0, 1)
+
+    assert read_processing_state(table_name) == (0, 1)
+    assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
+
+
+@django_db_all
+@no_silo_test
+def test_a_failed_postgres_write_does_not_break_the_pass() -> None:
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(table_name, 99, 2)
+
+    with (
+        override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}),
+        patch(
+            "sentry.hybridcloud.tasks.backfill_outboxes._watermark_model",
+            side_effect=RuntimeError("postgres is down"),
+        ),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+    ):
+        # No exception reaches the caller.
+        assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    assert read_processing_state(table_name) == (99, 2)
+    assert _counter_calls(metrics_mock, WATERMARK_DUAL_WRITE_ERROR_METRIC) >= 1
+    # The pass still reported, so one bad mirror did not stop the walk.
+    assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC)[table_name] == 99
+
+
+@django_db_all
+@no_silo_test
+def test_dual_write_updates_the_row_in_place() -> None:
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
+        set_processing_state(table_name, 10, 1)
+        assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+        set_processing_state(table_name, 20, 2)
+        assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    rows = list(ControlOutboxBackfillWatermark.objects.filter(table_name=table_name))
+    assert len(rows) == 1
+    assert (rows[0].low_bound, rows[0].version) == (20, 2)
+
+
+@django_db_all
+@no_silo_test
+def test_dual_write_picks_the_table_by_the_silo_of_the_model() -> None:
+    reset_processing_state()
+
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
+        _write_postgres_watermark(AuthProvider, 11, 1)
+        _write_postgres_watermark(Organization, 22, 1)
+
+    assert (
+        ControlOutboxBackfillWatermark.objects.get(table_name=AuthProvider._meta.db_table).low_bound
+        == 11
+    )
+    assert (
+        CellOutboxBackfillWatermark.objects.get(table_name=Organization._meta.db_table).low_bound
+        == 22
+    )
+
+
+@django_db_all
+@control_silo_test
+def test_dual_write_uses_the_control_table_in_control_silo() -> None:
+    reset_processing_state()
+
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
+        _write_postgres_watermark(AuthProvider, 7, 1)
+
+    row = ControlOutboxBackfillWatermark.objects.get(table_name=AuthProvider._meta.db_table)
+    assert (row.low_bound, row.version) == (7, 1)
+
+
+@django_db_all
+@cell_silo_test
+def test_dual_write_uses_the_cell_table_in_cell_silo() -> None:
+    reset_processing_state()
+
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
+        _write_postgres_watermark(Organization, 8, 1)
+
+    row = CellOutboxBackfillWatermark.objects.get(table_name=Organization._meta.db_table)
+    assert (row.low_bound, row.version) == (8, 1)

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -276,7 +276,7 @@ def _counter_calls(metrics_mock: Any, name: str) -> int:
 def test_watermark_report_runs_without_budget() -> None:
     """The pass sits above the budget branch, so a starved tick still reports."""
     reset_processing_state()
-    set_processing_state(AuthProvider, 41, 1)
+    set_processing_state(AuthProvider._meta.db_table, 41, 1)
 
     with patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock:
         # No budget at all, so the backfill loop itself does nothing.
@@ -292,7 +292,7 @@ def test_watermark_report_covers_a_finished_table() -> None:
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
     finished_version = AuthProvider.replication_version + 1
-    set_processing_state(AuthProvider, 0, finished_version)
+    set_processing_state(table_name, 0, finished_version)
 
     with patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock:
         # Budget of 1, so the loop really runs. Every control table is past its
@@ -321,7 +321,7 @@ def test_watermark_report_survives_a_failing_backfill_loop() -> None:
     """The loop above the report is unguarded. Its failure must not take the report away."""
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
-    set_processing_state(AuthProvider, 41, 1)
+    set_processing_state(table_name, 41, 1)
 
     def boom(model: Any, batch_size: int, force_synchronous: bool = False) -> Any:
         raise RuntimeError("the backfill loop is broken")
@@ -349,7 +349,7 @@ def test_watermark_report_carries_the_value_the_cycle_left() -> None:
     reset_processing_state()
     models = _backfill_models(SiloMode.CONTROL)
     for model in models:
-        set_processing_state(model, 3, 1)
+        set_processing_state(model._meta.db_table, 3, 1)
     with outbox_context(flush=False):
         for _ in range(5):
             Factories.create_user()
@@ -424,7 +424,7 @@ def test_watermark_report_leaves_a_stored_value_alone() -> None:
     """An existing key keeps its exact stored bytes after the pass."""
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
-    set_processing_state(AuthProvider, 12345, 3)
+    set_processing_state(table_name, 12345, 3)
     client = _get_redis_client()
     before = client.get(get_backfill_key(table_name))
 
@@ -441,7 +441,7 @@ def test_watermark_report_continues_when_one_table_raises() -> None:
     reset_processing_state()
     broken_table = AuthProvider._meta.db_table
     good_table = ApiToken._meta.db_table
-    set_processing_state(ApiToken, 7, 1)
+    set_processing_state(good_table, 7, 1)
 
     real_read = read_processing_state
 
@@ -523,7 +523,8 @@ def test_backfill_stops_at_the_budget() -> None:
 def test_watermark_report_hands_back_the_stored_pair() -> None:
     """The dual write mirrors this pair, so the report has to return it."""
     reset_processing_state()
-    set_processing_state(AuthProvider, 8080, 2)
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(table_name, 8080, 2)
 
     assert _report_watermark_for_model(AuthProvider, force_synchronous=False) == (8080, 2)
     # An absent key reports itself and yields nothing to mirror.
@@ -537,18 +538,18 @@ def test_dual_write_mirrors_every_key_on_a_starved_tick() -> None:
 
     reset_processing_state()
     seeded = {
-        AuthProvider: (41, 1),
-        ApiToken: (77, 2),
+        AuthProvider._meta.db_table: (41, 1),
+        ApiToken._meta.db_table: (77, 2),
     }
-    for model, (lower, version) in seeded.items():
-        set_processing_state(model, lower, version)
+    for table_name, (lower, version) in seeded.items():
+        set_processing_state(table_name, lower, version)
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
         # No budget at all, so the backfill loop itself does nothing.
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
-    for model, pair in seeded.items():
-        row = ControlOutboxBackfillWatermark.objects.get(table_name=model._meta.db_table)
+    for table_name, pair in seeded.items():
+        row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
         assert (row.low_bound, row.version) == pair
 
     # A table with no Redis key has nothing to mirror, so it gets no row.
@@ -562,7 +563,7 @@ def test_dual_write_mirrors_a_finished_table() -> None:
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
     finished_version = AuthProvider.replication_version + 1
-    set_processing_state(AuthProvider, 0, finished_version)
+    set_processing_state(table_name, 0, finished_version)
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
         # Budget of 1, so the loop really runs and finds no work for this table.
@@ -656,12 +657,12 @@ def test_dual_write_off_leaves_the_redis_state_identical() -> None:
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
 
-    set_processing_state(AuthProvider, 4242, 3)
+    set_processing_state(table_name, 4242, 3)
     backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
     without_option = read_processing_state(table_name)
 
     reset_processing_state()
-    set_processing_state(AuthProvider, 4242, 3)
+    set_processing_state(table_name, 4242, 3)
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
         backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
 
@@ -686,7 +687,7 @@ def test_a_read_never_creates_a_postgres_row() -> None:
 def test_a_failed_postgres_write_does_not_break_the_pass() -> None:
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
-    set_processing_state(AuthProvider, 99, 2)
+    set_processing_state(table_name, 99, 2)
 
     with (
         override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}),
@@ -712,9 +713,9 @@ def test_dual_write_updates_the_row_in_place() -> None:
     table_name = AuthProvider._meta.db_table
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
-        set_processing_state(AuthProvider, 10, 1)
+        set_processing_state(table_name, 10, 1)
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
-        set_processing_state(AuthProvider, 20, 2)
+        set_processing_state(table_name, 20, 2)
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
     rows = list(ControlOutboxBackfillWatermark.objects.filter(table_name=table_name))
@@ -728,8 +729,8 @@ def test_dual_write_picks_the_table_by_the_silo_of_the_model() -> None:
     reset_processing_state()
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
-        _write_postgres_watermark(AuthProvider, 11, 1)
-        _write_postgres_watermark(Organization, 22, 1)
+        _write_postgres_watermark(AuthProvider._meta.db_table, 11, 1)
+        _write_postgres_watermark(Organization._meta.db_table, 22, 1)
 
     assert (
         ControlOutboxBackfillWatermark.objects.get(table_name=AuthProvider._meta.db_table).low_bound
@@ -747,7 +748,7 @@ def test_dual_write_uses_the_control_table_in_control_silo() -> None:
     reset_processing_state()
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
-        _write_postgres_watermark(AuthProvider, 7, 1)
+        _write_postgres_watermark(AuthProvider._meta.db_table, 7, 1)
 
     row = ControlOutboxBackfillWatermark.objects.get(table_name=AuthProvider._meta.db_table)
     assert (row.low_bound, row.version) == (7, 1)
@@ -759,7 +760,7 @@ def test_dual_write_uses_the_cell_table_in_cell_silo() -> None:
     reset_processing_state()
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
-        _write_postgres_watermark(Organization, 8, 1)
+        _write_postgres_watermark(Organization._meta.db_table, 8, 1)
 
     row = CellOutboxBackfillWatermark.objects.get(table_name=Organization._meta.db_table)
     assert (row.low_bound, row.version) == (8, 1)


### PR DESCRIPTION
We've set it up so that Redis backfill watermarks are reported every cycle - no matter what the backfill budget - and we've created the models those keys will get migrated into. This PR is the fill step in which we write to Postgres every cycle so it's constantly synced w/ Redis. Redis is still the source of truth for reads.

We're writing at two sites which is redundant but there's a good reason for it: 
- hooking into the every-cycle reporting pass allows us to upsert the Postgres rows and guarantee it's synced during this migration period
- keeping the PG write site co-located with the Redis write-site means we'll easily be able to move the Postgres write cadence back to what it was in Redis pre-migration

So for now it's a little wasteful but it makes cleanup a lot easier and makes the migration a lot easier.

Notes:
- Option is False so we aren't doing anything when this ships
- We're swallowing Postgres write failures for now and just writing them to a metric. This will change when we introduce the read-from-postgres changes
- There was a little weirdness with MONOLITH silo mode, since it's not as easy to pick which PG model to write to - had to do some manual table name matching to get it to match what model is written to in producion.

Refs INFRENG-579
