### PR TITLE
fix(artifact-lookup): prefetch downloads so filestore errors are handled

### DIFF
--- a/src/sentry/api/endpoints/artifact_lookup.py
+++ b/src/sentry/api/endpoints/artifact_lookup.py
@@ -9,6 +9,7 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from symbolic.debuginfo import normalize_debug_id
 from symbolic.exceptions import SymbolicError
+from urllib3.exceptions import HTTPError
 
 from sentry import ratelimits
 from sentry.api.api_owners import ApiOwner
@@ -114,14 +115,14 @@ class ProjectArtifactLookupEndpoint(ProjectEndpoint):
         file = file_m.file
 
         try:
-            fp = file.getfile()
+            fp = file.getfile(prefetch=True)
             response = StreamingHttpResponse(
                 iter(lambda: fp.read(4096), b""), content_type="application/octet-stream"
             )
             response["Content-Length"] = file.size
             response["Content-Disposition"] = f'attachment; filename="{file.name}"'
             return response
-        except OSError:
+        except (OSError, HTTPError):
             raise Http404
 
     def get(self, request: Request, project: Project) -> Response:

--- a/tests/sentry/api/endpoints/test_project_artifact_lookup.py
+++ b/tests/sentry/api/endpoints/test_project_artifact_lookup.py
@@ -3,11 +3,13 @@ import zipfile
 from datetime import datetime, timedelta, timezone
 from hashlib import sha1
 from io import BytesIO
+from unittest.mock import patch
 from uuid import uuid4
 
 import orjson
 from django.core.files.base import ContentFile
 from django.urls import reverse
+from urllib3.exceptions import ProtocolError
 
 from sentry.models.artifactbundle import (
     ArtifactBundle,
@@ -763,6 +765,30 @@ class ArtifactLookupTest(APITestCase):
         )
 
         self.assert_download_matches_file(f"{url}?download=release_file/{rf_a.id}", file_content)
+
+    def test_download_protocol_error_returns_404(self) -> None:
+        file_a = make_file("app.js", b"legitimate-project-a-data", "release.file", {})
+        rf_a = ReleaseFile.objects.create(
+            organization_id=self.organization.id,
+            release_id=self.release.id,
+            file=file_a,
+            name="http://example.com/app.js",
+        )
+
+        self.login_as(user=self.user)
+
+        url = reverse(
+            "sentry-api-0-project-artifact-lookup",
+            kwargs={
+                "organization_id_or_slug": self.project.organization.slug,
+                "project_id_or_slug": self.project.slug,
+            },
+        )
+
+        with patch.object(File, "getfile", side_effect=ProtocolError("connection broken")):
+            response = self.client.get(f"{url}?download=release_file/{rf_a.id}")
+
+        assert response.status_code == 404
 
     def test_download_invalid_id(self) -> None:
         self.login_as(user=self.user)


### PR DESCRIPTION
## Summary
- Prefetch artifact-lookup downloads so a broken filestore connection is raised in the view, not later inside Granian's streaming iterator.
- Treat `HTTPError` (including urllib3 `ProtocolError`) like `OSError` and return 404.
- Companion: https://github.com/getsentry/getsentry/pull/21879 (filestore retry). Together they stop [SENTRY-5K7B](https://sentry.sentry.io/issues/SENTRY-5K7B) from failing canary as an unhandled ERROR.

## Test plan
- [ ] `pytest tests/sentry/api/endpoints/test_project_artifact_lookup.py::ArtifactLookupTest::test_download_protocol_error_returns_404`
- [ ] `pytest tests/sentry/api/endpoints/test_project_artifact_lookup.py::ArtifactLookupTest::test_same_project_release_file_download_allowed`
- [ ] Download a release file / artifact bundle still returns the bytes
- [ ] A `ProtocolError` from `getfile(prefetch=True)` returns 404, not a 500