### PR TITLE
ref(onboarding): Update the Koa onboarding for v11

### DIFF
--- a/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
@@ -29,12 +29,22 @@ describe('koa onboarding docs', () => {
     });
   });
 
-  it('includes error handler', () => {
+  it('starts the app with the --import flag', () => {
     renderWithOnboardingLayout(docs);
 
     expect(
-      screen.getByText(textWithMarkupMatcher(/Sentry\.setupKoaErrorHandler\(app\)/))
+      screen.getByText(
+        textWithMarkupMatcher(/node --import \.\/instrument\.mjs index\.mjs/)
+      )
     ).toBeInTheDocument();
+  });
+
+  it('does not include the deprecated koa error handler', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/Sentry\.setupKoaErrorHandler/))
+    ).not.toBeInTheDocument();
   });
 
   it('displays sample rates by default', () => {
@@ -115,7 +125,7 @@ describe('koa onboarding docs', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+          /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
         )
       )
     ).toBeInTheDocument();
@@ -141,7 +151,7 @@ describe('koa onboarding docs', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+          /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node-koa/onboarding.spec.tsx
@@ -34,7 +34,7 @@ describe('koa onboarding docs', () => {
 
     expect(
       screen.getByText(
-        textWithMarkupMatcher(/node --import \.\/instrument\.mjs index\.mjs/)
+        textWithMarkupMatcher(/node --import \.\/instrument\.js index\.js/)
       )
     ).toBeInTheDocument();
   });

--- a/static/app/gettingStartedDocs/node-koa/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-koa/onboarding.tsx
@@ -7,23 +7,17 @@ import type {
 import {StepType} from 'sentry/components/onboarding/gettingStartedDoc/types';
 import {getUploadSourceMapsStep} from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {
-  getImportInstrumentSnippet,
+  getImport,
   getInstallCodeBlock,
   getSdkInitSnippet,
-  getSentryImportSnippet,
 } from 'sentry/gettingStartedDocs/node/utils';
 import {t, tct} from 'sentry/locale';
 
 const getSdkSetupSnippet = () => `
-${getImportInstrumentSnippet()}
-
-// All other imports below
-${getSentryImportSnippet('@sentry/node')}
-const Koa = require("koa");
+${getImport('@sentry/node', 'esm-only').join('\n')}
+import Koa from "koa";
 
 const app = new Koa();
-
-Sentry.setupKoaErrorHandler(app);
 
 // All your controllers should live here
 
@@ -79,7 +73,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.mjs].',
             {code: <code />}
           ),
         },
@@ -89,15 +83,15 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs)',
-              code: getSdkInitSnippet(params, 'node'),
+              filename: 'instrument.mjs',
+              code: getSdkInitSnippet(params, 'node', 'esm-only'),
             },
           ],
         },
         {
           type: 'text',
           text: tct(
-            "Make sure to import [code:instrument.js/mjs] at the top of your file. Set up the error handler after all controllers and before any other error middleware. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)]. If you're running your application in ESM mode, or looking for alternative ways to set up Sentry, read about [docs:installation methods in our docs].",
+            'Start your application with the [code:--import] flag, so that [code:instrument.mjs] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
             {
               code: <code />,
               docs: (
@@ -108,14 +102,33 @@ export const onboarding: OnboardingConfig = {
         },
         {
           type: 'code',
+          language: 'bash',
+          code: 'node --import ./instrument.mjs index.mjs',
+        },
+        {
+          type: 'text',
+          text: tct(
+            'This is what your application entry point, usually [code:index.mjs], looks like:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           tabs: [
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'index.(js|mjs)',
+              filename: 'index.mjs',
               code: getSdkSetupSnippet(),
             },
           ],
+        },
+        {
+          type: 'text',
+          text: tct(
+            'The default [code:koaIntegration] captures errors from your middleware automatically. You do not have to add an error handler.',
+            {code: <code />}
+          ),
         },
       ],
     },

--- a/static/app/gettingStartedDocs/node-koa/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node-koa/onboarding.tsx
@@ -73,7 +73,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.mjs].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.js]. These snippets use ESM syntax, so your [code:package.json] needs [code:"type": "module"].',
             {code: <code />}
           ),
         },
@@ -83,7 +83,7 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'instrument.mjs',
+              filename: 'instrument.js',
               code: getSdkInitSnippet(params, 'node', 'esm-only'),
             },
           ],
@@ -91,7 +91,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'Start your application with the [code:--import] flag, so that [code:instrument.mjs] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
+            'Start your application with the [code:--import] flag, so that [code:instrument.js] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
             {
               code: <code />,
               docs: (
@@ -103,12 +103,12 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'code',
           language: 'bash',
-          code: 'node --import ./instrument.mjs index.mjs',
+          code: 'node --import ./instrument.js index.js',
         },
         {
           type: 'text',
           text: tct(
-            'This is what your application entry point, usually [code:index.mjs], looks like:',
+            'This is what your application entry point, usually [code:index.js], looks like:',
             {code: <code />}
           ),
         },
@@ -118,7 +118,7 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'index.mjs',
+              filename: 'index.js',
               code: getSdkSetupSnippet(),
             },
           ],

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -102,8 +102,8 @@ export function getImport(
       ];
 }
 
-function getProfilingImport(defaultMode?: 'esm' | 'cjs'): string {
-  return defaultMode === 'esm'
+function getProfilingImport(defaultMode?: 'esm' | 'cjs' | 'esm-only'): string {
+  return defaultMode === 'esm' || defaultMode === 'esm-only'
     ? 'import { nodeProfilingIntegration } from "@sentry/profiling-node";'
     : 'const { nodeProfilingIntegration } = require("@sentry/profiling-node");';
 }
@@ -144,7 +144,7 @@ function getDefaultNodeImports({
 }: {
   params: DocsParams;
   sdkImport: 'node' | 'aws' | 'gpc' | 'nestjs' | null;
-  defaultMode?: 'esm' | 'cjs';
+  defaultMode?: 'esm' | 'cjs' | 'esm-only';
 }) {
   if (sdkImport === null || !libraryMap[sdkImport]) {
     return '';
@@ -579,7 +579,7 @@ Sentry.logger.info('User triggered test log', { action: 'test_log' })`,
 export const getSdkInitSnippet = (
   params: DocsParams,
   sdkImport: 'node' | 'aws' | 'gpc' | 'nestjs' | null,
-  defaultMode?: 'esm' | 'cjs'
+  defaultMode?: 'esm' | 'cjs' | 'esm-only'
 ) => `${getDefaultNodeImports({params, sdkImport, defaultMode})}
 
 Sentry.init({


### PR DESCRIPTION
## What

Switches the Koa onboarding to ESM with a `node --import ./instrument.js` start command, and removes the `Sentry.setupKoaErrorHandler(app)` call.

## Why

v11 no longer supports `--require`, and the Koa error handler is registered automatically when the app starts.