### PR TITLE
ci(jest-balance): run the balancer weekly instead of twice a month

### DIFF
--- a/.github/workflows/jest-balance.yml
+++ b/.github/workflows/jest-balance.yml
@@ -2,7 +2,7 @@ name: jest balancer
 on:
   workflow_dispatch:
   schedule:
-    - cron: '0 0 1,15 * *'
+    - cron: '0 0 * * 0'
 jobs:
   jest-config:
     name: Configure Jest


### PR DESCRIPTION
The idea behind this is that recently for 2 weeks we had a less optimal split, which pushes time spend waiting up. If we run slightly more often then it'll be less optimal for less time.

Here we can see that after 14th up to the 31st the pink line, `Test (4,8)` was an outlier, fixed after the run on the 31st. These are the dates when the balancer ran.
<img width="794" height="456" alt="SCR-20260909-jvcw" src="https://github.com/user-attachments/assets/9659b972-8a7a-4e89-b944-f6f319eb7a43" />


---

The jest balancer runs the full jest matrix, records per-file runtimes, and publishes `jest-balance.json`. `frontend.yml` downloads that artifact from the most recent successful master run and uses it to spread test files evenly across shards.

On the current `1,15` cadence the timing data can be up to two weeks behind master. Tests get added, deleted, and rewritten in that window, so the shard split drifts and one shard ends up as the long pole of the frontend job. Weekly keeps the data within seven days and lands the refreshed artifact before the work week starts.

`0 0 * * 0` (Sundays, 00:00 UTC) rather than a weekday slot, so the extra matrix runs land when CI is quiet. The cost is roughly two more full jest matrix runs per month.

No feature flag — the schedule change takes effect once this merges to master. The `workflow_dispatch` trigger is untouched, so the balancer can still be run on demand.


https://claude.ai/code/session_01KvHjyGdpfxN4KkEmMxhdNr
