### PR TITLE
ref(dashboards): Surface dashboard starring beside the actions menu

### DIFF
--- a/static/app/views/dashboards/dashboardBreadcrumbTitle.spec.tsx
+++ b/static/app/views/dashboards/dashboardBreadcrumbTitle.spec.tsx
@@ -47,19 +47,24 @@ function renderTitle() {
     createdBy: UserFixture({name: 'Dashboard Owner', email: 'owner@example.com'}),
   });
 
-  render(
-    <DashboardBreadcrumbTitle
-      dashboard={dashboard}
-      hasUnsavedFilters={false}
-      isEditing={false}
-      isPreview={false}
-      isSaving={false}
-      onChange={jest.fn()}
-      onEdit={jest.fn()}
-    />,
-    {organization}
-  );
+  const props = {
+    dashboard,
+    hasUnsavedFilters: false,
+    isPreview: false,
+    isSaving: false,
+    onChange: jest.fn(),
+    onEdit: jest.fn(),
+  };
+
+  const {rerender} = render(<DashboardBreadcrumbTitle {...props} isEditing={false} />, {
+    organization,
+  });
   renderGlobalModal();
+
+  return {
+    setEditing: (isEditing: boolean) =>
+      rerender(<DashboardBreadcrumbTitle {...props} isEditing={isEditing} />),
+  };
 }
 
 describe('DashboardBreadcrumbTitle actions', () => {
@@ -84,6 +89,28 @@ describe('DashboardBreadcrumbTitle actions', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Dashboard actions'}));
     expect(screen.queryByRole('menuitemradio', {name: 'Star'})).not.toBeInTheDocument();
+  });
+
+  it('keeps the starred state after editing hides and restores the button', async () => {
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/dashboards/1/favorite/',
+      method: 'PUT',
+      body: {},
+    });
+
+    const {setEditing} = renderTitle();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Star'}));
+    expect(await screen.findByRole('button', {name: 'Unstar'})).toBeVisible();
+
+    // The title swaps to an editable field while editing, so the star is
+    // unmounted. `dashboard.isFavorited` is never refreshed by the toggle, so
+    // the state has to outlive the button or the star silently reverts.
+    setEditing(true);
+    expect(screen.queryByRole('button', {name: 'Unstar'})).not.toBeInTheDocument();
+
+    setEditing(false);
+    expect(await screen.findByRole('button', {name: 'Unstar'})).toBeVisible();
   });
 });
 

--- a/static/app/views/dashboards/dashboardBreadcrumbTitle.spec.tsx
+++ b/static/app/views/dashboards/dashboardBreadcrumbTitle.spec.tsx
@@ -47,24 +47,19 @@ function renderTitle() {
     createdBy: UserFixture({name: 'Dashboard Owner', email: 'owner@example.com'}),
   });
 
-  const props = {
-    dashboard,
-    hasUnsavedFilters: false,
-    isPreview: false,
-    isSaving: false,
-    onChange: jest.fn(),
-    onEdit: jest.fn(),
-  };
-
-  const {rerender} = render(<DashboardBreadcrumbTitle {...props} isEditing={false} />, {
-    organization,
-  });
+  render(
+    <DashboardBreadcrumbTitle
+      dashboard={dashboard}
+      hasUnsavedFilters={false}
+      isEditing={false}
+      isPreview={false}
+      isSaving={false}
+      onChange={jest.fn()}
+      onEdit={jest.fn()}
+    />,
+    {organization}
+  );
   renderGlobalModal();
