### PR TITLE
fix(dashboards): Don't fetch releases until page filters settle

### DIFF
--- a/static/app/views/dashboards/widgetCard/visualizationWidget.spec.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.spec.tsx
@@ -1,7 +1,7 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {DisplayType, WidgetType} from 'sentry/views/dashboards/types';
@@ -56,9 +56,11 @@ const tableResults = [
   },
 ];
 
+let releaseStatsRequest: jest.Mock;
+
 beforeEach(() => {
   jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture());
-  MockApiClient.addMockResponse({
+  releaseStatsRequest = MockApiClient.addMockResponse({
     url: '/organizations/org-slug/releases/stats/',
     body: [],
   });
@@ -92,5 +94,25 @@ describe('VisualizationWidget breakdown series labels', () => {
     });
 
     expect(screen.getByRole('link', {name: 'my_transaction'})).toBeInTheDocument();
+  });
+});
+
+describe('VisualizationWidget release stats', () => {
+  // Fetching releases walks every page of `/releases/stats/` serially, and each
+  // intermediate `selection` re-keys the query and restarts that walk, so an
+  // unsettled page filter state multiplies the request count.
+  it('does not fetch releases while page filters are unsettled', async () => {
+    jest.mocked(usePageFilters).mockReturnValue(PageFilterStateFixture({isReady: false}));
+
+    render(<VisualizationWidget widget={spansBreakdownWidget} selection={selection} />);
+
+    expect(await screen.findByText('my_transaction')).toBeInTheDocument();
+    expect(releaseStatsRequest).not.toHaveBeenCalled();
+  });
+
+  it('fetches releases once page filters are ready', async () => {
+    render(<VisualizationWidget widget={spansBreakdownWidget} selection={selection} />);
+
+    await waitFor(() => expect(releaseStatsRequest).toHaveBeenCalled());
   });
 });

--- a/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
+++ b/static/app/views/dashboards/widgetCard/visualizationWidget.tsx
@@ -111,7 +111,15 @@ export function VisualizationWidget({
       }
     : undefined;
 
-  const {releases: releasesWithDate} = useReleaseStats(selection);
+  // `useReleaseStats` walks every page of `/releases/stats/` one request at a
+  // time, so each distinct selection costs up to ten serial round trips. Wait
+  // for page filters to settle before starting: until then `selection` is the
+  // store default and will be replaced, and every intermediate value re-keys
+  // the query and restarts the walk from scratch.
+  const {isReady: arePageFiltersReady} = usePageFilters();
+  const {releases: releasesWithDate} = useReleaseStats(selection, {
+    enabled: arePageFiltersReady,
+  });
 
   const releases =
     releasesWithDate?.map(({date, version}) => ({


### PR DESCRIPTION
### Why?

The Seer markdown story page fires ~33 serial requests to the organization release stats endpoint on load.

`VisualizationWidget` fetches release markers through `useReleaseStats`, which walks every page of that endpoint one request at a time. The query is keyed on the `selection` it receives, so each intermediate page filter value restarts the walk from scratch. On a route that renders widget cards before page filters have initialized, one ten-request walk becomes thirty-plus.

The dashboard embed is the surface that exposed this, but the waterfall belongs to the widget card, so the fix lives there.

### How?

Gate the release fetch on `usePageFilters().isReady`, matching how `useReleases` already guards the same class of request in dashboards. Routes that initialize page filters are unaffected — measured request counts are unchanged there, and drop to zero where filters never settle.

<sub>Generated with Claude Code</sub>

https://claude.ai/code/session_01UEzV6yQobinJpWZ354b4ZE