### PR TITLE
ref(autofix): Pass project_id to rca-in-seer

### DIFF
--- a/src/sentry/seer/autofix_rca/dispatch.py
+++ b/src/sentry/seer/autofix_rca/dispatch.py
@@ -50,6 +50,7 @@ def trigger_autofix_rca_feature(
 
     payload = AutofixRCAPayload(
         group_id=group.id,
+        project_id=group.project_id,
         short_id=group.qualified_short_id or str(group.id),
         title=group.title or "Unknown error",
         culprit=group.culprit or "unknown",

--- a/src/sentry/seer/autofix_rca/models.py
+++ b/src/sentry/seer/autofix_rca/models.py
@@ -28,6 +28,7 @@ class AutofixRCAPayload(BaseModel):
         extra = "ignore"
 
     group_id: int
+    project_id: int
     short_id: str
     title: str
     culprit: str

--- a/tests/sentry/seer/autofix_rca/test_dispatch.py
+++ b/tests/sentry/seer/autofix_rca/test_dispatch.py
@@ -55,6 +55,7 @@ class TestTriggerAutofixRCAFeature(TestCase):
         assert run_kwargs["flush"] is True
         payload = run_kwargs["payload"]
         assert payload["group_id"] == self.group.id
+        assert payload["project_id"] == self.group.project_id
         assert payload["short_id"] == (self.group.qualified_short_id or str(self.group.id))
         assert payload["title"] == self.group.title
         assert payload["tweaks"]["user_context"] == "an upstream triage summary"


### PR DESCRIPTION
Passes project_id to autofix-rca-in-seer, matching legacy autofix

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>