### PR TITLE
chore(oxlint): Promote react/immutability to error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -594,7 +594,7 @@ const config = defineConfig({
     'react/function-component-definition': 'error',
     'react/globals': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/hooks': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
-    'react/immutability': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
+    'react/immutability': 'error',
     'react/incompatible-library': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/invariant': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/jsx-boolean-value': ['error', 'never'],

--- a/static/app/components/charts/useChartXRangeSelection.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.tsx
@@ -175,6 +175,7 @@ export function useChartXRangeSelection({
 
     setSelectionState(null);
 
+    // oxlint-disable-next-line react/immutability
     onClearSelection?.({selectionState, setSelectionState, clearSelection});
   }, [chartRef, onClearSelection, selectionState]);
 

--- a/static/app/components/charts/useChartZoom.tsx
+++ b/static/app/components/charts/useChartZoom.tsx
@@ -151,6 +151,7 @@ function useChartZoomCancel(disabled?: boolean) {
   );
 
   const handleMouseUp = useCallback(() => {
+    // oxlint-disable-next-line react/immutability
     document.body.removeEventListener('mouseup', handleMouseUp);
     document.body.removeEventListener('keydown', handleKeyDown, true);
   }, [handleKeyDown]);

--- a/static/app/components/commandPalette/ui/collection.spec.tsx
+++ b/static/app/components/commandPalette/ui/collection.spec.tsx
@@ -285,10 +285,12 @@ describe('Collection', () => {
       return null;
     }
     function CaptureA() {
+      // oxlint-disable-next-line react/immutability
       storeRefA.current = A.useStore();
       return null;
     }
     function CaptureB() {
+      // oxlint-disable-next-line react/immutability
       storeRefB.current = B.useStore();
       return null;
     }

--- a/static/app/components/core/form/field/radioField.tsx
+++ b/static/app/components/core/form/field/radioField.tsx
@@ -53,6 +53,7 @@ function RadioGroup({children, value, onChange, disabled}: RadioGroupProps) {
       onChange(newValue);
       if (autoSaveContext) {
         // Radios should reset to previous value on error
+        // oxlint-disable-next-line react/immutability
         autoSaveContext.resetOnErrorRef.current = true;
         field.handleBlur();
       }

--- a/static/app/components/core/input/numberDragInput.tsx
+++ b/static/app/components/core/input/numberDragInput.tsx
@@ -76,6 +76,7 @@ export function NumberDragInput({
 
     // Cleanup handlers
     document.removeEventListener('pointermove', onPointerMove);
+    // oxlint-disable-next-line react/immutability
     document.removeEventListener('pointerup', onPointerUp);
   }, [onPointerMove]);
 

--- a/static/app/components/core/modal/index.tsx
+++ b/static/app/components/core/modal/index.tsx
@@ -150,6 +150,7 @@ export function GlobalModal() {
   const focusTrap = useRef<FocusTrap | null>(null);
   // SentryApp might be missing on tests
   if (window.SentryApp) {
+    // oxlint-disable-next-line react/immutability
     window.SentryApp.modalFocusTrap = focusTrap;
   }
 

--- a/static/app/components/core/pictureInPicture/pictureInPicturePortal.tsx
+++ b/static/app/components/core/pictureInPicture/pictureInPicturePortal.tsx
@@ -47,6 +47,7 @@ export function PictureInPicturePortal({
   // which isn't guaranteed in the PiP document).
   useEffect(() => {
     const {documentElement, body} = pipWindow.document;
+    // oxlint-disable-next-line react/immutability
     documentElement.style.height = '100%';
     body.style.height = '100%';
     body.style.margin = '0';
@@ -55,6 +56,7 @@ export function PictureInPicturePortal({
   // Keep the PiP body's theme class in sync so global body selectors
   // (e.g. `body.theme-dark`) apply after a theme toggle.
   useEffect(() => {
+    // oxlint-disable-next-line react/immutability
     pipWindow.document.body.className = document.body.className;
   }, [pipWindow, theme]);
 

--- a/static/app/components/events/eventProcessingErrors.tsx
+++ b/static/app/components/events/eventProcessingErrors.tsx
@@ -77,6 +77,7 @@ function EventErrorDescription({error}: {error: ErrorMessage}) {
     const data = errorData || {};
     if (data.message === 'None') {
       // Python ensures a message string, but "None" doesn't make sense here
+      // oxlint-disable-next-line react/immutability
       delete data.message;
     }
 
@@ -84,11 +85,14 @@ function EventErrorDescription({error}: {error: ErrorMessage}) {
       // Separate the image name for readability
       const separator = /^([a-z]:\\|\\\\)/i.test(data.image_path) ? '\\' : '/';
       const path = data.image_path.split(separator);
+      // oxlint-disable-next-line react/immutability
       data.image_name = path.splice(-1, 1)[0];
+      // oxlint-disable-next-line react/immutability
       data.image_path = path.length ? path.join(separator) + separator : '';
     }
 
     if (typeof data.server_time === 'string' && typeof data.sdk_time === 'string') {
+      // oxlint-disable-next-line react/immutability
       data.message = t(
         'Adjusted timestamps by %s',
         moment

--- a/static/app/components/forms/formField/index.tsx
+++ b/static/app/components/forms/formField/index.tsx
@@ -226,6 +226,7 @@ export function FormField(props: FormFieldProps) {
   // wrapping FormField without it being wrapped in a Form. There's just too
   // many things that break.
   if (context.form === undefined) {
+    // oxlint-disable-next-line react/immutability
     (model as any).props = props;
   }
 

--- a/static/app/components/inspector.tsx
+++ b/static/app/components/inspector.tsx
@@ -414,6 +414,7 @@ export function SentryComponentInspector() {
           </ProfilingContextMenu>
           <div
             ref={el => {
+              // oxlint-disable-next-line react/immutability
               contextMenu.subMenuRef.current = el;
             }}
             data-inspector-skip

--- a/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
+++ b/static/app/components/profiling/flamegraph/flamegraphContextMenu.tsx
@@ -288,6 +288,7 @@ export function FlamegraphContextMenu(props: FlamegraphContextMenuProps) {
       </ProfilingContextMenu>
       <div
         ref={el => {
+          // oxlint-disable-next-line react/immutability
           props.contextMenu.subMenuRef.current = el;
         }}
         id="sub-menu-portal"
@@ -544,6 +545,7 @@ export function ContinuousFlamegraphContextMenu(props: FlamegraphContextMenuProp
       </ProfilingContextMenu>
       <div
         ref={el => {
+          // oxlint-disable-next-line react/immutability
           props.contextMenu.subMenuRef.current = el;
         }}
         id="sub-menu-portal"

--- a/static/app/components/similarScoreCard.tsx
+++ b/static/app/components/similarScoreCard.tsx
@@ -44,6 +44,7 @@ export function SimilarScoreCard({scoreList = []}: Props) {
 
         if (!title) {
           if (score !== null) {
+            // oxlint-disable-next-line react/immutability
             sumOtherScores += score;
             numOtherScores += 1;
           }

--- a/static/app/stories/apiReference.tsx
+++ b/static/app/stories/apiReference.tsx
@@ -115,6 +115,7 @@ function StoryDefinitionFilePath(props: {node: PropTreeNode}) {
               variant="transparent"
               icon={<IconChevron direction={expanded ? 'down' : 'right'} />}
               onClick={() => {
+                // oxlint-disable-next-line react/immutability
                 props.node.expanded = !expanded;
                 setExpanded(props.node.expanded);
               }}
@@ -228,8 +229,11 @@ function usePropTree(props: Props, query: string): PropTreeNode[] {
   const nodes = useMemo(() => {
     if (!query) {
       for (const {node} of root) {
+        // oxlint-disable-next-line react/immutability
         node.visible = true;
+        // oxlint-disable-next-line react/immutability
         node.expanded = true;
+        // oxlint-disable-next-line react/immutability
         node.result = null;
       }
 
@@ -250,8 +254,11 @@ function usePropTree(props: Props, query: string): PropTreeNode[] {
 
     // Mark all as not matching
     for (const {node} of root) {
+      // oxlint-disable-next-line react/immutability
       node.visible = false;
+      // oxlint-disable-next-line react/immutability
       node.expanded = false;
+      // oxlint-disable-next-line react/immutability
       node.result = null;
     }
 
@@ -266,22 +273,28 @@ function usePropTree(props: Props, query: string): PropTreeNode[] {
       const match = fzf(name, lowerCaseQuery, false);
 
       if (match.score > 0) {
+        // oxlint-disable-next-line react/immutability
         node.result = match;
+        // oxlint-disable-next-line react/immutability
         node.visible = true;
 
         if (Object.keys(node.children).length > 0) {
+          // oxlint-disable-next-line react/immutability
           node.expanded = true;
           for (const child of Object.values(node.children)) {
             child.visible = true;
           }
         }
         for (const p of path) {
+          // oxlint-disable-next-line react/immutability
           p.visible = true;
+          // oxlint-disable-next-line react/immutability
           p.expanded = true;
           // The entire path needs to contain max score of its child results so that
           // the entire path to it can be sorted by this score. The side effect of this is that results from the same
           // tree path with a lower score will be placed higher in the tree if that same path has a higher score anywhere
           // in the tree. This isn't ideal, but given that it favors the most relevant results, it makes it a good starting point.
+          // oxlint-disable-next-line react/immutability
           p.result = match.score > (p.result?.score ?? 0) ? match : p.result;
         }
       }

--- a/static/app/stories/view/storyTree.tsx
+++ b/static/app/stories/view/storyTree.tsx
@@ -629,6 +629,7 @@ function Folder(props: {node: StoryTreeNode}) {
   }, [storySlug, props.node]);
 
   if (hasActiveChild && !props.node.expanded) {
+    // oxlint-disable-next-line react/immutability
     props.node.expanded = true;
     setExpanded(true);
   }
@@ -645,6 +646,7 @@ function Folder(props: {node: StoryTreeNode}) {
     <li>
       <FolderName
         onClick={() => {
+          // oxlint-disable-next-line react/immutability
           props.node.expanded = !props.node.expanded;
           if (props.node.expanded) {
             for (const child of Object.values(props.node.children)) {

--- a/static/app/utils/api/useAggregatedQueryKeys.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.tsx
@@ -160,6 +160,7 @@ export function useAggregatedQueryKeys<AggregatableQueryKey, Data, ResponseData 
       });
 
       if (allQueuedQueries.length > queuedQueriesBatch.length) {
+        // oxlint-disable-next-line react/immutability
         fetchData();
       }
     } catch (error) {

--- a/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
+++ b/static/app/utils/profiling/hooks/useKeyboardNavigation.tsx
@@ -86,6 +86,7 @@ export function useKeyboardNavigation() {
 
   function getItemProps() {
     const idx = items.length;
+    // oxlint-disable-next-line react/immutability
     items.push({id: idx, node: null});
 
     return {

--- a/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
+++ b/static/app/utils/profiling/hooks/useVirtualizedTree/useVirtualizedTree.tsx
@@ -781,6 +781,7 @@ export function useVirtualizedTree<T extends TreeLike>(
           if (!firstChild) {
             return;
           }
+          // oxlint-disable-next-line react/immutability
           firstChild.style.height = `${newMaxHeight}px`;
           firstChild.style.maxHeight = `${newMaxHeight}px`;
         }

--- a/static/app/utils/useHoverOverlay.tsx
+++ b/static/app/utils/useHoverOverlay.tsx
@@ -496,6 +496,7 @@ function useHoverOverlay({
     }
 
     commitStatus('warming');
+    // oxlint-disable-next-line react/immutability
     openTimerRef.current = window.setTimeout(() => {
       commitStatus('open');
       warmUpGroup(group, selfTokenRef.current);
@@ -515,6 +516,7 @@ function useHoverOverlay({
     }
 
     commitStatus('cooling');
+    // oxlint-disable-next-line react/immutability
     hideTimerRef.current = window.setTimeout(() => {
       commitStatus('idle');
       startGroupCoolDown(group);

--- a/static/app/utils/useStableMergeRef.ts
+++ b/static/app/utils/useStableMergeRef.ts
@@ -23,6 +23,7 @@ export function useStableMergeRef<T>(stableRef: React.Ref<T> | undefined) {
       }
 
       const mergedRef = mergeRefs(ref, stableRef);
+      // oxlint-disable-next-line react/immutability
       cache.set(ref, mergedRef);
       return mergedRef;
     };

--- a/static/app/views/dashboards/dashboard.spec.tsx
+++ b/static/app/views/dashboards/dashboard.spec.tsx
@@ -800,6 +800,7 @@ describe('Dashboards > Dashboard', () => {
 
     function SnapshotCapture() {
       const {getLLMContext} = useLLMContext();
+      // oxlint-disable-next-line react/immutability
       snapshotRef.current = getLLMContext;
       return null;
     }

--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -380,6 +380,7 @@ function makeContextCapture() {
   const ref: {current: (() => LLMContextSnapshot) | null} = {current: null};
   function ContextCapture() {
     const {getLLMContext} = useLLMContext();
+    // oxlint-disable-next-line react/immutability
     ref.current = getLLMContext;
     return null;
   }

--- a/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricQueryRows.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/visualize/traceMetrics/metricsEquationVisualize/metricQueryRows.tsx
@@ -70,6 +70,7 @@ export function MetricQueryRows({
   // restore this state after a mode or dataset toggle.
   useEffect(() => {
     if (equationSnapshot) {
+      // oxlint-disable-next-line react/immutability
       equationSnapshot.current = {queries: metricQueries, selectedLabel};
     }
   }, [equationSnapshot, metricQueries, selectedLabel]);

--- a/static/app/views/dashboards/widgetCard/autoSizedText.tsx
+++ b/static/app/views/dashboards/widgetCard/autoSizedText.tsx
@@ -28,6 +28,7 @@ export function AutoSizedText({children}: Props) {
       const childDimensions = getElementDimensions(childElement);
       const parentDimensions = getElementDimensions(parentElement);
 
+      // oxlint-disable-next-line react/immutability
       adjustFontSize(childDimensions, parentDimensions);
       return;
     }

--- a/static/app/views/dashboards/widgetCard/index.tsx
+++ b/static/app/views/dashboards/widgetCard/index.tsx
@@ -212,6 +212,7 @@ function WidgetCard(props: Props) {
   } = props;
 
   if (widget.displayType === DisplayType.TOP_N) {
+    // oxlint-disable-next-line react/immutability
     widget.displayType = DisplayType.AREA;
   }
 

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -125,6 +125,7 @@ export function WidgetQueries({
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       rawResults = rawResults as EventsStats;
       if (rawResults.isMetricsData !== undefined) {
+        // oxlint-disable-next-line react/immutability
         isSeriesMetricsDataResults.push(rawResults.isMetricsData);
       }
       if (rawResults.isMetricsExtractedData !== undefined) {
@@ -178,6 +179,7 @@ export function WidgetQueries({
   const isTableMetricsExtractedDataResults: boolean[] = [];
   const afterFetchTableData = (rawResults: TableResult) => {
     if (rawResults.meta?.isMetricsData !== undefined) {
+      // oxlint-disable-next-line react/immutability
       isTableMetricsDataResults.push(rawResults.meta.isMetricsData);
     }
     if (rawResults.meta?.isMetricsExtractedData !== undefined) {

--- a/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/categoricalSeriesWidget/categoricalSeriesWidgetVisualization.tsx
@@ -196,6 +196,7 @@ export function CategoricalSeriesWidgetVisualization(
 
     if (plottable.needsColor) {
       color = palette[seriesColorIndex % palette.length]!;
+      // oxlint-disable-next-line react/immutability
       seriesColorIndex += 1;
     }
 

--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -533,6 +533,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     if (plottable.needsColor) {
       // For any timeseries in need of a color, pull from the chart palette
       color = palette[seriesColorIndex % palette.length]!; // Mod the index in case the number of plottables exceeds the palette length
+      // oxlint-disable-next-line react/immutability
       seriesColorIndex += 1;
     }
 

--- a/static/app/views/explore/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
+++ b/static/app/views/explore/replays/detail/breadcrumbs/useBreadcrumbFilters.tsx
@@ -117,6 +117,7 @@ export function useBreadcrumbFilters({frames}: Options): Return {
   // add custom breadcrumbs to filter
   frames.forEach(frame => {
     if (!(getFrameOpOrCategory(frame) in OPORCATEGORY_TO_TYPE)) {
+      // oxlint-disable-next-line react/immutability
       OPORCATEGORY_TO_TYPE[getFrameOpOrCategory(frame)] = 'custom';
     }
   });

--- a/static/app/views/explore/replays/detail/console/format.tsx
+++ b/static/app/views/explore/replays/detail/console/format.tsx
@@ -76,6 +76,7 @@ export function Format({onExpand, expandPaths, args}: FormatProps) {
     }
     switch (x) {
       case '%c':
+        // oxlint-disable-next-line react/immutability
         styling = args[i++];
         return '';
       case '%s': {

--- a/static/app/views/explore/replays/detail/header/useReplayMenuItems.tsx
+++ b/static/app/views/explore/replays/detail/header/useReplayMenuItems.tsx
@@ -90,6 +90,7 @@ export function useReplayMenuItems({
             try {
               const json = JSON.stringify(replay.getRRWebFrames());
               await navigator.clipboard.writeText(json);
+              // oxlint-disable-next-line react/immutability
               window.location.href = 'sentry-replay-debugger://open';
             } catch (error) {
               Sentry.captureException(error);

--- a/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
+++ b/static/app/views/insights/browser/webVitals/components/performanceScoreRing.tsx
@@ -85,6 +85,7 @@ export function PerformanceScoreRing({
         : 0;
       const rotate = currentRotate;
       if (sumMaxValues) {
+        // oxlint-disable-next-line react/immutability
         currentRotate += (360 * maxValue) / sumMaxValues;
       }
       const cx = radius + barWidth / 2;

--- a/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
+++ b/static/app/views/insights/browser/webVitals/queries/storedScoreQueries/useTransactionWebVitalsScoresQuery.tsx
@@ -45,6 +45,7 @@ export const useTransactionWebVitalsScoresQuery = ({
 
   if (sort !== undefined) {
     if (sort.field === 'avg(measurements.score.total)') {
+      // oxlint-disable-next-line react/immutability
       sort.field = 'performance_score(measurements.score.total)';
     }
   }

--- a/static/app/views/insights/common/components/chart.tsx
+++ b/static/app/views/insights/common/components/chart.tsx
@@ -422,6 +422,7 @@ export function Chart({
     // add top-padding to the chart in full screen so that the legend
     // and graph do not overlap
     if (renderingContext?.isFullscreen) {
+      // oxlint-disable-next-line react/immutability
       grid = {...grid, top: '20px'};
     }
 

--- a/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
+++ b/static/app/views/issueDetails/actions/seerCommandPaletteActions.tsx
@@ -92,6 +92,7 @@ export function SeerCommandPaletteActions({
     }
     if (integration.requires_identity && !integration.has_identity) {
       const currentUrl = window.location.href;
+      // oxlint-disable-next-line react/immutability
       window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
       return;
     }

--- a/static/app/views/issueDetails/eventList.tsx
+++ b/static/app/views/issueDetails/eventList.tsx
@@ -62,11 +62,13 @@ export function EventList({group}: EventListProps) {
     },
   });
 
+  // oxlint-disable-next-line react/immutability
   eventView.sorts = decodeSorts(location.query.sort).filter(sort =>
     fields.includes(sort.field)
   );
 
   if (!eventView.sorts.length) {
+    // oxlint-disable-next-line react/immutability
     eventView.sorts = [{field: 'timestamp', kind: 'desc'}];
   }
 

--- a/static/app/views/issueDetails/sidebar/autofixSection.spec.tsx
+++ b/static/app/views/issueDetails/sidebar/autofixSection.spec.tsx
@@ -564,6 +564,7 @@ describe('AutofixSection', () => {
 
     function ContextCapture() {
       const {getLLMContext} = useLLMContext();
+      // oxlint-disable-next-line react/immutability
       snapshotRef.current = getLLMContext;
       return null;
     }

--- a/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
+++ b/static/app/views/navigation/secondary/sections/issues/issuesSecondaryNavigation.spec.tsx
@@ -122,6 +122,7 @@ describe('IssuesSecondaryNavigation', () => {
 
       function ContextCapture() {
         const {getLLMContext} = useLLMContext();
+        // oxlint-disable-next-line react/immutability
         ref.current = () => getLLMContext().nodes;
         return null;
       }

--- a/static/app/views/performance/newTraceDetails/trace.tsx
+++ b/static/app/views/performance/newTraceDetails/trace.tsx
@@ -759,6 +759,7 @@ function CollapsedGapMarker({
     }
 
     event.preventDefault();
+    // oxlint-disable-next-line react/immutability
     scrollContainer.scrollTop += event.deltaY;
     scrollContainer.scrollLeft += event.deltaX;
   };

--- a/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
+++ b/static/app/views/performance/newTraceDetails/traceRenderers/traceVirtualizedList.tsx
@@ -136,6 +136,7 @@ export const useVirtualizedList = (
       scrollContainerRef.current = props.container.children[0] as HTMLElement | null;
     }
 
+    // oxlint-disable-next-line react/immutability
     props.container.style.height = '100%';
     props.container.style.overflow = 'auto';
     props.container.style.position = 'relative';

--- a/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
+++ b/static/app/views/performance/transactionSummary/transactionReplays/transactionReplays.tsx
@@ -98,6 +98,7 @@ function ReplaysContent({
   const location = useLocation();
 
   if (!eventView.query) {
+    // oxlint-disable-next-line react/immutability
     eventView.query = String(location.query.query ?? '');
   }
   const playlistQuery = usePlaylistQuery('transactionReplays', eventView);

--- a/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
+++ b/static/app/views/seerExplorer/contexts/llmContext.spec.tsx
@@ -21,6 +21,7 @@ function makeContextCapture() {
 
   function ContextCapture() {
     const {getLLMContext} = useLLMContext();
+    // oxlint-disable-next-line react/immutability
     ref.current = getLLMContext;
     return null;
   }
@@ -502,6 +503,7 @@ describe('getLLMContext — full tree vs componentOnly', () => {
     function DashboardWithCapture({name}: {name: string}) {
       useLLMContext({name});
       const {getLLMContext} = useLLMContext();
+      // oxlint-disable-next-line react/immutability
       innerRef.current = getLLMContext;
       return (
         <div>

--- a/static/gsApp/components/features/illustrations/alertsBackground.tsx
+++ b/static/gsApp/components/features/illustrations/alertsBackground.tsx
@@ -91,6 +91,7 @@ export function AlertsBackground({anchorRef}: Props) {
   const alertAnimationHook: React.Ref<SVGGElement> = el => {
     if (alertInterval !== undefined) {
       clearInterval(alertInterval);
+      // oxlint-disable-next-line react/immutability
       alertInterval = undefined;
     }
 

--- a/static/gsApp/views/amCheckout/steps/chooseYourBillingCycle.tsx
+++ b/static/gsApp/views/amCheckout/steps/chooseYourBillingCycle.tsx
@@ -58,6 +58,7 @@ export function ChooseYourBillingCycle({
           const formattedPriceBeforeDiscount = previousPlanPrice
             ? utils.formatPrice({cents: priceBeforeDiscount})
             : '';
+          // oxlint-disable-next-line react/immutability
           previousPlanPrice = priceAfterDiscount;
 
           return (


### PR DESCRIPTION
`react/immutability` has been sitting at `'off'` behind a TODO. Turning it on
surfaces 70 diagnostics on 66 lines across 43 files — all pre-existing, none
introduced here. Rewriting that code is a much larger job than flipping the
switch, and holding the rule off until it's done means every new violation
lands unchallenged in the meantime.

So this promotes the rule to `'error'` and suppresses each existing site
inline. The rule now gates new code; the 66 `oxlint-disable-next-line`
comments are an explicit backlog rather than an endorsement of the mutations
underneath them. Grepping for the disable comment gives the burn-down list.

What the compiler is objecting to:

| Count | Diagnostic |
|------:|------------|
| 50 | This value cannot be modified |
| 8 | Cannot reassign variable after render completes |
| 7 | Cannot modify local variables after render completes |
| 5 | Cannot access variable while it is being initialized |

They cluster in a few recognizable shapes — mutating a prop or a shared object
mid-render (`eventView.sorts = …`, `data.image_name = …`), writing to a ref
during render, and accumulating into a local across a render pass. Most are
small, isolated fixes; a reviewer wanting to spot-check should start with
`static/app/stories/apiReference.tsx`, which holds 13 of the 70 and is the one
place where the mutation is structural rather than incidental.

### One caveat worth knowing about

oxlint 1.81.0's React Compiler rules do not report deterministically. Three
full runs of this same config returned three different answers — 5 ×
`react(invariant)`, 26 × `react(memo-dependencies)`, then 70 ×
`react(immutability)` — and the first two leaked from rules explicitly set to
`'off'`, so the severity filter isn't holding.

That means a single `pnpm lint:js` is not a trustworthy violation list for
these rules, which is worth keeping in mind before promoting any of the
sibling `react/*` TODOs the same way. The suppression set here was verified
against 7 consecutive clean full runs, with type-aware linting confirmed
active (399 rules, not the degraded 370).

No feature flags, and no runtime or visual change — comments and one config
line only.
