### PR TITLE
feat(preprod): Make missing-base snapshot copy actionable

### DIFF
--- a/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_templates.py
@@ -248,7 +248,8 @@ def format_missing_base_snapshot_pr_comment(
 ) -> str:
     base_sha_markdown = format_commit_sha_markdown(base_sha, repo_url=base_repo_url)
     message = (
-        f"No base snapshot found for {base_sha_markdown}. "
-        "Make sure snapshots are uploaded from your main branch."
+        f"Base commit {base_sha_markdown} did not produce snapshots to compare against. "
+        "Did its snapshot job fail? "
+        "Try rebasing this branch on a commit with a successful snapshot job."
     )
     return _format_solo_comment(artifacts, snapshot_metrics_map, message, project=project)

--- a/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/templates.py
@@ -237,8 +237,9 @@ def format_missing_base_snapshot_status_check_messages(
     base_sha_markdown = format_commit_sha_markdown(base_sha, repo_url=base_repo_url)
     summary = _format_solo_snapshot_summary(artifacts, snapshot_metrics_map)
     summary += (
-        f"\n\nNo base snapshot found for {base_sha_markdown}. "
-        "Make sure snapshots are uploaded from your main branch."
+        f"\n\nBase commit {base_sha_markdown} did not produce snapshots to compare against. "
+        "Did its snapshot job fail? "
+        "Try rebasing this branch on a commit with a successful snapshot job."
     )
 
     settings_url = _get_settings_url(project)

--- a/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
+++ b/tests/sentry/preprod/vcs/pr_comments/test_snapshot_templates.py
@@ -599,10 +599,11 @@ class FormatSoloPrCommentTest(SnapshotPrCommentTestBase):
         assert "## Sentry Snapshot Testing" in result
         assert "2 uploaded" in result
         assert (
-            f"No base snapshot found for [`{base_sha}`]({base_repo_url}/commit/{base_sha})"
+            f"Base commit [`{base_sha}`]({base_repo_url}/commit/{base_sha}) did not produce snapshots"
             in result
         )
-        assert "main branch" in result
+        assert "Did its snapshot job fail?" in result
+        assert "Try rebasing this branch on a commit with a successful snapshot job." in result
         assert f"/settings/projects/{self.project.slug}/snapshots/" in result
 
     def test_missing_base_empty_artifacts_raises(self) -> None:

--- a/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
+++ b/tests/sentry/preprod/vcs/status_checks/snapshots/test_templates.py
@@ -969,9 +969,11 @@ class SnapshotMissingBaseFormattingTest(SnapshotStatusCheckTestBase):
         assert "24" in summary
         assert "✅ Uploaded" in summary
         assert (
-            f"No base snapshot found for [`{base_sha}`]({base_repo_url}/commit/{base_sha})"
+            f"Base commit [`{base_sha}`]({base_repo_url}/commit/{base_sha}) did not produce snapshots"
             in summary
         )
+        assert "Did its snapshot job fail?" in summary
+        assert "Try rebasing this branch on a commit with a successful snapshot job." in summary
 
     def test_missing_base_multiple_artifacts(self) -> None:
         artifacts = []
@@ -995,7 +997,7 @@ class SnapshotMissingBaseFormattingTest(SnapshotStatusCheckTestBase):
         assert subtitle == f"No base snapshot found for {base_sha}"
         for i in range(3):
             assert f"com.example.app{i}" in summary
-        assert f"No base snapshot found for `{base_sha}`" in summary
+        assert f"Base commit `{base_sha}` did not produce snapshots" in summary
 
     def test_missing_base_empty_artifacts_raises(self) -> None:
         with pytest.raises(ValueError, match="Cannot format messages for empty artifact list"):
@@ -1027,8 +1029,9 @@ class SnapshotMissingBaseFormattingTest(SnapshotStatusCheckTestBase):
             "| Name | Snapshots | Status |\n"
             "| :--- | :---: | :---: |\n"
             f"| [My App]({artifact_url})<br>`com.example.app` | 15 | ✅ Uploaded |"
-            f"\n\nNo base snapshot found for [`{base_sha}`]({base_repo_url}/commit/{base_sha}). "
-            "Make sure snapshots are uploaded from your main branch."
+            f"\n\nBase commit [`{base_sha}`]({base_repo_url}/commit/{base_sha}) did not produce "
+            "snapshots to compare against. Did its snapshot job fail? "
+            "Try rebasing this branch on a commit with a successful snapshot job."
             f"\n\n{configure_link}"
         )
         assert summary == expected


### PR DESCRIPTION
When a snapshot upload has no base to compare against, the GitHub check run and PR comment currently say "No base snapshot found for `<sha>`. Make sure snapshots are uploaded from your main branch." That tells the user what happened but not why the base might be missing or how to get unblocked, and a customer asked for something more actionable.

This rewords both surfaces to point at the linked base commit, ask whether its snapshot job failed, and suggest rebasing onto a commit with a successful snapshot job. The message is phrased as a question on purpose: the only signal we have is that no snapshot artifact arrived for the base SHA within the grace period, not that a job actually failed. The check-run subtitle is unchanged since it is plain text and already short.

A matching frontend banner is in a separate stacked PR since frontend and backend deploy independently.
