### PR TITLE
chore(oxlint): promote react/globals to an error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -592,7 +592,7 @@ const config = defineConfig({
     'react/error-boundaries': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/exhaustive-effect-dependencies': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/function-component-definition': 'error',
-    'react/globals': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
+    'react/globals': 'error',
     'react/hooks': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/immutability': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/incompatible-library': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.

--- a/static/app/components/commandPalette/ui/commandPalette.spec.tsx
+++ b/static/app/components/commandPalette/ui/commandPalette.spec.tsx
@@ -1317,6 +1317,7 @@ describe('CommandPalette', () => {
     let testDispatch: CommandPaletteDispatch;
 
     function DispatchCapture() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       testDispatch = useCommandPaletteDispatch();
       return null;
     }

--- a/static/app/utils/useChartInterval.spec.tsx
+++ b/static/app/utils/useChartInterval.spec.tsx
@@ -21,6 +21,7 @@ describe('useChartInterval', () => {
     let intervalOptions!: ReturnType<typeof useChartInterval>[2];
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [chartInterval, setChartInterval, intervalOptions] = useChartInterval();
       return null;
     }
@@ -63,6 +64,7 @@ describe('useChartInterval', () => {
     let chartInterval!: ReturnType<typeof useChartInterval>[0];
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [chartInterval] = useChartInterval({
         unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_SMALLEST,
       });
@@ -81,6 +83,7 @@ describe('useChartInterval', () => {
     let intervalOptions!: ReturnType<typeof useChartInterval>[2];
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [chartInterval, , intervalOptions] = useChartInterval({
         unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_BIGGEST,
       });
@@ -99,6 +102,7 @@ describe('useChartInterval', () => {
     let chartInterval!: ReturnType<typeof useChartInterval>[0];
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [chartInterval] = useChartInterval({
         unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_SECOND_BIGGEST,
       });
@@ -117,6 +121,7 @@ describe('useChartInterval', () => {
     let intervalOptions!: ReturnType<typeof useChartInterval>[2];
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [chartInterval, , intervalOptions] = useChartInterval();
       return null;
     }
@@ -144,6 +149,7 @@ describe('useChartInterval', () => {
     let intervalOptions!: ReturnType<typeof useChartInterval>[2];
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [chartInterval, , intervalOptions] = useChartInterval();
       return null;
     }
@@ -174,6 +180,7 @@ describe('useChartInterval', () => {
     let intervalOptions!: ReturnType<typeof useChartInterval>[2];
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [chartInterval, , intervalOptions] = useChartInterval();
       return null;
     }
@@ -192,6 +199,7 @@ describe('useChartInterval', () => {
     let chartInterval!: ReturnType<typeof useChartInterval>[0];
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [chartInterval] = useChartInterval();
       return null;
     }
@@ -211,6 +219,7 @@ describe('useChartInterval', () => {
     let chartInterval!: ReturnType<typeof useChartInterval>[0];
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [chartInterval] = useChartInterval({
         unspecifiedStrategy: ChartIntervalUnspecifiedStrategy.USE_SECOND_BIGGEST,
       });

--- a/static/app/utils/useLocation.spec.tsx
+++ b/static/app/utils/useLocation.spec.tsx
@@ -6,6 +6,7 @@ describe('useLocation', () => {
   it('returns the current location object', () => {
     let location: any;
     function HomePage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       location = useLocation();
       return null;
     }

--- a/static/app/utils/useNavigate.spec.tsx
+++ b/static/app/utils/useNavigate.spec.tsx
@@ -7,6 +7,7 @@ describe('useNavigate', () => {
     let navigate: ReturnType<typeof useNavigate> | undefined;
 
     function HomePage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       navigate = useNavigate();
       return null;
     }

--- a/static/app/utils/useParams.spec.tsx
+++ b/static/app/utils/useParams.spec.tsx
@@ -27,6 +27,7 @@ describe('useParams', () => {
     it('returns an empty object', () => {
       let params: any;
       function HomePage() {
+        // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
         params = useParams();
         return null;
       }
@@ -46,6 +47,7 @@ describe('useParams', () => {
     it('returns an object of the URL params', () => {
       let params: any;
       function HomePage() {
+        // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
         params = useParams();
         return null;
       }
@@ -73,7 +75,9 @@ describe('useParams', () => {
       let useParamsValue: any;
 
       function Component() {
+        // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
         originalParams = useReactRouter6Params();
+        // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
         useParamsValue = useParams();
         return (
           <div>rendered component for org: {useParamsValue.orgId ?? 'no org id'}</div>
@@ -104,7 +108,9 @@ describe('useParams', () => {
       let useParamsValue: any;
 
       function Component() {
+        // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
         originalParams = useReactRouter6Params();
+        // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
         useParamsValue = useParams();
         return (
           <div>rendered component for org: {useParamsValue.orgId ?? 'no org id'}</div>

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -149,6 +149,7 @@ describe('Thresholds', () => {
 
     function StateCapture() {
       const {state} = useWidgetBuilderContext();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       capturedState = state;
       return null;
     }
@@ -186,6 +187,7 @@ describe('Thresholds', () => {
     // deviates from the URL param update (e.g. null vs undefined behavior)
     function StateCapture() {
       const {state} = useWidgetBuilderContext();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       capturedState = state;
       return null;
     }

--- a/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
+++ b/static/app/views/explore/contexts/pageParamsContext/index.spec.tsx
@@ -53,14 +53,23 @@ describe('SpanQueryParamsProvider', () => {
   let setVisualizes: ReturnType<typeof useSetQueryParamsVisualizes>;
 
   function Component() {
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     queryParams = useQueryParams();
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setQueryParams = useSetQueryParams();
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setFields = useSetQueryParamsFields();
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setGroupBys = useSetQueryParamsGroupBys();
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setMode = useSetQueryParamsMode();
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setQuery = useSetQueryParamsQuery();
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setSortBys = useSetQueryParamsSortBys();
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setAggregateSortBys = useSetQueryParamsAggregateSortBys();
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setVisualizes = useSetQueryParamsVisualizes();
     return <br />;
   }

--- a/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
+++ b/static/app/views/explore/hooks/useAddToDashboard.spec.tsx
@@ -24,7 +24,9 @@ describe('AddToDashboardButton', () => {
   let setVisualizes: ReturnType<typeof useSetQueryParamsVisualizes>;
 
   function TestPage({visualizeIndex}: {visualizeIndex: number}) {
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setMode = useSetQueryParamsMode();
+    // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
     setVisualizes = useSetQueryParamsVisualizes();
     const {addToDashboard} = useAddToDashboard();
     return (

--- a/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
+++ b/static/app/views/explore/hooks/useDragNDropColumns.spec.tsx
@@ -15,7 +15,9 @@ describe('useDragNDropColumns', () => {
     let insertColumn: (column: string) => void;
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [columns, setColumns] = useState(initialColumns);
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       ({insertColumn} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
@@ -35,7 +37,9 @@ describe('useDragNDropColumns', () => {
     let updateColumnAtIndex: (i: number, column: string) => void;
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [columns, setColumns] = useState(initialColumns);
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       ({updateColumnAtIndex} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
@@ -53,7 +57,9 @@ describe('useDragNDropColumns', () => {
     let deleteColumnAtIndex: (index: number) => void;
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [columns, setColumns] = useState(initialColumns);
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       ({deleteColumnAtIndex} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
@@ -71,7 +77,9 @@ describe('useDragNDropColumns', () => {
     let onDragEnd: (arg: any) => void;
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [columns, setColumns] = useState(initialColumns);
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       ({onDragEnd} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
@@ -95,7 +103,9 @@ describe('useDragNDropColumns', () => {
     let onDragEnd: (arg: any) => void;
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [columns, setColumns] = useState(initialColumns);
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       ({editableColumns, onDragEnd} = useDragNDropColumns({
         columns,
         setColumns,
@@ -125,7 +135,9 @@ describe('useDragNDropColumns', () => {
     let editableColumns!: Array<Column<string>>;
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [columns, setColumns] = useState(initialColumns);
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       ({editableColumns} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
@@ -147,7 +159,9 @@ describe('useDragNDropColumns', () => {
     let editableColumns!: Array<Column<string>>;
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [columns, setColumns] = useState(duplicateColumns);
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       ({editableColumns} = useDragNDropColumns({columns, setColumns}));
       return null;
     }
@@ -167,7 +181,9 @@ describe('useDragNDropColumns', () => {
     let updateColumnAtIndex: (i: number, column: string) => void;
 
     function TestPage() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       [columns, setColumns] = useState(initialColumns);
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       ({editableColumns, updateColumnAtIndex} = useDragNDropColumns({
         columns,
         setColumns,

--- a/static/app/views/explore/logs/logsToolbar.spec.tsx
+++ b/static/app/views/explore/logs/logsToolbar.spec.tsx
@@ -262,6 +262,7 @@ describe('LogsToolbar', () => {
       let mode: Mode | undefined;
 
       function Component() {
+        // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
         mode = useQueryParamsMode();
         return <LogsToolbar />;
       }
@@ -345,6 +346,7 @@ describe('LogsToolbar', () => {
       let mode: Mode | undefined;
 
       function Component() {
+        // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
         mode = useQueryParamsMode();
         return <LogsToolbar />;
       }
@@ -549,6 +551,7 @@ describe('LogsToolbar', () => {
 
       let groupBys: readonly string[] = [];
       function Component() {
+        // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
         groupBys = useQueryParamsGroupBys();
         return <LogsToolbar />;
       }

--- a/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/index.spec.tsx
@@ -417,6 +417,7 @@ describe('MetricToolbar', () => {
 
     function Component() {
       const [queryParams, setQueryParams] = useState(initialQueryParams);
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       currentGroupBys = queryParams.groupBys;
 
       return (

--- a/static/app/views/explore/multiQueryMode/content.spec.tsx
+++ b/static/app/views/explore/multiQueryMode/content.spec.tsx
@@ -107,6 +107,7 @@ describe('MultiQueryModeContent', () => {
   it('changes to count(span.duration) when using count', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -185,6 +186,7 @@ describe('MultiQueryModeContent', () => {
   it('changes to epm() when using epm', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -250,6 +252,7 @@ describe('MultiQueryModeContent', () => {
   it('changes to failure_rate() when using failure_rate', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -328,6 +331,7 @@ describe('MultiQueryModeContent', () => {
   it('defaults count_unique argument to span.op', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -411,6 +415,7 @@ describe('MultiQueryModeContent', () => {
   it('updates visualization and outdated sorts', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -459,6 +464,7 @@ describe('MultiQueryModeContent', () => {
   it('explicitly selecting visualization persists it', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -495,6 +501,7 @@ describe('MultiQueryModeContent', () => {
   it('updates sorts', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -537,6 +544,7 @@ describe('MultiQueryModeContent', () => {
   it('updates group bys and outdated sorts', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -579,6 +587,7 @@ describe('MultiQueryModeContent', () => {
   it('allows changing a query', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -624,6 +633,7 @@ describe('MultiQueryModeContent', () => {
   it('allows changing case insensitivity', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -666,6 +676,7 @@ describe('MultiQueryModeContent', () => {
   it('allows adding a query', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -720,6 +731,7 @@ describe('MultiQueryModeContent', () => {
   it('allows duplicating a query', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -781,6 +793,7 @@ describe('MultiQueryModeContent', () => {
   it('allows deleting a query', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -885,6 +898,7 @@ describe('MultiQueryModeContent', () => {
   it('calls events and stats APIs', async () => {
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }
@@ -1033,6 +1047,7 @@ describe('MultiQueryModeContent', () => {
 
     let queries: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       queries = useReadQueriesFromLocation();
       return <MultiQueryModeContent />;
     }

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -235,6 +235,7 @@ describe('SpansTabContent', () => {
   it('publishes the aggregate sort to the LLM context in aggregate mode', async () => {
     let getLLMContext: ReturnType<typeof useLLMContext>['getLLMContext'] | undefined;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       ({getLLMContext} = useLLMContext());
       return <SpansTabContent datePageFilterProps={datePageFilterProps} />;
     }
@@ -291,7 +292,9 @@ describe('SpansTabContent', () => {
     let aggregateFields: ReturnType<typeof useQueryParamsAggregateFields> = [];
     let aggregateSortBys: ReturnType<typeof useQueryParamsAggregateSortBys> = [];
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       aggregateFields = useQueryParamsAggregateFields();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       aggregateSortBys = useQueryParamsAggregateSortBys();
       return <SpansTabContent datePageFilterProps={datePageFilterProps} />;
     }
@@ -338,7 +341,9 @@ describe('SpansTabContent', () => {
     let fields: readonly string[] = [];
     let groupBys: readonly string[] = [];
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       fields = useQueryParamsFields();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       groupBys = useQueryParamsGroupBys();
       return <SpansTabContent datePageFilterProps={datePageFilterProps} />;
     }

--- a/static/app/views/explore/toolbar/index.spec.tsx
+++ b/static/app/views/explore/toolbar/index.spec.tsx
@@ -112,6 +112,7 @@ describe('ExploreToolbar', () => {
   it('disables changing visualize fields for count', async () => {
     let visualizes: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
@@ -129,6 +130,7 @@ describe('ExploreToolbar', () => {
   it('changes to count(span.duration) when using count', async () => {
     let visualizes: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
@@ -159,6 +161,7 @@ describe('ExploreToolbar', () => {
   it('disables changing visualize fields for epm', async () => {
     let visualizes: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
@@ -180,6 +183,7 @@ describe('ExploreToolbar', () => {
   it('changes to epm() when using epm', async () => {
     let visualizes: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
@@ -216,6 +220,7 @@ describe('ExploreToolbar', () => {
   it('defaults count_unique argument to span.op', async () => {
     let visualizes: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
@@ -254,7 +259,9 @@ describe('ExploreToolbar', () => {
     let fields!: readonly string[];
     let visualizes: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       fields = useQueryParamsFields();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       visualizes = useQueryParamsVisualizes();
       return <ExploreToolbar />;
     }
@@ -329,6 +336,7 @@ describe('ExploreToolbar', () => {
     let groupBys: any;
 
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       groupBys = useQueryParamsGroupBys();
       return <ExploreToolbar />;
     }
@@ -587,6 +595,7 @@ describe('ExploreToolbar', () => {
     let groupBys: readonly string[] = [];
 
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       groupBys = useQueryParamsGroupBys();
       return <ExploreToolbar />;
     }
@@ -633,7 +642,9 @@ describe('ExploreToolbar', () => {
     let mode: Mode | undefined;
 
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       groupBys = useQueryParamsGroupBys();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       mode = useQueryParamsMode();
       return <ExploreToolbar />;
     }
@@ -662,7 +673,9 @@ describe('ExploreToolbar', () => {
     let mode: any;
 
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       groupBys = useQueryParamsGroupBys();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       mode = useQueryParamsMode();
       return <ExploreToolbar />;
     }
@@ -686,7 +699,9 @@ describe('ExploreToolbar', () => {
     let mode: any;
 
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       groupBys = useQueryParamsGroupBys();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       mode = useQueryParamsMode();
       return <ExploreToolbar />;
     }
@@ -707,6 +722,7 @@ describe('ExploreToolbar', () => {
     let aggregateFields: any;
 
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       aggregateFields = useQueryParamsAggregateFields();
       return <ExploreToolbar />;
     }
@@ -731,6 +747,7 @@ describe('ExploreToolbar', () => {
   it('allows changing sort by in samples mode', async () => {
     let sortBys: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       sortBys = useQueryParamsSortBys();
       return <ExploreToolbar />;
     }
@@ -783,7 +800,9 @@ describe('ExploreToolbar', () => {
     let sortBys: any;
     let setMode: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       setMode = useSetQueryParamsMode();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       sortBys = useQueryParamsAggregateSortBys();
       return <ExploreToolbar />;
     }
@@ -854,8 +873,11 @@ describe('ExploreToolbar', () => {
     let aggregateSortBys: any;
     let setMode: any;
     function Component() {
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       setMode = useSetQueryParamsMode();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       samplesSortBys = useQueryParamsSortBys();
+      // oxlint-disable-next-line react/globals -- Test captures the hook result in an outer variable to assert on it.
       aggregateSortBys = useQueryParamsAggregateSortBys();
       return <ExploreToolbar />;
     }

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -405,6 +405,7 @@ function renderHookWithProviders<Result = unknown, Props = unknown>(
   let memoryRouter: Router | null = null;
 
   function Wrapper({children}: {children?: React.ReactNode}) {
+    // oxlint-disable-next-line react/globals -- Test helper exposes the router built inside the wrapper.
     memoryRouter = makeRouter({
       children: <AllTheProviders>{children}</AllTheProviders>,
       history,


### PR DESCRIPTION
`react/globals` catches render-phase writes to variables declared outside a
component or hook. It has sat at `off` behind a TODO since the oxlint rollout.
Turning it on now costs nothing in production code — every one of the 110
diagnostics lives in a test file — and it starts blocking the pattern in app
code from this point forward.

All 110 diagnostics collapse onto 94 lines of the same test idiom: a
`Component` / `TestPage` wrapper assigns a hook's return value to a `let` in the
enclosing `it()` scope so the assertions can read it afterwards.

```tsx
let params: any;
function HomePage() {
  params = useParams();   // <- react/globals
  return null;
}
```

Each of those 94 sites gets an inline `// oxlint-disable-next-line
react/globals -- <reason>` comment, matching the `-- reason` convention already
used by the other oxlint suppressions in the tree.

### Why suppress instead of fix

The honest fix is to rewrite the capture — `renderHook`, a ref, or asserting
through rendered output instead of a captured variable. That is a real
improvement, but it touches 15 spec files and changes what the tests actually
exercise, which is not something to bundle into a lint-enablement PR. Blanket
`overrides` for `**/*.spec.tsx` in `oxlint.config.ts` was the other option, and
it is cheaper, but it hides the count: new violations would land silently in
any test file forever. Per-line suppressions keep the remaining work
enumerable and greppable, so the cleanup can happen file by file later.

### Notes for review

- No feature flag. The change is lint configuration plus comments.
- No screenshots — nothing renders differently, and no test assertion changed.
- The 94 inserted lines are comments only; the diff has zero executable
  changes outside `oxlint.config.ts`.
- Worth a skim: `tests/js/sentry-test/reactTestingLibrary.tsx` is the one
  non-spec file, where `renderHookWithProviders` assigns `memoryRouter` inside
  its wrapper so the helper can return the router.

https://claude.ai/code/session_01QHnxGWf1zJtM9JjMiCSUPS