-
-  return {
-    setEditing: (isEditing: boolean) =>
-      rerender(<DashboardBreadcrumbTitle {...props} isEditing={isEditing} />),
-  };
 }
 
 describe('DashboardBreadcrumbTitle actions', () => {
@@ -74,43 +69,6 @@ describe('DashboardBreadcrumbTitle actions', () => {
     await userEvent.click(screen.getByRole('button', {name: 'Dashboard actions'}));
 
     expect(screen.getByTestId('dashboard-edit')).toHaveTextContent('Edit');
-  });
-
-  it('surfaces starring as a button trailing the actions menu', async () => {
-    renderTitle();
-
-    const actions = screen.getAllByRole('button');
-    const menuIndex = actions.indexOf(
-      screen.getByRole('button', {name: 'Dashboard actions'})
-    );
-    const starIndex = actions.indexOf(screen.getByRole('button', {name: 'Star'}));
-
-    expect(starIndex).toBeGreaterThan(menuIndex);
-
-    await userEvent.click(screen.getByRole('button', {name: 'Dashboard actions'}));
-    expect(screen.queryByRole('menuitemradio', {name: 'Star'})).not.toBeInTheDocument();
-  });
-
-  it('keeps the starred state after editing hides and restores the button', async () => {
-    MockApiClient.addMockResponse({
-      url: '/organizations/org-slug/dashboards/1/favorite/',
-      method: 'PUT',
-      body: {},
-    });
-
-    const {setEditing} = renderTitle();
-
-    await userEvent.click(screen.getByRole('button', {name: 'Star'}));
-    expect(await screen.findByRole('button', {name: 'Unstar'})).toBeVisible();
-
-    // The title swaps to an editable field while editing, so the star is
-    // unmounted. `dashboard.isFavorited` is never refreshed by the toggle, so
-    // the state has to outlive the button or the star silently reverts.
-    setEditing(true);
-    expect(screen.queryByRole('button', {name: 'Unstar'})).not.toBeInTheDocument();
-
-    setEditing(false);
-    expect(await screen.findByRole('button', {name: 'Unstar'})).toBeVisible();
   });
 });
 

--- a/static/app/views/dashboards/dashboardBreadcrumbTitle.spec.tsx
+++ b/static/app/views/dashboards/dashboardBreadcrumbTitle.spec.tsx
@@ -70,6 +70,21 @@ describe('DashboardBreadcrumbTitle actions', () => {
 
     expect(screen.getByTestId('dashboard-edit')).toHaveTextContent('Edit');
   });
