### PR TITLE
chore(workflow-engine): Allow staff to manually create org/project detectors via endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_health_check.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_health_check.py
@@ -1,0 +1,107 @@
+from typing import TypedDict
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.api.bases import OrganizationEndpoint
+from sentry.api.permissions import StaffPermission
+from sentry.api.serializers import serialize
+from sentry.apidocs.constants import (
+    RESPONSE_BAD_REQUEST,
+    RESPONSE_FORBIDDEN,
+    RESPONSE_NOT_FOUND,
+    RESPONSE_UNAUTHORIZED,
+)
+from sentry.apidocs.response_types import ValidationErrorResponse
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.models.organization import Organization
+from sentry.workflow_engine.defaults.detectors import (
+    ensure_default_detectors,
+    ensure_default_organization_detectors,
+)
+from sentry.workflow_engine.endpoints.serializers.detector_serializer import (
+    DetectorSerializerResponse,
+)
+from sentry.workflow_engine.models import Detector
+
+
+class InboundHealthCheckSerializer(serializers.Serializer):
+    projects = serializers.ListField(
+        child=serializers.CharField(),
+        required=False,
+        help_text="Project slugs to perform additional health checks for.",
+    )
+
+
+class DetectorHealthCheckResponse(TypedDict):
+    """
+    Result of a detector health check on an organization and potentially projects.
+    """
+
+    organization: dict[str, DetectorSerializerResponse]
+    projects: dict[str, dict[str, DetectorSerializerResponse]] | None
+
+
+@cell_silo_endpoint
+class OrganizationDetectorHealthCheckEndpoint(OrganizationEndpoint):
+    publish_status = {
+        "POST": ApiPublishStatus.EXPERIMENTAL,
+    }
+    owner = ApiOwner.ISSUES
+
+    permission_classes = (StaffPermission,)
+
+    @extend_schema(
+        operation_id="Perform a Detector Health Check",
+        parameters=[],
+        responses={
+            201: inline_sentry_response_serializer(
+                "DetectorDetectorHealthCheckResponse", DetectorHealthCheckResponse
+            ),
+            400: RESPONSE_BAD_REQUEST,
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def post(
+        self, request: Request, organization: Organization
+    ) -> Response[ValidationErrorResponse] | Response[DetectorHealthCheckResponse]:
+        serializer = InboundHealthCheckSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=400)
+
+        organization_detectors_map = ensure_default_organization_detectors(organization)
+
+        organization_detectors: dict[str, DetectorSerializerResponse] = {}
+        for slug, detector in organization_detectors_map.items():
+            organization_detectors[slug] = serialize(detector, request.user)
+
+        project_slugs = serializer.validated_data.get("projects", [])
+        if project_slugs:
+            projects = self.get_projects(request, organization, project_slugs=set(project_slugs))
+        else:
+            projects = []
+
+        project_detectors_map: dict[str, dict[str, Detector]] = {}
+        for project in projects:
+            project_detectors_map[project.slug] = ensure_default_detectors(project=project)
+
+        requested_project_detectors: dict[str, dict[str, DetectorSerializerResponse]] = {}
+        for project_slug, detectors in project_detectors_map.items():
+            project_detectors: dict[str, DetectorSerializerResponse] = {}
+            for slug, detector in detectors.items():
+                project_detectors[slug] = serialize(detector, request.user)
+            requested_project_detectors[project_slug] = project_detectors
+
+        result: DetectorHealthCheckResponse = {
+            "organization": organization_detectors,
+            "projects": requested_project_detectors if requested_project_detectors else None,
+        }
+
+        return Response(result, status=201)

--- a/src/sentry/workflow_engine/endpoints/organization_detector_health_check.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_health_check.py
@@ -74,7 +74,7 @@ class OrganizationDetectorHealthCheckEndpoint(OrganizationEndpoint):
     ) -> Response[ValidationErrorResponse] | Response[DetectorHealthCheckResponse]:
         serializer = InboundHealthCheckSerializer(data=request.data)
         if not serializer.is_valid():
