### PR TITLE
chore(oxlint): Promote react/purity to error

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -641,7 +641,7 @@ const config = defineConfig({
     'react/memo-dependencies': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/no-deriving-state-in-effects': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/preserve-manual-memoization': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
-    'react/purity': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
+    'react/purity': 'error',
     'react/refs': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/require-render-return': 'error',
     'react/rule-suppression': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.

--- a/static/app/views/dashboards/utils/widgetQueryQueue.tsx
+++ b/static/app/views/dashboards/utils/widgetQueryQueue.tsx
@@ -59,6 +59,7 @@ export function WidgetQueryQueueProvider({children}: {children: React.ReactNode}
         onSettled: (_item: QueueItem, queuer) => {
           const queueIsEmpty = queuer.peekAllItems().length === 0;
           if (queueIsEmpty && startTimeRef.current) {
+            // oxlint-disable-next-line react/purity
             const endTime = performance.now();
             const totalTime = endTime - startTimeRef.current;
             startTimeRef.current = undefined;

--- a/static/app/views/explore/replays/detail/ai/useReplaySummary.tsx
+++ b/static/app/views/explore/replays/detail/ai/useReplaySummary.tsx
@@ -189,6 +189,7 @@ export function useReplaySummary(
           replayRecord?.id ?? ''
         ),
       });
+      // oxlint-disable-next-line react/purity
       startSummaryRequestTime.current = Date.now();
     },
   });

--- a/static/gsApp/components/upgradeNowModal/planTable.tsx
+++ b/static/gsApp/components/upgradeNowModal/planTable.tsx
@@ -34,6 +34,7 @@ export function PlanTable({
 
   const {billedAmount, creditApplied, effectiveAt} = previewData;
 
+  // oxlint-disable-next-line react/purity
   const effectiveNow = new Date(effectiveAt).getTime() <= Date.now() + 3600;
 
   return (


### PR DESCRIPTION
`react/purity` has been sitting at `'off'` behind a `TODO(ryan953)` for a while. While it is off, nothing stops new violations from landing, and the backlog quietly grows. This flips it to `'error'` so the rule actually holds the line going forward.

## How

Two things:

1. `'react/purity': 'off'` → `'error'` in `oxlint.config.ts`, and the now-stale TODO comment goes away.
2. Every pre-existing violation gets an inline `// oxlint-disable-next-line react/purity`.

That is 3 diagnostics across 3 files, all of them a clock read during render — `performance.now()`, `Date.now()`. Those are real: a value that changes on every render is exactly what the rule is built to catch. Fixing them is a behaviour change that belongs in its own PR with its own review. The suppressions are a backlog marker, not an endorsement.

## Why not fix the violations instead

For a rule this small (3 sites) fixing them inline was tempting. It was not done because the value here is the ratchet, not the cleanup: the two are separable, and mixing a config change with behaviour changes makes the behaviour changes harder to review and harder to revert on their own. The same shape is used across the sibling `react/*` promotion PRs so they stay uniform and independently revertable.

## Verification

`react/*` compiler diagnostics in oxlint are not always stable run-to-run, so the site list is the union of three full `oxlint` runs rather than one, and the result was confirmed with three consecutive clean runs plus `oxfmt --check`.

Comment placement is chosen by re-parsing each file with the TypeScript parser, using the script kind that matches the extension. Two silent failure modes make this worth doing properly rather than by regex: in JSX children position a `//` line is valid JSX *text* and would render to the user, and `{/* ... */}` at statement position is a valid empty block rather than a syntax error, so neither mistake announces itself. All three sites here are ordinary statement positions and get `//`.

## Feature flags

None. This is lint configuration only, with no runtime behaviour change.

## Related

One PR per rule, each independent and cut from `master`. They touch overlapping files, so expect textual conflicts on merge, but no ordering requirement:

- `react/purity` (this one)
- `react/refs`
- `react/rule-suppression` — #123951
- `react/set-state-in-effect`
- `react/static-components` — #123940

https://claude.ai/code/session_01L1JrizpenEtzEq8E6ztA4P
