### PR TITLE
ref(hybrid-cloud): read the outbox backfill watermark from postgres behind an option

### DIFF
--- a/src/sentry/hybridcloud/options.py
+++ b/src/sentry/hybridcloud/options.py
@@ -157,6 +157,13 @@ register(
 )
 
 register(
+    "hybrid_cloud.read_outbox_backfill_watermark_from_postgres",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
+register(
     "hybrid_cloud.authentication.disabled_organization_shards",
     type=Sequence,
     default=[],

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -134,14 +134,6 @@ def _write_postgres_watermark(table_name: str, value: int, version: int) -> None
 
 
 def read_processing_state(table_name: str) -> tuple[int, int] | None:
-    if _read_from_postgres_enabled():
-        postgres_state = _read_postgres_watermark(table_name)
-        if postgres_state is not None:
-            return postgres_state
-    return _read_redis_watermark(table_name)
-
-
-def get_processing_state(table_name: str) -> tuple[int, int]:
     postgres_enabled = _read_from_postgres_enabled()
 
     if postgres_enabled:
@@ -150,20 +142,25 @@ def get_processing_state(table_name: str) -> tuple[int, int]:
             return postgres_state
 
     redis_state = _read_redis_watermark(table_name)
-    if redis_state is not None:
-        if postgres_enabled:
-            metrics.incr(
-                WATERMARK_READ_REDIS_FALLBACK_METRIC,
-                tags=dict(table_name=table_name),
-                skip_internal=True,
-                sample_rate=1.0,
-            )
-        return redis_state
+    if redis_state is not None and postgres_enabled:
+        metrics.incr(
+            WATERMARK_READ_REDIS_FALLBACK_METRIC,
+            tags=dict(table_name=table_name),
+            skip_internal=True,
+            sample_rate=1.0,
+        )
+    return redis_state
+
+
+def get_processing_state(table_name: str) -> tuple[int, int]:
+    state = read_processing_state(table_name)
+    if state is not None:
+        return state
 
     state = (0, 1)
     lower, version = state
     _get_redis_client().set(get_backfill_key(table_name), json.dumps(state))
-    if postgres_enabled:
+    if _read_from_postgres_enabled():
         _write_postgres_watermark(table_name, lower, version)
     return state
 

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -86,6 +86,9 @@ def _control_backfill_tables() -> frozenset[str]:
 
 
 def _read_from_postgres_enabled() -> bool:
+    # Postgres can only be the source of truth while the dual write keeps it current
+    if not options.get(WRITE_WATERMARK_TO_POSTGRES_OPTION):
+        return False
     return bool(options.get(READ_WATERMARK_FROM_POSTGRES_OPTION))
 
 

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -109,15 +109,6 @@ def _read_postgres_watermark(table_name: str) -> tuple[int, int] | None:
     return row.low_bound, row.version
 
 
-def _count_redis_fallback(table_name: str) -> None:
-    metrics.incr(
-        WATERMARK_READ_REDIS_FALLBACK_METRIC,
-        tags=dict(table_name=table_name),
-        skip_internal=True,
-        sample_rate=1.0,
-    )
-
-
 def _write_postgres_watermark(table_name: str, value: int, version: int) -> None:
     if not options.get(WRITE_WATERMARK_TO_POSTGRES_OPTION):
         return
@@ -151,25 +142,26 @@ def get_processing_state(table_name: str) -> tuple[int, int]:
     """
     The watermark pair the backfill works from.
     """
-    redis_state = _read_redis_watermark(table_name)
+    postgres_enabled = _read_from_postgres_enabled()
 
-    if not _read_from_postgres_enabled():
-        state = redis_state if redis_state is not None else (0, 1)
-    else:
+    if postgres_enabled:
         postgres_state = _read_postgres_watermark(table_name)
         if postgres_state is not None:
-            state = postgres_state
-        elif redis_state is not None:
-            # TODO: clean this up once we're past the soak period
-            _count_redis_fallback(table_name)
-            state = redis_state
-        else:
-            state = (0, 1)
+            return postgres_state
 
-    if redis_state is None:
-        # TODO: clean this up once we're past the soak period
-        _get_redis_client().set(get_backfill_key(table_name), json.dumps(state))
+    redis_state = _read_redis_watermark(table_name)
+    if redis_state is not None:
+        if postgres_enabled:
+            metrics.incr(
+                WATERMARK_READ_REDIS_FALLBACK_METRIC,
+                tags=dict(table_name=table_name),
+                skip_internal=True,
+                sample_rate=1.0,
+            )
+        return redis_state
 
+    state = (0, 1)
+    _get_redis_client().set(get_backfill_key(table_name), json.dumps(state))
     return state
 
 

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -158,7 +158,10 @@ def get_processing_state(table_name: str) -> tuple[int, int]:
         return redis_state
 
     state = (0, 1)
+    lower, version = state
     _get_redis_client().set(get_backfill_key(table_name), json.dumps(state))
+    if postgres_enabled:
+        _write_postgres_watermark(table_name, lower, version)
     return state
 
 
@@ -354,13 +357,20 @@ def report_backfill_watermarks(silo_mode: SiloMode, force_synchronous: bool = Fa
     """
     Read every backfill watermark once, and report what it holds.
     """
+
+    # Writing to PG during the every-cycle reporting sweep was something we only needed
+    # to do during the dual-write phase to get PG synced up. If we've enabled the cutover
+    # flag, it's a signal that PG is at parity w/ Redis and we don't need to write every
+    # single cycle any longer
+    # TODO: remove this - and related logic - once cutover is done
+    sync_to_postgres = not _read_from_postgres_enabled()
+
     try:
         for model in _backfill_models(silo_mode):
             table_name = model._meta.db_table
             try:
                 state = _report_watermark_for_model(model, force_synchronous=force_synchronous)
-                if state is not None:
-                    # TODO: Once everything is cut over to PG, we'll remove this
+                if state is not None and sync_to_postgres:
                     lower, version = state
                     _write_postgres_watermark(table_name, lower, version)
             except Exception:

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 
 from django.apps import apps
 from django.conf import settings
-from django.db import IntegrityError, router, transaction
+from django.db import router, transaction
 from django.db.models import Max, Min, Model
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
@@ -109,20 +109,6 @@ def _read_postgres_watermark(table_name: str) -> tuple[int, int] | None:
     return row.low_bound, row.version
 
 
-def _create_postgres_watermark(table_name: str, value: int, version: int) -> None:
-    watermark_model = _watermark_model(table_name)
-    try:
-        with transaction.atomic(router.db_for_write(watermark_model)):
-            watermark_model.objects.get_or_create(
-                table_name=table_name,
-                defaults={"low_bound": value, "version": version},
-            )
-    except IntegrityError:
-        # There's a race condition where another scheduler can put the row in between
-        # the read + insert, but we don't need to do anything since it wrote the same values
-        pass
-
-
 def _count_redis_fallback(table_name: str) -> None:
     metrics.incr(
         WATERMARK_READ_REDIS_FALLBACK_METRIC,
@@ -177,7 +163,6 @@ def get_processing_state(table_name: str) -> tuple[int, int]:
             # TODO: clean this up once we're past the soak period
             _count_redis_fallback(table_name)
             state = redis_state
-            _create_postgres_watermark(table_name, state[0], state[1])
         else:
             state = (0, 1)
 

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 
 from django.apps import apps
 from django.conf import settings
-from django.db import router, transaction
+from django.db import IntegrityError, router, transaction
 from django.db.models import Max, Min, Model
 from sentry_redis_tools.clients import RedisCluster, StrictRedis
 
@@ -31,7 +31,10 @@ from sentry.utils import json, metrics, redis
 logger = logging.getLogger(__name__)
 
 WRITE_WATERMARK_TO_POSTGRES_OPTION = "hybrid_cloud.write_outbox_backfill_watermark_to_postgres"
+READ_WATERMARK_FROM_POSTGRES_OPTION = "hybrid_cloud.read_outbox_backfill_watermark_from_postgres"
 WATERMARK_DUAL_WRITE_ERROR_METRIC = "backfill_outboxes.watermark_dual_write_error"
+# TODO: delete this after cutover soak period, it's just for sanity checking we don't fallback at all
+WATERMARK_READ_REDIS_FALLBACK_METRIC = "backfill_outboxes.watermark_read_redis_fallback"
 
 
 def _get_redis_client() -> RedisCluster[str] | StrictRedis[str]:
@@ -60,10 +63,7 @@ def get_backfill_key(table_name: str) -> str:
     return f"outbox_backfill.{table_name}"
 
 
-def read_processing_state(table_name: str) -> tuple[int, int] | None:
-    """
-    Read-only way to look at the stored watermark pair
-    """
+def _read_redis_watermark(table_name: str) -> tuple[int, int] | None:
     client = _get_redis_client()
     v = client.get(get_backfill_key(table_name))
     if v is None:
@@ -85,6 +85,10 @@ def _control_backfill_tables() -> frozenset[str]:
     return frozenset(tables)
 
 
+def _read_from_postgres_enabled() -> bool:
+    return bool(options.get(READ_WATERMARK_FROM_POSTGRES_OPTION))
+
+
 def _watermark_model(table_name: str) -> type[BaseOutboxBackfillWatermark]:
     current_mode = SiloMode.get_current_mode()
     if current_mode == SiloMode.CONTROL:
@@ -98,6 +102,36 @@ def _watermark_model(table_name: str) -> type[BaseOutboxBackfillWatermark]:
     return CellOutboxBackfillWatermark
 
 
+def _read_postgres_watermark(table_name: str) -> tuple[int, int] | None:
+    row = _watermark_model(table_name).objects.filter(table_name=table_name).first()
+    if row is None:
+        return None
+    return row.low_bound, row.version
+
+
+def _create_postgres_watermark(table_name: str, value: int, version: int) -> None:
+    watermark_model = _watermark_model(table_name)
+    try:
+        with transaction.atomic(router.db_for_write(watermark_model)):
+            watermark_model.objects.get_or_create(
+                table_name=table_name,
+                defaults={"low_bound": value, "version": version},
+            )
+    except IntegrityError:
+        # There's a race condition where another scheduler can put the row in between
+        # the read + insert, but we don't need to do anything since it wrote the same values
+        pass
+
+
+def _count_redis_fallback(table_name: str) -> None:
+    metrics.incr(
+        WATERMARK_READ_REDIS_FALLBACK_METRIC,
+        tags=dict(table_name=table_name),
+        skip_internal=True,
+        sample_rate=1.0,
+    )
+
+
 def _write_postgres_watermark(table_name: str, value: int, version: int) -> None:
     if not options.get(WRITE_WATERMARK_TO_POSTGRES_OPTION):
         return
@@ -108,10 +142,6 @@ def _write_postgres_watermark(table_name: str, value: int, version: int) -> None
             defaults={"low_bound": value, "version": version},
         )
     except Exception:
-        # Mask failures since Redis is the source of truth
-        #
-        # TODO: update this so that when Postgres becomes promoted to the read-path,
-        # we don't swallow exceptions here. It will be conditional on the read-from-postgres flag.
         metrics.incr(
             WATERMARK_DUAL_WRITE_ERROR_METRIC,
             tags=dict(table_name=table_name),
@@ -119,21 +149,43 @@ def _write_postgres_watermark(table_name: str, value: int, version: int) -> None
             sample_rate=1.0,
         )
 
+        if _read_from_postgres_enabled():
+            raise
+
+
+def read_processing_state(table_name: str) -> tuple[int, int] | None:
+    if _read_from_postgres_enabled():
+        postgres_state = _read_postgres_watermark(table_name)
+        if postgres_state is not None:
+            return postgres_state
+    return _read_redis_watermark(table_name)
+
 
 def get_processing_state(table_name: str) -> tuple[int, int]:
-    result: tuple[int, int]
-    client = _get_redis_client()
-    key = get_backfill_key(table_name)
-    v = client.get(key)
-    if v is None:
-        result = (0, 1)
-        client.set(key, json.dumps(result))
+    """
+    The watermark pair the backfill works from.
+    """
+    redis_state = _read_redis_watermark(table_name)
+
+    if not _read_from_postgres_enabled():
+        state = redis_state if redis_state is not None else (0, 1)
     else:
-        lower, version = json.loads(v)
-        if not (isinstance(lower, int) and isinstance(version, int)):
-            raise TypeError("Expected processing data to be a tuple of (int, int)")
-        result = lower, version
-    return result
+        postgres_state = _read_postgres_watermark(table_name)
+        if postgres_state is not None:
+            state = postgres_state
+        elif redis_state is not None:
+            # TODO: clean this up once we're past the soak period
+            _count_redis_fallback(table_name)
+            state = redis_state
+            _create_postgres_watermark(table_name, state[0], state[1])
+        else:
+            state = (0, 1)
+
+    if redis_state is None:
+        # TODO: clean this up once we're past the soak period
+        _get_redis_client().set(get_backfill_key(table_name), json.dumps(state))
+
+    return state
 
 
 def set_processing_state(table_name: str, value: int, version: int) -> None:
@@ -333,6 +385,10 @@ def report_backfill_watermarks(silo_mode: SiloMode, force_synchronous: bool = Fa
             table_name = model._meta.db_table
             try:
                 state = _report_watermark_for_model(model, force_synchronous=force_synchronous)
+                if state is not None:
+                    # TODO: Once everything is cut over to PG, we'll remove this
+                    lower, version = state
+                    _write_postgres_watermark(table_name, lower, version)
             except Exception:
                 # One bad table must not stop the rest of the walk.
                 metrics.incr(
@@ -346,15 +402,6 @@ def report_backfill_watermarks(silo_mode: SiloMode, force_synchronous: bool = Fa
                     extra={"table_name": table_name},
                 )
                 continue
-
-            if state is None:
-                continue
-
-            # This write site is used only to guarantee full, consistent sync between
-            # Redis and PG during the migration period because it runs every cycle guaranteed
-            # TODO: Once everything is cut over to PG, we'll remove this
-            lower, version = state
-            _write_postgres_watermark(table_name, lower, version)
     except Exception:
         metrics.incr(WATERMARK_REPORT_ERROR_METRIC, skip_internal=True, sample_rate=1.0)
         logger.exception("backfill_outboxes.watermark_report_failed")

--- a/src/sentry/hybridcloud/tasks/backfill_outboxes.py
+++ b/src/sentry/hybridcloud/tasks/backfill_outboxes.py
@@ -139,9 +139,6 @@ def read_processing_state(table_name: str) -> tuple[int, int] | None:
 
 
 def get_processing_state(table_name: str) -> tuple[int, int]:
-    """
-    The watermark pair the backfill works from.
-    """
     postgres_enabled = _read_from_postgres_enabled()
 
     if postgres_enabled:

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, patch
 
 import pytest
 from django.apps import apps
-from django.db import IntegrityError, router, transaction
+from django.db import router, transaction
 from django.test.utils import override_settings
 
 from sentry.db.models import BaseModel
@@ -830,14 +830,27 @@ def test_a_missing_postgres_row_falls_back_to_redis() -> None:
         patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
     ):
         assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
-        # The fallback copied the pair into Postgres, so this one is a Postgres read.
-        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
         assert read_processing_state(AuthProvider._meta.db_table) == (4242, 3)
+
+    # The read path writes nothing, so the row is still missing and the fallback is
+    # counted on every read until the write path fills it.
+    assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
+    assert _counter_tables(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == [table_name]
+
+    # The reporting pass is the write path that repairs it, on the same cycle.
+    with override_options(READ_FROM_POSTGRES_OPTIONS):
+        assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
     row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
     assert (row.low_bound, row.version) == (4242, 3)
-    # The fallback fires once per table, not on every read.
-    assert _counter_tables(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == [table_name]
+
+    # With the row in place the fallback stops firing.
+    with (
+        override_options(READ_FROM_POSTGRES_OPTIONS),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+    ):
+        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
+    assert _counter_calls(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == 0
 
 
 @django_db_all
@@ -878,60 +891,6 @@ def test_a_double_miss_keeps_the_default() -> None:
     assert read_processing_state(AuthProvider._meta.db_table) == (0, 1)
     # A double miss creates no Postgres row: only the write path may.
     assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
-
-
-@django_db_all
-@no_silo_test
-def test_two_concurrent_reads_create_one_row() -> None:
-    """Two schedulers can reach the miss path at once. One row must come out of it."""
-    reset_processing_state()
-    table_name = AuthProvider._meta.db_table
-    set_processing_state(AuthProvider._meta.db_table, 4242, 3)
-
-    with (
-        override_options(READ_FROM_POSTGRES_OPTIONS),
-        # Both callers read Postgres before either of them has written to it.
-        patch(
-            "sentry.hybridcloud.tasks.backfill_outboxes._read_postgres_watermark",
-            return_value=None,
-        ),
-    ):
-        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
-        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
-
-    rows = list(ControlOutboxBackfillWatermark.objects.filter(table_name=table_name))
-    assert len(rows) == 1
-    assert (rows[0].low_bound, rows[0].version) == (4242, 3)
-
-
-@django_db_all
-@no_silo_test
-def test_a_lost_create_race_is_not_an_error() -> None:
-    """The unique index rejects the slower insert. That is the expected end, not a failure."""
-    reset_processing_state()
-    table_name = AuthProvider._meta.db_table
-    set_processing_state(AuthProvider._meta.db_table, 4242, 3)
-    # The row the other scheduler put in first.
-    ControlOutboxBackfillWatermark.objects.create(table_name=table_name, low_bound=4242, version=3)
-
-    with (
-        override_options(READ_FROM_POSTGRES_OPTIONS),
-        # This caller saw an empty Postgres, so it goes on to create the row.
-        patch(
-            "sentry.hybridcloud.tasks.backfill_outboxes._read_postgres_watermark",
-            return_value=None,
-        ),
-        patch.object(
-            ControlOutboxBackfillWatermark.objects,
-            "get_or_create",
-            side_effect=IntegrityError("duplicate key value violates unique constraint"),
-        ),
-    ):
-        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
-
-    rows = list(ControlOutboxBackfillWatermark.objects.filter(table_name=table_name))
-    assert len(rows) == 1
-    assert (rows[0].low_bound, rows[0].version) == (4242, 3)
 
 
 @django_db_all

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -27,6 +27,7 @@ from sentry.hybridcloud.tasks.backfill_outboxes import (
     _backfill_models,
     _get_redis_client,
     _read_postgres_watermark,
+    _read_redis_watermark,
     _report_watermark_for_model,
     _write_postgres_watermark,
     backfill_outboxes_for,
@@ -839,20 +840,29 @@ def test_a_missing_postgres_row_falls_back_to_redis() -> None:
     assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
     assert _counter_tables(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == [table_name]
 
-    # The reporting pass is the write path that repairs it, on the same cycle.
+    # The reporting sweep does not repair it either. It is a pre-cutover sync site, so the
+    # read option turns it off, and the fallback keeps answering from Redis.
     with override_options(READ_FROM_POSTGRES_OPTIONS):
+        assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
+
+
+@django_db_all
+@no_silo_test
+def test_the_reporting_sweep_mirrors_only_before_the_cutover() -> None:
+    """The sweep fills the rows the write path never reaches, then stands down."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(AuthProvider._meta.db_table, 4242, 3)
+    assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
+
+    # Read option off: a table the write path never touches still reaches Postgres.
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
     row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
     assert (row.low_bound, row.version) == (4242, 3)
-
-    # With the row in place the fallback stops firing.
-    with (
-        override_options(READ_FROM_POSTGRES_OPTIONS),
-        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
-    ):
-        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
-    assert _counter_calls(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == 0
 
 
 @django_db_all
@@ -898,8 +908,10 @@ def test_a_double_miss_keeps_the_default() -> None:
 
     # The read path still seeds Redis, so a rollback finds the pair it expects.
     assert read_processing_state(AuthProvider._meta.db_table) == (0, 1)
-    # A double miss creates no Postgres row: only the write path may.
-    assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
+    # The seed reaches Postgres too, or a table that never gets budget would stay absent
+    # from the store on the read path and report nothing.
+    assert _read_postgres_watermark(table_name) == (0, 1)
+    assert _read_redis_watermark(table_name) == (0, 1)
 
 
 @django_db_all
@@ -1041,11 +1053,11 @@ def test_a_cutover_cycle_does_not_restart_a_table() -> None:
         # No budget at all, so only the report pass runs.
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
-        # The report pass created the row from the Redis pair, so the next read matches.
+        # The fallback is what holds the walk in place, so the read still matches.
         assert read_processing_state(AuthProvider._meta.db_table) == (4242, 3)
 
-    row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
-    assert (row.low_bound, row.version) == (4242, 3)
+    # The report pass no longer mirrors after the cutover, so it wrote nothing.
+    assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
 
 
 @django_db_all
@@ -1093,7 +1105,7 @@ def test_read_option_on_leaves_the_redis_state_identical() -> None:
 @django_db_all
 @no_silo_test
 def test_a_failed_report_write_does_not_stop_the_walk() -> None:
-    """The report write raises now, so one bad table must not take the rest away."""
+    """The sync write only runs before the cutover, and one bad table must not stop it."""
     reset_processing_state()
     broken_table = AuthProvider._meta.db_table
     good_table = ApiToken._meta.db_table
@@ -1108,7 +1120,7 @@ def test_a_failed_report_write_does_not_stop_the_walk() -> None:
         return real_write(**kwargs)
 
     with (
-        override_options(READ_FROM_POSTGRES_OPTIONS),
+        override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}),
         patch.object(
             ControlOutboxBackfillWatermark.objects, "update_or_create", side_effect=fail_for_one
         ),
@@ -1117,8 +1129,9 @@ def test_a_failed_report_write_does_not_stop_the_walk() -> None:
         # No exception reaches the caller.
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
+    # Redis is still the read path here, so the failure stays masked and only counted.
     assert _counter_calls(metrics_mock, WATERMARK_DUAL_WRITE_ERROR_METRIC) == 1
-    assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 1
+    assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 0
     # The walk carried on past the broken table.
     assert ControlOutboxBackfillWatermark.objects.get(table_name=good_table).low_bound == 7
     assert not ControlOutboxBackfillWatermark.objects.filter(table_name=broken_table).exists()

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -865,9 +865,12 @@ def test_a_missing_postgres_row_falls_back_to_redis() -> None:
         assert read_processing_state(AuthProvider._meta.db_table) == (4242, 3)
 
     # The read path writes nothing, so the row is still missing and the fallback is
-    # counted on every read until the write path fills it.
+    # counted on every read, from either reader, until the write path fills it.
     assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
-    assert _counter_tables(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == [table_name]
+    assert _counter_tables(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == [
+        table_name,
+        table_name,
+    ]
 
     # The reporting sweep does not repair it either. It is a pre-cutover sync site, so the
     # read option turns it off, and the fallback keeps answering from Redis.
@@ -1078,7 +1081,10 @@ def test_a_cutover_cycle_does_not_restart_a_table() -> None:
     table_name = AuthProvider._meta.db_table
     set_processing_state(AuthProvider._meta.db_table, 4242, 3)
 
-    with override_options(READ_FROM_POSTGRES_OPTIONS):
+    with (
+        override_options(READ_FROM_POSTGRES_OPTIONS),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+    ):
         # No budget at all, so only the report pass runs.
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
@@ -1087,6 +1093,9 @@ def test_a_cutover_cycle_does_not_restart_a_table() -> None:
 
     # The report pass no longer mirrors after the cutover, so it wrote nothing.
     assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
+    # The report pass reads through the same fallback, so it is counted even when no
+    # batch runs at all.
+    assert table_name in _counter_tables(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC)
 
 
 @django_db_all

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -137,7 +137,9 @@ def test_control_processing_auth(task_runner: Callable[..., Any]) -> None:
         run_for_model(AuthIdentity)
         run_for_model(AuthProvider)
 
-    assert get_processing_state(AuthIdentity._meta.db_table)[1] == AuthIdentity.replication_version + 1
+    assert (
+        get_processing_state(AuthIdentity._meta.db_table)[1] == AuthIdentity.replication_version + 1
+    )
 
     with outbox_runner():
         assert ControlOutbox.objects.all().count() == 6

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -822,6 +822,35 @@ def test_read_option_off_keeps_the_redis_pair() -> None:
 
 @django_db_all
 @no_silo_test
+def test_the_read_option_needs_the_dual_write() -> None:
+    """The read option alone must not promote a pair the dual write is no longer keeping."""
+    reset_processing_state()
+    set_processing_state(AuthProvider._meta.db_table, 5, 1)
+    ControlOutboxBackfillWatermark.objects.create(
+        table_name=AuthProvider._meta.db_table, low_bound=500, version=3
+    )
+
+    with (
+        override_options({READ_WATERMARK_FROM_POSTGRES_OPTION: True}),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+    ):
+        assert get_processing_state(AuthProvider._meta.db_table) == (5, 1)
+        assert read_processing_state(AuthProvider._meta.db_table) == (5, 1)
+
+    # Redis is the plain read path here, not a fallback from Postgres, so nothing is counted.
+    assert _counter_calls(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == 0
+
+    # Turning the dual write off is a full rollback: the stale row stays ignored.
+    with override_options(READ_FROM_POSTGRES_OPTIONS):
+        assert read_processing_state(AuthProvider._meta.db_table) == (500, 3)
+    with override_options(
+        {**READ_FROM_POSTGRES_OPTIONS, WRITE_WATERMARK_TO_POSTGRES_OPTION: False}
+    ):
+        assert read_processing_state(AuthProvider._meta.db_table) == (5, 1)
+
+
+@django_db_all
+@no_silo_test
 def test_a_missing_postgres_row_falls_back_to_redis() -> None:
     """A table the dual write has not reached must not restart from the beginning."""
     reset_processing_state()

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -4,7 +4,7 @@ from unittest.mock import ANY, patch
 
 import pytest
 from django.apps import apps
-from django.db import router, transaction
+from django.db import IntegrityError, router, transaction
 from django.test.utils import override_settings
 
 from sentry.db.models import BaseModel
@@ -16,7 +16,9 @@ from sentry.hybridcloud.models.outboxbackfillwatermark import (
 )
 from sentry.hybridcloud.outbox.base import run_outbox_replications_for_self_hosted
 from sentry.hybridcloud.tasks.backfill_outboxes import (
+    READ_WATERMARK_FROM_POSTGRES_OPTION,
     WATERMARK_DUAL_WRITE_ERROR_METRIC,
+    WATERMARK_READ_REDIS_FALLBACK_METRIC,
     WATERMARK_REPORT_ERROR_METRIC,
     WATERMARK_STATE_METRIC,
     WATERMARK_TARGET_VERSION_METRIC,
@@ -24,6 +26,7 @@ from sentry.hybridcloud.tasks.backfill_outboxes import (
     WRITE_WATERMARK_TO_POSTGRES_OPTION,
     _backfill_models,
     _get_redis_client,
+    _read_postgres_watermark,
     _report_watermark_for_model,
     _write_postgres_watermark,
     backfill_outboxes_for,
@@ -134,9 +137,7 @@ def test_control_processing_auth(task_runner: Callable[..., Any]) -> None:
         run_for_model(AuthIdentity)
         run_for_model(AuthProvider)
 
-    assert (
-        get_processing_state(AuthIdentity._meta.db_table)[1] == AuthIdentity.replication_version + 1
-    )
+    assert get_processing_state(AuthIdentity._meta.db_table)[1] == AuthIdentity.replication_version + 1
 
     with outbox_runner():
         assert ControlOutbox.objects.all().count() == 6
@@ -271,6 +272,15 @@ def _counter_calls(metrics_mock: Any, name: str) -> int:
     return sum(1 for call in metrics_mock.incr.call_args_list if call.args[0] == name)
 
 
+def _counter_tables(metrics_mock: Any, name: str) -> list[str]:
+    """Collect the table_name tag of every counter call made under this name."""
+    return [
+        call.kwargs["tags"]["table_name"]
+        for call in metrics_mock.incr.call_args_list
+        if call.args[0] == name
+    ]
+
+
 @django_db_all
 @no_silo_test
 def test_watermark_report_runs_without_budget() -> None:
@@ -302,7 +312,7 @@ def test_watermark_report_covers_a_finished_table() -> None:
     # The loop did walk the tables: it created a key for every table that had none.
     assert read_processing_state(ApiToken._meta.db_table) == (0, 1)
     # It left the finished table alone.
-    assert read_processing_state(table_name) == (0, finished_version)
+    assert read_processing_state(AuthProvider._meta.db_table) == (0, finished_version)
     # The table is finished: its stored version is above every possible target.
     assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC)[table_name] == 0
     assert _gauge_values(metrics_mock, WATERMARK_VERSION_METRIC)[table_name] == finished_version
@@ -431,7 +441,7 @@ def test_watermark_report_leaves_a_stored_value_alone() -> None:
     backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
     assert client.get(get_backfill_key(table_name)) == before
-    assert read_processing_state(table_name) == (12345, 3)
+    assert read_processing_state(AuthProvider._meta.db_table) == (12345, 3)
 
 
 @django_db_all
@@ -592,7 +602,7 @@ def test_dual_write_mirrors_an_advancing_batch_into_postgres() -> None:
         # A budget of 2 against 5 users, so the loop advances auth_user and stops.
         backfill_outboxes_for(SiloMode.CONTROL, 0, 2)
 
-    stored = read_processing_state(table_name)
+    stored = read_processing_state(User._meta.db_table)
     assert stored is not None
     assert stored[0] > 0, "the batch did not advance the watermark"
 
@@ -621,7 +631,7 @@ def test_dual_write_mirrors_from_the_write_path_alone() -> None:
         batch = process_outbox_backfill_batch(User, batch_size=2)
 
     assert batch is not None
-    stored = read_processing_state(table_name)
+    stored = read_processing_state(User._meta.db_table)
     assert stored is not None
     row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
     assert (row.low_bound, row.version) == stored
@@ -632,7 +642,6 @@ def test_dual_write_mirrors_from_the_write_path_alone() -> None:
 def test_dual_write_off_leaves_postgres_empty() -> None:
     """Option off: the Redis path is what it is today and nothing reaches Postgres."""
     reset_processing_state()
-    table_name = User._meta.db_table
     with outbox_context(flush=False):
         for _ in range(5):
             Factories.create_user()
@@ -642,7 +651,7 @@ def test_dual_write_off_leaves_postgres_empty() -> None:
     ):
         backfill_outboxes_for(SiloMode.CONTROL, 0, 2)
 
-    stored = read_processing_state(table_name)
+    stored = read_processing_state(User._meta.db_table)
     assert stored is not None
     assert stored[0] > 0, "the batch did not advance the watermark"
 
@@ -659,26 +668,27 @@ def test_dual_write_off_leaves_the_redis_state_identical() -> None:
 
     set_processing_state(table_name, 4242, 3)
     backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
-    without_option = read_processing_state(table_name)
+    without_option = read_processing_state(AuthProvider._meta.db_table)
 
     reset_processing_state()
     set_processing_state(table_name, 4242, 3)
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
         backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
 
-    assert read_processing_state(table_name) == without_option
+    assert read_processing_state(AuthProvider._meta.db_table) == without_option
 
 
 @django_db_all
 @no_silo_test
-def test_a_read_never_creates_a_postgres_row() -> None:
+def test_a_read_creates_no_postgres_row_while_the_read_option_is_off() -> None:
+    """The dual write alone must leave the read path exactly as it is today."""
     reset_processing_state()
     table_name = AuthProvider._meta.db_table
 
     with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
-        assert get_processing_state(table_name) == (0, 1)
+        assert get_processing_state(AuthProvider._meta.db_table) == (0, 1)
 
-    assert read_processing_state(table_name) == (0, 1)
+    assert read_processing_state(AuthProvider._meta.db_table) == (0, 1)
     assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
 
 
@@ -700,7 +710,7 @@ def test_a_failed_postgres_write_does_not_break_the_pass() -> None:
         # No exception reaches the caller.
         assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
 
-    assert read_processing_state(table_name) == (99, 2)
+    assert read_processing_state(AuthProvider._meta.db_table) == (99, 2)
     assert _counter_calls(metrics_mock, WATERMARK_DUAL_WRITE_ERROR_METRIC) >= 1
     # The pass still reported, so one bad mirror did not stop the walk.
     assert _gauge_values(metrics_mock, WATERMARK_STATE_METRIC)[table_name] == 99
@@ -764,3 +774,383 @@ def test_dual_write_uses_the_cell_table_in_cell_silo() -> None:
 
     row = CellOutboxBackfillWatermark.objects.get(table_name=Organization._meta.db_table)
     assert (row.low_bound, row.version) == (8, 1)
+
+
+# The pair of options that promotes Postgres to the read path.
+READ_FROM_POSTGRES_OPTIONS = {
+    WRITE_WATERMARK_TO_POSTGRES_OPTION: True,
+    READ_WATERMARK_FROM_POSTGRES_OPTION: True,
+}
+
+
+@django_db_all
+@no_silo_test
+def test_read_option_on_takes_the_postgres_pair() -> None:
+    """Postgres wins over Redis once the read option is on."""
+    reset_processing_state()
+    set_processing_state(AuthProvider._meta.db_table, 5, 1)
+    ControlOutboxBackfillWatermark.objects.create(
+        table_name=AuthProvider._meta.db_table, low_bound=500, version=3
+    )
+
+    with override_options(READ_FROM_POSTGRES_OPTIONS):
+        assert get_processing_state(AuthProvider._meta.db_table) == (500, 3)
+        assert read_processing_state(AuthProvider._meta.db_table) == (500, 3)
+
+
+@django_db_all
+@no_silo_test
+def test_read_option_off_keeps_the_redis_pair() -> None:
+    """A Postgres row is ignored while the read option is off."""
+    reset_processing_state()
+    set_processing_state(AuthProvider._meta.db_table, 5, 1)
+    ControlOutboxBackfillWatermark.objects.create(
+        table_name=AuthProvider._meta.db_table, low_bound=500, version=3
+    )
+
+    assert get_processing_state(AuthProvider._meta.db_table) == (5, 1)
+    assert read_processing_state(AuthProvider._meta.db_table) == (5, 1)
+
+    # Dual write alone does not move the read path.
+    with override_options({WRITE_WATERMARK_TO_POSTGRES_OPTION: True}):
+        assert get_processing_state(AuthProvider._meta.db_table) == (5, 1)
+        assert read_processing_state(AuthProvider._meta.db_table) == (5, 1)
+
+
+@django_db_all
+@no_silo_test
+def test_a_missing_postgres_row_falls_back_to_redis() -> None:
+    """A table the dual write has not reached must not restart from the beginning."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(AuthProvider._meta.db_table, 4242, 3)
+
+    with (
+        override_options(READ_FROM_POSTGRES_OPTIONS),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+    ):
+        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
+        # The fallback copied the pair into Postgres, so this one is a Postgres read.
+        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
+        assert read_processing_state(AuthProvider._meta.db_table) == (4242, 3)
+
+    row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
+    assert (row.low_bound, row.version) == (4242, 3)
+    # The fallback fires once per table, not on every read.
+    assert _counter_tables(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == [table_name]
+
+
+@django_db_all
+@no_silo_test
+def test_a_lost_redis_key_is_reseeded_with_the_postgres_pair() -> None:
+    """A rollback must find the pair Postgres holds, not a default one."""
+    reset_processing_state()
+    finished_version = AuthProvider.replication_version + 1
+    ControlOutboxBackfillWatermark.objects.create(
+        table_name=AuthProvider._meta.db_table, low_bound=0, version=finished_version
+    )
+
+    with override_options(READ_FROM_POSTGRES_OPTIONS):
+        assert get_processing_state(AuthProvider._meta.db_table) == (0, finished_version)
+
+    # Options off: Redis holds the finished pair, so the table does not walk again.
+    assert read_processing_state(AuthProvider._meta.db_table) == (0, finished_version)
+
+
+@django_db_all
+@no_silo_test
+def test_a_double_miss_keeps_the_default() -> None:
+    """Neither store holds the table, so the default stays."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+
+    with (
+        override_options(READ_FROM_POSTGRES_OPTIONS),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+    ):
+        assert read_processing_state(AuthProvider._meta.db_table) is None
+        assert get_processing_state(AuthProvider._meta.db_table) == (0, 1)
+
+    # A double miss is not the fallback, so the fallback counter stays clean.
+    assert _counter_calls(metrics_mock, WATERMARK_READ_REDIS_FALLBACK_METRIC) == 0
+
+    # The read path still seeds Redis, so a rollback finds the pair it expects.
+    assert read_processing_state(AuthProvider._meta.db_table) == (0, 1)
+    # A double miss creates no Postgres row: only the write path may.
+    assert not ControlOutboxBackfillWatermark.objects.filter(table_name=table_name).exists()
+
+
+@django_db_all
+@no_silo_test
+def test_two_concurrent_reads_create_one_row() -> None:
+    """Two schedulers can reach the miss path at once. One row must come out of it."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(AuthProvider._meta.db_table, 4242, 3)
+
+    with (
+        override_options(READ_FROM_POSTGRES_OPTIONS),
+        # Both callers read Postgres before either of them has written to it.
+        patch(
+            "sentry.hybridcloud.tasks.backfill_outboxes._read_postgres_watermark",
+            return_value=None,
+        ),
+    ):
+        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
+        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
+
+    rows = list(ControlOutboxBackfillWatermark.objects.filter(table_name=table_name))
+    assert len(rows) == 1
+    assert (rows[0].low_bound, rows[0].version) == (4242, 3)
+
+
+@django_db_all
+@no_silo_test
+def test_a_lost_create_race_is_not_an_error() -> None:
+    """The unique index rejects the slower insert. That is the expected end, not a failure."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(AuthProvider._meta.db_table, 4242, 3)
+    # The row the other scheduler put in first.
+    ControlOutboxBackfillWatermark.objects.create(table_name=table_name, low_bound=4242, version=3)
+
+    with (
+        override_options(READ_FROM_POSTGRES_OPTIONS),
+        # This caller saw an empty Postgres, so it goes on to create the row.
+        patch(
+            "sentry.hybridcloud.tasks.backfill_outboxes._read_postgres_watermark",
+            return_value=None,
+        ),
+        patch.object(
+            ControlOutboxBackfillWatermark.objects,
+            "get_or_create",
+            side_effect=IntegrityError("duplicate key value violates unique constraint"),
+        ),
+    ):
+        assert get_processing_state(AuthProvider._meta.db_table) == (4242, 3)
+
+    rows = list(ControlOutboxBackfillWatermark.objects.filter(table_name=table_name))
+    assert len(rows) == 1
+    assert (rows[0].low_bound, rows[0].version) == (4242, 3)
+
+
+@django_db_all
+@no_silo_test
+def test_the_read_path_picks_the_table_by_the_silo_of_the_model() -> None:
+    reset_processing_state()
+    ControlOutboxBackfillWatermark.objects.create(
+        table_name=AuthProvider._meta.db_table, low_bound=11, version=1
+    )
+    CellOutboxBackfillWatermark.objects.create(
+        table_name=Organization._meta.db_table, low_bound=22, version=1
+    )
+
+    assert _read_postgres_watermark(AuthProvider._meta.db_table) == (11, 1)
+    assert _read_postgres_watermark(Organization._meta.db_table) == (22, 1)
+    # A table with no row of its own reads nothing.
+    assert _read_postgres_watermark(ApiToken._meta.db_table) is None
+
+
+@django_db_all
+@control_silo_test
+def test_the_read_path_uses_the_control_table_in_control_silo() -> None:
+    reset_processing_state()
+    ControlOutboxBackfillWatermark.objects.create(
+        table_name=AuthProvider._meta.db_table, low_bound=7, version=1
+    )
+
+    with override_options(READ_FROM_POSTGRES_OPTIONS):
+        assert read_processing_state(AuthProvider._meta.db_table) == (7, 1)
+
+
+@django_db_all
+@cell_silo_test
+def test_the_read_path_uses_the_cell_table_in_cell_silo() -> None:
+    reset_processing_state()
+    CellOutboxBackfillWatermark.objects.create(
+        table_name=Organization._meta.db_table, low_bound=8, version=1
+    )
+
+    with override_options(READ_FROM_POSTGRES_OPTIONS):
+        assert read_processing_state(Organization._meta.db_table) == (8, 1)
+
+
+@django_db_all
+@no_silo_test
+def test_a_finished_version_in_postgres_stops_the_walk() -> None:
+    """A table past its target version is skipped, whichever store holds the pair."""
+    reset_processing_state()
+    with outbox_context(flush=False):
+        for _ in range(5):
+            Factories.create_user()
+    ControlOutbox.objects.all().delete()
+
+    ControlOutboxBackfillWatermark.objects.create(
+        table_name=User._meta.db_table,
+        low_bound=0,
+        version=User.replication_version + 1,
+    )
+    # Redis still says there is work left. Postgres is the source of truth now.
+    set_processing_state(User._meta.db_table, 0, 1)
+
+    with override_options(
+        {
+            **READ_FROM_POSTGRES_OPTIONS,
+            "outbox_replication.auth_user.replication_version": User.replication_version,
+        }
+    ):
+        assert process_outbox_backfill_batch(User, batch_size=10) is None
+
+    assert ControlOutbox.objects.count() == 0
+
+
+@django_db_all
+@no_silo_test
+def test_a_version_bump_in_postgres_restarts_the_walk() -> None:
+    """A stored version below the target resets the bound, same as the Redis path."""
+    reset_processing_state()
+    with outbox_context(flush=False):
+        for _ in range(3):
+            Factories.create_user()
+    ControlOutbox.objects.all().delete()
+
+    ControlOutboxBackfillWatermark.objects.create(
+        table_name=User._meta.db_table, low_bound=10**9, version=0
+    )
+    set_processing_state(User._meta.db_table, 10**9, 0)
+
+    with override_options(
+        {
+            **READ_FROM_POSTGRES_OPTIONS,
+            "outbox_replication.auth_user.replication_version": User.replication_version,
+        }
+    ):
+        batch = process_outbox_backfill_batch(User, batch_size=10)
+
+    assert batch is not None
+    assert batch.low < 10**9, "the version bump did not reset the bound"
+    assert batch.version == User.replication_version
+    assert ControlOutbox.objects.count() == 3
+
+
+@django_db_all
+@no_silo_test
+def test_a_failed_postgres_write_is_raised_once_postgres_is_read() -> None:
+    """Postgres is the source of truth now, so a lost write cannot be masked."""
+    reset_processing_state()
+    with outbox_context(flush=False):
+        Factories.create_user()
+
+    with (
+        override_options(
+            {
+                **READ_FROM_POSTGRES_OPTIONS,
+                "outbox_replication.auth_user.replication_version": User.replication_version,
+            }
+        ),
+        patch.object(
+            ControlOutboxBackfillWatermark.objects,
+            "update_or_create",
+            side_effect=RuntimeError("postgres is down"),
+        ),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+        pytest.raises(RuntimeError),
+    ):
+        process_outbox_backfill_batch(User, batch_size=10)
+
+    assert _counter_calls(metrics_mock, WATERMARK_DUAL_WRITE_ERROR_METRIC) == 1
+
+
+@django_db_all
+@no_silo_test
+def test_a_cutover_cycle_does_not_restart_a_table() -> None:
+    """Turning the read option on with an empty Postgres keeps the walk where it was."""
+    reset_processing_state()
+    table_name = AuthProvider._meta.db_table
+    set_processing_state(AuthProvider._meta.db_table, 4242, 3)
+
+    with override_options(READ_FROM_POSTGRES_OPTIONS):
+        # No budget at all, so only the report pass runs.
+        assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+        # The report pass created the row from the Redis pair, so the next read matches.
+        assert read_processing_state(AuthProvider._meta.db_table) == (4242, 3)
+
+    row = ControlOutboxBackfillWatermark.objects.get(table_name=table_name)
+    assert (row.low_bound, row.version) == (4242, 3)
+
+
+@django_db_all
+@no_silo_test
+def test_a_rollback_finds_the_pair_the_cycle_left() -> None:
+    """Redis keeps being written, so turning the options off is an immediate rollback."""
+    reset_processing_state()
+    with outbox_context(flush=False):
+        for _ in range(5):
+            Factories.create_user()
+
+    with override_options(
+        {
+            **READ_FROM_POSTGRES_OPTIONS,
+            "outbox_replication.auth_user.replication_version": User.replication_version,
+        }
+    ):
+        # A budget of 2 against 5 users, so the loop advances auth_user and stops.
+        backfill_outboxes_for(SiloMode.CONTROL, 0, 2)
+
+    row = ControlOutboxBackfillWatermark.objects.get(table_name=User._meta.db_table)
+    assert row.low_bound > 0, "the batch did not advance the watermark"
+    # Options off: Redis holds the same pair Postgres does.
+    assert read_processing_state(User._meta.db_table) == (row.low_bound, row.version)
+
+
+@django_db_all
+@no_silo_test
+def test_read_option_on_leaves_the_redis_state_identical() -> None:
+    """The option must not change what a whole pass leaves in Redis."""
+    reset_processing_state()
+
+    set_processing_state(AuthProvider._meta.db_table, 4242, 3)
+    backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
+    without_options = read_processing_state(AuthProvider._meta.db_table)
+
+    reset_processing_state()
+    set_processing_state(AuthProvider._meta.db_table, 4242, 3)
+    with override_options(READ_FROM_POSTGRES_OPTIONS):
+        backfill_outboxes_for(SiloMode.CONTROL, 0, 1)
+
+    assert read_processing_state(AuthProvider._meta.db_table) == without_options
+
+
+@django_db_all
+@no_silo_test
+def test_a_failed_report_write_does_not_stop_the_walk() -> None:
+    """The report write raises now, so one bad table must not take the rest away."""
+    reset_processing_state()
+    broken_table = AuthProvider._meta.db_table
+    good_table = ApiToken._meta.db_table
+    set_processing_state(AuthProvider._meta.db_table, 41, 1)
+    set_processing_state(ApiToken._meta.db_table, 7, 1)
+
+    real_write = ControlOutboxBackfillWatermark.objects.update_or_create
+
+    def fail_for_one(**kwargs: Any) -> Any:
+        if kwargs["table_name"] == broken_table:
+            raise RuntimeError("postgres is down")
+        return real_write(**kwargs)
+
+    with (
+        override_options(READ_FROM_POSTGRES_OPTIONS),
+        patch.object(
+            ControlOutboxBackfillWatermark.objects, "update_or_create", side_effect=fail_for_one
+        ),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes.metrics") as metrics_mock,
+    ):
+        # No exception reaches the caller.
+        assert not backfill_outboxes_for(SiloMode.CONTROL, scheduled_count=10_000)
+
+    assert _counter_calls(metrics_mock, WATERMARK_DUAL_WRITE_ERROR_METRIC) == 1
+    assert _counter_calls(metrics_mock, WATERMARK_REPORT_ERROR_METRIC) == 1
+    # The walk carried on past the broken table.
+    assert ControlOutboxBackfillWatermark.objects.get(table_name=good_table).low_bound == 7
+    assert not ControlOutboxBackfillWatermark.objects.filter(table_name=broken_table).exists()

--- a/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
+++ b/tests/sentry/hybridcloud/tasks/test_backfill_outboxes.py
@@ -855,19 +855,26 @@ def test_a_missing_postgres_row_falls_back_to_redis() -> None:
 
 @django_db_all
 @no_silo_test
-def test_a_lost_redis_key_is_reseeded_with_the_postgres_pair() -> None:
-    """A rollback must find the pair Postgres holds, not a default one."""
+def test_a_postgres_hit_does_not_touch_redis() -> None:
+    """Redis is off the read path once Postgres answers, so it is not repaired either."""
     reset_processing_state()
     finished_version = AuthProvider.replication_version + 1
     ControlOutboxBackfillWatermark.objects.create(
         table_name=AuthProvider._meta.db_table, low_bound=0, version=finished_version
     )
 
-    with override_options(READ_FROM_POSTGRES_OPTIONS):
+    with (
+        override_options(READ_FROM_POSTGRES_OPTIONS),
+        patch("sentry.hybridcloud.tasks.backfill_outboxes._read_redis_watermark") as redis_mock,
+    ):
         assert get_processing_state(AuthProvider._meta.db_table) == (0, finished_version)
 
-    # Options off: Redis holds the finished pair, so the table does not walk again.
-    assert read_processing_state(AuthProvider._meta.db_table) == (0, finished_version)
+    redis_mock.assert_not_called()
+
+    # The cost of that: a table whose Redis key is gone is not reseeded from Postgres, so
+    # a rollback while the key is missing walks it again. Only set_processing_state writes
+    # Redis, and a finished table never reaches it.
+    assert read_processing_state(AuthProvider._meta.db_table) is None
 
 
 @django_db_all


### PR DESCRIPTION
3 of 3 PRs moving the outbox backfill watermark out of Redis.

We're dual-writing into both Redis and Postgres, this PR adds Postgres as the read path behind an option. Flags allow us to rollback to Redis (which stays synced up) if necessary.

Refs INFRENG-582