### PR TITLE
fix(workflows): Advertise missing scope for all-project updates

### DIFF
--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -5,11 +5,13 @@ from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
 
 from django.conf import settings
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import SAFE_METHODS, BasePermission, IsAuthenticated  # noqa: S012
 from rest_framework.request import Request
 
 from sentry.api.exceptions import (
     INSUFFICIENT_SCOPE_ATTR,
+    InsufficientScope,
     MemberDisabledOverLimit,
     SsoRequired,
     SuperuserRequired,
@@ -21,6 +23,7 @@ from sentry.auth.superuser import SUPERUSER_ORG_ID, is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.demo_mode.utils import get_readonly_scopes, is_demo_mode_enabled, is_demo_user
 from sentry.hybridcloud.rpc import extract_id_from
+from sentry.models.apiscopes import add_scope_hierarchy
 from sentry.models.orgauthtoken import is_org_auth_token_auth, update_org_auth_token_last_used
 from sentry.organizations.services.organization import (
     RpcOrganization,
@@ -46,6 +49,17 @@ def _least_privileged_scope(allowed_scopes: set[str]) -> str | None:
         if not implied.intersection(grantable_scopes - {scope}):
             return scope
     return min(grantable_scopes) if grantable_scopes else None
+
+
+def enforce_scope(request: Request, required_scope: str) -> None:
+    """Require a scope and distinguish token failures from other denials."""
+    if request.access.has_scope(required_scope):
+        return
+    if required_scope in add_scope_hierarchy(list(request.access.scopes)):
+        return
+    if request.auth and required_scope not in add_scope_hierarchy(request.auth.get_scopes()):
+        raise InsufficientScope([required_scope])
+    raise PermissionDenied
 
 
 class RelayPermission(BasePermission):

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -57,7 +57,11 @@ def enforce_scope(request: Request, required_scope: str) -> None:
         return
     if required_scope in add_scope_hierarchy(list(request.access.scopes)):
         return
-    if request.auth and required_scope not in add_scope_hierarchy(request.auth.get_scopes()):
+    if (
+        agent_token.is_agent_auth(request.auth)
+        and required_scope not in settings.SENTRY_TOKEN_ONLY_SCOPES
+        and request.access.would_have_scope_with_added_auth_scope(required_scope)
+    ):
         raise InsufficientScope([required_scope])
     raise PermissionDenied
 

--- a/src/sentry/auth/access.py
+++ b/src/sentry/auth/access.py
@@ -21,6 +21,7 @@ from sentry.auth.superuser import get_superuser_scopes, is_active_superuser
 from sentry.auth.system import is_system_auth
 from sentry.constants import ObjectStatus
 from sentry.data_secrecy.logic import should_allow_superuser_access
+from sentry.models.apiscopes import add_scope_hierarchy
 from sentry.models.organization import Organization
 from sentry.models.organizationmember import OrganizationMember
 from sentry.models.organizationmemberteam import OrganizationMemberTeam
@@ -132,6 +133,11 @@ class Access(abc.ABC):
         check_scope_declaration(scope)
         return scope in self.scopes
 
+    def would_have_scope_with_added_auth_scope(self, scope: str) -> bool:
+        """Whether adding ``scope`` to the current auth scope cap would grant it."""
+        check_scope_declaration(scope)
+        return False
+
     def get_organization_role(self) -> OrganizationRole | None:
         if self.role is not None:
             return organization_roles.get(self.role)
@@ -235,6 +241,15 @@ class DbAccess(Access):
     @property
     def role(self) -> str | None:
         return self._member.role if self._member else None
+
+    def would_have_scope_with_added_auth_scope(self, scope: str) -> bool:
+        check_scope_declaration(scope)
+        if self._member is None or self.scopes_upper_bound is None:
+            return False
+        candidate_scopes = _intersect_member_and_token_scopes(
+            self._member.get_scopes(), self.scopes_upper_bound | {scope}
+        )
+        return scope in add_scope_hierarchy(list(candidate_scopes))
 
     @cached_property
     def _team_memberships(self) -> Mapping[Team, OrganizationMemberTeam]:
@@ -466,6 +481,16 @@ class RpcBackedAccess(Access):
             self.rpc_user_organization_context.member.scopes,
             self.scopes_upper_bound,
         )
+
+    def would_have_scope_with_added_auth_scope(self, scope: str) -> bool:
+        check_scope_declaration(scope)
+        member = self.rpc_user_organization_context.member
+        if member is None or self.scopes_upper_bound is None:
+            return False
+        candidate_scopes = _intersect_member_and_token_scopes(
+            member.scopes, self.scopes_upper_bound | {scope}
+        )
+        return scope in add_scope_hierarchy(list(candidate_scopes))
 
     # TODO(cathy): remove this
     @property

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -76,7 +76,7 @@ from sentry.workflow_engine.endpoints.validators.detector_workflow_mutation impo
 )
 from sentry.workflow_engine.endpoints.validators.utils import (
     is_workflow_connected_to_all_projects_detector,
-    should_include_all_projects_detector_workflows,
+    should_include_all_projects_detector_workflows_or_raise,
 )
 from sentry.workflow_engine.models import DetectorWorkflow, Workflow
 from sentry.workflow_engine.models.workflow_fire_history import WorkflowFireHistory