+
+  it('surfaces starring as a button trailing the actions menu', async () => {
+    renderTitle();
+
+    const actions = screen.getAllByRole('button');
+    const menuIndex = actions.indexOf(
+      screen.getByRole('button', {name: 'Dashboard actions'})
+    );
+    const starIndex = actions.indexOf(screen.getByRole('button', {name: 'Star'}));
+
+    expect(starIndex).toBeGreaterThan(menuIndex);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Dashboard actions'}));
+    expect(screen.queryByRole('menuitemradio', {name: 'Star'})).not.toBeInTheDocument();
+  });
 });
 
 async function openRevisionHistory() {

--- a/static/app/views/dashboards/dashboardBreadcrumbTitle.tsx
+++ b/static/app/views/dashboards/dashboardBreadcrumbTitle.tsx
@@ -39,13 +39,17 @@ import {checkUserHasEditAccess} from 'sentry/views/dashboards/utils/checkUserHas
  * Star/unstar the dashboard. Sits beside the actions menu rather than inside it —
  * starring is a frequent, cheaply reversible action, so burying it a click deep
  * made it hard to find.
+ *
+ * Presentational on purpose: the starred state has to live in the parent, which
+ * stays mounted while this button does not (see `isFavorited` below).
  */
-function DashboardFavoriteButton({dashboard}: {dashboard: DashboardDetails}) {
-  const [isFavorited, setIsFavorited] = useState(dashboard.isFavorited);
-  const api = useApi();
-  const queryClient = useQueryClient();
-  const organization = useOrganization();
-
+function DashboardFavoriteButton({
+  isFavorited,
+  onToggle,
+}: {
+  isFavorited: boolean | undefined;
+  onToggle: () => void;
+}) {
   const label = isFavorited ? t('Unstar') : t('Star');
 
   return (
@@ -57,26 +61,7 @@ function DashboardFavoriteButton({dashboard}: {dashboard: DashboardDetails}) {
       icon={
         <IconStar isSolid={isFavorited} variant={isFavorited ? 'warning' : 'muted'} />
       }
-      onClick={async () => {
-        const nextIsFavorited = !isFavorited;
-        setIsFavorited(nextIsFavorited);
-        try {
-          await updateDashboardFavorite(
-            api,
-            queryClient,
-            organization,
-            dashboard.id,
-            nextIsFavorited
-          );
-          trackAnalytics('dashboards_manage.toggle_favorite', {
-            organization,
-            dashboard_id: dashboard.id,
-            favorited: nextIsFavorited,
-          });
-        } catch {
-          setIsFavorited(isFavorited);
-        }
-      }}
+      onClick={onToggle}
     />
   );
 }
@@ -100,6 +85,12 @@ export function DashboardBreadcrumbTitle({
   onChange,
   onEdit,
 }: DashboardBreadcrumbTitleProps) {
+  // Lives here rather than in `DashboardFavoriteButton` because the button
+  // unmounts while editing or previewing, and a toggle never writes back to
+  // `dashboard.isFavorited` — remounting from the prop would revert the star.
+  const [isFavorited, setIsFavorited] = useState(dashboard.isFavorited);
+  const api = useApi();
+  const queryClient = useQueryClient();
   const navigate = useNavigate();
   const organization = useOrganization();
   const currentUser = useUser();
@@ -153,6 +144,26 @@ export function DashboardBreadcrumbTitle({
     Boolean(dashboard.id) &&
     !isPrebuiltDashboard &&
     organization.features.includes('dashboards-edit');
+  const handleToggleFavorite = async () => {
+    const nextIsFavorited = !isFavorited;
+    setIsFavorited(nextIsFavorited);
+    try {
+      await updateDashboardFavorite(
+        api,
+        queryClient,
+        organization,
+        dashboard.id,
+        nextIsFavorited
+      );
+      trackAnalytics('dashboards_manage.toggle_favorite', {
+        organization,
+        dashboard_id: dashboard.id,
+        favorited: nextIsFavorited,
+      });
+    } catch {
+      setIsFavorited(isFavorited);
+    }
+  };
   const revisionItem = {
     key: 'revisions',
     label: t('Show version history'),
@@ -218,7 +229,15 @@ export function DashboardBreadcrumbTitle({
                   items: menuItems,
                 }
               : null,
-            {type: 'button', element: <DashboardFavoriteButton dashboard={dashboard} />},
+            {
+              type: 'button',
+              element: (
+                <DashboardFavoriteButton
+                  isFavorited={isFavorited}
+                  onToggle={handleToggleFavorite}
+                />
+              ),
+            },
           ],
         }}
       />

--- a/static/app/views/dashboards/dashboardBreadcrumbTitle.tsx
+++ b/static/app/views/dashboards/dashboardBreadcrumbTitle.tsx
@@ -58,8 +58,12 @@ function DashboardFavoriteButton({
       variant="transparent"
       aria-label={label}
       tooltipProps={{title: label}}
+      // Unstarred deliberately inherits the button's colour instead of going
+      // `muted` like the table-row stars do. This one sits directly beside the
+      // ellipsis trigger, which inherits too, so a dimmer star reads as a
+      // rendering bug next to its neighbour.
       icon={
-        <IconStar isSolid={isFavorited} variant={isFavorited ? 'warning' : 'muted'} />
+        <IconStar isSolid={isFavorited} variant={isFavorited ? 'warning' : undefined} />
       }
       onClick={onToggle}
     />

--- a/static/app/views/dashboards/dashboardBreadcrumbTitle.tsx
+++ b/static/app/views/dashboards/dashboardBreadcrumbTitle.tsx
@@ -2,6 +2,7 @@ import {useState, type ReactNode} from 'react';
 import {useQueryClient} from '@tanstack/react-query';
 
 import {BreadcrumbList} from '@sentry/scraps/breadcrumbList';
+import {Button} from '@sentry/scraps/button';
 
 import {updateDashboardFavorite} from 'sentry/actionCreators/dashboards';
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -34,6 +35,52 @@ import {useDuplicateDashboard} from 'sentry/views/dashboards/hooks/useDuplicateD
 import type {DashboardDetails} from 'sentry/views/dashboards/types';
 import {checkUserHasEditAccess} from 'sentry/views/dashboards/utils/checkUserHasEditAccess';
 
+/**
+ * Star/unstar the dashboard. Sits beside the actions menu rather than inside it —
+ * starring is a frequent, cheaply reversible action, so burying it a click deep
+ * made it hard to find.
+ */
+function DashboardFavoriteButton({dashboard}: {dashboard: DashboardDetails}) {
+  const [isFavorited, setIsFavorited] = useState(dashboard.isFavorited);
+  const api = useApi();
+  const queryClient = useQueryClient();
+  const organization = useOrganization();
+
+  const label = isFavorited ? t('Unstar') : t('Star');
+
+  return (
+    <Button
+      size="zero"
+      variant="transparent"
+      aria-label={label}
+      tooltipProps={{title: label}}
+      icon={
+        <IconStar isSolid={isFavorited} variant={isFavorited ? 'warning' : 'muted'} />
+      }
+      onClick={async () => {
+        const nextIsFavorited = !isFavorited;
+        setIsFavorited(nextIsFavorited);
+        try {
+          await updateDashboardFavorite(
+            api,
+            queryClient,
+            organization,
+            dashboard.id,
+            nextIsFavorited
+          );
+          trackAnalytics('dashboards_manage.toggle_favorite', {
+            organization,
+            dashboard_id: dashboard.id,
+            favorited: nextIsFavorited,
+          });
+        } catch {
+          setIsFavorited(isFavorited);
+        }
+      }}
+    />
+  );
+}
+
 interface DashboardBreadcrumbTitleProps {
   dashboard: DashboardDetails;
   hasUnsavedFilters: boolean;
@@ -53,11 +100,8 @@ export function DashboardBreadcrumbTitle({
   onChange,
   onEdit,
 }: DashboardBreadcrumbTitleProps) {
-  const [isFavorited, setIsFavorited] = useState(dashboard.isFavorited);
-  const api = useApi();
   const navigate = useNavigate();
   const organization = useOrganization();
-  const queryClient = useQueryClient();
   const currentUser = useUser();
   const {teams: userTeams} = useUserTeams();
   const openDashboardRevisions = useOpenDashboardRevisions(dashboard);
@@ -109,31 +153,6 @@ export function DashboardBreadcrumbTitle({
     Boolean(dashboard.id) &&
     !isPrebuiltDashboard &&
     organization.features.includes('dashboards-edit');
-  const favoriteItem = {
-    key: 'favorite',
-    label: isFavorited ? t('Unstar') : t('Star'),
-    leadingItems: <IconStar isSolid={isFavorited} />,
-    onAction: async () => {
-      const nextIsFavorited = !isFavorited;
-      setIsFavorited(nextIsFavorited);
-      try {
-        await updateDashboardFavorite(
-          api,
-          queryClient,
-          organization,
-          dashboard.id,
-          nextIsFavorited
-        );
-        trackAnalytics('dashboards_manage.toggle_favorite', {
-          organization,
-          dashboard_id: dashboard.id,
-          favorited: nextIsFavorited,
-        });
-      } catch {
-        setIsFavorited(isFavorited);
-      }
-    },
-  };
   const revisionItem = {
     key: 'revisions',
     label: t('Show version history'),
@@ -176,7 +195,6 @@ export function DashboardBreadcrumbTitle({
       },
     };
     const menuItems = [
-      favoriteItem,
       ...(canViewRevisions ? [revisionItem] : []),
       ...(isDashboardEditor ? [editItem] : []),
       ...(isPrebuiltDashboard ? [duplicateItem] : []),
@@ -188,12 +206,20 @@ export function DashboardBreadcrumbTitle({
         item={{
           type: 'page-title',
           label: dashboard.title,
-          trailingActions: {
-            type: 'menu',
-            triggerLabel: t('Dashboard actions'),
-            triggerIcon: <IconEllipsis />,
-            items: menuItems,
-          },
+          trailingActions: [
+            // Starring used to be the one item every dashboard had, so the menu
+            // was unconditional. Now that it has moved out, hide the trigger
+            // when nothing is left to put behind it.
+            menuItems.length > 0
+              ? {
+                  type: 'menu',
+                  triggerLabel: t('Dashboard actions'),
+                  triggerIcon: <IconEllipsis />,
+                  items: menuItems,
+                }
+              : null,
+            {type: 'button', element: <DashboardFavoriteButton dashboard={dashboard} />},
+          ],
         }}
       />
     );

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -697,9 +697,13 @@ describe('Dashboards > Detail', () => {
       ).toBeInTheDocument();
       expect(within(breadcrumbs).queryByText('Custom Errors')).not.toBeInTheDocument();
 
+      // Starring trails the actions menu as its own button, rather than hiding
+      // a click deep inside it.
+      expect(screen.getByRole('button', {name: 'Star'})).toBeVisible();
+
       await userEvent.click(screen.getByRole('button', {name: 'Dashboard actions'}));
       expect(await screen.findByRole('menuitemradio', {name: 'Edit'})).toBeVisible();
-      expect(screen.getByRole('menuitemradio', {name: 'Star'})).toBeVisible();
+      expect(screen.queryByRole('menuitemradio', {name: 'Star'})).not.toBeInTheDocument();
       expect(
         screen.getByRole('menuitemradio', {name: 'Show version history'})
       ).toBeVisible();
@@ -738,12 +742,13 @@ describe('Dashboards > Detail', () => {
         }
       );
 
+      expect(await screen.findByRole('button', {name: 'Star'})).toBeVisible();
+
       await userEvent.click(
         await screen.findByRole('button', {name: 'Dashboard actions'})
       );
 
-      expect(await screen.findByRole('menuitemradio', {name: 'Star'})).toBeVisible();
-      expect(screen.getByRole('menuitemradio', {name: 'Duplicate'})).toBeVisible();
+      expect(await screen.findByRole('menuitemradio', {name: 'Duplicate'})).toBeVisible();
       expect(screen.queryByRole('menuitemradio', {name: 'Edit'})).not.toBeInTheDocument();
       expect(
         screen.queryByRole('menuitemradio', {name: 'Show version history'})
@@ -2151,10 +2156,7 @@ describe('Dashboards > Detail', () => {
         },
       });
 
-      await userEvent.click(
-        await screen.findByRole('button', {name: 'Dashboard actions'})
-      );
-      expect(await screen.findByRole('menuitemradio', {name: 'Star'})).toBeVisible();
+      expect(await screen.findByRole('button', {name: 'Star'})).toBeVisible();
     });
 
     it('renders favorite button in favorited state', async () => {
@@ -2177,10 +2179,7 @@ describe('Dashboards > Detail', () => {
         },
       });
 
-      await userEvent.click(
-        await screen.findByRole('button', {name: 'Dashboard actions'})
-      );
-      expect(await screen.findByRole('menuitemradio', {name: 'Unstar'})).toBeVisible();
+      expect(await screen.findByRole('button', {name: 'Unstar'})).toBeVisible();
     });
 
     it('toggles favorite button', async () => {
@@ -2208,13 +2207,9 @@ describe('Dashboards > Detail', () => {
         },
       });
 
-      await userEvent.click(
-        await screen.findByRole('button', {name: 'Dashboard actions'})
-      );
-      await userEvent.click(await screen.findByRole('menuitemradio', {name: 'Unstar'}));
+      await userEvent.click(await screen.findByRole('button', {name: 'Unstar'}));
 
-      await userEvent.click(screen.getByRole('button', {name: 'Dashboard actions'}));
-      expect(await screen.findByRole('menuitemradio', {name: 'Star'})).toBeVisible();
+      expect(await screen.findByRole('button', {name: 'Star'})).toBeVisible();
     });
 
     it('does not render save or edit features on prebuilt insights dashboards', async () => {

--- a/static/app/views/dashboards/detail.spec.tsx
+++ b/static/app/views/dashboards/detail.spec.tsx
@@ -2212,6 +2212,43 @@ describe('Dashboards > Detail', () => {
       expect(await screen.findByRole('button', {name: 'Star'})).toBeVisible();
     });
 
+    it('keeps the starred state after entering and leaving edit mode', async () => {
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/',
+        body: DashboardFixture([], {
+          id: '1',
+          title: 'Custom Errors',
+          isFavorited: false,
+        }),
+      });
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/dashboards/1/favorite/',
+        method: 'PUT',
+        body: {isFavorited: true},
+      });
+      render(<ViewEditDashboard />, {
+        ...makeDashboardRouterConfig({
+          pathname: '/organizations/org-slug/dashboard/1/',
+          route: DASHBOARD_ROUTE,
+          query: {},
+        }),
+        organization: {
+          features: initialData.organization.features,
+        },
+      });
+
+      await userEvent.click(await screen.findByRole('button', {name: 'Star'}));
+      expect(await screen.findByRole('button', {name: 'Unstar'})).toBeVisible();
+
+      // Editing swaps the page title for an editable field, so the star is
+      // unmounted and back again. Starring never refetches the dashboard, so
+      // the state has to survive that or the star silently reverts.
+      await activateDashboardEditMode();
+      await userEvent.click(screen.getByRole('button', {name: 'Cancel'}));
+
+      expect(await screen.findByRole('button', {name: 'Unstar'})).toBeVisible();
+    });
+
     it('does not render save or edit features on prebuilt insights dashboards', async () => {
       render(
         <DashboardDetail


### PR DESCRIPTION
Starring a dashboard moved into the page-title ellipsis menu in #121282, and feedback was that it ended up too buried. This pulls it back out as its own button trailing the menu, following the same trailing-action shape as the replay details header (#123569).