### PR TITLE
feat(onboarding): Update Next.js onboarding for SDK v11

### DIFF
--- a/static/app/gettingStartedDocs/javascript-nextjs/index.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/index.tsx
@@ -30,7 +30,7 @@ export const docs: Docs = {
       {
         type: 'text',
         text: tct(
-          'In Next.js you can configure document response headers via the headers option in [code:next.config.js]:',
+          'In Next.js you can configure document response headers via the headers option in [code:next.config.(js|mjs|ts)]. Import [code:withSentryConfig] from [code:@sentry/nextjs/config]:',
           {
             code: <code />,
           }
@@ -42,38 +42,42 @@ export const docs: Docs = {
           {
             label: 'ESM',
             language: 'javascript',
-            filename: 'next.config.js',
+            filename: 'next.config.mjs',
             code: `
-  export default withSentryConfig({
-    async headers() {
-      return [{
-        source: "/:path*",
-        headers: [{
-          key: "Document-Policy",
-          value: "js-profiling",
-        }],
-      }];
-    },
-    // ... other Next.js config options
-  });`,
+import { withSentryConfig } from "@sentry/nextjs/config";
+
+export default withSentryConfig({
+  async headers() {
+    return [{
+      source: "/:path*",
+      headers: [{
+        key: "Document-Policy",
+        value: "js-profiling",
+      }],
+    }];
+  },
+  // ... other Next.js config options
+});`,
           },
           {
             label: 'CJS',
             language: 'javascript',
             filename: 'next.config.js',
             code: `
-  module.exports = withSentryConfig({
-    async headers() {
-      return [{
-        source: "/:path*",
-        headers: [{
-          key: "Document-Policy",
-          value: "js-profiling",
-        }],
-      }];
-    },
-    // ... other Next.js config options
-  });`,
+const { withSentryConfig } = require("@sentry/nextjs/config");
+
+module.exports = withSentryConfig({
+  async headers() {
+    return [{
+      source: "/:path*",
+      headers: [{
+        key: "Document-Policy",
+        value: "js-profiling",
+      }],
+    }];
+  },
+  // ... other Next.js config options
+});`,
           },
         ],
       },

--- a/static/app/gettingStartedDocs/javascript-nextjs/onboarding.spec.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/onboarding.spec.tsx
@@ -19,6 +19,11 @@ describe('javascript-nextjs onboarding docs', () => {
     expect(
       screen.getByText(textWithMarkupMatcher(/npx @sentry\/wizard@latest -i nextjs/))
     ).toBeInTheDocument();
+
+    // States the minimum supported Next.js version
+    expect(
+      screen.getByText(textWithMarkupMatcher(/requires Next\.js 14 or later/))
+    ).toBeInTheDocument();
   });
 
   it('displays the verify instructions', () => {

--- a/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/onboarding.tsx
@@ -19,6 +19,12 @@ export const onboarding: OnboardingConfig = {
       content: [
         {
           type: 'text',
+          text: tct('The Sentry Next.js SDK requires Next.js [code:14] or later.', {
+            code: <code />,
+          }),
+        },
+        {
+          type: 'text',
           text: tct(
             'Configure your app automatically by running the [wizardLink:Sentry wizard] in the root of your project.',
             {

--- a/static/app/gettingStartedDocs/javascript-nextjs/performance.tsx
+++ b/static/app/gettingStartedDocs/javascript-nextjs/performance.tsx
@@ -9,7 +9,7 @@ import {getInstallSnippet} from './utils';
 export const performance: OnboardingConfig = {
   introduction: () =>
     t(
-      "Adding Performance to your React project is simple. Make sure you've got these basics down."
+      "Adding Performance to your Next.js project is simple. Make sure you've got these basics down."
     ),
   install: params => [
     {
@@ -34,7 +34,7 @@ export const performance: OnboardingConfig = {
         {
           type: 'text',
           text: tct(
-            'To configure, set [code:tracesSampleRate] in your config files, [code:sentry.server.config.js], [code:instrumentation-client.(js|ts)], and [code:sentry.edge.config.js]:',
+            'To configure, set [code:tracesSampleRate] in your config files, [code:instrumentation-client.(js|ts)], [code:sentry.server.config.(js|ts)], and [code:sentry.edge.config.(js|ts)]:',
             {code: <code />}
           ),
         },
@@ -93,26 +93,13 @@ Sentry.init({
         {
           type: 'code',
           language: 'javascript',
+          filename: 'instrumentation-client.(js|ts)',
           code: `
-// instrumentation-client.(js|ts)
 Sentry.init({
   dsn: "${params.dsn.public}",
-  integrations: [Sentry.browserTracingIntegration()],
   tracePropagationTargets: ["localhost", /^https:\\/\\/yourserver\\.io\\/api/]
 });
 `,
-        },
-        {
-          type: 'text',
-          text: tct(
-            "If you're using version [code:7.57.x] or below, you'll need to have our [link:tracing feature enabled] in order for distributed tracing to work.",
-            {
-              code: <code />,
-              link: (
-                <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/tracing/" />
-              ),
-            }
-          ),
         },
       ],
     },
@@ -124,7 +111,7 @@ Sentry.init({
         {
           type: 'text',
           text: tct(
-            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your NextJS application.',
+            'Verify that performance monitoring is working correctly with our [link:automatic instrumentation] by simply using your Next.js application.',
             {
               link: (
                 <ExternalLink href="https://docs.sentry.io/platforms/javascript/guides/nextjs/tracing/instrumentation/automatic-instrumentation/" />


### PR DESCRIPTION
Update the in-product Next.js onboarding for @sentry/nextjs v11.

- State that the SDK requires Next.js 14 or later in the install step.
- Import `withSentryConfig` from `@sentry/nextjs/config` in the profiling `next.config` snippet, and label the ESM tab `next.config.mjs`. The root export is removed in v11. The `./config` entry point already exists in 10.x, so the snippet also works for users who have not upgraded yet.
- Drop the paragraph about SDK versions 7.57.x and below needing tracing enabled for distributed tracing.
- Remove `browserTracingIntegration` from the distributed tracing snippet, since the Next.js SDK adds it by default.
- Fix "React project" to "Next.js project" and "NextJS" to "Next.js" in the performance onboarding, and use a consistent `(js|ts)` suffix for the three config file names.

Checked and unchanged: `reactComponentAnnotation`, `enableOpenTelemetrySetup` and `sendDefaultPii` do not appear in this onboarding, the agent monitoring step already targets `sentry.server.config` only, and all docs links resolve.

closes [SDK-1435](https://linear.app/getsentry/issue/SDK-1435/update-the-javascript-nextjs-in-product-onboarding-for-v11)