### PR TITLE
ref(oxlint): promote react/invariant to error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -596,7 +596,7 @@ const config = defineConfig({
     'react/hooks': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/immutability': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/incompatible-library': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
-    'react/invariant': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
+    'react/invariant': 'error',
     'react/jsx-boolean-value': ['error', 'never'],
     'react/jsx-fragments': ['error', 'element'],
     'react/jsx-key': [

--- a/static/app/components/autoSelectText.tsx
+++ b/static/app/components/autoSelectText.tsx
@@ -23,6 +23,7 @@ export function AutoSelectText({children, className, ref, ...props}: Props) {
     selectText: () => handleClick(),
   }));
 
+  // oxlint-disable-next-line react/invariant -- React Compiler internal error in PruneHoistedContexts; the hoisted handleClick is valid.
   function handleClick() {
     if (!element.current) {
       return;

--- a/static/app/components/autoSelectText.tsx
+++ b/static/app/components/autoSelectText.tsx
@@ -17,19 +17,18 @@ type AutoSelectHandle = {
 export function AutoSelectText({children, className, ref, ...props}: Props) {
   const element = useRef<HTMLSpanElement>(null);
 
-  // We need to expose a selectText method to parent components
-  // and need an imperative ref handle.
-  useImperativeHandle(ref, () => ({
-    selectText: () => handleClick(),
-  }));
-
-  // oxlint-disable-next-line react/invariant -- React Compiler internal error in PruneHoistedContexts; the hoisted handleClick is valid.
   function handleClick() {
     if (!element.current) {
       return;
     }
     selectText(element.current);
   }
+
+  // We need to expose a selectText method to parent components
+  // and need an imperative ref handle.
+  useImperativeHandle(ref, () => ({
+    selectText: () => handleClick(),
+  }));
 
   // use an inner span here for the selection as otherwise the selectText
   // function will create a range that includes the entire part of the

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -362,12 +362,11 @@ export function EditHighlightsModal({
           onRemoveContextKey={(contextType, contextKey) => {
             trackAnalytics('highlights.edit_modal.remove_context_key', {organization});
             setHighlightContext(() => {
-              const {[contextType]: highlightContextKeys, ...newHighlightContext} =
-                highlightContext;
-              // oxlint-disable-next-line react/invariant -- React Compiler internal error in InferMutationAliasingEffects; highlightContextKeys is initialized.
-              const newHighlightContextKeys = (highlightContextKeys ?? []).filter(
-                key => key !== contextKey
-              );
+              const newHighlightContextKeys = (
+                highlightContext[contextType] ?? []
+              ).filter(key => key !== contextKey);
+              const newHighlightContext = {...highlightContext};
+              delete newHighlightContext[contextType];
               return newHighlightContextKeys.length === 0
                 ? newHighlightContext
                 : {

--- a/static/app/components/events/highlights/editHighlightsModal.tsx
+++ b/static/app/components/events/highlights/editHighlightsModal.tsx
@@ -364,6 +364,7 @@ export function EditHighlightsModal({
             setHighlightContext(() => {
               const {[contextType]: highlightContextKeys, ...newHighlightContext} =
                 highlightContext;
+              // oxlint-disable-next-line react/invariant -- React Compiler internal error in InferMutationAliasingEffects; highlightContextKeys is initialized.
               const newHighlightContextKeys = (highlightContextKeys ?? []).filter(
                 key => key !== contextKey
               );

--- a/static/app/views/explore/releases/drawer/filesChangedList.tsx
+++ b/static/app/views/explore/releases/drawer/filesChangedList.tsx
@@ -56,6 +56,7 @@ export function FilesChangedList({releaseRepos, release}: FilesChangedProps) {
       organization,
       release,
       activeRepository: activeReleaseRepo,
+      // oxlint-disable-next-line react/invariant -- React Compiler internal error in InferMutationAliasingEffects; rdFilesCursor is initialized.
       cursor: rdFilesCursor,
     }),
     select: selectJsonWithHeaders,

--- a/static/app/views/explore/releases/drawer/filesChangedList.tsx
+++ b/static/app/views/explore/releases/drawer/filesChangedList.tsx
@@ -34,15 +34,14 @@ interface FilesChangedProps {
 export function FilesChangedList({releaseRepos, release}: FilesChangedProps) {
   const navigate = useNavigate();
   const organization = useOrganization();
-  const {
-    [ReleasesDrawerFields.ACTIVE_REPO]: rdActiveRepo,
-    [ReleasesDrawerFields.FILES_CURSOR]: rdFilesCursor,
-  } = useLocationQuery({
+  const locationQuery = useLocationQuery({
     fields: {
       [ReleasesDrawerFields.FILES_CURSOR]: decodeScalar,
       [ReleasesDrawerFields.ACTIVE_REPO]: decodeScalar,
     },
   });
+  const rdActiveRepo = locationQuery[ReleasesDrawerFields.ACTIVE_REPO];
+  const rdFilesCursor = locationQuery[ReleasesDrawerFields.FILES_CURSOR];
   const activeReleaseRepo =
     releaseRepos.find(repo => repo.name === rdActiveRepo) ?? releaseRepos[0];
 
@@ -56,7 +55,6 @@ export function FilesChangedList({releaseRepos, release}: FilesChangedProps) {
       organization,
       release,
       activeRepository: activeReleaseRepo,
-      // oxlint-disable-next-line react/invariant -- React Compiler internal error in InferMutationAliasingEffects; rdFilesCursor is initialized.
       cursor: rdFilesCursor,
     }),
     select: selectJsonWithHeaders,

--- a/static/app/views/issueDetails/eventGraphWidget.tsx
+++ b/static/app/views/issueDetails/eventGraphWidget.tsx
@@ -22,11 +22,12 @@ export default function EventGraphWidget({
   chartRef,
 }: LoadableChartWidgetProps) {
   const {groupId} = useParams();
-  const {[ReleasesDrawerFields.EVENT_ID]: eventId} = useLocationQuery({
+  const locationQuery = useLocationQuery({
     fields: {
       [ReleasesDrawerFields.EVENT_ID]: decodeScalar,
     },
   });
+  const eventId = locationQuery[ReleasesDrawerFields.EVENT_ID];
 
   const {
     event,
@@ -34,7 +35,6 @@ export default function EventGraphWidget({
     isPending,
     isError,
   } = useFetchGroupAndEvent({
-    // oxlint-disable-next-line react/invariant -- React Compiler internal error in InferMutationAliasingEffects; eventId is initialized.
     eventId,
     groupId,
     enabled: Boolean(eventId && groupId),

--- a/static/app/views/issueDetails/eventGraphWidget.tsx
+++ b/static/app/views/issueDetails/eventGraphWidget.tsx
@@ -34,6 +34,7 @@ export default function EventGraphWidget({
     isPending,
     isError,
   } = useFetchGroupAndEvent({
+    // oxlint-disable-next-line react/invariant -- React Compiler internal error in InferMutationAliasingEffects; eventId is initialized.
     eventId,
     groupId,
     enabled: Boolean(eventId && groupId),

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -81,17 +81,15 @@ export function EAPChartsWidget({transactionName, query}: EAPChartsWidgetProps) 
   const location = useLocation();
   const navigate = useNavigate();
 
-  const {
-    [SpanFields.SPAN_CATEGORY]: spanCategoryUrlParam,
-    [SELECTED_CHART_QUERY_PARAM]: selectedChartUrlParam,
-  } = useLocationQuery({
+  const locationQuery = useLocationQuery({
     fields: {
       [SpanFields.SPAN_CATEGORY]: decodeScalar,
       [SELECTED_CHART_QUERY_PARAM]: decodeScalar,
     },
   });
+  const spanCategoryUrlParam = locationQuery[SpanFields.SPAN_CATEGORY];
+  const selectedChartUrlParam = locationQuery[SELECTED_CHART_QUERY_PARAM];
 
-  // oxlint-disable-next-line react/invariant -- React Compiler internal error in InferMutationAliasingEffects; selectedChartUrlParam is initialized.
   const selectedChart = WIDGET_OPTIONS[selectedChartUrlParam as EAPWidgetType]
     ? (selectedChartUrlParam as EAPWidgetType)
     : EAPWidgetType.DURATION_BREAKDOWN;

--- a/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
+++ b/static/app/views/performance/transactionSummary/transactionOverview/eapChartsWidget.tsx
@@ -91,6 +91,7 @@ export function EAPChartsWidget({transactionName, query}: EAPChartsWidgetProps) 
     },
   });
 
+  // oxlint-disable-next-line react/invariant -- React Compiler internal error in InferMutationAliasingEffects; selectedChartUrlParam is initialized.
   const selectedChart = WIDGET_OPTIONS[selectedChartUrlParam as EAPWidgetType]
     ? (selectedChartUrlParam as EAPWidgetType)
     : EAPWidgetType.DURATION_BREAKDOWN;


### PR DESCRIPTION
`react/invariant` was one of the remaining React Compiler rules parked at `off` behind a TODO. It fires when the compiler bails out on a component, which silently costs that component its memoization, so it is worth failing CI on rather than leaving as a warning nobody reads.

All five violations turned out to share a single cause, so they are fixed here rather than suppressed.

Four are computed-key destructures — `const {[ReleasesDrawerFields.EVENT_ID]: eventId} = useLocationQuery(...)` — which is what trips `InferMutationAliasingEffects`. Reading the same properties with plain member access clears the error and matches how the surrounding code already reads these values; `editHighlightsModal` does exactly that a few lines further down. The fifth, in `autoSelectText`, called `handleClick` above its own declaration and leaned on hoisting, which is what `PruneHoistedContexts` objected to. Moving the declaration above its first use removes the forward reference.

Only `editHighlightsModal` changes shape rather than just moving lines around: the dynamic-key rest-destructure that omitted one context type becomes a shallow copy plus `delete`. Same result, and it avoids the computed destructure.

**Review focus:** `editHighlightsModal` is the one real logic rewrite. Its existing spec covers that path — it clicks a remove-context button and asserts the remaining count — and passes.

**On verification.** oxlint's React Compiler diagnostics have been unstable between runs in this repo, so "the lint is green" is weak evidence on its own. Each error was first reproduced with its suppression removed and then confirmed cleared by the rewrite, so the rewrites are the reason the errors are gone rather than run-to-run noise. Beyond that: five consecutive full lint runs clean, `tsc --build --force` passes, and the specs for the touched components pass. `autoSelectText` has no spec, but its change is a pure statement reorder.

No feature flags. No user-visible behavior change, so there is nothing to screenshot.

https://claude.ai/code/session_011PwkRBHxwPavWxoaoDB3f6
