### PR TITLE
feat(loader): Support JavaScript v11 in loader settings

### DIFF
--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.spec.tsx
@@ -513,7 +513,7 @@ describe('Loader Script Settings', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables logs and metrics for SDK version 10.x', () => {
+  it.each(['10.x', '11.x'])('enables logs and metrics for SDK version %s', sdkVersion => {
     const {organization, project} = initializeOrg();
     const params = {
       projectSlug: project.slug,
@@ -532,7 +532,7 @@ describe('Loader Script Settings', () => {
             ...fullDynamicSdkLoaderOptions,
             hasLogsAndMetrics: true,
           },
-          browserSdkVersion: '10.x',
+          browserSdkVersion: sdkVersion,
         }}
       />
     );

--- a/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
+++ b/static/app/views/settings/project/projectKeys/details/loaderSettings.tsx
@@ -430,10 +430,11 @@ function sdkVersionSupportsPerformanceAndReplay(sdkVersion: string): boolean {
     sdkVersion === '7.x' ||
     sdkVersion === '8.x' ||
     sdkVersion === '9.x' ||
-    sdkVersion === '10.x'
+    sdkVersion === '10.x' ||
+    sdkVersion === '11.x'
   );
 }
 
 function sdkVersionSupportsLogsAndMetrics(sdkVersion: string): boolean {
-  return sdkVersion === '10.x';
+  return sdkVersion === '10.x' || sdkVersion === '11.x';
 }


### PR DESCRIPTION
Treat JavaScript SDK 11.x as supporting performance, replay, logs, and metrics in the loader settings UI. Extend the logs and metrics test to cover both 10.x and 11.x.

Merge and deploy this frontend PR before merging the companion backend PR that makes 11.x selectable. The deployed frontend must recognize v11 capabilities before the backend exposes the new version.

Companion backend PR: https://github.com/getsentry/sentry/pull/123893. Merge it only after this frontend change has deployed to production.
