### PR TITLE
feat(preprod): Show actionable alert when no base snapshot build exists

### DIFF
--- a/static/app/components/preprod/snapshotStatusBadge.tsx
+++ b/static/app/components/preprod/snapshotStatusBadge.tsx
@@ -35,7 +35,11 @@ export function SnapshotStatusBadge({
   }
   if (comparisonState === 'no_base_build') {
     return (
-      <Tooltip title={t('No base snapshot was found for comparison.')}>
+      <Tooltip
+        title={t(
+          'The base commit did not produce snapshots to compare against. Did its snapshot job fail? Try rebasing this branch on a commit with a successful snapshot job.'
+        )}
+      >
         <Tag variant="danger">{t('No base build')}</Tag>
       </Tooltip>
     );


### PR DESCRIPTION
Stacked on #123943.

When a snapshot upload's base commit never produced snapshots, the snapshot page only shows a "No base build" tag whose tooltip says no base snapshot was found. There is no visible message in the page body, no link to the missing commit, and no hint about how to recover. A customer asked for actionable copy here.

This adds a warning banner above the snapshot view whenever `comparison_state` is `no_base_build`. It links to the base commit using the existing `getShaUrl` helper, asks whether that commit's snapshot job failed, and suggests rebasing onto a commit with a successful snapshot job. When no commit URL can be built the short SHA is shown as plain monospace text. The badge tooltip is updated to the same wording. No new API data is needed since `vcs_info` already carries the base SHA, repo and provider.

The wording stays a question because the backend only knows that no base artifact arrived, not that a job failed. The GitHub check run and PR comment get the same copy in #123943.
