### PR TITLE
fix(hc): Makes user replica mapping flushes asynchronous to reduce latency

### DIFF
--- a/src/sentry/hybridcloud/services/organizationmember_mapping/impl.py
+++ b/src/sentry/hybridcloud/services/organizationmember_mapping/impl.py
@@ -6,6 +6,7 @@
 
 from django.db import IntegrityError, router, transaction
 
+from sentry import options
 from sentry.hybridcloud.models.outbox import outbox_context
 from sentry.hybridcloud.services.organizationmember_mapping import (
     OrganizationMemberMappingService,
@@ -44,8 +45,20 @@ class DatabaseBackedOrganizationMemberMappingService(OrganizationMemberMappingSe
                 except User.DoesNotExist:
                     return
                 if user is not None:
-                    for outbox in user.outboxes_for_update():
-                        outbox.save()
+                    async_flush_enabled = options.get("hybrid_cloud.org_member_async_flush_enabled")
+
+                    # There are cases where this user outbox flush can occur
+                    # within an RPC linked to another outbox flush, so we
+                    # defer flushing this change immediately. While this will
+                    # introduce some replication lag, it avoids additional
+                    # contention and potential deadlocks.
+                    if async_flush_enabled:
+                        with outbox_context(flush=False):
+                            for outbox in user.outboxes_for_update():
+                                outbox.save()
+                    else:
+                        for outbox in user.outboxes_for_update():
+                            outbox.save()
 
         orm_mapping: OrganizationMemberMapping = OrganizationMemberMapping(
             organization_id=organization_id

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -2588,6 +2588,12 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "hybrid_cloud.org_member_async_flush_enabled",
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # List of event IDs to pass through
 register(
     "hybrid_cloud.audit_log_event_id_invalid_pass_list",

--- a/tests/sentry/hybridcloud/test_organizationmembermapping.py
+++ b/tests/sentry/hybridcloud/test_organizationmembermapping.py
@@ -1,5 +1,10 @@
+from unittest.mock import patch
+
 from django.db import router, transaction
 
+from sentry.hybridcloud.models.outbox import ControlOutbox
+from sentry.hybridcloud.outbox.category import OutboxCategory
+from sentry.hybridcloud.rpc.service import RpcResponseException
 from sentry.hybridcloud.services.organizationmember_mapping import (
     RpcOrganizationMemberMappingUpdate,
     organizationmember_mapping_service,
@@ -127,6 +132,57 @@ class OrganizationMappingTest(TransactionTestCase, HybridCloudTestMixin):
             == orgmember_mapping.invite_status
             == InviteStatus.REQUESTED_TO_BE_INVITED.value
         )
+
+    def test_upsert_does_not_drain_user_shard_inline(self) -> None:
+        user = self.create_user("deferred@example.com")
+        ControlOutbox.objects.filter(shard_identifier=user.id).delete()
+
+        organizationmember_mapping_service.upsert_mapping(
+            organization_id=self.organization.id,
+            organizationmember_id=222222,
+            mapping=RpcOrganizationMemberMappingUpdate(
+                role="member",
+                user_id=user.id,
+                email=None,
+                inviter_id=None,
+                invite_status=None,
+            ),
+        )
+
+        # The user outbox is written transactionally with the mapping, but a
+        # surviving row means it was not drained inline -- delivery is left to the
+        # scheduled drain instead of fanning out more RPCs inside this RPC handler.
+        assert ControlOutbox.objects.filter(
+            shard_identifier=user.id, category=OutboxCategory.USER_UPDATE.value
+        ).exists()
+
+    def test_upsert_succeeds_when_cell_replication_fails(self) -> None:
+        user = self.create_user("unreachable@example.com")
+
+        with patch(
+            "sentry.hybridcloud.rpc.caching.cell_caching_service.clear_key",
+            side_effect=RpcResponseException(
+                service_name="region_caching",
+                method_name="clear_key",
+                message="Received malformed 200 response of 0 byte(s)",
+            ),
+        ):
+            result = organizationmember_mapping_service.upsert_mapping(
+                organization_id=self.organization.id,
+                organizationmember_id=333333,
+                mapping=RpcOrganizationMemberMappingUpdate(
+                    role="member",
+                    user_id=user.id,
+                    email=None,
+                    inviter_id=None,
+                    invite_status=None,
+                ),
+            )
+
+        assert result.user_id == user.id
+        assert OrganizationMemberMapping.objects.filter(
+            organization_id=self.organization.id, organizationmember_id=333333
+        ).exists()
 
     def test_create_mapping_updates_org_members(self) -> None:
         assert self.user.is_active


### PR DESCRIPTION
Adds an option-gated mode to defer flushes to Org Member replica outboxes in order to ease contention concerns with nested outbox flows, like org provisioning.

When the `hybrid_cloud.org_member_async_flush_enabled` option is enabled, outbox flushes are deferred, allowing the current context to immediately respond to the caller.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>