### PR TITLE
ref(seer): Gate the autofix embeds on the Seer plan, not the rollout flag

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -549,7 +549,7 @@
         }
       }
     ],
-    "featureFlag": "organizations:seer-agent-autofix"
+    "featureFlag": ["organizations:seat-based-seer-enabled", "organizations:seer-added"]
   },
   {
     "name": "alert",
@@ -1609,6 +1609,6 @@
         }
       }
     ],
-    "featureFlag": "organizations:seer-agent-autofix"
+    "featureFlag": ["organizations:seat-based-seer-enabled", "organizations:seer-added"]
   }
 ]

--- a/src/sentry/seer/agent/embed_widgets.py
+++ b/src/sentry/seer/agent/embed_widgets.py
@@ -15,9 +15,11 @@ _WIDGETS: list[dict[str, Any]] = json.loads(
 def get_embed_widgets(organization: Any = None, actor: Any = None) -> list[dict[str, Any]]:
     """Return embed widget definitions, filtered by per-widget feature flags.
 
-    Each widget entry may include a ``featureFlag`` key (set in ``seerTags.ts``).
-    When present the widget is only included if the org has that flag enabled.
-    Widgets without ``featureFlag`` are always included.
+    Each widget entry may include a ``featureFlag`` key (set in ``schemas.ts``),
+    holding either one flag or a list of them. A list is satisfied by any one of
+    its flags, so an entitlement split across several plan flags matches on the
+    one flag the org's plan actually grants. Widgets without ``featureFlag`` are
+    always included.
     """
     has_flags = any("featureFlag" in w for w in _WIDGETS)
     if not has_flags:
@@ -25,9 +27,13 @@ def get_embed_widgets(organization: Any = None, actor: Any = None) -> list[dict[
 
     from sentry import features
 
-    return [
-        w
-        for w in _WIDGETS
-        if "featureFlag" not in w
-        or (organization is not None and features.has(w["featureFlag"], organization, actor=actor))
-    ]
+    def is_visible(widget: dict[str, Any]) -> bool:
+        flag = widget.get("featureFlag")
+        if flag is None:
+            return True
+        if organization is None:
+            return False
+        flags = [flag] if isinstance(flag, str) else flag
+        return any(features.has(f, organization, actor=actor) for f in flags)
+
+    return [w for w in _WIDGETS if is_visible(w)]

--- a/static/app/components/seer/markdown/__stories__/embedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/embedStory.tsx
@@ -101,7 +101,9 @@ export function EmbedStory({children, name}: EmbedStoryProps) {
     <Stack gap="md">
       <Text size="sm" variant="muted">
         Level: {schema.level.join(', ')}
-        {'featureFlag' in schema ? ` · Flag: ${schema.featureFlag}` : null}
+        {'featureFlag' in schema
+          ? ` · Flag: ${[schema.featureFlag].flat().join(' or ')}`
+          : null}
       </Text>
       <Text size="sm" variant="muted">
         {schema.description}

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -83,8 +83,23 @@ interface SeerEmbedSchema {
   level: SeerEmbedLevel[];
   schema: z.ZodObject;
   examples?: SeerEmbedExample[];
-  featureFlag?: string;
+  /**
+   * Org feature(s) the widget is offered behind. A list is satisfied by any one
+   * of its flags, which is what an entitlement spread over several plan flags
+   * needs — the org holds whichever one its plan grants, never all of them.
+   */
+  featureFlag?: string | string[];
 }
+
+/**
+ * Autofix is a Seer plan entitlement, and the two plan shapes grant it under
+ * different flags: seat-based plans and legacy usage-based ones. Matching the
+ * pair is the same test the frontend's `orgHasSeerAccess` makes.
+ */
+const SEER_PLAN_FEATURES = [
+  'organizations:seat-based-seer-enabled',
+  'organizations:seer-added',
+];
 
 export const SEER_EMBED_SCHEMAS = {
   timestamp: {
@@ -326,7 +341,7 @@ export const SEER_EMBED_SCHEMAS = {
     ],
   },
   autofix: {
-    featureFlag: 'organizations:seer-agent-autofix',
+    featureFlag: SEER_PLAN_FEATURES,
     description:
       'Render one step of a Seer Autofix run (root cause, solution, or code ' +
       'changes) as a collapsible block linking back to the issue. ' +
@@ -927,7 +942,7 @@ export const SEER_EMBED_SCHEMAS = {
     ],
   },
   autofixRef: {
-    featureFlag: 'organizations:seer-agent-autofix',
+    featureFlag: SEER_PLAN_FEATURES,
     description:
       'Render a live view of one Seer Autofix step (root cause, solution, code ' +
       'changes, or PR iteration) that fetches and updates itself in the browser. ' +
@@ -987,7 +1002,7 @@ export function seerEmbedsToJsonSchemas(): Array<{
   level: SeerEmbedLevel[];
   name: string;
   examples?: Array<{data: Record<string, unknown>; label: string}>;
-  featureFlag?: string;
+  featureFlag?: string | string[];
 }> {
   return Object.entries(SEER_EMBED_SCHEMAS).map(([name, entry]) => {
     const def: SeerEmbedSchema = entry;

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -101,7 +101,7 @@ interface SeerEmbedSchema {
  * different flags: seat-based plans and legacy usage-based ones. Matching the
  * pair is the same test the frontend's `orgHasSeerAccess` makes.
  */
-const SEER_PLAN_FEATURES = [
+const SEER_PLAN_AUTOFIX_FEATURES = [
   'organizations:seat-based-seer-enabled',
   'organizations:seer-added',
 ];
@@ -346,7 +346,7 @@ export const SEER_EMBED_SCHEMAS = {
     ],
   },
   autofix: {
-    featureFlag: SEER_PLAN_FEATURES,
+    featureFlag: SEER_PLAN_AUTOFIX_FEATURES,
     description:
       'Render one step of a Seer Autofix run (root cause, solution, or code ' +
       'changes) as a collapsible block linking back to the issue. ' +
@@ -947,7 +947,7 @@ export const SEER_EMBED_SCHEMAS = {
     ],
   },
   autofixRef: {
-    featureFlag: SEER_PLAN_FEATURES,
+    featureFlag: SEER_PLAN_AUTOFIX_FEATURES,
     description:
       'Render a live view of one Seer Autofix step (root cause, solution, code ' +
       'changes, or PR iteration) that fetches and updates itself in the browser. ' +

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -84,9 +84,14 @@ interface SeerEmbedSchema {
   schema: z.ZodObject;
   examples?: SeerEmbedExample[];
   /**
-   * Org feature(s) the widget is offered behind. A list is satisfied by any one
-   * of its flags, which is what an entitlement spread over several plan flags
-   * needs — the org holds whichever one its plan grants, never all of them.
+   * Org feature(s) the widget is offered behind. Gates generation only: it
+   * reaches Python through `embed_widgets.generated.json` and decides which
+   * widgets the agent is told it may emit. Rendering never reads it, so an
+   * embed already present in a conversation renders whether or not the org
+   * holds the flag.
+   *
+   * A list is satisfied by any one of its flags — an entitlement spread across
+   * several plan flags is granted by whichever one the org's plan carries.
    */
   featureFlag?: string | string[];
 }

--- a/tests/sentry/seer/agent/test_embed_widgets.py
+++ b/tests/sentry/seer/agent/test_embed_widgets.py
@@ -4,12 +4,21 @@ from sentry.seer.agent.embed_widgets import get_embed_widgets
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers import with_feature
 
+_FLAG = "organizations:seer-explorer-embeds"
+_OTHER_FLAG = "organizations:seer-added"
+
 _UNFLAGGED_WIDGET = {"name": "timestamp", "description": "A timestamp", "level": ["inline"]}
 _FLAGGED_WIDGET = {
-    "name": "autofix",
-    "description": "The result of an Autofix step/action.",
+    "name": "flagged",
+    "description": "A widget behind a feature flag.",
     "level": ["block"],
-    "featureFlag": "organizations:seer-agent-autofix",
+    "featureFlag": _FLAG,
+}
+_MULTI_FLAGGED_WIDGET = {
+    "name": "multi",
+    "description": "A widget behind either of two feature flags.",
+    "level": ["block"],
+    "featureFlag": [_FLAG, _OTHER_FLAG],
 }
 
 
@@ -33,7 +42,7 @@ class GetEmbedWidgetsTest(TestCase):
         names = {w["name"] for w in widgets}
         assert names == {"timestamp"}
 
-    @with_feature("organizations:seer-agent-autofix")
+    @with_feature(_FLAG)
     def test_flagged_widget_included_with_flag(self):
         with patch(
             "sentry.seer.agent.embed_widgets._WIDGETS",
@@ -42,9 +51,9 @@ class GetEmbedWidgetsTest(TestCase):
             widgets = get_embed_widgets(self.organization, self.user)
 
         names = {w["name"] for w in widgets}
-        assert names == {"timestamp", "autofix"}
+        assert names == {"timestamp", "flagged"}
 
-    @with_feature("organizations:seer-agent-autofix")
+    @with_feature(_FLAG)
     def test_flagged_widget_excluded_without_organization(self):
         # A widget's flag can't be evaluated without an org, so it is dropped even
         # when the flag would otherwise be enabled.
@@ -56,3 +65,26 @@ class GetEmbedWidgetsTest(TestCase):
 
         names = {w["name"] for w in widgets}
         assert names == {"timestamp"}
+
+    def test_multi_flagged_widget_excluded_without_any_flag(self):
+        with patch(
+            "sentry.seer.agent.embed_widgets._WIDGETS",
+            [_UNFLAGGED_WIDGET, _MULTI_FLAGGED_WIDGET],
+        ):
+            widgets = get_embed_widgets(self.organization, self.user)
+
+        names = {w["name"] for w in widgets}
+        assert names == {"timestamp"}
+
+    @with_feature(_OTHER_FLAG)
+    def test_multi_flagged_widget_included_with_one_flag(self):
+        # Any one flag in the list is enough: an org holds whichever flag its
+        # plan grants, never the whole list.
+        with patch(
+            "sentry.seer.agent.embed_widgets._WIDGETS",
+            [_UNFLAGGED_WIDGET, _MULTI_FLAGGED_WIDGET],
+        ):
+            widgets = get_embed_widgets(self.organization, self.user)
+
+        names = {w["name"] for w in widgets}
+        assert names == {"timestamp", "multi"}


### PR DESCRIPTION
The `autofix` and `autofixRef` embed widgets were offered behind
`organizations:seer-agent-autofix`. That flag is a rollout control that never
left the dev cohort — in the options automator it carries a single segment,
`user_email in *_reasoning_platform_dev`. It does not track who pays for Seer,
so an org on a Seer plan sees no autofix card while a dev on no Seer plan does.

Autofix is a plan entitlement, so the widgets now match the plan instead. Both
autofix embeds are gated on the same pair the frontend's `orgHasSeerAccess`
tests:

- `organizations:seat-based-seer-enabled` — seat-based Seer plans
- `organizations:seer-added` — legacy usage-based Seer plans

Both are already registered in sentry's `temporary.py` with `api_expose=True`,
so `features.has()` resolves them without new plumbing.

This is the sentry-side follow-up that getsentry/seer#8113 called out and
deliberately left alone: that PR moved the same gate on the seer side, from the
rollout flag to the subscription. **It should merge after #8113, not before** —
until seer stops refusing non-flagged orgs, widening the widget gate only
changes which half of the round trip refuses.

### Why `featureFlag` grew a list form

A widget's `featureFlag` now takes either one flag or a list, and a list is
satisfied by **any** entry. Seer access is two flags OR'd together because the
two plan shapes grant it differently, and an org holds whichever one its plan
grants — never both. Encoding that as a single string is not possible, so the
options were a list with any-of semantics or picking one flag and dropping
legacy usage-based orgs.

I widened the existing `featureFlag` rather than adding a second `featureFlags`
key: other widgets (`gen-ai-conversations`) still use the single-string form,
and two parallel gating keys would each need checking on the backend for no
gain. Existing entries are untouched.

### Flag removal order

Removing `organizations:seer-agent-autofix` takes three PRs, each deployed
before the next merges — a FlagPole flag auto-registers an option, so it travels
the `configoptions` path and inverting the order turns the automator red on
`main`:

1. **This PR** — collapse the reads. Afterwards `rg seer-agent-autofix src/ static/ tests/` finds only the registration.
2. getsentry/sentry-options-automator#9675 — drop the `feature.organizations:seer-agent-autofix` block from `options/default/flagpole.yaml`. Merges once this deploys to all regions.
3. #123952 — delete the `manager.add(...)` line from `temporary.py`, after step 2's automator run is green. Stacked on this branch, so retarget it to `master` when this merges.

Steps 2 and 3 are separate PRs on purpose, and merge in that order.

**Feature flags to test with:** `organizations:seat-based-seer-enabled` and
`organizations:seer-added` (either one should now surface the autofix embeds),
and `organizations:seer-agent-autofix` (an org on that flag alone must no longer
surface them).

No screenshots: this changes which widget definitions are sent to the agent, and
the widgets themselves render unchanged.

https://claude.ai/code/session_01W7fvTViw2SA8YyThqPp4cQ
