### PR TITLE
ref(onboarding): Change wording of transactions | fix bootstrapApplication order

### DIFF
--- a/static/app/gettingStartedDocs/javascript-angular/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/onboarding.spec.tsx
@@ -32,6 +32,31 @@ describe('javascript-angular onboarding docs', () => {
     ).toHaveLength(2);
   });
 
+  it('bootstraps the standalone component with the application config', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedOptions: {configType: AngularConfigType.APP},
+    });
+
+    expect(
+      screen.getByText(
+        textWithMarkupMatcher(/bootstrapApplication\(AppComponent, appConfig\)/)
+      )
+    ).toBeInTheDocument();
+  });
+
+  it('bootstraps the root module for NgModule applications', () => {
+    renderWithOnboardingLayout(docs, {
+      selectedOptions: {configType: AngularConfigType.MODULE},
+    });
+
+    expect(
+      screen.getByText(textWithMarkupMatcher(/\.bootstrapModule\(AppModule\)/))
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(textWithMarkupMatcher(/bootstrapApplication/))
+    ).not.toBeInTheDocument();
+  });
+
   it('displays sample rates by default', () => {
     renderWithOnboardingLayout(docs, {
       selectedOptions: {

--- a/static/app/gettingStartedDocs/javascript-angular/utils.tsx
+++ b/static/app/gettingStartedDocs/javascript-angular/utils.tsx
@@ -71,7 +71,7 @@ const getDynamicParts = (params: Params): string[] => {
   if (params.isPerformanceSelected) {
     dynamicParts.push(`
       // Tracing
-      tracesSampleRate: 1.0, //  Capture 100% of the transactions
+      tracesSampleRate: 1.0, // Capture 100% of traces. Adjust this value in production.
       // Set 'tracePropagationTargets' to control for which URLs distributed tracing should be enabled
       tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/]`);
   }
@@ -114,7 +114,7 @@ platformBrowserDynamic()
   .bootstrapModule(AppModule)
   .catch((err) => console.error(err));`
     : `
-bootstrapApplication(appConfig, AppComponent)
+bootstrapApplication(AppComponent, appConfig)
   .catch((err) => console.error(err));`;
 
   const config = buildSdkConfig({


### PR DESCRIPTION
ref [SDK-1431](https://linear.app/getsentry/issue/SDK-1431/update-the-javascript-angular-in-product-onboarding-for-v11)

It seems `bootstrapApplication` had the wrong order (based [on the docs](https://angular.dev/api/platform-browser/bootstrapApplication#api)) and the wording also changed from transactions to traces