### PR TITLE
fix(HC): Wraps RPC JSON body parsing in explicit error-handling, updates RPC internal error handling in API

### DIFF
--- a/src/sentry/hybridcloud/rpc/service.py
+++ b/src/sentry/hybridcloud/rpc/service.py
@@ -650,7 +650,21 @@ class _RemoteSiloCall:
                 unit="byte",
             )
             if response.status_code == 200:
-                return response.json()
+                try:
+                    return response.json()
+                except ValueError as e:
+                    # Handle the case where the response from the remote silo
+                    # is not valid JSON. This could arise if we receive errors
+                    # from the LB rather than the application.
+                    metrics.incr(
+                        "hybrid_cloud.dispatch_rpc.failure",
+                        tags=self._metrics_tags(kind="malformed_response"),
+                    )
+                    raise RpcResponseException(
+                        service_name=self.service_name,
+                        method_name=self.method_name,
+                        message=f"Received malformed 200 response of {len(response.content)} byte(s)",
+                    ) from e
             self._raise_from_response_status_error(response)
 
     @contextmanager

--- a/tests/sentry/hybridcloud/test_rpc.py
+++ b/tests/sentry/hybridcloud/test_rpc.py
@@ -14,6 +14,7 @@ from sentry.auth.services.auth import AuthService
 from sentry.hybridcloud.rpc.service import (
     RpcAuthenticationSetupException,
     RpcDisabledException,
+    RpcResponseException,
     _RemoteSiloCall,
     dispatch_remote_call,
     dispatch_to_local_service,
@@ -166,6 +167,35 @@ class DispatchRemoteCallTest(TestCase):
 
         result = dispatch_remote_call(None, "organization", "get_organization_by_id", {"id": 0})
         assert result is None
+
+    @staticmethod
+    def _set_up_mock_raw_response(service_name: str, body: str) -> None:
+        responses.add(
+            responses.POST,
+            f"{settings.SENTRY_CONTROL_ADDRESS}/api/0/internal/rpc/{service_name}/",
+            content_type="json",
+            body=body,
+        )
+
+    @responses.activate
+    @override_settings(SILO_MODE=SiloMode.CELL)
+    def test_cell_to_control_empty_body(self) -> None:
+        self._set_up_mock_raw_response("organization/get_organization_by_id", "")
+
+        with pytest.raises(RpcResponseException) as excinfo:
+            dispatch_remote_call(None, "organization", "get_organization_by_id", {"id": 0})
+
+        assert "malformed 200 response of 0 byte(s)" in str(excinfo.value)
+
+    @responses.activate
+    @override_settings(SILO_MODE=SiloMode.CELL)
+    def test_cell_to_control_non_json_body(self) -> None:
+        self._set_up_mock_raw_response(
+            "organization/get_organization_by_id", "<html>502 Bad Gateway</html>"
+        )
+
+        with pytest.raises(RpcResponseException):
+            dispatch_remote_call(None, "organization", "get_organization_by_id", {"id": 0})
 
     @responses.activate
     @override_cells(_CELLS)


### PR DESCRIPTION
Minor fixes for 2 potential RPC failure cases:
1. RPC body deserialization fails due to empty or non-JSON responses, which currently raise a ValueError that gets propagated as a generic exception.
2. Error handling for internal RPC errors get propagated as 400s with "Invalid Service Request" instead of a 500, which would be a more accurate categorization.

Both of these should help add a bit more context when we encounter failures in more complicated outbox flows, like org provisioning.


---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>