### PR TITLE
chore(workflow-engine): Create scheduled repair task for missing all projects detectors

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1041,14 +1041,6 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "workflow_engine:sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         "schedule": timedelta(seconds=15),
     },
-    "health-check-organization-detectors": {
-        "task": "workflow_engine:sentry.workflow_engine.tasks.health_check.health_check_organization_detectors",
-        "schedule": crontab("*/30", "*", "*", "*", "*"),
-    },
-    "health-check-project-detectors": {
-        "task": "workflow_engine:sentry.workflow_engine.tasks.health_check.health_check_project_detectors",
-        "schedule": crontab("*/30", "*", "*", "*", "*"),
-    },
     "resolve-stale-sourcemap-detectors": {
         "task": "workflow_engine:sentry.processing_errors.tasks.resolve_stale_sourcemap_detectors",
         "schedule": crontab("*/5", "*", "*", "*", "*"),

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1009,6 +1009,7 @@ TASKWORKER_IMPORTS: tuple[str, ...] = (
     "sentry.uptime.rdap.tasks",
     "sentry.uptime.subscriptions.tasks",
     "sentry.workflow_engine.tasks.delayed_workflows",
+    "sentry.workflow_engine.tasks.health_check",
     "sentry.workflow_engine.tasks.workflows",
     "sentry.workflow_engine.tasks.actions",
     "sentry.tasks.seer.explorer_index",
@@ -1039,6 +1040,14 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
     "flush-delayed-workflows": {
         "task": "workflow_engine:sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         "schedule": timedelta(seconds=15),
+    },
+    "health-check-organization-detectors": {
+        "task": "workflow_engine:sentry.workflow_engine.tasks.health_check.health_check_organization_detectors",
+        "schedule": crontab("*/30", "*", "*", "*", "*"),
+    },
+    "health-check-project-detectors": {
+        "task": "workflow_engine:sentry.workflow_engine.tasks.health_check.health_check_project_detectors",
+        "schedule": crontab("*/30", "*", "*", "*", "*"),
     },
     "resolve-stale-sourcemap-detectors": {
         "task": "workflow_engine:sentry.processing_errors.tasks.resolve_stale_sourcemap_detectors",

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3649,12 +3649,6 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 register(
-    "workflow_engine.tasks.health_check_project.enabled",
-    type=Bool,
-    default=False,
-    flags=FLAG_AUTOMATOR_MODIFIABLE,
-)
-register(
     "workflow_engine.tasks.health_check_organization.enabled",
     type=Bool,
     default=False,

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -3648,6 +3648,18 @@ register(
     default=False,
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
+register(
+    "workflow_engine.tasks.health_check_project.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+register(
+    "workflow_engine.tasks.health_check_organization.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 register(
     "workflow_engine.group.type_id.open_periods_type_denylist",

--- a/src/sentry/workflow_engine/tasks/__init__.py
+++ b/src/sentry/workflow_engine/tasks/__init__.py
@@ -1,8 +1,11 @@
 __all__ = [
+    "health_check_organization_detectors",
+    "health_check_project_detectors",
     "process_delayed_workflows",
     "process_workflow_activity",
     "process_workflows_event",
 ]
 
 from .delayed_workflows import process_delayed_workflows
+from .health_check import health_check_organization_detectors, health_check_project_detectors
 from .workflows import process_workflow_activity, process_workflows_event

--- a/src/sentry/workflow_engine/tasks/__init__.py
+++ b/src/sentry/workflow_engine/tasks/__init__.py
@@ -1,11 +1,10 @@
 __all__ = [
     "health_check_organization_detectors",
-    "health_check_project_detectors",
     "process_delayed_workflows",
     "process_workflow_activity",
     "process_workflows_event",
 ]
 
 from .delayed_workflows import process_delayed_workflows
-from .health_check import health_check_organization_detectors, health_check_project_detectors
+from .health_check import health_check_organization_detectors
 from .workflows import process_workflow_activity, process_workflows_event

--- a/src/sentry/workflow_engine/tasks/health_check.py
+++ b/src/sentry/workflow_engine/tasks/health_check.py
@@ -58,10 +58,17 @@ def health_check_organization_detectors() -> None:
     silo_mode=SiloMode.CELL,
 )
 def ensure_default_detectors_for_organization(organization_id: int) -> None:
-    from sentry.workflow_engine.defaults.detectors import ensure_default_organization_detectors
+    from sentry.workflow_engine.defaults.detectors import (
+        UnableToAcquireLockApiError,
+        ensure_default_organization_detectors,
+    )
 
     organization = Organization.objects.get_or_none(
         id=organization_id, status=OrganizationStatus.ACTIVE
     )
-    if organization:
+    if not organization:
+        return
+    try:
         ensure_default_organization_detectors(organization)
+    except UnableToAcquireLockApiError:
+        return

--- a/src/sentry/workflow_engine/tasks/health_check.py
+++ b/src/sentry/workflow_engine/tasks/health_check.py
@@ -3,8 +3,7 @@ import logging
 from django.db.models import Exists, Func, JSONField, OuterRef
 
 from sentry import options
-from sentry.constants import ObjectStatus
-from sentry.models.organization import Organization
+from sentry.models.organization import Organization, OrganizationStatus
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import workflow_engine_tasks
@@ -35,7 +34,8 @@ def health_check_organization_detectors() -> None:
         config__organization_id=Func(OuterRef("id"), function="to_jsonb", output_field=JSONField()),
     )
     organization_ids = (
-        Organization.objects.annotate(has_all_projects_detector=Exists(all_projects_detector))
+        Organization.objects.filter(status=OrganizationStatus.ACTIVE)
+        .annotate(has_all_projects_detector=Exists(all_projects_detector))
         .filter(has_all_projects_detector=False)
         .values_list("id", flat=True)[:HEALTH_CHECK_BUFFER_SIZE]
     )
@@ -60,6 +60,8 @@ def health_check_organization_detectors() -> None:
 def ensure_default_detectors_for_organization(organization_id: int) -> None:
     from sentry.workflow_engine.defaults.detectors import ensure_default_organization_detectors
 
-    organization = Organization.objects.get_or_none(id=organization_id, status=ObjectStatus.ACTIVE)
+    organization = Organization.objects.get_or_none(
+        id=organization_id, status=OrganizationStatus.ACTIVE
+    )
     if organization:
         ensure_default_organization_detectors(organization)

--- a/src/sentry/workflow_engine/tasks/health_check.py
+++ b/src/sentry/workflow_engine/tasks/health_check.py
@@ -112,8 +112,9 @@ def health_check_project_detectors() -> None:
 def ensure_default_detectors_for_org(organization_id: int) -> None:
     from sentry.workflow_engine.defaults.detectors import ensure_default_organization_detectors
 
-    organization = Organization.objects.get(id=organization_id, status=ObjectStatus.ACTIVE)
-    ensure_default_organization_detectors(organization)
+    organization = Organization.objects.get_or_none(id=organization_id, status=ObjectStatus.ACTIVE)
+    if organization:
+        ensure_default_organization_detectors(organization)
 
 
 @instrumented_task(
@@ -125,5 +126,6 @@ def ensure_default_detectors_for_org(organization_id: int) -> None:
 def ensure_default_detectors_for_project(project_id: int) -> None:
     from sentry.workflow_engine.defaults.detectors import ensure_default_detectors
 
-    project = Project.objects.get(id=project_id, status=ObjectStatus.ACTIVE)
-    ensure_default_detectors(project)
+    project = Project.objects.get_or_none(id=project_id, status=ObjectStatus.ACTIVE)
+    if project:
+        ensure_default_detectors(project)

--- a/src/sentry/workflow_engine/tasks/health_check.py
+++ b/src/sentry/workflow_engine/tasks/health_check.py
@@ -1,0 +1,129 @@
+import logging
+
+from django.db.models import Count, Exists, Func, JSONField, OuterRef, Q, QuerySet
+
+from sentry import options
+from sentry.constants import ObjectStatus
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+from sentry.silo.base import SiloMode
+from sentry.tasks.base import instrumented_task
+from sentry.taskworker.namespaces import workflow_engine_tasks
+
+logger = logging.getLogger(__name__)
+
+HEALTH_CHECK_BUFFER_SIZE = 1000
+# Performance detectors are intentionally excluded because their expected presence depends on a
+# project-scoped feature flag. These are the only detector types expected for every active project.
+SYSTEM_DETECTOR_TYPES = ("error", "issue_stream")
+NUM_EXPECTED_CORE_DETECTORS = len(SYSTEM_DETECTOR_TYPES)
+
+
+def _organizations_missing_all_projects_detector() -> QuerySet[Organization]:
+    from sentry.workflow_engine.models import Detector
+
+    all_projects_detector = Detector.objects.filter(
+        type="issue_stream",
+        project__isnull=True,
+        config__organization_id=Func(OuterRef("id"), function="to_jsonb", output_field=JSONField()),
+    )
+    return Organization.objects.annotate(
+        has_all_projects_detector=Exists(all_projects_detector)
+    ).filter(has_all_projects_detector=False)
+
+
+@instrumented_task(
+    name="sentry.workflow_engine.tasks.health_check.health_check_organization_detectors",
+    namespace=workflow_engine_tasks,
+    processing_deadline_duration=60 * 5,
+    silo_mode=SiloMode.CELL,
+)
+def health_check_organization_detectors() -> None:
+    from sentry.workflow_engine.models import Detector
+
+    if not options.get("workflow_engine.tasks.health_check_organization.enabled"):
+        return
+
+    if not options.get("workflow_engine.auto_creation.all_projects_detector"):
+        return
+
+    all_projects_detector = Detector.objects.filter(
+        type="issue_stream",
+        project__isnull=True,
+        config__organization_id=Func(OuterRef("id"), function="to_jsonb", output_field=JSONField()),
+    )
+    organization_ids = (
+        Organization.objects.annotate(has_all_projects_detector=Exists(all_projects_detector))
+        .filter(has_all_projects_detector=False)
+        .values_list("id", flat=True)[:HEALTH_CHECK_BUFFER_SIZE]
+    )
+
+    org_count = 0
+    for organization_id in organization_ids:
+        ensure_default_detectors_for_org.delay(organization_id=organization_id)
+        org_count += 1
+
+    logger.info(
+        "workflow_engine.tasks.health_check_organization_detectors.dispatched",
+        extra={"org_count": org_count},
+    )
+
+
+@instrumented_task(
+    name="sentry.workflow_engine.tasks.health_check.health_check_project_detectors",
+    namespace=workflow_engine_tasks,
+    processing_deadline_duration=60 * 5,
+    silo_mode=SiloMode.CELL,
+)
+def health_check_project_detectors() -> None:
+    if not options.get("workflow_engine.tasks.health_check_project.enabled"):
+        return
+
+    project_ids = (
+        Project.objects.filter(status=ObjectStatus.ACTIVE)
+        .annotate(
+            num_system_detectors=Count(
+                "detector__type",
+                distinct=True,
+                filter=Q(detector__type__in=SYSTEM_DETECTOR_TYPES),
+            )
+        )
+        .filter(num_system_detectors__lt=NUM_EXPECTED_CORE_DETECTORS)
+        .values_list("id", flat=True)[:HEALTH_CHECK_BUFFER_SIZE]
+    )
+
+    project_count = 0
+    for project_id in project_ids:
+        ensure_default_detectors_for_project.delay(project_id=project_id)
+        project_count += 1
+
+    logger.info(
+        "workflow_engine.tasks.health_check_project_detectors.dispatched",
+        extra={"project_count": project_count},
+    )
+
+
+@instrumented_task(
+    name="sentry.workflow_engine.tasks.health_check.ensure_default_detectors_for_org",
+    namespace=workflow_engine_tasks,
+    processing_deadline_duration=60,
+    silo_mode=SiloMode.CELL,
+)
+def ensure_default_detectors_for_org(organization_id: int) -> None:
+    from sentry.workflow_engine.defaults.detectors import ensure_default_organization_detectors
+
+    organization = Organization.objects.get(id=organization_id, status=ObjectStatus.ACTIVE)
+    ensure_default_organization_detectors(organization)
+
+
+@instrumented_task(
+    name="sentry.workflow_engine.tasks.health_check.ensure_default_detectors_for_project",
+    namespace=workflow_engine_tasks,
+    processing_deadline_duration=60,
+    silo_mode=SiloMode.CELL,
+)
+def ensure_default_detectors_for_project(project_id: int) -> None:
+    from sentry.workflow_engine.defaults.detectors import ensure_default_detectors
+
+    project = Project.objects.get(id=project_id, status=ObjectStatus.ACTIVE)
+    ensure_default_detectors(project)

--- a/src/sentry/workflow_engine/tasks/health_check.py
+++ b/src/sentry/workflow_engine/tasks/health_check.py
@@ -1,11 +1,10 @@
 import logging
 
-from django.db.models import Count, Exists, Func, JSONField, OuterRef, Q, QuerySet
+from django.db.models import Exists, Func, JSONField, OuterRef
 
 from sentry import options
 from sentry.constants import ObjectStatus
 from sentry.models.organization import Organization
-from sentry.models.project import Project
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
 from sentry.taskworker.namespaces import workflow_engine_tasks
@@ -13,23 +12,6 @@ from sentry.taskworker.namespaces import workflow_engine_tasks
 logger = logging.getLogger(__name__)
 
 HEALTH_CHECK_BUFFER_SIZE = 1000
-# Performance detectors are intentionally excluded because their expected presence depends on a
-# project-scoped feature flag. These are the only detector types expected for every active project.
-SYSTEM_DETECTOR_TYPES = ("error", "issue_stream")
-NUM_EXPECTED_CORE_DETECTORS = len(SYSTEM_DETECTOR_TYPES)
-
-
-def _organizations_missing_all_projects_detector() -> QuerySet[Organization]:
-    from sentry.workflow_engine.models import Detector
-
-    all_projects_detector = Detector.objects.filter(
-        type="issue_stream",
-        project__isnull=True,
-        config__organization_id=Func(OuterRef("id"), function="to_jsonb", output_field=JSONField()),
-    )
-    return Organization.objects.annotate(
-        has_all_projects_detector=Exists(all_projects_detector)
-    ).filter(has_all_projects_detector=False)
 
 
 @instrumented_task(
@@ -60,7 +42,7 @@ def health_check_organization_detectors() -> None:
 
     org_count = 0
     for organization_id in organization_ids:
-        ensure_default_detectors_for_org.delay(organization_id=organization_id)
+        ensure_default_detectors_for_organization.delay(organization_id=organization_id)
         org_count += 1
 
     logger.info(
@@ -70,62 +52,14 @@ def health_check_organization_detectors() -> None:
 
 
 @instrumented_task(
-    name="sentry.workflow_engine.tasks.health_check.health_check_project_detectors",
-    namespace=workflow_engine_tasks,
-    processing_deadline_duration=60 * 5,
-    silo_mode=SiloMode.CELL,
-)
-def health_check_project_detectors() -> None:
-    if not options.get("workflow_engine.tasks.health_check_project.enabled"):
-        return
-
-    project_ids = (
-        Project.objects.filter(status=ObjectStatus.ACTIVE)
-        .annotate(
-            num_system_detectors=Count(
-                "detector__type",
-                distinct=True,
-                filter=Q(detector__type__in=SYSTEM_DETECTOR_TYPES),
-            )
-        )
-        .filter(num_system_detectors__lt=NUM_EXPECTED_CORE_DETECTORS)
-        .values_list("id", flat=True)[:HEALTH_CHECK_BUFFER_SIZE]
-    )
-
-    project_count = 0
-    for project_id in project_ids:
-        ensure_default_detectors_for_project.delay(project_id=project_id)
-        project_count += 1
-
-    logger.info(
-        "workflow_engine.tasks.health_check_project_detectors.dispatched",
-        extra={"project_count": project_count},
-    )
-
-
-@instrumented_task(
-    name="sentry.workflow_engine.tasks.health_check.ensure_default_detectors_for_org",
+    name="sentry.workflow_engine.tasks.health_check.ensure_default_detectors_for_organization",
     namespace=workflow_engine_tasks,
     processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
 )
-def ensure_default_detectors_for_org(organization_id: int) -> None:
+def ensure_default_detectors_for_organization(organization_id: int) -> None:
     from sentry.workflow_engine.defaults.detectors import ensure_default_organization_detectors
 
     organization = Organization.objects.get_or_none(id=organization_id, status=ObjectStatus.ACTIVE)
     if organization:
         ensure_default_organization_detectors(organization)
-
-
-@instrumented_task(
-    name="sentry.workflow_engine.tasks.health_check.ensure_default_detectors_for_project",
-    namespace=workflow_engine_tasks,
-    processing_deadline_duration=60,
-    silo_mode=SiloMode.CELL,
-)
-def ensure_default_detectors_for_project(project_id: int) -> None:
-    from sentry.workflow_engine.defaults.detectors import ensure_default_detectors
-
-    project = Project.objects.get_or_none(id=project_id, status=ObjectStatus.ACTIVE)
-    if project:
-        ensure_default_detectors(project)

--- a/tests/sentry/workflow_engine/tasks/test_health_check.py
+++ b/tests/sentry/workflow_engine/tasks/test_health_check.py
@@ -1,0 +1,174 @@
+from unittest import mock
+
+from sentry.grouping.grouptype import ErrorGroupType
+from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
+from sentry.workflow_engine.models import Detector
+from sentry.workflow_engine.tasks.health_check import (
+    health_check_organization_detectors,
+    health_check_project_detectors,
+)
+from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
+
+
+class TestHealthCheckOrganizationDetectors(TestCase):
+    @override_options(
+        {
+            "workflow_engine.auto_creation.all_projects_detector": True,
+            "workflow_engine.tasks.health_check_organization.enabled": True,
+        }
+    )
+    def test_no_missing_detectors(self) -> None:
+        detector = self.create_all_projects_detector(self.organization)
+
+        with self.tasks():
+            health_check_organization_detectors()
+
+        assert Detector.objects.filter(
+            id=detector.id,
+            project__isnull=True,
+            config__organization_id=self.organization.id,
+        ).exists()
+        assert (
+            Detector.objects.filter(
+                project__isnull=True,
+                config__organization_id=self.organization.id,
+            ).count()
+            == 1
+        )
+
+    @override_options(
+        {
+            "workflow_engine.auto_creation.all_projects_detector": True,
+            "workflow_engine.tasks.health_check_organization.enabled": True,
+        }
+    )
+    def test_missing_org_detector(self) -> None:
+        assert not Detector.objects.filter(
+            project__isnull=True,
+            config__organization_id=self.organization.id,
+        ).exists()
+
+        with self.tasks():
+            health_check_organization_detectors()
+
+        assert Detector.objects.filter(
+            project__isnull=True,
+            config__organization_id=self.organization.id,
+        ).exists()
+
+    @override_options(
+        {
+            "workflow_engine.auto_creation.all_projects_detector": True,
+            "workflow_engine.tasks.health_check_organization.enabled": True,
+        }
+    )
+    def test_buffer_size_limit(self) -> None:
+        second_organization = self.create_organization()
+        third_organization = self.create_organization()
+        Detector.objects.filter(
+            project__isnull=True,
+            config__organization_id__in=(
+                self.organization.id,
+                second_organization.id,
+                third_organization.id,
+            ),
+        ).delete()
+
+        with (
+            mock.patch("sentry.workflow_engine.tasks.health_check.HEALTH_CHECK_BUFFER_SIZE", 2),
+            self.tasks(),
+        ):
+            health_check_organization_detectors()
+
+        assert (
+            Detector.objects.filter(
+                project__isnull=True,
+                config__organization_id__in=(
+                    self.organization.id,
+                    second_organization.id,
+                    third_organization.id,
+                ),
+            ).count()
+            == 2
+        )
+
+    @override_options({"workflow_engine.tasks.health_check_organization.enabled": True})
+    def test_all_projects_detector_option_disabled(self) -> None:
+        with self.tasks():
+            health_check_organization_detectors()
+
+        assert not Detector.objects.filter(
+            project__isnull=True,
+            config__organization_id=self.organization.id,
+        ).exists()
+
+    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
+    def test_health_check_disabled(self) -> None:
+        with self.tasks():
+            health_check_organization_detectors()
+
+        assert not Detector.objects.filter(
+            project__isnull=True,
+            config__organization_id=self.organization.id,
+        ).exists()
+
+
+class TestHealthCheckProjectDetectors(TestCase):
+    @override_options({"workflow_engine.tasks.health_check_project.enabled": True})
+    def test_no_missing_detectors(self) -> None:
+        with self.tasks():
+            health_check_project_detectors()
+
+        assert (
+            Detector.objects.filter(
+                project=self.project,
+                type__in=(ErrorGroupType.slug, IssueStreamGroupType.slug),
+            ).count()
+            == 2
+        )
+
+    @override_options({"workflow_engine.tasks.health_check_project.enabled": True})
+    def test_missing_project_detector(self) -> None:
+        Detector.objects.filter(project=self.project, type=ErrorGroupType.slug).delete()
+
+        with self.tasks():
+            health_check_project_detectors()
+
+        assert Detector.objects.filter(
+            project=self.project,
+            type=ErrorGroupType.slug,
+        ).exists()
+
+    @override_options({"workflow_engine.tasks.health_check_project.enabled": True})
+    def test_buffer_size_limit(self) -> None:
+        second_project = self.create_project(organization=self.organization)
+        third_project = self.create_project(organization=self.organization)
+        Detector.objects.filter(
+            project__in=(self.project, second_project, third_project), type=ErrorGroupType.slug
+        ).delete()
+
+        with (
+            mock.patch("sentry.workflow_engine.tasks.health_check.HEALTH_CHECK_BUFFER_SIZE", 2),
+            self.tasks(),
+        ):
+            health_check_project_detectors()
+
+        assert (
+            Detector.objects.filter(
+                project__in=(self.project, second_project, third_project),
+                type=ErrorGroupType.slug,
+            ).count()
+            == 2
+        )
+
+    def test_health_check_disabled(self) -> None:
+        Detector.objects.filter(project=self.project, type=ErrorGroupType.slug).delete()
+
+        with self.tasks():
+            health_check_project_detectors()
+
+        assert not Detector.objects.filter(
+            project=self.project,
+            type=ErrorGroupType.slug,
+        ).exists()

--- a/tests/sentry/workflow_engine/tasks/test_health_check.py
+++ b/tests/sentry/workflow_engine/tasks/test_health_check.py
@@ -1,24 +1,22 @@
 from unittest import mock
 
+from sentry.models.organization import OrganizationStatus
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.workflow_engine.models import Detector
-from sentry.workflow_engine.tasks.health_check import (
-    health_check_organization_detectors,
-)
+from sentry.workflow_engine.tasks.health_check import health_check_organization_detectors
+
+HEALTH_CHECK_OPTIONS = {
+    "workflow_engine.auto_creation.all_projects_detector": True,
+    "workflow_engine.tasks.health_check_organization.enabled": True,
+}
 
 
 class TestHealthCheckOrganizationDetectors(TestCase):
-    @override_options(
-        {
-            "workflow_engine.auto_creation.all_projects_detector": True,
-            "workflow_engine.tasks.health_check_organization.enabled": True,
-        }
-    )
     def test_no_missing_detectors(self) -> None:
         detector = self.create_all_projects_detector(self.organization)
 
-        with self.tasks():
+        with override_options(HEALTH_CHECK_OPTIONS), self.tasks():
             health_check_organization_detectors()
 
         assert Detector.objects.filter(
@@ -34,19 +32,13 @@ class TestHealthCheckOrganizationDetectors(TestCase):
             == 1
         )
 
-    @override_options(
-        {
-            "workflow_engine.auto_creation.all_projects_detector": True,
-            "workflow_engine.tasks.health_check_organization.enabled": True,
-        }
-    )
     def test_missing_org_detector(self) -> None:
         assert not Detector.objects.filter(
             project__isnull=True,
             config__organization_id=self.organization.id,
         ).exists()
 
-        with self.tasks():
+        with override_options(HEALTH_CHECK_OPTIONS), self.tasks():
             health_check_organization_detectors()
 
         assert Detector.objects.filter(
@@ -54,25 +46,16 @@ class TestHealthCheckOrganizationDetectors(TestCase):
             config__organization_id=self.organization.id,
         ).exists()
 
-    @override_options(
-        {
-            "workflow_engine.auto_creation.all_projects_detector": True,
-            "workflow_engine.tasks.health_check_organization.enabled": True,
-        }
-    )
     def test_buffer_size_limit(self) -> None:
-        second_organization = self.create_organization()
-        third_organization = self.create_organization()
-        Detector.objects.filter(
-            project__isnull=True,
-            config__organization_id__in=(
-                self.organization.id,
-                second_organization.id,
-                third_organization.id,
-            ),
-        ).delete()
+        organizations = [
+            self.organization,
+            self.create_organization(),
+            self.create_organization(),
+        ]
+        organization_ids = [organization.id for organization in organizations]
 
         with (
+            override_options(HEALTH_CHECK_OPTIONS),
             mock.patch("sentry.workflow_engine.tasks.health_check.HEALTH_CHECK_BUFFER_SIZE", 2),
             self.tasks(),
         ):
@@ -81,18 +64,16 @@ class TestHealthCheckOrganizationDetectors(TestCase):
         assert (
             Detector.objects.filter(
                 project__isnull=True,
-                config__organization_id__in=(
-                    self.organization.id,
-                    second_organization.id,
-                    third_organization.id,
-                ),
+                config__organization_id__in=organization_ids,
             ).count()
             == 2
         )
 
-    @override_options({"workflow_engine.tasks.health_check_organization.enabled": True})
     def test_all_projects_detector_option_disabled(self) -> None:
-        with self.tasks():
+        with (
+            override_options({"workflow_engine.tasks.health_check_organization.enabled": True}),
+            self.tasks(),
+        ):
             health_check_organization_detectors()
 
         assert not Detector.objects.filter(
@@ -100,9 +81,22 @@ class TestHealthCheckOrganizationDetectors(TestCase):
             config__organization_id=self.organization.id,
         ).exists()
 
-    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
     def test_health_check_disabled(self) -> None:
-        with self.tasks():
+        with (
+            override_options({"workflow_engine.auto_creation.all_projects_detector": True}),
+            self.tasks(),
+        ):
+            health_check_organization_detectors()
+
+        assert not Detector.objects.filter(
+            project__isnull=True,
+            config__organization_id=self.organization.id,
+        ).exists()
+
+    def test_inactive_organization_ignored(self) -> None:
+        self.organization.update(status=OrganizationStatus.PENDING_DELETION)
+
+        with override_options(HEALTH_CHECK_OPTIONS), self.tasks():
             health_check_organization_detectors()
 
         assert not Detector.objects.filter(

--- a/tests/sentry/workflow_engine/tasks/test_health_check.py
+++ b/tests/sentry/workflow_engine/tasks/test_health_check.py
@@ -1,14 +1,11 @@
 from unittest import mock
 
-from sentry.grouping.grouptype import ErrorGroupType
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
 from sentry.workflow_engine.models import Detector
 from sentry.workflow_engine.tasks.health_check import (
     health_check_organization_detectors,
-    health_check_project_detectors,
 )
-from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 
 class TestHealthCheckOrganizationDetectors(TestCase):
@@ -111,64 +108,4 @@ class TestHealthCheckOrganizationDetectors(TestCase):
         assert not Detector.objects.filter(
             project__isnull=True,
             config__organization_id=self.organization.id,
-        ).exists()
-
-
-class TestHealthCheckProjectDetectors(TestCase):
-    @override_options({"workflow_engine.tasks.health_check_project.enabled": True})
-    def test_no_missing_detectors(self) -> None:
-        with self.tasks():
-            health_check_project_detectors()
-
-        assert (
-            Detector.objects.filter(
-                project=self.project,
-                type__in=(ErrorGroupType.slug, IssueStreamGroupType.slug),
-            ).count()
-            == 2
-        )
-
-    @override_options({"workflow_engine.tasks.health_check_project.enabled": True})
-    def test_missing_project_detector(self) -> None:
-        Detector.objects.filter(project=self.project, type=ErrorGroupType.slug).delete()
-
-        with self.tasks():
-            health_check_project_detectors()
-
-        assert Detector.objects.filter(
-            project=self.project,
-            type=ErrorGroupType.slug,
-        ).exists()
-
-    @override_options({"workflow_engine.tasks.health_check_project.enabled": True})
-    def test_buffer_size_limit(self) -> None:
-        second_project = self.create_project(organization=self.organization)
-        third_project = self.create_project(organization=self.organization)
-        Detector.objects.filter(
-            project__in=(self.project, second_project, third_project), type=ErrorGroupType.slug
-        ).delete()
-
-        with (
-            mock.patch("sentry.workflow_engine.tasks.health_check.HEALTH_CHECK_BUFFER_SIZE", 2),
-            self.tasks(),
-        ):
-            health_check_project_detectors()
-
-        assert (
-            Detector.objects.filter(
-                project__in=(self.project, second_project, third_project),
-                type=ErrorGroupType.slug,
-            ).count()
-            == 2
-        )
-
-    def test_health_check_disabled(self) -> None:
-        Detector.objects.filter(project=self.project, type=ErrorGroupType.slug).delete()
-
-        with self.tasks():
-            health_check_project_detectors()
-
-        assert not Detector.objects.filter(
-            project=self.project,
-            type=ErrorGroupType.slug,
         ).exists()


### PR DESCRIPTION
Creates a task that will be scheduled to chip away at any organizations that don't receive all project detectors after they're created. 
