### PR TITLE
fix(HC): Updates RPC error reporting code

### DIFF
--- a/src/sentry/api/endpoints/internal/rpc.py
+++ b/src/sentry/api/endpoints/internal/rpc.py
@@ -1,7 +1,7 @@
 import pydantic
 import sentry_sdk
 from rest_framework import status
-from rest_framework.exceptions import NotFound, ParseError, PermissionDenied, ValidationError
+from rest_framework.exceptions import NotFound, ParseError, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -106,6 +106,12 @@ class InternalRpcServiceEndpoint(Endpoint):
                 raise Exception(
                     f"Problem processing rpc service endpoint {service_name}/{method_name}"
                 ) from e
+            # Something failed internally when processing the RPC, so we return
+            # a 500 error to the caller.
+            sentry_sdk.set_tag("rpc_implementation_error", type(e).__name__)
             sentry_sdk.capture_exception()
-            raise ValidationError from e
+            return Response(
+                data={"detail": "Internal error in RPC service"},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
         return Response(data=result)

--- a/tests/sentry/api/endpoints/test_rpc.py
+++ b/tests/sentry/api/endpoints/test_rpc.py
@@ -145,6 +145,22 @@ class RpcServiceEndpointTest(APITestCase):
             "detail": ErrorDetail(string="Malformed request.", code="parse_error")
         }
 
+    def test_implementation_error_returns_500(self) -> None:
+        path = self._get_path("organization", "get_organization_by_id")
+        data = {"args": {"id": 0}}
+
+        with (
+            patch("sentry.api.endpoints.internal.rpc.in_test_environment", return_value=False),
+            patch(
+                "sentry.api.endpoints.internal.rpc.dispatch_to_local_service",
+                side_effect=OSError("cell unreachable"),
+            ),
+        ):
+            response = self._send_post_request(path, data)
+
+        assert response.status_code == 500
+        assert response.data == {"detail": "Internal error in RPC service"}
+
     def test_viewer_context_propagated_from_meta(self) -> None:
         """ViewerContext in meta is set as the contextvar during dispatch."""
         organization = self.create_organization()


### PR DESCRIPTION
Updates error reporting endpoint to record explicit 500 responses rather than 400s with a vague error statement.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>