### PR TITLE
fix(attachments): Save pending attachments when saving a transaction

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2581,8 +2581,9 @@ def save_attachments(cache_key: str | None, attachments: list[Attachment], job: 
         )
 
 
+@trace
 def save_pending_attachments(
-    *, project: Project, event_id: str, group_id: int, source: str
+    *, project: Project, event_id: str, group_id: int | None, source: str
 ) -> None:
     """
     Promote any :class:`PendingEventAttachment` rows for ``event_id`` into real
@@ -2893,6 +2894,19 @@ def save_transaction_events(
     _materialize_event_metrics(jobs)
     _nodestore_save_many(jobs=jobs, app_feature="transactions")
     _eventstream_insert_many(jobs)
+
+    for job in jobs:
+        # NOTE: This puts a postgres query in the critical ingestion path for transactions.
+        # `save_pending_attachments` currently early-returns for most projects, but before graduation,
+        # we should make sure that the extra load on postgres is justifiable, given the facts that transactions
+        # are a legacy feature and transaction attachments are a niche use case.
+        safe_execute(
+            save_pending_attachments,
+            project=projects[job["project_id"]],
+            event_id=job["event"].event_id,
+            group_id=None,
+            source="save_transaction_events",
+        )
 
     for job in jobs:
         track_sampled_event(

--- a/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
+++ b/tests/sentry/ingest/ingest_consumer/test_ingest_consumer_processing.py
@@ -952,6 +952,107 @@ def test_individual_attachment_before_event(
 
 
 @django_db_all
+def test_individual_attachment_before_transaction(django_cache, default_project) -> None:
+    """
+    An attachment can also be parked ahead of a *transaction*.
+
+    Transactions never get a group and are saved by `save_transaction_events`, not
+    `save_error_events`, so promotion has to happen there too. Without it the row is
+    never promoted and expires with its blob after `PENDING_ATTACHMENT_TTL`.
+    """
+    from sentry.utils.outcomes import Outcome, track_outcome
+
+    event_id = uuid.uuid4().hex
+    retention_days = 66
+    payload = b"Hello World!"
+    now = timezone.now()
+
+    with (
+        Feature(
+            {
+                "organizations:event-attachments": True,
+                "projects:defer-attachment-storage": True,
+            }
+        ),
+        patch("sentry.event_manager.track_outcome", wraps=track_outcome) as track,
+    ):
+        process_individual_attachment(
+            {
+                "type": "attachment",
+                "attachment": {
+                    "id": "ca90fb45-6dd9-40a0-a18f-8693aa621abb",
+                    "name": "foo.txt",
+                    "content_type": "text/plain",
+                    "attachment_type": "event.attachment",
+                    "chunks": 0,
+                    "data": payload,
+                    "size": len(payload),
+                    "retention_days": retention_days,
+                },
+                "event_id": event_id,
+                "project_id": default_project.id,
+            },
+            project=default_project,
+        )
+
+        # Parked, not stored, and not billed yet.
+        (pending_attachment,) = PendingEventAttachment.objects.filter(project_id=default_project.id)
+        assert pending_attachment.event_id == event_id
+        assert not EventAttachment.objects.filter(project_id=default_project.id).exists()
+        assert track.call_count == 0
+
+        # Now the transaction arrives.
+        manager = EventManager(
+            {
+                "event_id": event_id,
+                "type": "transaction",
+                "transaction": "wait",
+                "contexts": {
+                    "trace": {
+                        "op": "foobar",
+                        "trace_id": "a0fa8803753e40fd8124b21eeb2986b5",
+                        "span_id": "bf5be759039ede9a",
+                    }
+                },
+                "spans": [],
+                "start_timestamp": (now - datetime.timedelta(seconds=1)).isoformat(),
+                "timestamp": now.isoformat(),
+            }
+        )
+        manager.normalize()
+        event = manager.save(default_project.id)
+
+    assert event.get_event_type() == "transaction"
+    assert event.group_id is None
+
+    assert not PendingEventAttachment.objects.filter(project_id=default_project.id).exists()
+
+    (attachment,) = EventAttachment.objects.filter(project_id=default_project.id)
+    assert attachment.event_id == event_id
+    assert attachment.name == "foo.txt"
+    assert attachment.content_type == "text/plain"
+    assert attachment.size == len(payload)
+    # A transaction has no group, so neither does its attachment.
+    assert attachment.group_id is None
+    with attachment.getfile() as file_contents:
+        assert file_contents.read() == payload
+    # The promoted row carries the full retention, not the pending TTL.
+    delta = attachment.date_expires - (timezone.now() + datetime.timedelta(days=retention_days))
+    assert abs(delta.total_seconds()) < 3600
+
+    # Billed exactly once, on promotion.
+    attachment_outcomes = [
+        call.kwargs
+        for call in track.mock_calls
+        if call.kwargs.get("category") == DataCategory.ATTACHMENT
+    ]
+    assert len(attachment_outcomes) == 1
+    assert attachment_outcomes[0]["outcome"] == Outcome.ACCEPTED
+    assert attachment_outcomes[0]["quantity"] == len(payload)
+    assert attachment_outcomes[0]["event_id"] == event_id
+
+
+@django_db_all
 def test_userreport_reverse_order(django_cache, default_project) -> None:
     """
     Test that ingesting a userreport before the event works. This is relevant


### PR DESCRIPTION
The pending attachment logic was incomplete for transactions, leaving attachments that arrive _before_ the transaction orphaned.

This PR contains a functional fix, but puts a postgres query on the ingestion path for every transaction -> might be too heavy for GA.

Fixes INGEST-1188