### PR TITLE
feat(derived): Track unnecessary ReconcileStatusActions

### DIFF
--- a/src/sentry/issues/derived/aggregators.py
+++ b/src/sentry/issues/derived/aggregators.py
@@ -29,7 +29,12 @@ from sentry.issues.action_log.types import (
     ViewAction,
 )
 from sentry.issues.derived.features import (
+    _COUNTERFACTUAL_STATUS,
+    _MIRROR_STATUS,
+    _WATCHED_RECONCILE_ID,
     BLOCKER,
+    FIRST_NO_CHANGE_RECONCILE_ID,
+    FIRST_SUPERSEDED_RECONCILE_ID,
     HAS_OPEN_FIX_PR,
     HAS_ROOT_CAUSE,
     IS_ASSIGNED,
@@ -58,19 +63,40 @@ def track_views(state: StateView, entry: GroupActionLogEntry) -> AggregatorResul
     return emit(VIEW_COUNT.value(state[VIEW_COUNT] + 1))
 
 
+_STATUS_SCOPE = (
+    ResolveAction,
+    SetResolvedInReleaseAction,
+    SetResolvedByAgeAction,
+    SetResolvedInCommitAction,
+    ArchiveAction,
+    UnresolveAction,
+    SetEscalatingAction,
+    SetRegressedAction,
+    ReconcileStatusAction,
+)
+
+
+def _natural_status_transition(current: IssueStatus, entry: GroupActionLogEntry) -> IssueStatus:
+    """New status after a non-reconcile status action. Unchanged if the entry is a no-op."""
+    match entry.action:
+        case (
+            ResolveAction()
+            | SetResolvedInReleaseAction()
+            | SetResolvedByAgeAction()
+            | SetResolvedInCommitAction()
+            | ArchiveAction()
+        ) if current == IssueStatus.OPEN:
+            return IssueStatus.CLOSED
+        case UnresolveAction() | SetRegressedAction() | SetEscalatingAction() if (
+            current == IssueStatus.CLOSED
+        ):
+            return IssueStatus.OPEN
+    return current
+
+
 @aggregator(
-    (STATUS,),
-    scope=(
-        ResolveAction,
-        SetResolvedInReleaseAction,
-        SetResolvedByAgeAction,
-        SetResolvedInCommitAction,
-        ArchiveAction,
-        UnresolveAction,
-        SetEscalatingAction,
-        SetRegressedAction,
-        ReconcileStatusAction,
-    ),
+    (STATUS, FIRST_NO_CHANGE_RECONCILE_ID),
+    scope=_STATUS_SCOPE,
 )
 def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
     # A merge preserves the destination group's status. Ignore actions migrated
@@ -85,20 +111,81 @@ def track_status(state: StateView, entry: GroupActionLogEntry) -> AggregatorResu
             new_status = IssueStatus(raw_status)
             if new_status != current:
                 return emit(STATUS.value(new_status))
-        case (
-            ResolveAction()
-            | SetResolvedInReleaseAction()
-            | SetResolvedByAgeAction()
-            | SetResolvedInCommitAction()
-            | ArchiveAction()
-        ) if current == IssueStatus.OPEN:
-            return emit(STATUS.value(IssueStatus.CLOSED))
-        case UnresolveAction() | SetRegressedAction() | SetEscalatingAction() if (
-            current == IssueStatus.CLOSED
-        ):
-            return emit(STATUS.value(IssueStatus.OPEN))
+            if state[FIRST_NO_CHANGE_RECONCILE_ID] is None:
+                return emit(FIRST_NO_CHANGE_RECONCILE_ID.value(entry.id))
+            return None
+        case _:
+            new_status = _natural_status_transition(current, entry)
+            if new_status != current:
+                return emit(STATUS.value(new_status))
 
     return None
+
+
+@aggregator(
+    (
+        FIRST_SUPERSEDED_RECONCILE_ID,
+        _MIRROR_STATUS,
+        _COUNTERFACTUAL_STATUS,
+        _WATCHED_RECONCILE_ID,
+    ),
+    scope=_STATUS_SCOPE,
+)
+def track_reconcile_redundancy(state: StateView, entry: GroupActionLogEntry) -> AggregatorResult:
+    """Detect ReconcileStatusActions that a later natural event would have made redundant.
+
+    Maintains a self-contained STATUS mirror plus a counterfactual mirror that
+    ignores the currently-watched reconcile. When the two converge, the watched
+    reconcile is superseded. Any subsequent reconcile cancels an in-flight watch.
+    """
+    if state[FIRST_SUPERSEDED_RECONCILE_ID] is not None:
+        return None
+    if entry.original_group_id is not None:
+        return None
+
+    mirror = state[_MIRROR_STATUS]
+    counterfactual = state[_COUNTERFACTUAL_STATUS]
+    watched = state[_WATCHED_RECONCILE_ID]
+
+    match entry.action:
+        case ReconcileStatusAction(status=raw_status):
+            target = IssueStatus(raw_status)
+            # Any reconcile invalidates an in-flight watch; a status-changing
+            # reconcile then starts a fresh watch on itself.
+            if target != mirror:
+                return emit(
+                    _MIRROR_STATUS.value(target),
+                    _COUNTERFACTUAL_STATUS.value(mirror),
+                    _WATCHED_RECONCILE_ID.value(entry.id),
+                )
+            if watched is None:
+                return None
+            return emit(
+                _COUNTERFACTUAL_STATUS.value(None),
+                _WATCHED_RECONCILE_ID.value(None),
+            )
+        case _:
+            new_mirror = _natural_status_transition(mirror, entry)
+            if watched is None:
+                if new_mirror == mirror:
+                    return None
+                return emit(_MIRROR_STATUS.value(new_mirror))
+
+            assert counterfactual is not None
+            new_counterfactual = _natural_status_transition(counterfactual, entry)
+            if new_mirror == new_counterfactual:
+                return emit(
+                    FIRST_SUPERSEDED_RECONCILE_ID.value(watched),
+                    _MIRROR_STATUS.value(new_mirror),
+                    _COUNTERFACTUAL_STATUS.value(None),
+                    _WATCHED_RECONCILE_ID.value(None),
+                )
+            if new_mirror == mirror and new_counterfactual == counterfactual:
+                return None
+            return emit(
+                _MIRROR_STATUS.value(new_mirror),
+                _COUNTERFACTUAL_STATUS.value(new_counterfactual),
+            )
 
 
 # Progress for open issues (None when closed).
@@ -307,6 +394,7 @@ def track_blocker(state: StateView, entry: GroupActionLogEntry) -> AggregatorRes
 AGGREGATORS: list[Aggregator[GroupActionLogEntry]] = [
     track_views,
     track_status,
+    track_reconcile_redundancy,
     track_assignment,
     track_root_cause,
     track_open_fix_prs,

--- a/src/sentry/issues/derived/check.py
+++ b/src/sentry/issues/derived/check.py
@@ -5,7 +5,12 @@ from datetime import datetime, timedelta
 from typing import Any, NamedTuple, TypedDict
 from uuid import uuid4
 
-from sentry.issues.derived.features import STATUS, IssueStatus
+from sentry.issues.derived.features import (
+    FIRST_NO_CHANGE_RECONCILE_ID,
+    FIRST_SUPERSEDED_RECONCILE_ID,
+    STATUS,
+    IssueStatus,
+)
 from sentry.issues.derived.framework import Feature, Pipeline
 from sentry.issues.derived.gate import derived_should_be_correct
 from sentry.issues.derived.processing import DEFAULT_BATCH_SIZE
@@ -243,6 +248,24 @@ def _entries_through_target_cursor(
     )
 
 
+def _log_redundant_reconciles(target: GroupDerivedData) -> None:
+    """Log when a GDD records a no-change or superseded reconcile, for coverage."""
+    data = target.data or {}
+    no_change_id = data.get(FIRST_NO_CHANGE_RECONCILE_ID.name)
+    superseded_id = data.get(FIRST_SUPERSEDED_RECONCILE_ID.name)
+    if no_change_id is None and superseded_id is None:
+        return
+    logger.info(
+        "check_derived_data.redundant_reconcile",
+        extra={
+            "group_id": target.group_id,
+            "pipeline_hash": target.pipeline_hash,
+            "first_no_change_reconcile_id": no_change_id,
+            "first_superseded_reconcile_id": superseded_id,
+        },
+    )
+
+
 def check_derived_data(
     target: GroupDerivedData,
     pipeline: Pipeline[GroupActionLogEntry],
@@ -261,6 +284,8 @@ def check_derived_data(
             return CheckInvalidated()
     else:
         check_id = CheckId.new_for_derived_data(target)
+
+    _log_redundant_reconciles(target)
 
     replayed_derived = _check_cache.get(check_id)
     if replayed_derived is None:

--- a/src/sentry/issues/derived/features.py
+++ b/src/sentry/issues/derived/features.py
@@ -19,6 +19,26 @@ STATUS = Feature[IssueStatus](
     "status", default=IssueStatus.OPEN, codec=EnumCodec(IssueStatus), version=2
 )
 
+# Id of the first ReconcileStatusAction whose target equaled the current status.
+# First-write-wins; never cleared. Used to find reconciles that can be deleted.
+FIRST_NO_CHANGE_RECONCILE_ID = Feature[int | None]("first_no_change_reconcile_id", default=None)
+
+# Id of the first ReconcileStatusAction that changed status, but which a later
+# natural status event would have driven STATUS to the same value anyway.
+# First-write-wins; never cleared.
+FIRST_SUPERSEDED_RECONCILE_ID = Feature[int | None]("first_superseded_reconcile_id", default=None)
+
+# Internal to reconcile-redundancy detection; do not consume.
+_MIRROR_STATUS = Feature[IssueStatus](
+    "_mirror_status", default=IssueStatus.OPEN, codec=EnumCodec(IssueStatus)
+)
+_COUNTERFACTUAL_STATUS = Feature[IssueStatus | None](
+    "_counterfactual_status",
+    default=None,
+    codec=OptionalCodec(EnumCodec(IssueStatus)),
+)
+_WATCHED_RECONCILE_ID = Feature[int | None]("_watched_reconcile_id", default=None)
+
 # The current Progress of the issue.
 PROGRESS = Feature[IssueProgressState | None](
     "progress",

--- a/tests/sentry/issues/derived/test_aggregators.py
+++ b/tests/sentry/issues/derived/test_aggregators.py
@@ -22,6 +22,8 @@ from sentry.issues.action_log.types import (
 from sentry.issues.derived.aggregators import AGGREGATORS
 from sentry.issues.derived.features import (
     BLOCKER,
+    FIRST_NO_CHANGE_RECONCILE_ID,
+    FIRST_SUPERSEDED_RECONCILE_ID,
     LAST_COMPLETED_AUTOFIX_STEP,
     LAST_PROGRESSED_AT,
     PROGRESS,
@@ -66,6 +68,7 @@ class FakeEntry:
     actor_id: int = 0
     data: dict[str, object] = field(default_factory=dict)
     original_group_id: int | None = None
+    id: int = 0
 
     @property
     def action(self) -> GroupAction:
@@ -85,12 +88,18 @@ def _resolved_pr_data(pr_id: int) -> dict[str, object]:
     return {"pull_request": pr_id}
 
 
-def _reconcile_entry(status: IssueStatus, *, original_group_id: int | None = None) -> FakeEntry:
+def _reconcile_entry(
+    status: IssueStatus,
+    *,
+    id: int = 0,
+    original_group_id: int | None = None,
+) -> FakeEntry:
     action = ReconcileStatusAction(status=status.value)
     return FakeEntry(
         type=GroupActionType.RECONCILE_STATUS,
         data=action.dict(),
         original_group_id=original_group_id,
+        id=id,
     )
 
 
@@ -417,6 +426,162 @@ class TestReconcileStatus:
         )
         assert state[STATUS] == IssueStatus.OPEN
         assert state[PROGRESS] == IssueProgressState.IDENTIFIED
+
+
+# ---------------------------------------------------------------------------
+# FIRST_NO_CHANGE_RECONCILE_ID / FIRST_SUPERSEDED_RECONCILE_ID
+# ---------------------------------------------------------------------------
+
+
+class TestNoChangeReconcile:
+    def test_same_status_records_id(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_NO_CHANGE_RECONCILE_ID,
+                [_reconcile_entry(IssueStatus.OPEN, id=7)],
+            )
+            == 7
+        )
+
+    def test_different_status_does_not_record(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_NO_CHANGE_RECONCILE_ID,
+                [_reconcile_entry(IssueStatus.CLOSED, id=7)],
+            )
+            is None
+        )
+
+    def test_first_write_wins(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_NO_CHANGE_RECONCILE_ID,
+                [
+                    _reconcile_entry(IssueStatus.OPEN, id=7),
+                    _reconcile_entry(IssueStatus.OPEN, id=8),
+                ],
+            )
+            == 7
+        )
+
+    def test_after_close(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_NO_CHANGE_RECONCILE_ID,
+                [
+                    FakeEntry(type=GroupActionType.RESOLVE, id=1),
+                    _reconcile_entry(IssueStatus.CLOSED, id=9),
+                ],
+            )
+            == 9
+        )
+
+    def test_merged_source_ignored(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_NO_CHANGE_RECONCILE_ID,
+                [_reconcile_entry(IssueStatus.OPEN, id=7, original_group_id=123)],
+            )
+            is None
+        )
+
+
+class TestSupersededReconcile:
+    def test_reconcile_then_natural_close(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_SUPERSEDED_RECONCILE_ID,
+                [
+                    _reconcile_entry(IssueStatus.CLOSED, id=10),
+                    FakeEntry(type=GroupActionType.RESOLVE, id=11),
+                ],
+            )
+            == 10
+        )
+
+    def test_reconcile_then_unresolve_converges(self) -> None:
+        # Reconcile OPEN->CLOSED; unresolve brings true status back to OPEN,
+        # matching the counterfactual that never closed.
+        assert (
+            _run_for_feature(
+                FIRST_SUPERSEDED_RECONCILE_ID,
+                [
+                    _reconcile_entry(IssueStatus.CLOSED, id=10),
+                    FakeEntry(type=GroupActionType.UNRESOLVE, id=11),
+                ],
+            )
+            == 10
+        )
+
+    def test_no_later_event_leaves_none(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_SUPERSEDED_RECONCILE_ID,
+                [_reconcile_entry(IssueStatus.CLOSED, id=10)],
+            )
+            is None
+        )
+
+    def test_later_reconcile_invalidates_and_starts_new_watch(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_SUPERSEDED_RECONCILE_ID,
+                [
+                    _reconcile_entry(IssueStatus.CLOSED, id=10),
+                    _reconcile_entry(IssueStatus.OPEN, id=11),
+                    FakeEntry(type=GroupActionType.RESOLVE, id=12),
+                ],
+            )
+            == 11
+        )
+
+    def test_no_change_reconcile_does_not_set_superseded(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_SUPERSEDED_RECONCILE_ID,
+                [_reconcile_entry(IssueStatus.OPEN, id=7)],
+            )
+            is None
+        )
+
+    def test_first_write_wins(self) -> None:
+        p = _pipeline(targets=(FIRST_SUPERSEDED_RECONCILE_ID,))
+        state = p.run(
+            [
+                _reconcile_entry(IssueStatus.CLOSED, id=10),
+                FakeEntry(type=GroupActionType.RESOLVE, id=11),
+                # Another status-changing reconcile + natural close would also
+                # supersede, but first-write-wins keeps the earlier id.
+                FakeEntry(type=GroupActionType.UNRESOLVE, id=12),
+                _reconcile_entry(IssueStatus.CLOSED, id=13),
+                FakeEntry(type=GroupActionType.RESOLVE, id=14),
+            ]
+        )
+        assert state[FIRST_SUPERSEDED_RECONCILE_ID] == 10
+
+    def test_merged_source_ignored(self) -> None:
+        assert (
+            _run_for_feature(
+                FIRST_SUPERSEDED_RECONCILE_ID,
+                [
+                    _reconcile_entry(IssueStatus.CLOSED, id=10, original_group_id=123),
+                    FakeEntry(type=GroupActionType.RESOLVE, id=11),
+                ],
+            )
+            is None
+        )
+
+    def test_status_and_no_change_together(self) -> None:
+        p = _pipeline(targets=(STATUS, FIRST_NO_CHANGE_RECONCILE_ID, FIRST_SUPERSEDED_RECONCILE_ID))
+        state = p.run(
+            [
+                FakeEntry(type=GroupActionType.RESOLVE, id=1),
+                _reconcile_entry(IssueStatus.CLOSED, id=2),
+            ]
+        )
+        assert state[STATUS] == IssueStatus.CLOSED
+        assert state[FIRST_NO_CHANGE_RECONCILE_ID] == 2
+        assert state[FIRST_SUPERSEDED_RECONCILE_ID] is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sentry/issues/derived/test_check.py
+++ b/tests/sentry/issues/derived/test_check.py
@@ -1,4 +1,8 @@
-from sentry.issues.derived.check import StatusInconsistency, check_status_consistency
+from sentry.issues.derived.check import (
+    StatusInconsistency,
+    _log_redundant_reconciles,
+    check_status_consistency,
+)
 from sentry.issues.derived.features import IssueStatus
 from sentry.models.group import GroupStatus
 from sentry.testutils.cases import TestCase
@@ -34,3 +38,23 @@ class CheckStatusConsistencyTest(TestCase):
         derived = self.create_group_derived_data(group=group, data={"status": "open"})
 
         assert check_status_consistency(group, derived) is None
+
+    def test_logs_redundant_reconcile(self) -> None:
+        group = self.create_group()
+        derived = self.create_group_derived_data(
+            group=group,
+            data={
+                "status": "open",
+                "first_no_change_reconcile_id": 42,
+                "first_superseded_reconcile_id": 99,
+            },
+        )
+        with self.assertLogs("sentry.issues.derived.check", level="INFO") as cm:
+            _log_redundant_reconciles(derived)
+        assert any("check_derived_data.redundant_reconcile" in msg for msg in cm.output)
+
+    def test_skips_log_when_no_redundancy(self) -> None:
+        group = self.create_group()
+        derived = self.create_group_derived_data(group=group, data={"status": "open"})
+        with self.assertNoLogs("sentry.issues.derived.check", level="INFO"):
+            _log_redundant_reconciles(derived)


### PR DESCRIPTION
Unnecessary reconciles are worth being aware of and ultimately removing.
They are not real actions, and if we manage to fix the algorithms or backfill data to make them unnecessary, the log is improved by removing them.
