### PR TITLE
ref(tabs): Remove disableOverflow prop

### DIFF
--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -294,7 +294,6 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
     orientation,
     size,
     keyboardActivation = 'manual',
-    disableOverflow,
     ...otherRootProps
   } = rootProps;
 
@@ -333,7 +332,7 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
     tabItemsRef,
     tabItems: props.items,
     // Overflow only applies to horizontal tab lists.
-    disabled: disableOverflow || orientation !== 'horizontal',
+    disabled: orientation !== 'horizontal',
   });
 
   const overflowMenuItems = useMemo(() => {

--- a/static/app/components/core/tabs/tabs.mdx
+++ b/static/app/components/core/tabs/tabs.mdx
@@ -286,12 +286,6 @@ When there are too many tabs to fit, they automatically overflow into a dropdown
 </Tabs>
 ```
 
-To disable overflow (forcing horizontal scroll instead), use `disableOverflow`:
-
-```jsx
-<Tabs disableOverflow>{/* tabs will scroll horizontally instead of overflowing */}</Tabs>
-```
-
 ## Keyboard Navigation
 
 `<Tabs>` provides full keyboard support automatically:

--- a/static/app/components/core/tabs/tabs.tsx
+++ b/static/app/components/core/tabs/tabs.tsx
@@ -29,10 +29,6 @@ interface TabsProps<T>
    * selected tab item.
    */
   defaultValue?: T;
-  /**
-   * Disable tabs from being put in the overflow menu.
-   */
-  disableOverflow?: boolean;
   disabled?: boolean;
   /**
    * Callback when the selected tab changes.

--- a/static/app/components/externalIssues/externalIssueForm.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.tsx
@@ -388,7 +388,7 @@ export function ExternalIssueForm({
       >
         <Stack area="content" align="stretch" gap="lg" minWidth={0}>
           <Heading as="h2">{title}</Heading>
-          <Tabs value={action} onChange={handleClick} disableOverflow>
+          <Tabs value={action} onChange={handleClick}>
             <TabList>
               <TabList.Item key="create">{t('Create')}</TabList.Item>
               <TabList.Item key="link">{t('Link')}</TabList.Item>

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -192,11 +192,7 @@ export function ConversationSpanDetail({
       ) : isError ? (
         <EmptyTab message={t('Failed to load span details')} />
       ) : (
-        <TabStateProvider<DetailTab>
-          value={activeTab}
-          onChange={onTabChange}
-          disableOverflow
-        >
+        <TabStateProvider<DetailTab> value={activeTab} onChange={onTabChange}>
           <Flex flexShrink={0}>
             <TabList>
               <TabList.Item key="input">{t('Input')}</TabList.Item>

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -104,12 +104,7 @@ export function ExploreTables(props: ExploreTablesProps) {
   return (
     <Fragment>
       <Flex justify="between" marginBottom="md" gap="md" wrap="wrap">
-        <Tabs
-          value={tab}
-          onChange={newTab => setTab(newTab, 'click')}
-          size="sm"
-          disableOverflow
-        >
+        <Tabs value={tab} onChange={newTab => setTab(newTab, 'click')} size="sm">
           <TabList variant="floating">
             <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
             <TabList.Item

--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
@@ -149,7 +149,7 @@ export function IssueDetailsEventNavigation({
           }}
         />
       </Navigation>
-      <Tabs value={currentEventKey} disableOverflow onChange={onTabChange} size="xs">
+      <Tabs value={currentEventKey} onChange={onTabChange} size="xs">
         <TabList variant="floating">
           {eventNavPresets.map(({key, label, tooltip}) => {
             const eventPath =

--- a/static/app/views/settings/organizationDataForwarding/edit.tsx
+++ b/static/app/views/settings/organizationDataForwarding/edit.tsx
@@ -112,7 +112,7 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
                   )}
                 />
               )}
-              <Tabs value={dataForwarder.provider} disableOverflow>
+              <Tabs value={dataForwarder.provider}>
                 <TabList variant="floating">
                   {Object.entries(ProviderLabels).map(([key, label]) => (
                     <TabList.Item

--- a/static/app/views/settings/organizationDataForwarding/setup.tsx
+++ b/static/app/views/settings/organizationDataForwarding/setup.tsx
@@ -109,7 +109,7 @@ export default function OrganizationDataForwardingSetup() {
                   features={features}
                 />
               )}
-              <Tabs value={provider} onChange={setProvider} disableOverflow>
+              <Tabs value={provider} onChange={setProvider}>
                 <TabList variant="floating">
                   {Object.entries(ProviderLabels).map(([key, label]) => (
                     <TabList.Item


### PR DESCRIPTION
We are removing the disableOverflow prop from the Tabs component. Previously, this prop forced all tabs into a single horizontal row instead of moving excess items into the overflow menu ("..."), which caused the tab bar to bleed past its container bounds in narrow layouts. Removing this prop ensures tabs remain contained and responsive across all screen sizes.

The issue:

<img width="553" height="1124" alt="image" src="https://github.com/user-attachments/assets/b66a9406-9d1e-4429-ba87-a3b06b3545d2" />


Follow-up of https://github.com/getsentry/sentry/pull/123548#discussion_r3965384114

