### PR TITLE
fix(inbox): avoid separating old PRs when there are no new ones to show

### DIFF
--- a/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.spec.tsx
@@ -207,7 +207,9 @@ describe('LinkedPullRequests', () => {
       screen.queryByRole('link', {name: /Pull request #122/})
     ).not.toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', {name: 'Show other PRs'}));
+    await userEvent.click(
+      screen.getByRole('button', {name: 'PRs before last regression'})
+    );
 
     const historicalPullRequests = screen.getByRole('list', {
       name: 'Other linked pull requests',
@@ -215,7 +217,40 @@ describe('LinkedPullRequests', () => {
     expect(
       within(historicalPullRequests).getByRole('link', {name: /Pull request #122/})
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', {name: 'Hide other PRs'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'PRs before last regression'})
+    ).toBeInTheDocument();
+  });
+
+  it('keeps completed pull requests visible when there are no active pull requests', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/issues/${group.id}/pull-requests/`,
+      body: {
+        latestRegressionAt: '2026-06-08T23:11:32.000000Z',
+        pullRequests: [
+          {
+            ...PullRequestFixture({id: '122', repository}),
+            attribution: null,
+            dateLinked: '2026-06-08T23:10:32.000000Z',
+            status: 'merged',
+          },
+        ],
+      },
+    });
+
+    render(<LinkedPullRequests collapseBeforeLatestRegression group={group} />, {
+      organization,
+    });
+
+    const pullRequests = await screen.findByRole('list', {
+      name: 'Linked pull requests',
+    });
+    expect(
+      within(pullRequests).getByRole('link', {name: /Pull request #122/})
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'PRs before last regression'})
+    ).not.toBeInTheDocument();
   });
 
   it('deduplicates pull request ids from group activity', () => {

--- a/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
+++ b/static/app/components/group/externalIssuesList/linkedPullRequests.tsx
@@ -416,22 +416,31 @@ export function LinkedPullRequests({
   const {currentPullRequests, historicalPullRequests} = collapseBeforeLatestRegression
     ? partitionLinkedPullRequests(data.pullRequests, data.latestRegressionAt)
     : {currentPullRequests: data.pullRequests, historicalPullRequests: []};
+  const shouldCollapseHistoricalPullRequests = currentPullRequests.some(
+    pullRequest => pullRequest.status === 'open' || pullRequest.status === 'draft'
+  );
+  const visiblePullRequests = shouldCollapseHistoricalPullRequests
+    ? currentPullRequests
+    : data.pullRequests;
+  const collapsedPullRequests = shouldCollapseHistoricalPullRequests
+    ? historicalPullRequests
+    : [];
 
   return (
     <Stack gap="sm" width="100%">
-      {currentPullRequests.length > 0 && (
+      {visiblePullRequests.length > 0 && (
         <PullRequestList
           ariaLabel={t('Linked pull requests')}
           group={group}
-          pullRequests={currentPullRequests}
+          pullRequests={visiblePullRequests}
           variant={variant}
         />
       )}
-      {historicalPullRequests.length > 0 && (
+      {collapsedPullRequests.length > 0 && (
         <HistoricalPullRequests
           key={group.id}
           group={group}
-          pullRequests={historicalPullRequests}
+          pullRequests={collapsedPullRequests}
           variant={variant}
         />
       )}
@@ -491,9 +500,7 @@ function HistoricalPullRequests({
 
   return (
     <Disclosure size="sm" expanded={expanded} onExpandedChange={setExpanded}>
-      <Disclosure.Title>
-        {expanded ? t('Hide other PRs') : t('Show other PRs')}
-      </Disclosure.Title>
+      <Disclosure.Title>{t('PRs before last regression')}</Disclosure.Title>
       <Disclosure.Content>
         <PullRequestList
           ariaLabel={t('Other linked pull requests')}


### PR DESCRIPTION
We are collapsing old PRs under a separate section so that they don't get mixed up with newer, open PRs. However, it looks a bit strange to do this when there are no new PRs to display.

This change shows the simple list of PRs when that is the case.

While making this change, I also changed to the label to be more descriptive: `Show other PRs` -> `PRs before latest regression`

Before:

<img width="1402" height="210" alt="CleanShot 2026-09-09 at 12 00 24@2x" src="https://github.com/user-attachments/assets/817c0806-fbef-4347-b718-ebdab6526507" />

After:

<img width="1510" height="302" alt="CleanShot 2026-09-09 at 11 59 46@2x" src="https://github.com/user-attachments/assets/3f4460f6-ecf0-4780-a875-8c2f9e4b03de" />