### PR TITLE
ref(autofix): Stop storing results in extras

### DIFF
--- a/src/sentry/seer/autofix_rca/delivery.py
+++ b/src/sentry/seer/autofix_rca/delivery.py
@@ -75,6 +75,9 @@ def deliver_autofix_rca_result(
             logger.warning("autofix_rca.delivery.no_result", extra={**log_extra, "status": status})
             return
 
+        # Clear any stale delivery error_message now that this delivery has succeeded.
+        extras.pop("error_message", None)
+
         agent_run.update(
             using=using,
             extras={**extras, "status": "completed"},

--- a/src/sentry/seer/autofix_rca/delivery.py
+++ b/src/sentry/seer/autofix_rca/delivery.py
@@ -77,7 +77,6 @@ def deliver_autofix_rca_result(
 
         # Clear any stale delivery error_message now that this delivery has succeeded.
         extras.pop("error_message", None)
-        extras.pop("result", None)
 
         agent_run.update(
             using=using,

--- a/src/sentry/seer/autofix_rca/delivery.py
+++ b/src/sentry/seer/autofix_rca/delivery.py
@@ -77,6 +77,7 @@ def deliver_autofix_rca_result(
 
         # Clear any stale delivery error_message now that this delivery has succeeded.
         extras.pop("error_message", None)
+        extras.pop("result", None)
 
         agent_run.update(
             using=using,

--- a/src/sentry/seer/autofix_rca/delivery.py
+++ b/src/sentry/seer/autofix_rca/delivery.py
@@ -75,11 +75,9 @@ def deliver_autofix_rca_result(
             logger.warning("autofix_rca.delivery.no_result", extra={**log_extra, "status": status})
             return
 
-        # Persist and claim the result before triggering non-idempotent downstream actions.
-        extras.pop("error_message", None)
         agent_run.update(
             using=using,
-            extras={**extras, "status": "completed", "result": result},
+            extras={**extras, "status": "completed"},
         )
 
         group_id = agent_run.group_id

--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -46,6 +46,14 @@ def trigger_autofix_rca_feature(
             data_category=DataCategory.SEER_AUTOFIX,
         )
         if not has_budget:
+            logger.warning(
+                "autofix_rca.dispatch.quota_denied",
+                extra={
+                    "group_id": group.id,
+                    "organization_id": group.organization.id,
+                    "referrer": referrer.value,
+                },
+            )
             raise NoSeerQuotaException()
 
     payload = AutofixRCAPayload(
@@ -104,6 +112,13 @@ def trigger_autofix_rca_feature(
             "organization_id": group.organization.id,
             "run_id": run.seer_run_state_id,
             "referrer": referrer.value,
+            "stopping_point": stopping_point,
+            "intelligence_level": intelligence_level,
+            "reasoning_effort": reasoning_effort,
+            "flush": flush,
+            "allow_free_cohort": allow_free_cohort,
+            "user_context": user_context,
+            "enable_bash_tools": enable_bash_tools,
         },
     )
 

--- a/tests/sentry/seer/autofix_rca/test_delivery.py
+++ b/tests/sentry/seer/autofix_rca/test_delivery.py
@@ -162,9 +162,6 @@ class TestDeliverAutofixRCAResult(TestCase):
             result=None,
             error="temporary error",
         )
-        self.agent_run.refresh_from_db()
-        self.agent_run.extras = {**self.agent_run.extras, "result": {"stale": True}}
-        self.agent_run.save(update_fields=["extras"])
 
         deliver_autofix_rca_result(
             organization_id=self.organization.id,
@@ -177,7 +174,6 @@ class TestDeliverAutofixRCAResult(TestCase):
         self.agent_run.refresh_from_db()
         assert self.agent_run.extras["status"] == "completed"
         assert "error_message" not in self.agent_run.extras
-        assert "result" not in self.agent_run.extras
 
     def test_night_shift_run_is_not_matched(self) -> None:
         seer_run = self.create_seer_run(organization=self.organization, type="feature_run")

--- a/tests/sentry/seer/autofix_rca/test_delivery.py
+++ b/tests/sentry/seer/autofix_rca/test_delivery.py
@@ -52,7 +52,7 @@ class TestDeliverAutofixRCAResult(TestCase):
         mock_logger.warning.assert_called_once()
         assert "autofix_rca.delivery.missing_run" in mock_logger.warning.call_args.args[0]
 
-    def test_completed_result_is_persisted(self) -> None:
+    def test_completed_result_is_not_persisted_and_routing_metadata_is_preserved(self) -> None:
         self.agent_run.extras = {
             **self.agent_run.extras,
             "stopping_point": AutofixStoppingPoint.OPEN_PR.value,
@@ -69,7 +69,7 @@ class TestDeliverAutofixRCAResult(TestCase):
 
         self.agent_run.refresh_from_db()
         assert self.agent_run.extras["status"] == "completed"
-        assert self.agent_run.extras["result"] == VALID_RESULT
+        assert "result" not in self.agent_run.extras
         assert self.agent_run.extras["referrer"] == AutofixReferrer.WEB.value
         assert self.agent_run.extras["stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
 
@@ -118,7 +118,7 @@ class TestDeliverAutofixRCAResult(TestCase):
 
         self.agent_run.refresh_from_db()
         assert self.agent_run.extras["status"] == "completed"
-        assert self.agent_run.extras["result"] == VALID_RESULT
+        assert "result" not in self.agent_run.extras
 
     def test_delivery_claim_uses_row_lock(self) -> None:
         using = router.db_for_write(SeerAgentRun)
@@ -162,6 +162,10 @@ class TestDeliverAutofixRCAResult(TestCase):
             result=None,
             error="temporary error",
         )
+        self.agent_run.refresh_from_db()
+        self.agent_run.extras = {**self.agent_run.extras, "result": {"stale": True}}
+        self.agent_run.save(update_fields=["extras"])
+
         deliver_autofix_rca_result(
             organization_id=self.organization.id,
             run_uuid=self.agent_run.run.uuid,
@@ -173,7 +177,7 @@ class TestDeliverAutofixRCAResult(TestCase):
         self.agent_run.refresh_from_db()
         assert self.agent_run.extras["status"] == "completed"
         assert "error_message" not in self.agent_run.extras
-        assert self.agent_run.extras["result"] == VALID_RESULT
+        assert "result" not in self.agent_run.extras
 
     def test_night_shift_run_is_not_matched(self) -> None:
         seer_run = self.create_seer_run(organization=self.organization, type="feature_run")


### PR DESCRIPTION
After inc-2500, we realized we were accidentally storing the rca results artifact in the SeerAgentRun.extras field. This removes that setting.

Also adds a bit more logging.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>