### PR TITLE
feat(loader): Make JavaScript v11 available in the backend

### DIFF
--- a/src/sentry/loader/browsersdkversion.py
+++ b/src/sentry/loader/browsersdkversion.py
@@ -37,7 +37,7 @@ def get_highest_browser_sdk_version(versions):
 
 
 def get_all_browser_sdk_version_versions():
-    return ["latest", "10.x", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x"]
+    return ["latest", "11.x", "10.x", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x"]
 
 
 def get_all_browser_sdk_version_choices():
@@ -72,7 +72,7 @@ def match_selected_version_to_browser_sdk_version(selected_version):
         return get_highest_browser_sdk_version([x for x in versions if Version(x) < Version("8")])
     return get_highest_browser_sdk_version(
         # Filter for all versions that match the selected versions major
-        [x for x in versions if x.startswith(selected_version[0])]
+        [x for x in versions if x.split(".")[0] == selected_version.split(".")[0]]
     )
 
 

--- a/src/sentry/projectoptions/defaults.py
+++ b/src/sentry/projectoptions/defaults.py
@@ -182,8 +182,8 @@ register(
 register(
     key="sentry:loader_available_sdk_versions",
     epoch_defaults={
-        1: ["10.x", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x"],
-        11: ["10.x", "9.x", "8.x", "7.x"],
+        1: ["11.x", "10.x", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x"],
+        11: ["11.x", "10.x", "9.x", "8.x", "7.x"],
     },
 )
 

--- a/tests/sentry/loader/test_browsersdkversion.py
+++ b/tests/sentry/loader/test_browsersdkversion.py
@@ -20,6 +20,9 @@ MOCK_VERSIONS = [
     "8.0.1-beta2",
     "8.1.1",
     "10.2.3",
+    "11.0.0",
+    "11.1.0",
+    "11.2.0-beta.0",
 ]
 
 
@@ -27,6 +30,7 @@ class BrowserSdkVersionTestCase(TestCase):
     def test_get_all_browser_sdk_version_versions(self) -> None:
         assert "latest" in get_all_browser_sdk_version_versions()
         assert "4.x" in get_all_browser_sdk_version_versions()
+        assert "11.x" in get_all_browser_sdk_version_versions()
 
     @mock.patch(
         "sentry.loader.browsersdkversion.load_version_from_file", return_value=MOCK_VERSIONS
@@ -34,7 +38,7 @@ class BrowserSdkVersionTestCase(TestCase):
     def test_get_highest_browser_sdk_version_from_versions(
         self, load_version_from_file: mock.MagicMock
     ) -> None:
-        assert str(get_highest_browser_sdk_version(load_version_from_file())) == "10.2.3"
+        assert str(get_highest_browser_sdk_version(load_version_from_file())) == "11.1.0"
 
     @mock.patch(
         "sentry.loader.browsersdkversion.load_version_from_file", return_value=MOCK_VERSIONS
@@ -43,6 +47,7 @@ class BrowserSdkVersionTestCase(TestCase):
         assert str(match_selected_version_to_browser_sdk_version("4.x")) == "4.6.4"
         assert str(match_selected_version_to_browser_sdk_version("5.x")) == "5.10.1"
         assert str(match_selected_version_to_browser_sdk_version("10.x")) == "10.2.3"
+        assert str(match_selected_version_to_browser_sdk_version("11.x")) == "11.1.0"
         assert (
             str(match_selected_version_to_browser_sdk_version("latest")) == "5.10.1"
         )  # Should not select version 8, since v8 is the first version that doesn't support latest

--- a/tests/sentry/projectoptions/test_basic.py
+++ b/tests/sentry/projectoptions/test_basic.py
@@ -1,7 +1,7 @@
 from unittest import mock
 
 from sentry.models.options.project_option import ProjectOption
-from sentry.projectoptions import default_manager, defaults
+from sentry.projectoptions import default_manager, defaults, get_well_known_default
 from sentry.projectoptions.manager import WellKnownProjectOption
 from sentry.testutils.pytest.fixtures import django_db_all
 
@@ -47,6 +47,18 @@ def test_epoch_defaults() -> None:
     assert option.get_default(epoch=20) == "new-value"
     assert option.get_default(epoch=42) == "latest-value"
     assert option.get_default(epoch=100) == "latest-value"
+
+
+def test_loader_version_defaults() -> None:
+    assert get_well_known_default("sentry:default_loader_version", epoch=14) == "9.x"
+    assert (
+        get_well_known_default("sentry:default_loader_version", epoch=defaults.LATEST_EPOCH)
+        == "10.x"
+    )
+    assert "11.x" in get_well_known_default("sentry:loader_available_sdk_versions", epoch=1)
+    assert "11.x" in get_well_known_default(
+        "sentry:loader_available_sdk_versions", epoch=defaults.LATEST_EPOCH
+    )
 
 
 @django_db_all


### PR DESCRIPTION
Make JavaScript SDK 11.x available in the loader version choices while keeping the default loader version at 10.x. Match the complete major version when resolving SDK releases so 10.x and 11.x each resolve to their own latest stable release.

Deployment order: merge this backend PR only after the companion frontend PR has been merged and deployed to production. Merging the frontend alone is not sufficient; its v11 loader controls must be deployed before this backend exposes 11.x as a selectable version.

Regression coverage checks v11 availability, stable release selection, and the unchanged default loader version.

Frontend prerequisite: https://github.com/getsentry/sentry/pull/123892.
