### PR TITLE
chore(oxlint): Report unused lint disable directives

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -223,7 +223,10 @@ const config = defineConfig({
   },
   options: {
     typeAware: enableTypeAwareLinting,
-    reportUnusedDisableDirectives: 'off',
+    // Only report unused directives when the full rule set runs. Without
+    // type-aware linting the type-aware rules never fire, so the suppressions
+    // that silence them look unused and `--fix` would delete live ones.
+    reportUnusedDisableDirectives: enableTypeAwareLinting ? 'error' : 'off',
   },
   env: {
     builtin: true,

--- a/static/app/chartcuterie/config.tsx
+++ b/static/app/chartcuterie/config.tsx
@@ -8,7 +8,6 @@
  * into the configuration file loaded by the service.
  */
 
-// eslint-disable-next-line no-restricted-imports -- @TODO(jonasbadalic): Remove theme import
 import {lightTheme} from 'sentry/utils/theme/theme';
 
 import {makeDashboardsWidgetCharts} from './dashboardsWidget';

--- a/static/app/components/charts/components/tooltip.tsx
+++ b/static/app/components/charts/components/tooltip.tsx
@@ -410,7 +410,6 @@ export function computeChartTooltip(
      */
     position(pos, _params, dom, _rec, size) {
       // Types seem to be broken on dom
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       dom = dom as HTMLDivElement;
       // Center the tooltip slightly above the cursor.
       const [tipWidth, tipHeight] = size.contentSize;

--- a/static/app/components/charts/useChartXRangeSelection.spec.tsx
+++ b/static/app/components/charts/useChartXRangeSelection.spec.tsx
@@ -579,7 +579,6 @@ describe('useChartXRangeSelection', () => {
           }),
         {
           initialProps: {
-            // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
             selection: initialSelection as typeof initialSelection | undefined,
           },
         }

--- a/static/app/components/core/alert/alert.snapshots.tsx
+++ b/static/app/components/core/alert/alert.snapshots.tsx
@@ -2,7 +2,6 @@ import {ThemeProvider} from '@emotion/react';
 
 import {Alert, type AlertProps} from '@sentry/scraps/alert';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const themes = {light: lightTheme, dark: darkTheme};

--- a/static/app/components/core/badge/badge.snapshots.tsx
+++ b/static/app/components/core/badge/badge.snapshots.tsx
@@ -2,7 +2,6 @@ import {ThemeProvider} from '@emotion/react';
 
 // eslint-disable-next-line @sentry/scraps/no-core-import -- SSR snapshot needs direct import to avoid barrel re-exports with heavy deps
 import {Badge, type BadgeProps} from 'sentry/components/core/badge/badge';
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const themes = {light: lightTheme, dark: darkTheme};

--- a/static/app/components/core/button/button.snapshots.tsx
+++ b/static/app/components/core/button/button.snapshots.tsx
@@ -3,7 +3,6 @@ import {ThemeProvider} from '@emotion/react';
 import {Button, type ButtonProps} from '@sentry/scraps/button';
 
 import {IconEdit} from 'sentry/icons';
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 import type {ButtonSize} from './types';

--- a/static/app/components/core/checkbox/checkbox.snapshots.tsx
+++ b/static/app/components/core/checkbox/checkbox.snapshots.tsx
@@ -2,7 +2,6 @@ import {ThemeProvider} from '@emotion/react';
 
 import {Checkbox, type CheckboxProps} from '@sentry/scraps/checkbox';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const themes = {light: lightTheme, dark: darkTheme};

--- a/static/app/components/core/chip/chip.snapshots.tsx
+++ b/static/app/components/core/chip/chip.snapshots.tsx
@@ -2,7 +2,6 @@ import {ThemeProvider} from '@emotion/react';
 
 import {Chip} from '@sentry/scraps/chip';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const themes = {light: lightTheme, dark: darkTheme};

--- a/static/app/components/core/code/codeBlock.tsx
+++ b/static/app/components/core/code/codeBlock.tsx
@@ -9,7 +9,6 @@ import {useTranslation} from '@sentry/scraps/translationContext';
 
 import {IconCopy} from 'sentry/icons';
 import {getPrismLanguage, loadPrismLanguage} from 'sentry/utils/prism';
-// eslint-disable-next-line no-restricted-imports
 import {darkTheme} from 'sentry/utils/theme/theme';
 
 interface CodeBlockProps {

--- a/static/app/components/core/input/inputGroup.snapshots.tsx
+++ b/static/app/components/core/input/inputGroup.snapshots.tsx
@@ -4,7 +4,6 @@ import {InputGroup} from '@sentry/scraps/input';
 import type {InputProps} from '@sentry/scraps/input';
 
 import {IconSearch} from 'sentry/icons';
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const themes = {light: lightTheme, dark: darkTheme};

--- a/static/app/components/core/radio/radio.snapshots.tsx
+++ b/static/app/components/core/radio/radio.snapshots.tsx
@@ -2,7 +2,6 @@ import {ThemeProvider} from '@emotion/react';
 
 import {Radio} from '@sentry/scraps/radio';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const themes = {light: lightTheme, dark: darkTheme};

--- a/static/app/components/core/switch/switch.snapshots.tsx
+++ b/static/app/components/core/switch/switch.snapshots.tsx
@@ -2,7 +2,6 @@ import {ThemeProvider} from '@emotion/react';
 
 import {Switch, type SwitchProps} from '@sentry/scraps/switch';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const themes = {light: lightTheme, dark: darkTheme};

--- a/static/app/components/core/tabs/tabList.snapshots.tsx
+++ b/static/app/components/core/tabs/tabList.snapshots.tsx
@@ -3,7 +3,6 @@ import {ThemeProvider} from '@emotion/react';
 
 import {TabList, Tabs} from '@sentry/scraps/tabs';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const themes = {light: lightTheme, dark: darkTheme};

--- a/static/app/components/core/text/text.snapshots.tsx
+++ b/static/app/components/core/text/text.snapshots.tsx
@@ -3,7 +3,6 @@ import {ThemeProvider} from '@emotion/react';
 import {Container} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const themes = {light: lightTheme, dark: darkTheme};

--- a/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
+++ b/static/app/components/pageFilters/project/projectPageFilter.spec.tsx
@@ -587,7 +587,6 @@ describe('ProjectPageFilter', () => {
       memberCount: 52,
       nonMemberCount: 1,
       urlProjects: [] as number[],
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       urlQuery: {} as Record<string, string>,
       triggerName: 'My Projects',
     },

--- a/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
+++ b/static/app/components/preprod/preprodBuildsSnapshotTable.snapshots.tsx
@@ -1,6 +1,5 @@
 import {ThemeProvider} from '@emotion/react';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import type {BuildDetailsApiResponse} from 'sentry/views/preprod/types/buildDetailsTypes';
 import {BuildDetailsState} from 'sentry/views/preprod/types/buildDetailsTypes';

--- a/static/app/components/themeAndStyleProvider.tsx
+++ b/static/app/components/themeAndStyleProvider.tsx
@@ -8,7 +8,6 @@ import {NODE_ENV} from 'sentry/constants';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {useLegacyStore} from 'sentry/stores/useLegacyStore';
 import {GlobalStyles} from 'sentry/styles/global';
-// eslint-disable-next-line no-restricted-imports
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 const SentryComponentInspector =

--- a/static/app/debug/notifications/components/debugNotificationsLanding.tsx
+++ b/static/app/debug/notifications/components/debugNotificationsLanding.tsx
@@ -9,7 +9,6 @@ import {Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 // Mimicking useStoriesDarkMode -> Don't use these elsewhere please 🙏
-// eslint-disable-next-line no-restricted-imports
 import {darkTheme} from 'sentry/utils/theme/theme';
 
 function DarkModeProvider(props: PropsWithChildren) {

--- a/static/app/stories/view/useStoriesDarkMode.tsx
+++ b/static/app/stories/view/useStoriesDarkMode.tsx
@@ -3,7 +3,6 @@ import {ThemeProvider, type Theme} from '@emotion/react';
 
 // these utils are for stories that have forced dark mode
 // which is a very specific sanctioned use case
-// eslint-disable-next-line no-restricted-imports
 import {darkTheme} from 'sentry/utils/theme/theme';
 
 /**

--- a/static/app/utils/theme/theme.tsx
+++ b/static/app/utils/theme/theme.tsx
@@ -12,9 +12,7 @@ import {css} from '@emotion/react';
 import {spring, type Transition} from 'framer-motion';
 
 import {IS_ACCEPTANCE_TEST, NODE_ENV} from 'sentry/constants/env';
-// eslint-disable-next-line no-restricted-imports
 import {darkTheme as baseDarkTheme} from 'sentry/utils/theme/scraps/theme/dark';
-// eslint-disable-next-line no-restricted-imports
 import {lightTheme as baseLightTheme} from 'sentry/utils/theme/scraps/theme/light';
 import {color} from 'sentry/utils/theme/scraps/tokens/color';
 import {typography} from 'sentry/utils/theme/scraps/tokens/typography';
@@ -650,13 +648,11 @@ function makeChartColorPalette<T extends ChartColorPalette>(
     length: Length | number | 'all'
   ): T[Length] {
     if (length === 'all') {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       return palette.at(-1) as unknown as T[Length];
     }
     // @TODO(jonasbadalic) we guarantee type safety and sort of guarantee runtime safety by clamping and
     // the palette is not sparse, but we should probably add a runtime check here as well.
     const index = Math.max(0, Math.min(palette.length - 1, length));
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     return palette[index] as unknown as T[Length];
   };
 }

--- a/static/app/views/dashboards/widgetCard/widgetQueries.tsx
+++ b/static/app/views/dashboards/widgetCard/widgetQueries.tsx
@@ -122,7 +122,6 @@ export function WidgetQueries({
   const isSeriesMetricsExtractedDataResults: Array<boolean | undefined> = [];
   const afterFetchSeriesData = (rawResults: SeriesResult) => {
     if (rawResults.data) {
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
       rawResults = rawResults as EventsStats;
       if (rawResults.isMetricsData !== undefined) {
         // oxlint-disable-next-line react/immutability

--- a/static/app/views/explore/contexts/logs/logsPageParams.tsx
+++ b/static/app/views/explore/contexts/logs/logsPageParams.tsx
@@ -33,7 +33,6 @@ export function usePersistedLogsPageParams() {
   });
 
   return useLocalStorageState(getLogsParamsStorageKey(LOGS_PARAMS_VERSION), {
-    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     fields: defaultLogFields() as string[],
     sortBys: [logsTimestampDescendingSortBy],
   });

--- a/static/app/views/explore/conversations/hooks/useFocusedToolSpan.spec.tsx
+++ b/static/app/views/explore/conversations/hooks/useFocusedToolSpan.spec.tsx
@@ -32,7 +32,6 @@ describe('useFocusedToolSpan', () => {
           onSpanFound,
         }),
       {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         initialProps: {focusedTool: 'first-tool' as string | null},
       }
     );

--- a/static/app/views/explore/spans/tracesExportModalButton.spec.tsx
+++ b/static/app/views/explore/spans/tracesExportModalButton.spec.tsx
@@ -55,7 +55,6 @@ function makeQueryResult(
   >(queryClient, {queryKey, enabled: false}).getCurrentResult();
 
   return {
-    // eslint-disable-next-line @tanstack/query/no-rest-destructuring
     ...base,
     data: error ? undefined : data,
     error,

--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -431,7 +431,6 @@ function makeQueryResult(
   >(queryClient, {queryKey, enabled: false}).getCurrentResult();
 
   return {
-    // eslint-disable-next-line @tanstack/query/no-rest-destructuring
     ...base,
     data,
     error: null,

--- a/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
+++ b/static/app/views/insights/common/queries/useSortedTimeSeries.tsx
@@ -138,7 +138,6 @@ export const useSortedTimeSeries = <
   }, [result.data]);
 
   return {
-    // eslint-disable-next-line @tanstack/query/no-rest-destructuring
     ...result,
     data,
     meta: result.data?.meta,

--- a/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/diffImageDisplay.snapshots.tsx
@@ -1,6 +1,5 @@
 import {ThemeProvider} from '@emotion/react';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import type {
   SnapshotDiffPair,

--- a/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/singleImageDisplay.snapshots.tsx
@@ -1,6 +1,5 @@
 import {ThemeProvider} from '@emotion/react';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 import {SingleImageDisplay} from './singleImageDisplay';

--- a/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.snapshots.tsx
@@ -1,6 +1,5 @@
 import {ThemeProvider} from '@emotion/react';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import type {
   SnapshotDiffPair,

--- a/static/app/views/preprod/snapshots/main/snapshotCards.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.tsx
@@ -14,7 +14,6 @@ import {IconFile, IconInfo, IconLink, IconMoon, IconSun, IconWarning} from 'sent
 import {t} from 'sentry/locale';
 import {ConfigStore} from 'sentry/stores/configStore';
 import {formatPercentage} from 'sentry/utils/number/formatPercentage';
-// eslint-disable-next-line no-restricted-imports
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import type {ContentVariant} from 'sentry/utils/theme/types';
 import {useCopyToClipboard} from 'sentry/utils/useCopyToClipboard';

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -6,7 +6,6 @@ import {CompactSelect as mockCompactSelect} from 'sentry-test/snapshots/mocks/co
 import {Tag} from '@sentry/scraps/badge';
 
 import {t} from 'sentry/locale';
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 import type {DiffMode} from './imageDisplay/diffImageDisplay';

--- a/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/sidebar/snapshotSidebarContent.snapshots.tsx
@@ -1,6 +1,5 @@
 import {ThemeProvider} from '@emotion/react';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import {DiffStatus} from 'sentry/views/preprod/types/snapshotTypes';
 

--- a/static/gsAdmin/views/layout.tsx
+++ b/static/gsAdmin/views/layout.tsx
@@ -14,7 +14,6 @@ import {ListLink} from 'sentry/components/links/listLink';
 import {IconChevron, IconMenu, IconSentry, IconSliders} from 'sentry/icons';
 import {ScrapsProviders} from 'sentry/scrapsProviders';
 import {localStorageWrapper} from 'sentry/utils/localStorage';
-// eslint-disable-next-line no-restricted-imports
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 import {GlobalAlertProvider} from 'sentry/views/app/globalAlerts';
 import {SystemAlerts} from 'sentry/views/app/systemAlerts';

--- a/static/gsApp/components/billingDetails/panel.snapshots.tsx
+++ b/static/gsApp/components/billingDetails/panel.snapshots.tsx
@@ -4,7 +4,6 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {BillingDetailsFixture} from 'getsentry-test/fixtures/billingDetails';
 import {SubscriptionFixture} from 'getsentry-test/fixtures/subscription';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {lightTheme} from 'sentry/utils/theme/theme';
 
 import {BillingDetailsPanel} from 'getsentry/components/billingDetails/panel';

--- a/static/oxlint/eslintPluginSentry/noDefaultExports.spec.ts
+++ b/static/oxlint/eslintPluginSentry/noDefaultExports.spec.ts
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line import-js/no-extraneous-dependencies
 import parser from '@typescript-eslint/parser';
 import {RuleTester} from '@typescript-eslint/rule-tester';
 import {TSESLint} from '@typescript-eslint/utils';

--- a/static/oxlint/eslintPluginSentry/noRedundantDefaultArgument.spec.ts
+++ b/static/oxlint/eslintPluginSentry/noRedundantDefaultArgument.spec.ts
@@ -1,4 +1,3 @@
-// oxlint-disable-next-line import-js/no-extraneous-dependencies
 import parser from '@typescript-eslint/parser';
 import {RuleTester} from '@typescript-eslint/rule-tester';
 import {TSESLint} from '@typescript-eslint/utils';

--- a/tests/js/fixtures/theme.tsx
+++ b/tests/js/fixtures/theme.tsx
@@ -1,4 +1,3 @@
-// eslint-disable-next-line no-restricted-imports
 import {lightTheme} from 'sentry/utils/theme/theme';
 
 export const ThemeFixture = () => {

--- a/tests/js/sentry-test/reactTestingLibrary.tsx
+++ b/tests/js/sentry-test/reactTestingLibrary.tsx
@@ -481,9 +481,7 @@ instrumentUserEvent();
 export * from '@testing-library/react';
 
 export {
-  // eslint-disable-next-line import/export
   fireEvent,
-  // eslint-disable-next-line import/export
   render,
   renderGlobalModal,
   renderHookWithProviders,

--- a/tests/js/sentry-test/snapshots/snapshot-framework.ts
+++ b/tests/js/sentry-test/snapshots/snapshot-framework.ts
@@ -2,7 +2,6 @@ import type {ReactElement} from 'react';
 
 import {Tooltip as mockTooltip} from 'sentry-test/snapshots/mocks/tooltip';
 
-// eslint-disable-next-line no-restricted-imports -- SSR snapshot rendering needs direct theme access
 import {lightTheme} from 'sentry/utils/theme/theme';
 
 import {closeBrowser, takeSnapshot, type SnapshotInteraction} from './snapshot';

--- a/tests/js/setup.ts
+++ b/tests/js/setup.ts
@@ -416,7 +416,6 @@ if (globalThis.setImmediate === undefined) {
  */
 const FLAKY_RERUN_COUNT = 50;
 
-/* eslint-disable jest/valid-title */
 it.isKnownFlake = function isKnownFlake(
   name: string,
   fn: jest.ProvidesCallback,
@@ -433,4 +432,3 @@ it.isKnownFlake = function isKnownFlake(
     }
   });
 };
-/* eslint-enable jest/valid-title */


### PR DESCRIPTION
Oxlint had `reportUnusedDisableDirectives` set to `off` since the ESLint migration, so a `// eslint-disable-next-line` comment kept working as a comment long after the rule it named stopped firing. Nothing removed them, and 45 had collected. A stale suppression is worse than no suppression: it reads as "this line is a known exception" when the rule would pass on its own, and it silently swallows the rule again if that line later regresses.

This turns the option on as an error and deletes the directives it finds. Most are `no-restricted-imports` on theme imports in `*.snapshots.tsx` files that an override already exempts, plus `@typescript-eslint/no-unnecessary-type-assertion` on assertions the rule now accepts.

**The option is gated on `enableTypeAwareLinting`, and that is the part worth reviewing.** Type-aware rules do not run when `typeAware` is off, so every suppression that silences one of them looks unused. Ungated, the same tree reports 44 unused directives with type-aware linting on and 100 with it off. Pre-commit runs with `typeAware` off locally, so an ungated `'error'` would fail pre-commit on suppressions CI considers live, and a `--fix` in that mode would delete them. Gating on the same flag keeps the check to runs that evaluate the full rule set.

`'warn'` was the other option and is the weaker one — warnings do not fail CI, so the comments would accumulate again at the same rate.

Two notes for review:

- Oxlint has no autofix for unused directives, so `--fix` reports them but changes nothing. The removals here are manual.
- `tests/js/setup.ts` held a `/* eslint-disable jest/valid-title */` … `/* eslint-enable */` pair where only the `enable` was reported. Removing just that line would have quietly extended the disable to the end of the file, so I checked the block instead — the file lints clean with neither, and both are gone.

No feature flags. The behavior change is confined to lint runs; no application code changes.

https://claude.ai/code/session_01DxuTmYbQRt1CJzLfAbXJ8X
