### PR TITLE
ref(preprod): Register snapshot tasks under a preprod.snapshots alias

### DIFF
--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -53,7 +53,7 @@ from sentry.preprod.snapshots.reconstruction import reconstruct_base_manifest
 from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import preprod_tasks
+from sentry.taskworker.namespaces import preprod_snapshots_tasks, preprod_tasks
 from sentry.utils import metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
@@ -734,6 +734,7 @@ def _process_chunk(
 @instrumented_task(
     name="sentry.preprod.tasks.process_snapshot_comparison_chunk",
     namespace=preprod_tasks,
+    alias_namespace=preprod_snapshots_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=CHUNK_PROCESSING_DEADLINE,
@@ -789,6 +790,7 @@ def process_snapshot_comparison_chunk(
 @instrumented_task(
     name="sentry.preprod.tasks.compare_snapshots",
     namespace=preprod_tasks,
+    alias_namespace=preprod_snapshots_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=300,
@@ -1167,6 +1169,7 @@ def _finalize_if_all_chunks_done(
 @instrumented_task(
     name="sentry.preprod.tasks.finalize_snapshot_comparison",
     namespace=preprod_tasks,
+    alias_namespace=preprod_snapshots_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=300,

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -23,7 +23,7 @@ from sentry.preprod.snapshots.zip_builder import (
 )
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import preprod_tasks
+from sentry.taskworker.namespaces import preprod_snapshots_tasks, preprod_tasks
 from sentry.users.services.user.service import user_service
 from sentry.utils.email import MessageBuilder
 
@@ -110,6 +110,7 @@ def _upload_archive_multipart(session: Session, key: str, tmp: IO[bytes]) -> Non
 @instrumented_task(
     name="sentry.preprod.tasks.build_snapshot_images_zip",
     namespace=preprod_tasks,
+    alias_namespace=preprod_snapshots_tasks,
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=900,
 )

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -34,7 +34,7 @@ from sentry.preprod.vcs.status_checks.snapshots.config import (
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import preprod_tasks
+from sentry.taskworker.namespaces import preprod_snapshots_tasks, preprod_tasks
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,7 @@ def get_snapshot_pr_comment_reporting_criteria(project: Project) -> SnapshotChan
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_snapshot_pr_comment",
     namespace=preprod_tasks,
+    alias_namespace=preprod_snapshots_tasks,
     processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=60),
@@ -234,6 +235,7 @@ def create_preprod_snapshot_pr_comment_task(
 @instrumented_task(
     name="sentry.preprod.tasks.post_snapshot_pr_comment",
     namespace=preprod_tasks,
+    alias_namespace=preprod_snapshots_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=4, on=(ApiError, ConnectionError, TimeoutError)),

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -40,7 +40,7 @@ from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import preprod_tasks
+from sentry.taskworker.namespaces import preprod_snapshots_tasks, preprod_tasks
 
 logger = logging.getLogger(__name__)
 
@@ -51,6 +51,7 @@ APPROVE_SNAPSHOT_ACTION_IDENTIFIER = "approve_snapshots"
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_snapshot_status_check",
     namespace=preprod_tasks,
+    alias_namespace=preprod_snapshots_tasks,
     processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=60),
@@ -363,6 +364,7 @@ def _compute_snapshot_status(
 @instrumented_task(
     name="sentry.preprod.tasks.post_snapshot_status_check",
     namespace=preprod_tasks,
+    alias_namespace=preprod_snapshots_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=4, on=(ApiError, ConnectionError, TimeoutError)),

--- a/src/sentry/taskworker/namespaces.py
+++ b/src/sentry/taskworker/namespaces.py
@@ -231,6 +231,11 @@ preprod_tasks = app.taskregistry.create_namespace(
     app_feature="preprod",
 )
 
+preprod_snapshots_tasks = app.taskregistry.create_namespace(
+    "preprod.snapshots",
+    app_feature="snapshots",
+)
+
 profiling_tasks = app.taskregistry.create_namespace(
     "profiling",
     app_feature="profiles",


### PR DESCRIPTION
Introduce a `preprod.snapshots` taskworker namespace and register all eight snapshot tasks (comparison chunks, finalize, compare, archive build, PR comments, and status checks) under it as an alias. `preprod` stays the primary namespace, so producers keep emitting exactly what they do today and there is no runtime change. The only effect is that every worker running this code recognizes `preprod.snapshots`.

This is the first half of a two-step move. Workers report a terminal `FAILURE` for any activation whose namespace is not in their registry, and taskworker deployments roll with old and new pods overlapping. Switching producers to `preprod.snapshots` in the same deploy would let old pods on the shared default topic silently drop snapshot work during the overlap. Landing recognition first and letting it roll out fully makes the switch in #124209 safe. Shared artifact cleanup and email delivery remain in their existing namespaces.
