### PR TITLE
feat(tabs): Remove disableOverflow prop and correct automatic overflow behavior

### DIFF
--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -19,7 +19,7 @@ import type {Node, Orientation} from '@react-types/shared';
 
 import type {SelectOption} from '@sentry/scraps/compactSelect';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
-import {Container} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 import {useTranslation} from '@sentry/scraps/translationContext';
 
@@ -255,6 +255,10 @@ function OverflowMenu({state, overflowMenuItems, disabled}: OverflowMenuProps) {
         onChange={opt => state.setSelectedKey(opt.value)}
         disabled={disabled}
         position="bottom-end"
+        // The menu renders inline, so fixed positioning lets it escape clipped
+        // tab containers such as the conversation span details panel.
+        strategy="fixed"
+        preventOverflowOptions={{boundary: document.body}}
         size="sm"
         offset={4}
         trigger={triggerProps => (
@@ -294,7 +298,6 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
     orientation,
     size,
     keyboardActivation = 'manual',
-    disableOverflow,
     ...otherRootProps
   } = rootProps;
 
@@ -333,7 +336,7 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
     tabItemsRef,
     tabItems: props.items,
     // Overflow only applies to horizontal tab lists.
-    disabled: disableOverflow || orientation !== 'horizontal',
+    disabled: orientation !== 'horizontal',
   });
 
   const overflowMenuItems = useMemo(() => {
@@ -354,7 +357,11 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
 
       return {
         value: key,
-        label: itemProps.children,
+        label: (
+          <Flex align="center" gap="md">
+            {itemProps.children}
+          </Flex>
+        ),
         disabled: itemProps.disabled,
         tooltip: itemProps.tooltip?.title,
         tooltipOptions: itemProps.tooltip,

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -259,7 +259,6 @@ function OverflowMenu({state, overflowMenuItems, disabled}: OverflowMenuProps) {
         // The menu renders inline, so fixed positioning lets it escape clipped
         // tab containers such as the conversation span details panel.
         strategy="fixed"
-        preventOverflowOptions={{boundary: document.body}}
         size="sm"
         offset={4}
         trigger={triggerProps => (
@@ -372,12 +371,7 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
   }, [state.collection, overflowTabs]);
 
   return (
-    <Container
-      position="relative"
-      width={orientation === 'horizontal' ? '100%' : undefined}
-      style={outerWrapStyles}
-      ref={outerWrapRef}
-    >
+    <Container position="relative" style={outerWrapStyles} ref={outerWrapRef}>
       <TabListWrap
         {...tabListProps}
         orientation={orientation}

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -256,9 +256,6 @@ function OverflowMenu({state, overflowMenuItems, disabled}: OverflowMenuProps) {
         onChange={opt => state.setSelectedKey(opt.value)}
         disabled={disabled}
         position="bottom-end"
-        // The menu renders inline, so fixed positioning lets it escape clipped
-        // tab containers such as the conversation span details panel.
-        strategy="fixed"
         size="sm"
         offset={4}
         trigger={triggerProps => (

--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -168,7 +168,8 @@ function useOverflowTabs({
         }
         const nextUsed =
           used + (tabWidthsRef.current.get(key) ?? 0) + (index === 0 ? 0 : gap);
-        // Always keep the first tab to avoid an empty tab bar.
+        // Always keep the first tab visible so the tab bar never collapses to
+        // only the overflow trigger.
         if (index === 0 || nextUsed <= budget) {
           used = nextUsed;
         } else {
@@ -371,7 +372,12 @@ function BaseTabList({outerWrapStyles, variant = 'flat', ...props}: BaseTabListP
   }, [state.collection, overflowTabs]);
 
   return (
-    <Container position="relative" style={outerWrapStyles} ref={outerWrapRef}>
+    <Container
+      position="relative"
+      width={orientation === 'horizontal' ? '100%' : undefined}
+      style={outerWrapStyles}
+      ref={outerWrapRef}
+    >
       <TabListWrap
         {...tabListProps}
         orientation={orientation}

--- a/static/app/components/core/tabs/tabs.mdx
+++ b/static/app/components/core/tabs/tabs.mdx
@@ -240,29 +240,27 @@ Tabs come in two visual variants: `flat` (default) and `floating`. The variant i
 
 Tabs support both horizontal and vertical orientation:
 
-<Storybook.Demo>
-  <Storybook.SideBySide>
-    <Tabs orientation="horizontal">
-      <TabList>
-        <TabList.Item key="one">Tab 1</TabList.Item>
-        <TabList.Item key="two">Tab 2</TabList.Item>
-      </TabList>
-      <TabPanels>
-        <TabPanels.Item key="one">Horizontal content 1</TabPanels.Item>
-        <TabPanels.Item key="two">Horizontal content 2</TabPanels.Item>
-      </TabPanels>
-    </Tabs>
-    <Tabs orientation="vertical">
-      <TabList>
-        <TabList.Item key="one">Tab 1</TabList.Item>
-        <TabList.Item key="two">Tab 2</TabList.Item>
-      </TabList>
-      <TabPanels>
-        <TabPanels.Item key="one">Vertical content 1</TabPanels.Item>
-        <TabPanels.Item key="two">Vertical content 2</TabPanels.Item>
-      </TabPanels>
-    </Tabs>
-  </Storybook.SideBySide>
+<Storybook.Demo direction="column" align="stretch" gap="3xl">
+  <Tabs orientation="horizontal">
+    <TabList>
+      <TabList.Item key="one">Tab 1</TabList.Item>
+      <TabList.Item key="two">Tab 2</TabList.Item>
+    </TabList>
+    <TabPanels>
+      <TabPanels.Item key="one">Horizontal content 1</TabPanels.Item>
+      <TabPanels.Item key="two">Horizontal content 2</TabPanels.Item>
+    </TabPanels>
+  </Tabs>
+  <Tabs orientation="vertical">
+    <TabList>
+      <TabList.Item key="one">Tab 1</TabList.Item>
+      <TabList.Item key="two">Tab 2</TabList.Item>
+    </TabList>
+    <TabPanels>
+      <TabPanels.Item key="one">Vertical content 1</TabPanels.Item>
+      <TabPanels.Item key="two">Vertical content 2</TabPanels.Item>
+    </TabPanels>
+  </Tabs>
 </Storybook.Demo>
 
 ```jsx
@@ -274,15 +272,43 @@ Tabs support both horizontal and vertical orientation:
 
 When there are too many tabs to fit, they automatically overflow into a dropdown menu. This behavior is built-in and requires no configuration.
 
+Resize the demo to see tabs move into and out of the overflow menu.
+
+<Storybook.Demo resizable>
+  <Tabs defaultValue="overview">
+    <TabList>
+      <TabList.Item key="overview">Overview</TabList.Item>
+      <TabList.Item key="activity">Activity</TabList.Item>
+      <TabList.Item key="feedback">User Feedback</TabList.Item>
+      <TabList.Item key="attachments">Attachments</TabList.Item>
+      <TabList.Item key="settings">Settings</TabList.Item>
+    </TabList>
+    <TabPanels>
+      <TabPanels.Item key="overview">Overview content</TabPanels.Item>
+      <TabPanels.Item key="activity">Activity content</TabPanels.Item>
+      <TabPanels.Item key="feedback">User feedback content</TabPanels.Item>
+      <TabPanels.Item key="attachments">Attachments content</TabPanels.Item>
+      <TabPanels.Item key="settings">Settings content</TabPanels.Item>
+    </TabPanels>
+  </Tabs>
+</Storybook.Demo>
+
 ```jsx
-<Tabs>
+<Tabs defaultValue="overview">
   <TabList>
-    {/* Many tabs - extras will automatically go into overflow menu */}
-    {Array.from({length: 20}, (_, i) => (
-      <TabList.Item key={i}>Tab {i + 1}</TabList.Item>
-    ))}
+    <TabList.Item key="overview">Overview</TabList.Item>
+    <TabList.Item key="activity">Activity</TabList.Item>
+    <TabList.Item key="feedback">User Feedback</TabList.Item>
+    <TabList.Item key="attachments">Attachments</TabList.Item>
+    <TabList.Item key="settings">Settings</TabList.Item>
   </TabList>
-  {/* panels */}
+  <TabPanels>
+    <TabPanels.Item key="overview">Overview content</TabPanels.Item>
+    <TabPanels.Item key="activity">Activity content</TabPanels.Item>
+    <TabPanels.Item key="feedback">User feedback content</TabPanels.Item>
+    <TabPanels.Item key="attachments">Attachments content</TabPanels.Item>
+    <TabPanels.Item key="settings">Settings content</TabPanels.Item>
+  </TabPanels>
 </Tabs>
 ```
 
@@ -328,12 +354,14 @@ Use tabs to organize related content into distinct views:
 Sync tabs with URL parameters for shareable links:
 
 ```jsx
-const [tab, setTab] = useState(queryParams.tab || 'overview');
+import {parseAsStringLiteral, useQueryState} from 'nuqs';
 
-useEffect(() => {
-  // Update URL when tab changes
-  router.push({pathname, query: {...query, tab}});
-}, [tab]);
+const TAB_VALUES = ['overview', 'activity'] as const;
+
+const [tab, setTab] = useQueryState(
+  'tab',
+  parseAsStringLiteral(TAB_VALUES).withDefault('overview')
+);
 
 <Tabs value={tab} onChange={setTab}>
   {/* tabs */}

--- a/static/app/components/core/tabs/tabs.mdx
+++ b/static/app/components/core/tabs/tabs.mdx
@@ -286,12 +286,6 @@ When there are too many tabs to fit, they automatically overflow into a dropdown
 </Tabs>
 ```
 
-To disable overflow (forcing horizontal scroll instead), use `disableOverflow`:
-
-```jsx
-<Tabs disableOverflow>{/* tabs will scroll horizontally instead of overflowing */}</Tabs>
-```
-
 ## Keyboard Navigation
 
 `<Tabs>` provides full keyboard support automatically:

--- a/static/app/components/core/tabs/tabs.spec.tsx
+++ b/static/app/components/core/tabs/tabs.spec.tsx
@@ -391,6 +391,20 @@ describe('Tabs overflow', () => {
     expect(screen.queryByRole('option', {name: 'Activity'})).not.toBeInTheDocument();
   });
 
+  it('keeps the first tab visible when only it and the overflow trigger fit', async () => {
+    containerWidth = 120;
+    renderTabs();
+
+    expect(screen.getByRole('tab', {name: 'Details'})).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'More tabs'}));
+
+    expect(screen.queryByRole('option', {name: 'Details'})).not.toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Activity'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'User Feedback'})).toBeInTheDocument();
+    expect(screen.getByRole('option', {name: 'Attachments'})).toBeInTheDocument();
+  });
+
   it('recomputes overflow when the container is resized', async () => {
     containerWidth = 1000;
     renderTabs();

--- a/static/app/components/core/tabs/tabs.tsx
+++ b/static/app/components/core/tabs/tabs.tsx
@@ -101,8 +101,9 @@ const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
   flex-direction: ${p => (p.orientation === 'horizontal' ? 'column' : 'row')};
   flex-grow: 1;
   min-width: 0;
-  /* Give horizontal tabs a definite width for overflow measurement. */
-  width: ${p => (p.orientation === 'horizontal' ? '100%' : 'auto')};
+  /* Let horizontal tabs share a wrapping row and fill a column layout. */
+  flex-basis: ${p => (p.orientation === 'horizontal' ? '0' : 'auto')};
+  align-self: ${p => (p.orientation === 'horizontal' ? 'stretch' : 'auto')};
 
   ${p =>
     p.orientation === 'vertical' &&

--- a/static/app/components/core/tabs/tabs.tsx
+++ b/static/app/components/core/tabs/tabs.tsx
@@ -103,6 +103,12 @@ const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
   min-width: 0;
 
   ${p =>
+    p.orientation === 'horizontal' &&
+    css`
+      width: 100%;
+    `}
+
+  ${p =>
     p.orientation === 'vertical' &&
     css`
       height: 100%;

--- a/static/app/components/core/tabs/tabs.tsx
+++ b/static/app/components/core/tabs/tabs.tsx
@@ -101,12 +101,8 @@ const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
   flex-direction: ${p => (p.orientation === 'horizontal' ? 'column' : 'row')};
   flex-grow: 1;
   min-width: 0;
-
-  ${p =>
-    p.orientation === 'horizontal' &&
-    css`
-      width: 100%;
-    `}
+  /* Give horizontal tabs a definite width for overflow measurement. */
+  width: ${p => (p.orientation === 'horizontal' ? '100%' : 'auto')};
 
   ${p =>
     p.orientation === 'vertical' &&

--- a/static/app/components/core/tabs/tabs.tsx
+++ b/static/app/components/core/tabs/tabs.tsx
@@ -29,10 +29,6 @@ interface TabsProps<T>
    * selected tab item.
    */
   defaultValue?: T;
-  /**
-   * Disable tabs from being put in the overflow menu.
-   */
-  disableOverflow?: boolean;
   disabled?: boolean;
   /**
    * Callback when the selected tab changes.
@@ -104,6 +100,7 @@ const TabsWrap = styled('div', {shouldForwardProp: tabsShouldForwardProp})<{
   display: flex;
   flex-direction: ${p => (p.orientation === 'horizontal' ? 'column' : 'row')};
   flex-grow: 1;
+  min-width: 0;
 
   ${p =>
     p.orientation === 'vertical' &&

--- a/static/app/components/externalIssues/externalIssueForm.tsx
+++ b/static/app/components/externalIssues/externalIssueForm.tsx
@@ -388,7 +388,7 @@ export function ExternalIssueForm({
       >
         <Stack area="content" align="stretch" gap="lg" minWidth={0}>
           <Heading as="h2">{title}</Heading>
-          <Tabs value={action} onChange={handleClick} disableOverflow>
+          <Tabs value={action} onChange={handleClick}>
             <TabList>
               <TabList.Item key="create">{t('Create')}</TabList.Item>
               <TabList.Item key="link">{t('Link')}</TabList.Item>

--- a/static/app/stories/demo.tsx
+++ b/static/app/stories/demo.tsx
@@ -26,7 +26,7 @@ export function Demo({resizable, ...props}: DemoProps) {
         marginTop="md"
         style={{marginBottom: '-1lh'}}
       >
-        <Flex
+        <DemoContent
           data-test-id="storybook-demo"
           width="100%"
           align="center"
@@ -78,7 +78,7 @@ export function Demo({resizable, ...props}: DemoProps) {
       </Flex>
       <Flex align="center" justify="center" padding="xl">
         <ResizableWindow ref={containerRef}>
-          <Flex
+          <DemoContent
             flex="1"
             data-test-id="storybook-demo"
             width="100%"
@@ -95,6 +95,12 @@ export function Demo({resizable, ...props}: DemoProps) {
     </DemoChrome>
   );
 }
+
+const DemoContent = styled(Flex)`
+  &:has([aria-haspopup][aria-expanded='true']) {
+    overflow: visible;
+  }
+`;
 
 function useContainerBreakpoints(): Array<[ContainerBreakpointSize, number]> {
   const theme = useTheme();

--- a/static/app/stories/demo.tsx
+++ b/static/app/stories/demo.tsx
@@ -8,7 +8,7 @@ import {Text} from '@sentry/scraps/text';
 import type {ContainerBreakpointSize} from 'sentry/utils/theme';
 import {useDimensions} from 'sentry/utils/useDimensions';
 
-import {ResizableWindow} from './resizableWindow';
+import {allowOpenOverlayOverflowCss, ResizableWindow} from './resizableWindow';
 
 interface DemoProps extends FlexProps {
   resizable?: boolean;
@@ -26,7 +26,8 @@ export function Demo({resizable, ...props}: DemoProps) {
         marginTop="md"
         style={{marginBottom: '-1lh'}}
       >
-        <DemoContent
+        <Flex
+          css={allowOpenOverlayOverflowCss}
           data-test-id="storybook-demo"
           width="100%"
           align="center"
@@ -78,7 +79,8 @@ export function Demo({resizable, ...props}: DemoProps) {
       </Flex>
       <Flex align="center" justify="center" padding="xl">
         <ResizableWindow ref={containerRef}>
-          <DemoContent
+          <Flex
+            css={allowOpenOverlayOverflowCss}
             flex="1"
             data-test-id="storybook-demo"
             width="100%"
@@ -95,12 +97,6 @@ export function Demo({resizable, ...props}: DemoProps) {
     </DemoChrome>
   );
 }
-
-const DemoContent = styled(Flex)`
-  &:has([aria-haspopup][aria-expanded='true']) {
-    overflow: visible;
-  }
-`;
 
 function useContainerBreakpoints(): Array<[ContainerBreakpointSize, number]> {
   const theme = useTheme();

--- a/static/app/stories/resizableWindow.tsx
+++ b/static/app/stories/resizableWindow.tsx
@@ -1,4 +1,5 @@
 import {type Ref, type ReactNode, useCallback, useRef, useState} from 'react';
+import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Container} from '@sentry/scraps/layout';
@@ -34,9 +35,15 @@ export function ResizableWindow({children, className, ref}: ResizableWindowProps
       <Handle data-edge="bottom" onPointerDown={e => handlePointerDown(e, 'bottom')} />
       <Handle data-edge="corner" onPointerDown={e => handlePointerDown(e, 'corner')} />
       {/* -2 offsets the parent's top border so children align flush */}
-      <WindowContent height="inherit" flex="1" overflow="hidden" style={{marginTop: -2}}>
+      <Container
+        css={allowOpenOverlayOverflowCss}
+        height="inherit"
+        flex="1"
+        overflow="hidden"
+        style={{marginTop: -2}}
+      >
         {children}
-      </WindowContent>
+      </Container>
     </WindowRoot>
   );
 }
@@ -99,7 +106,7 @@ const WindowRoot = styled(Container)`
   }
 `;
 
-const WindowContent = styled(Container)`
+export const allowOpenOverlayOverflowCss = css`
   &:has([aria-haspopup][aria-expanded='true']) {
     overflow: visible;
   }

--- a/static/app/stories/resizableWindow.tsx
+++ b/static/app/stories/resizableWindow.tsx
@@ -34,9 +34,9 @@ export function ResizableWindow({children, className, ref}: ResizableWindowProps
       <Handle data-edge="bottom" onPointerDown={e => handlePointerDown(e, 'bottom')} />
       <Handle data-edge="corner" onPointerDown={e => handlePointerDown(e, 'corner')} />
       {/* -2 offsets the parent's top border so children align flush */}
-      <Container height="inherit" flex="1" overflow="hidden" style={{marginTop: -2}}>
+      <WindowContent height="inherit" flex="1" overflow="hidden" style={{marginTop: -2}}>
         {children}
-      </Container>
+      </WindowContent>
     </WindowRoot>
   );
 }
@@ -96,6 +96,12 @@ const WindowRoot = styled(Container)`
     user-select: none;
     /* eslint-disable-next-line @sentry/scraps/use-semantic-token */
     border-color: ${p => p.theme.tokens.graphics.neutral.moderate};
+  }
+`;
+
+const WindowContent = styled(Container)`
+  &:has([aria-haspopup][aria-expanded='true']) {
+    overflow: visible;
   }
 `;
 

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -193,13 +193,11 @@ export function ConversationSpanDetail({
         <EmptyTab message={t('Failed to load span details')} />
       ) : (
         <TabStateProvider<DetailTab> value={activeTab} onChange={onTabChange}>
-          <Container flexShrink={0}>
-            <TabList>
-              <TabList.Item key="input">{t('Input')}</TabList.Item>
-              <TabList.Item key="output">{t('Output')}</TabList.Item>
-              <TabList.Item key="attributes">{t('Attributes')}</TabList.Item>
-            </TabList>
-          </Container>
+          <TabList>
+            <TabList.Item key="input">{t('Input')}</TabList.Item>
+            <TabList.Item key="output">{t('Output')}</TabList.Item>
+            <TabList.Item key="attributes">{t('Attributes')}</TabList.Item>
+          </TabList>
 
           <Container
             flex="0 0 auto"

--- a/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
+++ b/static/app/views/explore/conversations/components/conversationSpanDetail.tsx
@@ -192,18 +192,14 @@ export function ConversationSpanDetail({
       ) : isError ? (
         <EmptyTab message={t('Failed to load span details')} />
       ) : (
-        <TabStateProvider<DetailTab>
-          value={activeTab}
-          onChange={onTabChange}
-          disableOverflow
-        >
-          <Flex flexShrink={0}>
+        <TabStateProvider<DetailTab> value={activeTab} onChange={onTabChange}>
+          <Container flexShrink={0}>
             <TabList>
               <TabList.Item key="input">{t('Input')}</TabList.Item>
               <TabList.Item key="output">{t('Output')}</TabList.Item>
               <TabList.Item key="attributes">{t('Attributes')}</TabList.Item>
             </TabList>
-          </Flex>
+          </Container>
 
           <Container
             flex="0 0 auto"

--- a/static/app/views/explore/tables/index.tsx
+++ b/static/app/views/explore/tables/index.tsx
@@ -104,12 +104,7 @@ export function ExploreTables(props: ExploreTablesProps) {
   return (
     <Fragment>
       <Flex justify="between" marginBottom="md" gap="md" wrap="wrap">
-        <Tabs
-          value={tab}
-          onChange={newTab => setTab(newTab, 'click')}
-          size="sm"
-          disableOverflow
-        >
+        <Tabs value={tab} onChange={newTab => setTab(newTab, 'click')} size="sm">
           <TabList variant="floating">
             <TabList.Item key={Tab.SPAN}>{t('Span Samples')}</TabList.Item>
             <TabList.Item

--- a/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
+++ b/static/app/views/issueDetails/eventNavigation/issueDetailsEventNavigation.tsx
@@ -149,7 +149,7 @@ export function IssueDetailsEventNavigation({
           }}
         />
       </Navigation>
-      <Tabs value={currentEventKey} disableOverflow onChange={onTabChange} size="xs">
+      <Tabs value={currentEventKey} onChange={onTabChange} size="xs">
         <TabList variant="floating">
           {eventNavPresets.map(({key, label, tooltip}) => {
             const eventPath =

--- a/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
@@ -67,13 +67,15 @@ export function TraceTabsAndVitals({
 
   return (
     <ToolbarLayout>
-      <Tabs value={currentTab} onChange={onTabChange}>
-        <TabList variant="floating">
-          {tabOptions.map(tab => (
-            <TabList.Item key={tab.slug}>{tab.label}</TabList.Item>
-          ))}
-        </TabList>
-      </Tabs>
+      <Flex flex={1} minWidth="0" width="100%">
+        <Tabs value={currentTab} onChange={onTabChange}>
+          <TabList variant="floating">
+            {tabOptions.map(tab => (
+              <TabList.Item key={tab.slug}>{tab.label}</TabList.Item>
+            ))}
+          </TabList>
+        </Tabs>
+      </Flex>
       <TraceContextVitals rootEventResults={rootEventResults} tree={tree} />
     </ToolbarLayout>
   );

--- a/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
+++ b/static/app/views/performance/newTraceDetails/traceTabsAndVitals.tsx
@@ -67,15 +67,13 @@ export function TraceTabsAndVitals({
 
   return (
     <ToolbarLayout>
-      <Flex flex={1} minWidth="0" width="100%">
-        <Tabs value={currentTab} onChange={onTabChange}>
-          <TabList variant="floating">
-            {tabOptions.map(tab => (
-              <TabList.Item key={tab.slug}>{tab.label}</TabList.Item>
-            ))}
-          </TabList>
-        </Tabs>
-      </Flex>
+      <Tabs value={currentTab} onChange={onTabChange}>
+        <TabList variant="floating">
+          {tabOptions.map(tab => (
+            <TabList.Item key={tab.slug}>{tab.label}</TabList.Item>
+          ))}
+        </TabList>
+      </Tabs>
       <TraceContextVitals rootEventResults={rootEventResults} tree={tree} />
     </ToolbarLayout>
   );

--- a/static/app/views/settings/organizationDataForwarding/edit.tsx
+++ b/static/app/views/settings/organizationDataForwarding/edit.tsx
@@ -112,7 +112,7 @@ function OrganizationDataForwardingEdit({dataForwarder}: {dataForwarder: DataFor
                   )}
                 />
               )}
-              <Tabs value={dataForwarder.provider} disableOverflow>
+              <Tabs value={dataForwarder.provider}>
                 <TabList variant="floating">
                   {Object.entries(ProviderLabels).map(([key, label]) => (
                     <TabList.Item

--- a/static/app/views/settings/organizationDataForwarding/setup.tsx
+++ b/static/app/views/settings/organizationDataForwarding/setup.tsx
@@ -109,7 +109,7 @@ export default function OrganizationDataForwardingSetup() {
                   features={features}
                 />
               )}
-              <Tabs value={provider} onChange={setProvider} disableOverflow>
+              <Tabs value={provider} onChange={setProvider}>
                 <TabList variant="floating">
                   {Object.entries(ProviderLabels).map(([key, label]) => (
                     <TabList.Item


### PR DESCRIPTION
We are removing the disableOverflow prop from the Tabs component. Previously, this prop forced all tabs into a single horizontal row instead of moving excess items into the overflow menu ("..."), which caused the tab bar to bleed past its container bounds in narrow layouts. Removing this prop ensures tabs remain contained and responsive across all screen sizes. 

**Before**

https://github.com/user-attachments/assets/5375b59a-d344-442b-9c8d-81b64048762d




**After**

https://github.com/user-attachments/assets/22cfdc66-0f70-4eeb-ba5c-c799b4200b8c


_Note_

This PR also fixes an existing bug:

<img width="233" height="193" alt="image" src="https://github.com/user-attachments/assets/6c3f6d9b-9045-489e-9c3a-cdc201943f23" />





Follow-up of https://github.com/getsentry/sentry/pull/123548#discussion_r3965384114