-            return Response(as_validation_errors(serializer.errors), status=400)
+            return Response(as_validation_errors(serializer), status=400)
 
         organization_detectors_map = ensure_default_organization_detectors(organization)
 

--- a/src/sentry/workflow_engine/endpoints/organization_detector_health_check.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_health_check.py
@@ -17,7 +17,7 @@ from sentry.apidocs.constants import (
     RESPONSE_NOT_FOUND,
     RESPONSE_UNAUTHORIZED,
 )
-from sentry.apidocs.response_types import ValidationErrorResponse
+from sentry.apidocs.response_types import ValidationErrorResponse, as_validation_errors
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.models.organization import Organization
 from sentry.workflow_engine.defaults.detectors import (
@@ -32,9 +32,9 @@ from sentry.workflow_engine.models import Detector
 
 class InboundHealthCheckSerializer(serializers.Serializer):
     projects = serializers.ListField(
-        child=serializers.CharField(),
+        child=serializers.IntegerField(),
         required=False,
-        help_text="Project slugs to perform additional health checks for.",
+        help_text="Project ids to perform additional health checks for.",
     )
 
 
@@ -74,7 +74,7 @@ class OrganizationDetectorHealthCheckEndpoint(OrganizationEndpoint):
     ) -> Response[ValidationErrorResponse] | Response[DetectorHealthCheckResponse]:
         serializer = InboundHealthCheckSerializer(data=request.data)
         if not serializer.is_valid():
-            return Response(serializer.errors, status=400)
+            return Response(as_validation_errors(serializer.errors), status=400)
 
         organization_detectors_map = ensure_default_organization_detectors(organization)
 
@@ -82,9 +82,9 @@ class OrganizationDetectorHealthCheckEndpoint(OrganizationEndpoint):
         for slug, detector in organization_detectors_map.items():
             organization_detectors[slug] = serialize(detector, request.user)
 
-        project_slugs = serializer.validated_data.get("projects", [])
-        if project_slugs:
-            projects = self.get_projects(request, organization, project_slugs=set(project_slugs))
+        project_ids = serializer.validated_data.get("projects", [])
+        if project_ids:
+            projects = self.get_projects(request, organization, project_ids=set(project_ids))
         else:
             projects = []
 

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -7,6 +7,7 @@ from .organization_data_condition_index import OrganizationDataConditionIndexEnd
 from .organization_detector_anomaly_data import OrganizationDetectorAnomalyDataEndpoint
 from .organization_detector_count import OrganizationDetectorCountEndpoint
 from .organization_detector_details import OrganizationDetectorDetailsEndpoint
+from .organization_detector_health_check import OrganizationDetectorHealthCheckEndpoint
 from .organization_detector_index import OrganizationDetectorIndexEndpoint
 from .organization_detector_types import OrganizationDetectorTypeIndexEndpoint
 from .organization_incident_groupopenperiod_index import (
@@ -35,6 +36,11 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/workflows/$",
         OrganizationWorkflowIndexEndpoint.as_view(),
         name="sentry-api-0-organization-workflow-index",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/detectors/health-check/$",
+        OrganizationDetectorHealthCheckEndpoint.as_view(),
+        name="sentry-api-0-organization-detector-health-check",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/detectors/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -128,6 +128,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/detectors/$detectorId/'
   | '/organizations/$organizationIdOrSlug/detectors/$detectorId/anomaly-data/'
   | '/organizations/$organizationIdOrSlug/detectors/count/'
+  | '/organizations/$organizationIdOrSlug/detectors/health-check/'
   | '/organizations/$organizationIdOrSlug/discover/homepage/'
   | '/organizations/$organizationIdOrSlug/discover/saved/'
   | '/organizations/$organizationIdOrSlug/discover/saved/$queryId/'

--- a/static/gsAdmin/views/customerDetails.spec.tsx
+++ b/static/gsAdmin/views/customerDetails.spec.tsx
@@ -2667,6 +2667,47 @@ describe('Customer Details', () => {
       expect(screen.queryByText('Delete Billing Metric History')).not.toBeInTheDocument();
     });
   });
