### PR TITLE
feat(onboarding): Add Remix 2.x support | remove 1.x support

### DIFF
--- a/static/app/gettingStartedDocs/javascript-remix/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-remix/onboarding.spec.tsx
@@ -21,6 +21,14 @@ describe('javascript-remix onboarding docs', () => {
     ).toBeInTheDocument();
   });
 
+  it('documents the supported Remix version', () => {
+    renderWithOnboardingLayout(docs);
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/supports Remix 2\.x/))
+    ).toBeInTheDocument();
+  });
+
   it('has metrics onboarding configuration', () => {
     expect(docs.metricsOnboarding).toBeDefined();
     expect(docs.metricsOnboarding?.install).toBeDefined();

--- a/static/app/gettingStartedDocs/javascript-remix/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-remix/onboarding.tsx
@@ -13,12 +13,9 @@ import {getInstallContent} from './utils';
 export const onboarding: OnboardingConfig = {
   introduction: () => (
     <p>
-      {tct(
-        "Sentry's integration with [remixLink:Remix] supports Remix 1.0.0 and above.",
-        {
-          remixLink: <ExternalLink href="https://remix.run/" />,
-        }
-      )}
+      {tct("Sentry's integration with [remixLink:Remix] supports Remix 2.x.", {
+        remixLink: <ExternalLink href="https://remix.run/" />,
+      })}
     </p>
   ),
   install: (params: DocsParams) => [


### PR DESCRIPTION
Nothing more than changing the version range. Remix v3 is not yet supported as of https://github.com/getsentry/sentry-javascript/issues/23901 and the rest of the onboarding is wizard driven.