### PR TITLE
test(preprod): Avoid duplicate snapshot tests and retry waits

### DIFF
--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -55,7 +55,8 @@ class ChunksDoneIndicesTest(TestCase):
         assert (timezone.now() - comparison.date_updated).total_seconds() < 5
 
 
-def test_retry_objectstore_retries_once_on_429():
+@patch("sentry.preprod.snapshots.tasks.time.sleep")
+def test_retry_objectstore_retries_once_on_429(mock_sleep: MagicMock) -> None:
     calls = {"n": 0}
 
     def op():
@@ -66,6 +67,7 @@ def test_retry_objectstore_retries_once_on_429():
 
     assert _retry_objectstore(op) == "ok"
     assert calls["n"] == 2
+    mock_sleep.assert_called_once_with(0.5)
 
 
 def test_retry_objectstore_fails_fast_on_404():
@@ -76,12 +78,15 @@ def test_retry_objectstore_fails_fast_on_404():
         _retry_objectstore(op)
 
 
-def test_retry_objectstore_gives_up_after_max_attempts():
-    def op():
-        raise RequestError("unavailable", 503, "unavailable")
+@patch("sentry.preprod.snapshots.tasks.time.sleep")
+def test_retry_objectstore_gives_up_after_max_attempts(mock_sleep: MagicMock) -> None:
+    operation = MagicMock(side_effect=RequestError("unavailable", 503, "unavailable"))
 
     with pytest.raises(RequestError):
-        _retry_objectstore(op)
+        _retry_objectstore(operation)
+
+    assert operation.call_count == 2
+    mock_sleep.assert_called_once_with(0.5)
 
 
 def _mock_session_with_manifests(manifests_by_key: dict[str, bytes]) -> MagicMock:

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_tasks.py
@@ -20,8 +20,7 @@ from sentry.testutils.silo import cell_silo_test
 _sentinel = object()
 
 
-@cell_silo_test
-class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
+class SnapshotPrCommentTaskTestBase(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
@@ -80,6 +79,9 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
 
         return artifact, metrics
 
+
+@cell_silo_test
+class CreatePreprodSnapshotPrCommentTaskTest(SnapshotPrCommentTaskTestBase):
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.post_snapshot_pr_comment_task.delay")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.evaluate_snapshot_changes_by_artifact_id")
     @patch("sentry.preprod.vcs.pr_comments.snapshot_tasks.get_commit_context_client")
@@ -309,7 +311,7 @@ class CreatePreprodSnapshotPrCommentTaskTest(TestCase):
 
 
 @cell_silo_test
-class CreateSnapshotPrCommentSoloTest(CreatePreprodSnapshotPrCommentTaskTest):
+class CreateSnapshotPrCommentSoloTest(SnapshotPrCommentTaskTestBase):
     def _create_previous_snapshot(self, app_id: str = "com.example.app") -> None:
         prev_cc = CommitComparison.objects.create(
             organization_id=self.organization.id,


### PR DESCRIPTION
Avoid running 13 snapshot PR-comment tests twice by extracting setup and artifact helpers into a base class with no tests. The regular and solo-comment suites now inherit that shared base instead of the solo suite inheriting another collected test suite. Every distinct scenario and the existing fixture behavior are preserved.

Mock the two objectstore retry waits rather than sleeping for real. The tests still check retry attempts, exception propagation, and the requested backoff delay; production retry behavior is unchanged.

In a local before/after run of the same four snapshot suites, pytest time dropped from 63.96s for 135 executions to 55.51s for 122 executions (about 13% faster; wall-clock 71.90s to 61.80s). Comparing the test reports confirmed that only the 13 duplicate inherited executions disappeared, with each scenario still passing in its original suite. The PR-comment test bodies and shared helpers are unchanged.