+
+  describe('performs detector health check', () => {
+    it('calls the health check endpoint', async () => {
+      setUpMocks(organization);
+
+      const healthCheckMock = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/detectors/health-check/`,
+        method: 'POST',
+        body: {
+          organization: {},
+          projects: null,
+        },
+      });
+
+      render(<CustomerDetails />, {
+        initialRouterConfig: {
+          location: {pathname: `/customers/${organization.slug}`},
+          route: '/customers/:orgId',
+        },
+        organization,
+      });
+
+      await openCustomerActions();
+
+      await userEvent.click(screen.getByText('Perform Detector Health Check'));
+
+      renderGlobalModal();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Confirm'}));
+
+      await waitFor(() =>
+        expect(healthCheckMock).toHaveBeenCalledWith(
+          `/organizations/${organization.slug}/detectors/health-check/`,
+          expect.objectContaining({
+            method: 'POST',
+            data: {},
+          })
+        )
+      );
+    });
+  });
 });
 
 describe('Gift Categories Availability', () => {

--- a/static/gsAdmin/views/customerDetails.tsx
+++ b/static/gsAdmin/views/customerDetails.tsx
@@ -68,6 +68,7 @@ import {SuspendAccountAction} from 'admin/components/suspendAccountAction';
 import {openToggleConsolePlatformsModal} from 'admin/components/toggleConsolePlatformsModal';
 import {toggleSpendAllocationModal} from 'admin/components/toggleSpendAllocationModal';
 import {TrialSubscriptionAction} from 'admin/components/trialSubscriptionAction';
+import {useDetectorHealthCheck} from 'admin/views/useDetectorHealthCheck';
 import {RESERVED_BUDGET_QUOTA} from 'getsentry/constants';
 import type {BilledDataCategoryInfo, BillingConfig, Subscription} from 'getsentry/types';
 import {
@@ -136,6 +137,8 @@ export function CustomerDetails() {
     isError: isErrorBillingConfig,
     isPending: isPendingBillingConfig,
   } = useApiQuery<BillingConfig>(BILLING_CONFIG_QUERY_KEY, {staleTime: Infinity});
+
+  const detectorHealthCheck = useDetectorHealthCheck({orgSlug: orgId});
 
   const onUpdateMutation = useMutation({
     mutationFn: (params: Record<string, any>) =>
@@ -887,6 +890,15 @@ export function CustomerDetails() {
               ),
             },
             onAction: params => onUpdateMutation.mutate({...params}),
+          },
+          {
+            key: 'performDetectorHealthCheck',
+            name: 'Perform Detector Health Check',
+            help: 'Verify that all sentry-managed detectors exist for this customer, and create them if not.',
+            confirmModalOpts: {
+              showAuditFields: true,
+            },
+            onAction: _params => detectorHealthCheck.mutate(),
           },
         ]}
         sections={[

--- a/static/gsAdmin/views/projectDetails.tsx
+++ b/static/gsAdmin/views/projectDetails.tsx
@@ -26,6 +26,7 @@ import {DetailsContainer} from 'admin/components/detailsContainer';
 import {DetailsPage} from 'admin/components/detailsPage';
 import {EventUsers} from 'admin/components/eventUsers';
 import {getLogQuery} from 'admin/utils';
+import {useDetectorHealthCheck} from 'admin/views/useDetectorHealthCheck';
 
 import {DynamicSamplingPanel} from './dynamicSamplingPanel';
 
@@ -50,6 +51,11 @@ export function ProjectDetails() {
   const api = useApi();
   const location = useLocation();
   const navigate = useNavigate();
+
+  const detectorHealthCheck = useDetectorHealthCheck({
+    orgSlug: orgId,
+    projectIds: projectId ? [projectId] : undefined,
+  });
 
   const handleRemoveEmail = (userHash: string) => {
     const endpoint = `/projects/${orgId}/${projectId}/users/${userHash}/`;
@@ -160,6 +166,17 @@ export function ProjectDetails() {
       <DetailsPage
         rootName="Projects"
         name={`${data.slug} (${organization.name})`}
+        actions={[
+          {
+            key: 'performDetectorHealthCheck',
+            name: 'Perform Detector Health Check',
+            help: 'Verify that all sentry-managed detectors exist for this organization and project, creating them if not.',
+            confirmModalOpts: {
+              showAuditFields: true,
+            },
+            onAction: _params => detectorHealthCheck.mutate(),
+          },
+        ]}
         sections={[
           {
             content: overview,

--- a/static/gsAdmin/views/useDetectorHealthCheck.ts
+++ b/static/gsAdmin/views/useDetectorHealthCheck.ts
@@ -1,0 +1,65 @@
+import {useQuery} from '@tanstack/react-query';
+import {useMutation} from '@tanstack/react-query';
+
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  addSuccessMessage,
+} from 'sentry/actionCreators/indicator';
+import {t} from 'sentry/locale';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
+import {fetchMutation} from 'sentry/utils/queryClient';
+import {RequestError} from 'sentry/utils/requestError/requestError';
+
+export type DetectorHealthCheckResponse = {
+  organization: Record<string, Detector>;
+  projects: Record<string, Record<string, Detector>> | null;
+};
+
+/**
+ * Runs a detector health check against the sentry API. The check verifies
+ * that all system detectors exist for the org (and optionally a set
+ * of projects), creating them if necessary.
+ */
+export function useDetectorHealthCheck({
+  orgSlug,
+  projectIds = [],
+}: {
+  orgSlug: string;
+  projectIds?: string[];
+}) {
+  const url = getApiUrl('/organizations/$organizationIdOrSlug/detectors/health-check/', {
+    path: {organizationIdOrSlug: orgSlug},
+  });
+  const data = projectIds.length ? {} : {projects: projectIds};
+
+  return useMutation({
+    mutationFn: () => {
+      return fetchMutation<DetectorHealthCheckResponse>({method: 'POST', url, data});
+    },
+    onMutate: () => {
+      addLoadingMessage(t('Performing health check...'));
+    },
+    onSuccess: ({organization: organizationDetectors, projects}) => {
+      const organizationLevelCount = Object.values(organizationDetectors).length;
+      let summaryMessage = `Organization has ${organizationLevelCount} system detectors.`;
+      Object.entries(projects ?? {}).forEach(([slug, projectDetectors]) => {
+        const projectLevelCount = Object.values(projectDetectors).length;
+        summaryMessage.concat(
+          ` Project '${slug}' has ${projectLevelCount} system detectors`
+        );
+      });
+      addSuccessMessage(`Detector health check completed. ${summaryMessage}`);
+    },
+    onError: (error: Error) => {
+      if (error instanceof RequestError && error.responseJSON) {
+        addErrorMessage(
+          `Detector health check failed: ${JSON.stringify(error.responseJSON)}`
+        );
+      } else {
+        addErrorMessage(`Detector health check failed.`);
+      }
+    },
+  });
+}

--- a/static/gsAdmin/views/useDetectorHealthCheck.ts
+++ b/static/gsAdmin/views/useDetectorHealthCheck.ts
@@ -1,4 +1,3 @@
-import {useQuery} from '@tanstack/react-query';
 import {useMutation} from '@tanstack/react-query';
 
 import {
@@ -32,7 +31,7 @@ export function useDetectorHealthCheck({
   const url = getApiUrl('/organizations/$organizationIdOrSlug/detectors/health-check/', {
     path: {organizationIdOrSlug: orgSlug},
   });
-  const data = projectIds.length ? {} : {projects: projectIds};
+  const data = projectIds.length ? {projects: projectIds} : {};
 
   return useMutation({
     mutationFn: () => {

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_health_check.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_health_check.py
@@ -1,0 +1,63 @@
+from rest_framework import status
+
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.testutils.cases import APITestCase
+from sentry.testutils.silo import cell_silo_test
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
+
+
+@cell_silo_test
+class OrganizationDetectorHealthCheckTest(APITestCase):
+    endpoint = "sentry-api-0-organization-detector-health-check"
+    method = "POST"
+
+    def setUp(self) -> None:
+        self.staff_user = self.create_user(is_staff=True)
+
+    def test_requires_staff(self) -> None:
+        self.login_as(user=self.user)
+        self.get_error_response(self.organization.slug, status_code=status.HTTP_403_FORBIDDEN)
+
+    def test_org_only(self) -> None:
+        self.login_as(user=self.staff_user, staff=True)
+        response = self.get_success_response(
+            self.organization.slug, status_code=status.HTTP_201_CREATED
+        )
+        assert "organization" in response.data
+        assert isinstance(response.data["organization"], dict)
+        assert response.data["projects"] is None
+
+    def test_with_projects(self) -> None:
+        self.login_as(user=self.staff_user, staff=True)
+        response = self.get_success_response(
+            self.organization.slug,
+            projects=[self.project.slug],
+            status_code=status.HTTP_201_CREATED,
+        )
+
+        assert "organization" in response.data
+        assert self.project.slug in response.data["projects"]
+
+        project_detectors = response.data["projects"][self.project.slug]
+        assert ErrorGroupType.slug in project_detectors
+        assert IssueStreamGroupType.slug in project_detectors
+
+    def test_multiple_projects(self) -> None:
+        self.login_as(user=self.staff_user, staff=True)
+        project_2 = self.create_project(organization=self.organization)
+        response = self.get_success_response(
+            self.organization.slug,
+            projects=[self.project.slug, project_2.slug],
+            status_code=status.HTTP_201_CREATED,
+        )
+
+        assert self.project.slug in response.data["projects"]
+        assert project_2.slug in response.data["projects"]
+
+    def test_invalid_project(self) -> None:
+        self.login_as(user=self.staff_user, staff=True)
+        self.get_error_response(
+            self.organization.slug,
+            projects=["nonexistent-project"],
+            status_code=status.HTTP_403_FORBIDDEN,
+        )

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_health_check.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_health_check.py
@@ -31,7 +31,7 @@ class OrganizationDetectorHealthCheckTest(APITestCase):
         self.login_as(user=self.staff_user, staff=True)
         response = self.get_success_response(
             self.organization.slug,
-            projects=[self.project.slug],
+            projects=[self.project.id],
             status_code=status.HTTP_201_CREATED,
         )
 
@@ -47,17 +47,25 @@ class OrganizationDetectorHealthCheckTest(APITestCase):
         project_2 = self.create_project(organization=self.organization)
         response = self.get_success_response(
             self.organization.slug,
-            projects=[self.project.slug, project_2.slug],
+            projects=[self.project.id, project_2.id],
             status_code=status.HTTP_201_CREATED,
         )
 
         assert self.project.slug in response.data["projects"]
         assert project_2.slug in response.data["projects"]
 
-    def test_invalid_project(self) -> None:
+    def test_invalid_project_returns_400(self) -> None:
         self.login_as(user=self.staff_user, staff=True)
         self.get_error_response(
             self.organization.slug,
             projects=["nonexistent-project"],
+            status_code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    def test_inaccessible_project_returns_403(self) -> None:
+        self.login_as(user=self.staff_user, staff=True)
+        self.get_error_response(
+            self.organization.slug,
+            projects=[512345],
             status_code=status.HTTP_403_FORBIDDEN,
         )


### PR DESCRIPTION
Surfaced in _admin and only accessible with staff permissions to allow repairing individual problem projects/customers easily. 

Got into a workable place, but we'll probably go with a scheduled repeated runner instead, that will be a follow up separate PR, so this lives in draft mode.