### PR TITLE
fix(search): Parse backtick-delimited aggregate query arguments

### DIFF
--- a/src/sentry/api/event_search.py
+++ b/src/sentry/api/event_search.py
@@ -158,7 +158,8 @@ explicit_array_tag_key =   "tags" open_bracket escaped_key spaces comma spaces "
 
 aggregate_key                    = key open_paren spaces function_args? spaces closed_paren
 function_args                    = aggregate_param (spaces comma spaces !comma aggregate_param?)*
-aggregate_param                  = explicit_tag_key_aggregate_param / quoted_aggregate_param / raw_aggregate_param
+aggregate_param                  = explicit_tag_key_aggregate_param / query_aggregate_param / quoted_aggregate_param / raw_aggregate_param
+query_aggregate_param            = "`" (quoted_value / ~r"[^`\"]+")* "`"
 raw_aggregate_param              = ~r"[^()\t\n, \"]+"
 quoted_aggregate_param           = '"' ('\\"' / ~r'[^\t\n\"]')* '"'
 explicit_tag_key_aggregate_param = explicit_tag_key / explicit_number_tag_key / explicit_string_tag_key / explicit_boolean_tag_key
@@ -1641,6 +1642,9 @@ class SearchVisitor(NodeVisitor[list[QueryToken]]):
 
     def visit_aggregate_param(self, node: Node, children: tuple[str]) -> str:
         return children[0]
+
+    def visit_query_aggregate_param(self, node: Node, children: object) -> str:
+        return node.text
 
     def visit_raw_aggregate_param(self, node: Node, children: object) -> str:
         return node.text

--- a/tests/sentry/api/test_event_search.py
+++ b/tests/sentry/api/test_event_search.py
@@ -349,6 +349,21 @@ class ParseSearchQueryBackendTest(SimpleTestCase):
             SearchFilter(key=SearchKey(name="z"), operator="=", value=SearchValue(raw_value="1")),
         ]
 
+    def test_conditional_aggregate_query_argument(self) -> None:
+        for predicate in [
+            "x:1 AND (y:2 OR z:3)",
+            'span.description:"hello world"',
+            'gen_ai.tool.name:["search docs",calculator]',
+            r'span.description:"say \"hello\""',
+        ]:
+            assert parse_search_query(f"count_if(`{predicate}`,span.duration):>0") == [
+                AggregateFilter(
+                    key=AggregateKey(f"count_if(`{predicate}`, span.duration)"),
+                    operator=">",
+                    value=SearchValue(0.0),
+                )
+            ]
+
     def test_paren_expression_of_empty_string(self) -> None:
         assert parse_search_query('("")') == parse_search_query('""') == []
 


### PR DESCRIPTION
Support backtick-delimited search predicates as a single argument to conditional aggregates, including Boolean groups, quoted values, and lists:

```text
count_if(`span.description:"hello world" AND (x:1 OR y:2)`,span.duration):>0
```

Today, the parser does not recognize backtick-delimited arguments. Spaces, parentheses, quotes, and commas inside the predicate can break argument parsing and turn the aggregate into unrelated search terms.
