### PR TITLE
ref(agents): Drop unused trace error binding

### DIFF
--- a/static/app/views/insights/pages/agents/hooks/useAITrace.tsx
+++ b/static/app/views/insights/pages/agents/hooks/useAITrace.tsx
@@ -107,7 +107,7 @@ export function useAITrace(traceSlug: string, timestamp?: number): UseAITraceRes
 
         setNodes(flattenedNodes);
         setIsLoading(false);
-      } catch (err) {
+      } catch {
         setError(true);
         setIsLoading(false);
       }


### PR DESCRIPTION
The AI trace loader binds the caught error even though the failure path only updates loading and error state.

Omit the unused catch binding so the handler states its intent directly without changing failure behavior.
