### PR TITLE
chore(oxlint): Remove TODO from react/rule-suppression

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -647,7 +647,7 @@ const config = defineConfig({
     'react/purity': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/refs': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/require-render-return': 'error',
-    'react/rule-suppression': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
+    'react/rule-suppression': 'off',
     'react/set-state-in-effect': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.
     'react/set-state-in-render': 'error',
     'react/static-components': 'off', // TODO(ryan953): Fix violations and promote this warning to an error.


### PR DESCRIPTION
We don't need to enable this one. No need for the TODO.