### PR TITLE
feat(onboarding): Update Node onboarding for SDK v11

### DIFF
--- a/static/app/gettingStartedDocs/node/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/node/onboarding.spec.tsx
@@ -29,6 +29,16 @@ describe('node onboarding docs', () => {
     });
   });
 
+  it('starts the app with the --import flag', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/node --import \.\/instrument\.mjs index\.mjs/)
+      )
+    ).toBeInTheDocument();
+  });
+
   it('displays sample rates by default', () => {
     renderWithOnboardingLayout(docs, {
       selectedProducts: [
@@ -67,7 +77,7 @@ describe('node onboarding docs', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+          /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
         )
       )
     ).toBeInTheDocument();
@@ -93,7 +103,7 @@ describe('node onboarding docs', () => {
     expect(
       screen.getByText(
         textWithMarkupMatcher(
-          /const { nodeProfilingIntegration } = require\("@sentry\/profiling-node"\)/
+          /import { nodeProfilingIntegration } from "@sentry\/profiling-node"/
         )
       )
     ).toBeInTheDocument();

--- a/static/app/gettingStartedDocs/node/onboarding.tsx
+++ b/static/app/gettingStartedDocs/node/onboarding.tsx
@@ -11,24 +11,64 @@ import {
 } from 'sentry/components/onboarding/gettingStartedDoc/utils';
 import {t, tct} from 'sentry/locale';
 
-import {
-  getImportInstrumentSnippet,
-  getInstallCodeBlock,
-  getSdkInitSnippet,
-} from './utils';
+import {getInstallCodeBlock, getSdkInitSnippet} from './utils';
 
-const getSdkSetupSnippet = () => `
-${getImportInstrumentSnippet()}
-
-// All other imports below
-const { createServer } = require("node:http");
+const getEntryPointSnippet = () => `import { createServer } from "node:http";
 
 const server = createServer((req, res) => {
   // server code
 });
 
-server.listen(3000, "127.0.0.1");
-`;
+server.listen(3000, "127.0.0.1");`;
+
+/**
+ * The log and metric calls the verify snippet makes before it throws.
+ *
+ * @param indent The whitespace put in front of every line.
+ */
+const getVerifySignalsSnippet = (params: DocsParams, indent: string) =>
+  `${
+    params.isLogsSelected
+      ? `
+${indent}// Send a log before throwing the error
+${indent}Sentry.logger.info('User triggered test error', {
+${indent}  action: 'test_error',
+${indent}});`
+      : ''
+  }${
+    params.isMetricsSelected
+      ? `
+${indent}// Send a test metric before throwing the error
+${indent}Sentry.metrics.count('test_counter', 1);`
+      : ''
+  }`;
+
+const getVerifySnippet = (params: DocsParams) => {
+  if (!params.isPerformanceSelected) {
+    return `
+import * as Sentry from "@sentry/node";
+${getVerifySignalsSnippet(params, '')}
+try {
+  foo();
+} catch (e) {
+  Sentry.captureException(e);
+}`;
+  }
+
+  return `
+import * as Sentry from "@sentry/node";
+
+Sentry.startSpan({
+  op: "test",
+  name: "My First Test Span",
+}, () => {
+  try {${getVerifySignalsSnippet(params, '    ')}
+    foo();
+  } catch (e) {
+    Sentry.captureException(e);
+  }
+});`;
+};
 
 export const onboarding: OnboardingConfig = {
   hideInstructionsCopy: true,
@@ -61,7 +101,7 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'To initialize the SDK before everything else, create an external file called [code:instrument.js/mjs].',
+            'To initialize the SDK before everything else, create an external file called [code:instrument.mjs].',
             {code: <code />}
           ),
         },
@@ -71,15 +111,15 @@ export const onboarding: OnboardingConfig = {
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs)',
-              code: getSdkInitSnippet(params, 'node'),
+              filename: 'instrument.mjs',
+              code: getSdkInitSnippet(params, 'node', 'esm-only'),
             },
           ],
         },
         {
           type: 'text',
           text: tct(
-            "Make sure to import [code:instrument.js/mjs] at the top of your file. Set up the error handler after all controllers and before any other error middleware. This setup is typically done in your application's entry point file, which is usually [code:index.(js|ts)]. If you're running your application in ESM mode, or looking for alternative ways to set up Sentry, read about [docs:installation methods in our docs].",
+            'Start your application with the [code:--import] flag, so that [code:instrument.mjs] loads before any other module. For alternative ways to set up Sentry, read about [docs:installation methods in our docs].',
             {
               code: <code />,
               docs: (
@@ -90,12 +130,24 @@ export const onboarding: OnboardingConfig = {
         },
         {
           type: 'code',
+          language: 'bash',
+          code: 'node --import ./instrument.mjs index.mjs',
+        },
+        {
+          type: 'text',
+          text: tct(
+            'This is what your application entry point, usually [code:index.mjs], looks like:',
+            {code: <code />}
+          ),
+        },
+        {
+          type: 'code',
           tabs: [
             {
               label: 'JavaScript',
               language: 'javascript',
-              filename: 'instrument.(js|mjs)',
-              code: getSdkSetupSnippet(),
+              filename: 'index.mjs',
+              code: getEntryPointSnippet(),
             },
           ],
         },
@@ -120,62 +172,24 @@ export const onboarding: OnboardingConfig = {
         {
           type: 'code',
           language: 'javascript',
-          code: params.isPerformanceSelected
-            ? `
-const Sentry = require("@sentry/node");
-
-Sentry.startSpan({
-  op: "test",
-  name: "My First Test Span",
-}, () => {
-  try {${
-    params.isLogsSelected
-      ? `
-    // Send a log before throwing the error
-    Sentry.logger.info('User triggered test error', {
-      action: 'test_error_span',
-    });`
-      : ''
-  }${
-    params.isMetricsSelected
-      ? `
-    // Send a test metric before throwing the error
-    Sentry.metrics.count('test_counter', 1);`
-      : ''
-  }
-    foo();
-  } catch (e) {
-    Sentry.captureException(e);
-  }
-});`
-            : `
-const Sentry = require("@sentry/node");
-${
-  params.isLogsSelected
-    ? `
-// Send a log before throwing the error
-Sentry.logger.info('User triggered test error', {
-  action: 'test_error_basic',
-});`
-    : ''
-}${
-                params.isMetricsSelected
-                  ? `
-// Send a test metric before throwing the error
-Sentry.metrics.count('test_counter', 1);`
-                  : ''
-              }
-try {
-  foo();
-} catch (e) {
-  Sentry.captureException(e);
-}`,
+          code: getVerifySnippet(params),
         },
       ],
     },
   ],
   nextSteps: (params: DocsParams) => {
     const steps = [];
+
+    if (params.isPerformanceSelected) {
+      steps.push({
+        id: 'tracing',
+        name: t('Tracing'),
+        description: t(
+          'Learn which libraries the SDK instruments for you, and how to add your own spans.'
+        ),
+        link: 'https://docs.sentry.io/platforms/javascript/guides/node/tracing/',
+      });
+    }
 
     if (params.isLogsSelected) {
       steps.push({

--- a/static/app/gettingStartedDocs/node/utils.tsx
+++ b/static/app/gettingStartedDocs/node/utils.tsx
@@ -102,8 +102,8 @@ export function getImport(
       ];
 }
 
-function getProfilingImport(defaultMode?: 'esm' | 'cjs'): string {
-  return defaultMode === 'esm'
+function getProfilingImport(defaultMode?: 'esm' | 'cjs' | 'esm-only'): string {
+  return defaultMode === 'esm' || defaultMode === 'esm-only'
     ? 'import { nodeProfilingIntegration } from "@sentry/profiling-node";'
     : 'const { nodeProfilingIntegration } = require("@sentry/profiling-node");';
 }
@@ -144,7 +144,7 @@ function getDefaultNodeImports({
 }: {
   params: DocsParams;
   sdkImport: 'node' | 'aws' | 'gpc' | 'nestjs' | null;
-  defaultMode?: 'esm' | 'cjs';
+  defaultMode?: 'esm' | 'cjs' | 'esm-only';
 }) {
   if (sdkImport === null || !libraryMap[sdkImport]) {
     return '';
@@ -579,7 +579,7 @@ Sentry.logger.info('User triggered test log', { action: 'test_log' })`,
 export const getSdkInitSnippet = (
   params: DocsParams,
   sdkImport: 'node' | 'aws' | 'gpc' | 'nestjs' | null,
-  defaultMode?: 'esm' | 'cjs'
+  defaultMode?: 'esm' | 'cjs' | 'esm-only'
 ) => `${getDefaultNodeImports({params, sdkImport, defaultMode})}
 
 Sentry.init({


### PR DESCRIPTION
closes SDK-1446

The Node onboarding still described a v10 setup: the entry point snippet was mislabelled as `instrument.(js|mjs)`, the text carried an Express error handler note that does not belong in the generic Node guide, and ESM was left to a docs link.

The configure step is now ESM only, in the shape the Express guide uses. `instrument.mjs` holds the `Sentry.init()` call, the app starts with `node --import ./instrument.mjs index.mjs`, and `index.mjs` is shown as the entry point.

Widen `getSdkInitSnippet()` to take `esm-only`, so the snippet drops the CommonJS hint comment that an ESM only guide does not need.

Pull the verify snippet into `getVerifySnippet()` so the tracing and the plain branch share one set of log and metric lines, and add a tracing next step when tracing is selected.

This is the same as #123779