### PR TITLE
chore(oxlint): let stories import test fixtures

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -156,6 +156,13 @@ const storyFilesPolicy = {
         },
       },
     },
+    {
+      to: {
+        file: {
+          categories: 'test-fixtures',
+        },
+      },
+    },
   ],
 };
 
@@ -333,6 +340,13 @@ const config = defineConfig({
           'static/gsApp/__fixtures__/**/*',
           'static/**/*{t,T}estUtils*.{js,jsx,mjs,ts,tsx}',
         ],
+      },
+      // Fixtures are a second, narrower classification on top of test-support.
+      // Stories need realistic data objects, so they are granted this subset
+      // without opening up mocks, render helpers, or the rest of test-support.
+      {
+        category: 'test-fixtures',
+        pattern: ['tests/js/fixtures/**/*', 'static/gsApp/__fixtures__/**/*'],
       },
       {
         category: 'sentry-locale',


### PR DESCRIPTION
A `*.stories.tsx` file that imports `sentry-fixture/*` fails the boundaries rule with `sentry is not allowed to import test`. Stories are the one place outside tests that legitimately needs realistic domain objects, so today there is no way to render a component in Storybook against representative data — you either hand-roll a partial object inline or skip the story.

Fixtures now carry a second, narrower `test-fixtures` file category on top of `test-support`, and `storyFilesPolicy` grants story files access to it. `@boundaries/eslint-plugin` gives each file an array of categories, so a fixture is both `test-support` and `test-fixtures` at once — the existing test and test-support rules keep matching and did not need to change.

What stays blocked:

- Production files still cannot import fixtures (`static/app/components/foo.tsx` importing `sentry-fixture/project` still errors).
- Stories still cannot reach the rest of `test-support` — `sentry-test` render helpers, jest mocks, `testUtils` — none of which belong in a Storybook bundle.

The obvious alternative, granting stories all of `test-support`, was not taken for that second reason: it is one line shorter but pulls testing-library wrappers and mock plumbing into the story graph.

No feature flag; this is lint config only. Verified by adding a throwaway story that imports `ProjectFixture` (errors before, clean after) and a throwaway production file doing the same (still errors), then a full-repo `oxlint` run which is clean.

https://claude.ai/code/session_014YoTVy5WRSJSDzUK3zMY6i