@@ -136,7 +136,7 @@ class OrganizationWorkflowEndpoint(OrganizationEndpoint):
         workflow = kwargs["workflow"]
         organization = kwargs["organization"]
         if is_workflow_connected_to_all_projects_detector(workflow):
-            if not should_include_all_projects_detector_workflows(request, organization):
+            if not should_include_all_projects_detector_workflows_or_raise(request, organization):
                 raise PermissionDenied
             return args, kwargs
 
@@ -246,7 +246,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         all_projects_detector = get_all_projects_detector(organization.id)
         if all_projects_detector:
             all_projects_workflows_q = Q(detectorworkflow__detector_id=all_projects_detector.id)
-            if should_include_all_projects_detector_workflows(request, organization):
+            if should_include_all_projects_detector_workflows_or_raise(request, organization):
                 accessible_workflows |= all_projects_workflows_q
             else:
                 queryset = queryset.exclude(all_projects_workflows_q)

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -246,8 +246,10 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         all_projects_detector = get_all_projects_detector(organization.id)
         if all_projects_detector:
             all_projects_workflows_q = Q(detectorworkflow__detector_id=all_projects_detector.id)
-            should_check_all_projects_access = (
-                request.method == "GET" or queryset.filter(all_projects_workflows_q).exists()
+            has_explicit_workflow_selector = bool(raw_idlist or raw_detectorlist or raw_query)
+            should_check_all_projects_access = request.method == "GET" or (
+                has_explicit_workflow_selector
+                and queryset.filter(all_projects_workflows_q).exists()
             )
             if should_check_all_projects_access and (
                 should_include_all_projects_detector_workflows_or_raise(request, organization)

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -247,20 +247,7 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         all_projects_detector = get_all_projects_detector(organization.id)
         if all_projects_detector:
             all_projects_workflows_q = Q(detectorworkflow__detector_id=all_projects_detector.id)
-            has_explicit_workflow_selector = bool(raw_idlist or raw_detectorlist or raw_query)
-            should_enforce_all_projects_access = request.method != "GET" and (
-                has_explicit_workflow_selector
-                and queryset.filter(all_projects_workflows_q).exists()
-            )
-            if should_enforce_all_projects_access:
-                include_all_projects_workflows = (
-                    should_include_all_projects_detector_workflows_or_raise(request, organization)
-                )
-            else:
-                include_all_projects_workflows = should_include_all_projects_detector_workflows(
-                    request, organization
-                )
-            if include_all_projects_workflows:
+            if should_include_all_projects_detector_workflows(request, organization):
                 accessible_workflows |= all_projects_workflows_q
             else:
                 queryset = queryset.exclude(all_projects_workflows_q)
@@ -275,13 +262,25 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         queryset = self.filter_workflows(request, organization)
         workflows = list(queryset)
 
-        if not workflows:
-            return queryset, workflows
-
         if raw_idlist := request.GET.getlist("id"):
             requested_ids = set(to_valid_int_id_list("id", raw_idlist))
-            if requested_ids != {workflow.id for workflow in workflows}:
+            missing_workflow_ids = requested_ids - {workflow.id for workflow in workflows}
+            if missing_workflow_ids:
+                all_projects_detector = get_all_projects_detector(organization.id)
+                if (
+                    all_projects_detector
+                    and DetectorWorkflow.objects.filter(
+                        detector_id=all_projects_detector.id,
+                        workflow_id__in=missing_workflow_ids,
+                    ).exists()
+                ):
+                    should_include_all_projects_detector_workflows_or_raise(request, organization)
+                if not workflows:
+                    return queryset, workflows
                 raise PermissionDenied
+
+        if not workflows:
+            return queryset, workflows
 
         if not can_edit_workflows(workflows, request):
             raise PermissionDenied

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -76,6 +76,7 @@ from sentry.workflow_engine.endpoints.validators.detector_workflow_mutation impo
 )
 from sentry.workflow_engine.endpoints.validators.utils import (
     is_workflow_connected_to_all_projects_detector,
+    should_include_all_projects_detector_workflows,
     should_include_all_projects_detector_workflows_or_raise,
 )
 from sentry.workflow_engine.models import DetectorWorkflow, Workflow
@@ -247,13 +248,19 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         if all_projects_detector:
             all_projects_workflows_q = Q(detectorworkflow__detector_id=all_projects_detector.id)
             has_explicit_workflow_selector = bool(raw_idlist or raw_detectorlist or raw_query)
-            should_check_all_projects_access = request.method == "GET" or (
+            should_enforce_all_projects_access = request.method != "GET" and (
                 has_explicit_workflow_selector
                 and queryset.filter(all_projects_workflows_q).exists()
             )
-            if should_check_all_projects_access and (
-                should_include_all_projects_detector_workflows_or_raise(request, organization)
-            ):
+            if should_enforce_all_projects_access:
+                include_all_projects_workflows = (
+                    should_include_all_projects_detector_workflows_or_raise(request, organization)
+                )
+            else:
+                include_all_projects_workflows = should_include_all_projects_detector_workflows(
+                    request, organization
+                )
+            if include_all_projects_workflows:
                 accessible_workflows |= all_projects_workflows_q
             else:
                 queryset = queryset.exclude(all_projects_workflows_q)

--- a/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_index.py
@@ -246,7 +246,12 @@ class OrganizationWorkflowIndexEndpoint(OrganizationEndpoint):
         all_projects_detector = get_all_projects_detector(organization.id)
         if all_projects_detector:
             all_projects_workflows_q = Q(detectorworkflow__detector_id=all_projects_detector.id)
-            if should_include_all_projects_detector_workflows_or_raise(request, organization):
+            should_check_all_projects_access = (
+                request.method == "GET" or queryset.filter(all_projects_workflows_q).exists()
+            )
+            if should_check_all_projects_access and (
+                should_include_all_projects_detector_workflows_or_raise(request, organization)
+            ):
                 accessible_workflows |= all_projects_workflows_q
             else:
                 queryset = queryset.exclude(all_projects_workflows_q)

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -412,6 +412,15 @@ def should_include_all_projects_detector(request: Request, organization: Organiz
     )
 
 
+def should_include_all_projects_detector_workflows(
+    request: Request, organization: Organization
+) -> bool:
+    return features.has("organizations:workflow-engine-all-projects-detector", organization) and (
+        request.method == "GET"
+        or can_edit_all_project_detector_workflow_connections(request=request)
+    )
+
+
 def should_include_all_projects_detector_workflows_or_raise(
     request: Request, organization: Organization
 ) -> bool:

--- a/src/sentry/workflow_engine/endpoints/validators/utils.py
+++ b/src/sentry/workflow_engine/endpoints/validators/utils.py
@@ -12,6 +12,7 @@ from rest_framework.exceptions import PermissionDenied
 from rest_framework.request import Request
 
 from sentry import audit_log, features
+from sentry.api.permissions import enforce_scope
 from sentry.issues import grouptype
 from sentry.models.organization import Organization
 from sentry.models.project import Project
@@ -411,14 +412,16 @@ def should_include_all_projects_detector(request: Request, organization: Organiz
     )
 
 
-def should_include_all_projects_detector_workflows(
+def should_include_all_projects_detector_workflows_or_raise(
     request: Request, organization: Organization
 ) -> bool:
     """
     The flag is always required to show these workflows, but if it isn't a GET request, also check
     that the caller has org:write. alerts:write is not sufficient to connect an all projects detector.
     """
-    return features.has("organizations:workflow-engine-all-projects-detector", organization) and (
-        request.method == "GET"
-        or can_edit_all_project_detector_workflow_connections(request=request)
-    )
+    if not features.has("organizations:workflow-engine-all-projects-detector", organization):
+        return False
+    if request.method == "GET":
+        return True
+    enforce_scope(request, "org:write")
+    return True

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -2,6 +2,8 @@ from contextlib import AbstractContextManager
 from unittest import mock
 
 import responses
+from django.test import override_settings
+from rest_framework.test import APIClient
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
@@ -12,6 +14,7 @@ from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.incidents.grouptype import MetricIssue
 from sentry.models.auditlogentry import AuditLogEntry
 from sentry.models.rule import Rule
+from sentry.seer import agent_token
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers import TaskRunner
@@ -36,6 +39,8 @@ from tests.sentry.workflow_engine.test_base import (
     MockActionValidatorTranslator,
     ProjectAccessTestMixin,
 )
+
+AGENT_TOKEN_SECRET = "test-seer-api-shared-secret-thirty-two-bytes!"
 
 
 class OrganizationWorkflowDetailsBaseTest(APITestCase):
@@ -235,6 +240,7 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
             status_code=400,
         )
 
+    @with_feature("organizations:workflow-engine-all-projects-detector")
     def test_all_projects_workflow_requires_org_write(self) -> None:
         detector = ensure_default_all_projects_detector(self.organization.id)
         self.create_detector_workflow(workflow=self.workflow, detector=detector)
@@ -254,6 +260,32 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
 
         self.workflow.refresh_from_db()
         assert self.workflow.name != "Unauthorized update"
+
+    @with_feature("organizations:workflow-engine-all-projects-detector")
+    @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
+    def test_all_projects_workflow_agent_token_advertises_org_write(self) -> None:
+        detector = ensure_default_all_projects_detector(self.organization.id)
+        self.create_detector_workflow(workflow=self.workflow, detector=detector)
+        token, _ = agent_token.encode_agent_token(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            scopes=["org:read"],
+            session_id="workflow-update",
+        )
+        client = APIClient()
+
+        with self.feature(agent_token.FEATURE_FLAG):
+            response = client.put(
+                f"/api/0/organizations/{self.organization.slug}/workflows/{self.workflow.id}/",
+                data={**self.valid_workflow, "name": "Unauthorized update"},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        assert response.status_code == 403, response.content
+        assert (
+            response["WWW-Authenticate"] == 'Bearer error="insufficient_scope", scope="org:write"'
+        )
 
     def test_update_action_filter_with_string_encoded_id(self) -> None:
         dcg = DataConditionGroup.objects.create(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -287,6 +287,34 @@ class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
             response["WWW-Authenticate"] == 'Bearer error="insufficient_scope", scope="org:write"'
         )
 
+    @with_feature("organizations:workflow-engine-all-projects-detector")
+    @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
+    def test_all_projects_workflow_agent_token_does_not_advertise_ungrantable_scope(self) -> None:
+        detector = ensure_default_all_projects_detector(self.organization.id)
+        self.create_detector_workflow(workflow=self.workflow, detector=detector)
+        user = self.create_user()
+        self.create_member(
+            user=user, organization=self.organization, role="member", teams=[self.team]
+        )
+        token, _ = agent_token.encode_agent_token(
+            user_id=user.id,
+            organization_id=self.organization.id,
+            scopes=["org:read"],
+            session_id="workflow-update",
+        )
+        client = APIClient()
+
+        with self.feature(agent_token.FEATURE_FLAG):
+            response = client.put(
+                f"/api/0/organizations/{self.organization.slug}/workflows/{self.workflow.id}/",
+                data={**self.valid_workflow, "name": "Unauthorized update"},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        assert response.status_code == 403, response.content
+        assert "insufficient_scope" not in response.get("WWW-Authenticate", "")
+
     def test_update_action_filter_with_string_encoded_id(self) -> None:
         dcg = DataConditionGroup.objects.create(
             organization=self.organization,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -1675,6 +1675,34 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
         assert self.workflow_three.enabled is False
 
     @with_feature("organizations:workflow-engine-all-projects-detector")
+    def test_bulk_enable_workflows_by_ids_including_all_projects(self) -> None:
+        all_projects_workflow = self.create_workflow(
+            organization_id=self.organization.id, enabled=False
+        )
+        self.create_detector_workflow(
+            workflow=all_projects_workflow,
+            detector=ensure_default_all_projects_detector(self.organization.id),
+        )
+
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params=[
+                ("id", str(self.workflow.id)),
+                ("id", str(all_projects_workflow.id)),
+            ],
+            raw_data={"enabled": True},
+        )
+
+        self.workflow.refresh_from_db()
+        all_projects_workflow.refresh_from_db()
+        assert self.workflow.enabled is True
+        assert all_projects_workflow.enabled is True
+        assert {workflow["id"] for workflow in response.data} == {
+            str(self.workflow.id),
+            str(all_projects_workflow.id),
+        }
+
+    @with_feature("organizations:workflow-engine-all-projects-detector")
     @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
     def test_agent_token_can_update_ordinary_workflow_when_all_projects_workflow_exists(
         self,

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -3,6 +3,8 @@ from typing import Any
 from unittest import mock
 
 import responses
+from django.test import override_settings
+from rest_framework.test import APIClient
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
@@ -11,6 +13,7 @@ from sentry.deletions.models.scheduleddeletion import CellScheduledDeletion
 from sentry.deletions.tasks.scheduled import run_scheduled_deletions
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.incidents.grouptype import MetricIssue
+from sentry.seer import agent_token
 from sentry.testutils.asserts import assert_org_audit_log_exists
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.helpers.features import with_feature
@@ -34,6 +37,8 @@ from tests.sentry.workflow_engine.test_base import (
     MockActionValidatorTranslator,
     ProjectAccessTestMixin,
 )
+
+AGENT_TOKEN_SECRET = "test-seer-api-shared-secret-thirty-two-bytes!"
 
 
 class OrganizationWorkflowAPITestCase(APITestCase):
@@ -1657,6 +1662,69 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
         # Verify third workflow is unaffected
         self.workflow_three.refresh_from_db()
         assert self.workflow_three.enabled is False
+
+    @with_feature("organizations:workflow-engine-all-projects-detector")
+    @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
+    def test_agent_token_can_update_ordinary_workflow_when_all_projects_workflow_exists(
+        self,
+    ) -> None:
+        all_projects_workflow = self.create_workflow(organization_id=self.organization.id)
+        self.create_detector_workflow(
+            workflow=all_projects_workflow,
+            detector=ensure_default_all_projects_detector(self.organization.id),
+        )
+        token, _ = agent_token.encode_agent_token(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            scopes=["alerts:write"],
+            session_id="workflow-update",
+        )
+        client = APIClient()
+
+        with self.feature(agent_token.FEATURE_FLAG):
+            response = client.put(
+                f"/api/0/organizations/{self.organization.slug}/workflows/",
+                data={"enabled": True},
+                format="json",
+                query_params={"id": str(self.workflow.id)},
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        assert response.status_code == 200, response.content
+        self.workflow.refresh_from_db()
+        assert self.workflow.enabled is True
+
+    @with_feature("organizations:workflow-engine-all-projects-detector")
+    @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
+    def test_all_projects_workflow_agent_token_advertises_org_write(self) -> None:
+        all_projects_workflow = self.create_workflow(
+            organization_id=self.organization.id, enabled=False
+        )
+        self.create_detector_workflow(
+            workflow=all_projects_workflow,
+            detector=ensure_default_all_projects_detector(self.organization.id),
+        )
+        token, _ = agent_token.encode_agent_token(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            scopes=["alerts:write"],
+            session_id="workflow-update",
+        )
+        client = APIClient()
+
+        with self.feature(agent_token.FEATURE_FLAG):
+            response = client.put(
+                f"/api/0/organizations/{self.organization.slug}/workflows/",
+                data={"enabled": True},
+                format="json",
+                query_params={"id": str(all_projects_workflow.id)},
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        assert response.status_code == 403, response.content
+        assert (
+            response["WWW-Authenticate"] == 'Bearer error="insufficient_scope", scope="org:write"'
+        )
 
     def test_bulk_enable_all_projects_slug_sentinel_includes_detached_workflows(self) -> None:
         self.create_detector_workflow(

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -1541,6 +1541,17 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
             organization_id=self.organization.id, name="Third Workflow", enabled=False
         )
 
+    def _create_alerts_write_agent_client(self) -> APIClient:
+        token, _ = agent_token.encode_agent_token(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            scopes=["alerts:write"],
+            session_id="workflow-update",
+        )
+        client = APIClient()
+        client.credentials(HTTP_AUTHORIZATION=f"Bearer {token}")
+        return client
+
     def test_team_admin_can_update_project_scoped_workflow(self) -> None:
         detector = self.create_detector(project=self.project)
         self.create_detector_workflow(workflow=self.workflow, detector=detector)
@@ -1673,13 +1684,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
             workflow=all_projects_workflow,
             detector=ensure_default_all_projects_detector(self.organization.id),
         )
-        token, _ = agent_token.encode_agent_token(
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            scopes=["alerts:write"],
-            session_id="workflow-update",
-        )
-        client = APIClient()
+        client = self._create_alerts_write_agent_client()
 
         with self.feature(agent_token.FEATURE_FLAG):
             response = client.put(
@@ -1687,12 +1692,67 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
                 data={"enabled": True},
                 format="json",
                 query_params={"id": str(self.workflow.id)},
-                HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
         assert response.status_code == 200, response.content
         self.workflow.refresh_from_db()
         assert self.workflow.enabled is True
+
+    @with_feature("organizations:workflow-engine-all-projects-detector")
+    @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
+    def test_agent_token_can_update_by_project_when_all_projects_workflow_exists(self) -> None:
+        self.create_detector_workflow(
+            workflow=self.workflow,
+            detector=self.create_detector(project=self.project),
+        )
+        all_projects_workflow = self.create_workflow(
+            organization_id=self.organization.id, enabled=False
+        )
+        self.create_detector_workflow(
+            workflow=all_projects_workflow,
+            detector=ensure_default_all_projects_detector(self.organization.id),
+        )
+        client = self._create_alerts_write_agent_client()
+
+        with self.feature(agent_token.FEATURE_FLAG):
+            response = client.put(
+                f"/api/0/organizations/{self.organization.slug}/workflows/",
+                data={"enabled": True},
+                format="json",
+                query_params={"project": str(self.project.id)},
+            )
+
+        assert response.status_code == 200, response.content
+        self.workflow.refresh_from_db()
+        all_projects_workflow.refresh_from_db()
+        assert self.workflow.enabled is True
+        assert all_projects_workflow.enabled is False
+
+    @with_feature("organizations:workflow-engine-all-projects-detector")
+    @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
+    def test_agent_token_can_update_all_accessible_when_all_projects_workflow_exists(self) -> None:
+        all_projects_workflow = self.create_workflow(
+            organization_id=self.organization.id, enabled=False
+        )
+        self.create_detector_workflow(
+            workflow=all_projects_workflow,
+            detector=ensure_default_all_projects_detector(self.organization.id),
+        )
+        client = self._create_alerts_write_agent_client()
+
+        with self.feature(agent_token.FEATURE_FLAG):
+            response = client.put(
+                f"/api/0/organizations/{self.organization.slug}/workflows/",
+                data={"enabled": True},
+                format="json",
+                query_params={"projectSlug": "$all"},
+            )
+
+        assert response.status_code == 200, response.content
+        self.workflow.refresh_from_db()
+        all_projects_workflow.refresh_from_db()
+        assert self.workflow.enabled is True
+        assert all_projects_workflow.enabled is False
 
     @with_feature("organizations:workflow-engine-all-projects-detector")
     @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
@@ -1704,13 +1764,7 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
             workflow=all_projects_workflow,
             detector=ensure_default_all_projects_detector(self.organization.id),
         )
-        token, _ = agent_token.encode_agent_token(
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            scopes=["alerts:write"],
-            session_id="workflow-update",
-        )
-        client = APIClient()
+        client = self._create_alerts_write_agent_client()
 
         with self.feature(agent_token.FEATURE_FLAG):
             response = client.put(
@@ -1718,7 +1772,6 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
                 data={"enabled": True},
                 format="json",
                 query_params={"id": str(all_projects_workflow.id)},
-                HTTP_AUTHORIZATION=f"Bearer {token}",
             )
 
         assert response.status_code == 403, response.content

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_index.py
@@ -1779,9 +1779,17 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
             response["WWW-Authenticate"] == 'Bearer error="insufficient_scope", scope="org:write"'
         )
 
+    @with_feature("organizations:workflow-engine-all-projects-detector")
     def test_bulk_enable_all_projects_slug_sentinel_includes_detached_workflows(self) -> None:
         self.create_detector_workflow(
             workflow=self.workflow, detector=self.create_detector(project=self.project)
+        )
+        all_projects_workflow = self.create_workflow(
+            organization_id=self.organization.id, enabled=False
+        )
+        self.create_detector_workflow(
+            workflow=all_projects_workflow,
+            detector=ensure_default_all_projects_detector(self.organization.id),
         )
 
         response = self.get_success_response(
@@ -1793,13 +1801,16 @@ class OrganizationWorkflowPutTest(OrganizationWorkflowAPITestCase):
         self.workflow.refresh_from_db()
         self.workflow_two.refresh_from_db()
         self.workflow_three.refresh_from_db()
+        all_projects_workflow.refresh_from_db()
         assert self.workflow.enabled is True
         assert self.workflow_two.enabled is True
         assert self.workflow_three.enabled is True
+        assert all_projects_workflow.enabled is True
         assert {workflow["id"] for workflow in response.data} == {
             str(self.workflow.id),
             str(self.workflow_two.id),
             str(self.workflow_three.id),
+            str(all_projects_workflow.id),
         }
 
     def test_bulk_disable_workflows_by_ids_success(self) -> None:


### PR DESCRIPTION
Agent-authenticated all-project workflow mutations that lack `org:write` now return an RFC 6750 `insufficient_scope` challenge only when that scope is grantable to the delegating member. This lets Seer request approval and retry without advertising a scope that would still fail the same role check.

The explicit scope enforcement runs only when a mutation actually targets a workflow connected to the all-project detector. Ordinary bulk mutations continue to work with `alerts:write` even when the organization also has an all-project workflow. Feature-flag, GET, session-auth, and ordinary permission-denial behavior remain unchanged.