### PR TITLE
fix(deps): Drop unused image-size transitive dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,8 @@
     "overrides": {
       "@isaacs/brace-expansion": "5.0.1",
       "diff@>=4.0.0 <4.0.4": "4.0.4",
-      "diff@>=5.0.0 <5.2.2": "5.2.2"
+      "diff@>=5.0.0 <5.2.2": "5.2.2",
+      "image-size": "-"
     },
     "packageExtensions": {
       "@sentry/webpack-plugin@5.3.0": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,7 @@ overrides:
   '@isaacs/brace-expansion': 5.0.1
   diff@>=4.0.0 <4.0.4: 4.0.4
   diff@>=5.0.0 <5.2.2: 5.2.2
+  image-size: '-'
 
 packageExtensionsChecksum: sha256-0VZ2XeajIU53t75fxV6NpDm9r5YxmYRM0rEQhyaaIlQ=
 
@@ -6066,11 +6067,6 @@ packages:
   ignore@6.0.2:
     resolution: {integrity: sha512-InwqeHHN2XpumIkMvpl/DCJVrAHgCsG5+cn1XlnLWGwtZBm8QJfSusItfrwx81CTp5agNZqpKU2J/ccC5nGT4A==}
     engines: {node: '>= 4'}
-
-  image-size@0.5.5:
-    resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
 
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
@@ -14573,9 +14569,6 @@ snapshots:
 
   ignore@6.0.2: {}
 
-  image-size@0.5.5:
-    optional: true
-
   import-fresh@3.3.0:
     dependencies:
       parent-module: 1.0.1
@@ -15420,7 +15413,6 @@ snapshots:
     optionalDependencies:
       errno: 0.1.7
       graceful-fs: 4.2.11
-      image-size: 0.5.5
       make-dir: 2.1.0
       mime: 1.6.0
       needle: 3.1.0


### PR DESCRIPTION
Removes `image-size` from the dependency graph via a pnpm override, closing Dependabot alerts [682](https://github.com/getsentry/sentry/security/dependabot/682) (GHSA-5p2g-fcmc-qvqq) and [683](https://github.com/getsentry/sentry/security/dependabot/683) (GHSA-w3rx-r6r6-pgpr). Neither has an upstream fix — the advisories cap at `<= 2.0.2` with no patched version published.

### Why removal rather than an upgrade

`image-size` reaches us only as an **optional** dependency of `less@4.3.0` (`pnpm why` shows `less` as the sole path, directly and via `less-loader`). `less` requires it lazily, from one call site, purely to implement the `image-size()`, `image-width()` and `image-height()` LESS functions:

```js
// less/lib/less-node/image-size.js:28
const sizeOf = require('image-size');
```

Nothing in the repo uses those functions — grepping all 38 `.less` files under `static/less/` returns zero hits. So there is no functionality to preserve and nothing to replace it with; `less` simply stops registering three functions we never call.

### Worth knowing: both alerts are false positives against the version we ship

We resolve `image-size@0.5.5`, not 2.x. The advisories describe infinite loops in the **ICNS**, **JXL** and **HEIF** parsers, and 0.5.5 contains none of them. Its `lib/types.js` enumerates the complete supported set — `bmp, gif, jpg, png, psd, svg, tiff, webp, dds` — and `lib/types/` holds exactly those nine files. ICNS support landed in 1.x, JXL/HEIF in 2.x. The only `while` loops in 0.5.5 live in `jpg.js` and `tiff.js`, neither matching what the GHSAs describe. The alerts fire solely because the advisory range sweeps up every ancient version.

Reachability was already nil on top of that: the code reads image files from disk at build time, never attacker-supplied buffers. Dependabot labels the scope `runtime` only because `less` sits in `dependencies` rather than `devDependencies`; it is a build-time CSS compiler.

Dismissing both as not-applicable would have been defensible. Removing the package is cheap and permanently forecloses this and any future `image-size` advisory, so it seemed the better trade.

### Verification

- Clean-room install of `less` + `less-loader` with the override present produces no `image-size` anywhere in `node_modules` — this is what CI's `--frozen-lockfile` install does.
- `static/less/sentry.less`, the entrypoint referenced at `rspack.config.ts:288`, compiles to **byte-identical** CSS with and without the package (112,728 bytes both ways).
- Lockfile change is 1 insertion / 9 deletions: the resolution block, the snapshot entry, and the one line under `less@4.3.0`'s `optionalDependencies`. No other package in the graph moved.

### Note for reviewers

The tradeoff of `"image-size": "-"` is that if someone later writes `image-size()` in a `.less` file, the build fails with a module-not-found rather than working. Given we are on emotion/CSS-in-JS for anything new and these 38 files are legacy bootstrap, that felt acceptable — and CI would surface it immediately rather than silently.

Moving `less`/`less-loader` to `devDependencies` was considered and rejected: it would reclassify the alert scope but not clear the alerts.

https://claude.ai/code/session_01CeiwiHwrev5Vap9j6csjxV