### PR TITLE
feat(preprod): Auto-approve snapshots with sub-threshold hash diffs

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4453,3 +4453,10 @@ register(
     type=Sequence,
     flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
 )
+
+register(
+    "preprod.snapshots.auto-approve-sibling-diffs.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)

--- a/src/sentry/preprod/snapshots/manifest.py
+++ b/src/sentry/preprod/snapshots/manifest.py
@@ -114,6 +114,7 @@ class ChunkCandidate(BaseModel):
     base_hash: str
     pixel_count: int
     diff_threshold: float
+    kind: Literal["base", "sibling"] = "base"
 
 
 class ChunkAssignment(BaseModel):
@@ -127,8 +128,11 @@ class ComparisonPlan(BaseModel):
     chunks: list[ChunkAssignment]
     # Results that need no odiff (added/removed/skipped/renamed/unchanged/exceeds-pixel-limit).
     non_diff_images: dict[str, ComparisonImageResult]
+    sibling_artifact_id: int | None = None
+    sibling_comparison_key: str | None = None
 
 
 class ChunkResult(BaseModel):
     chunk_index: int
     images: dict[str, ComparisonImageResult]
+    sibling_images: dict[str, ComparisonImageResult] = {}

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -389,6 +389,7 @@ class SiblingComparison(NamedTuple):
     artifact_id: int
     comparison_key: str
     manifest: ComparisonManifest
+    snapshot_manifest: SnapshotManifest
 
 
 def _find_approved_sibling(
@@ -424,6 +425,7 @@ def _find_approved_sibling(
             head_snapshot_metrics__preprod_artifact=approved_sibling,
             state=PreprodSnapshotComparison.State.SUCCESS,
         )
+        .select_related("head_snapshot_metrics")
         .order_by("-date_updated")
         .first()
     )
@@ -446,7 +448,27 @@ def _find_approved_sibling(
             },
         )
         return None
-    return SiblingComparison(approved_sibling.id, comparison_key, manifest)
+
+    snapshot_manifest_key = (sibling_comparison.head_snapshot_metrics.extras or {}).get(
+        "manifest_key"
+    )
+    if not snapshot_manifest_key:
+        return None
+
+    try:
+        snapshot_manifest = _get_json(session, snapshot_manifest_key, SnapshotManifest)
+    except Exception:
+        logger.exception(
+            "auto_approve: failed to load sibling snapshot manifest",
+            extra={
+                "head_artifact_id": head_artifact.id,
+                "sibling_artifact_id": approved_sibling.id,
+                "manifest_key": snapshot_manifest_key,
+            },
+        )
+        return None
+
+    return SiblingComparison(approved_sibling.id, comparison_key, manifest, snapshot_manifest)
 
 
 def _try_auto_approve_snapshot(
@@ -628,6 +650,9 @@ def _build_comparison_plan(
 
     # Diff hash-differing images against the approved sibling so finalize can auto-approve.
     if sibling is not None and diff_sibling_images:
+        sibling_meta_by_hash = {
+            m.content_hash: m for m in sibling.snapshot_manifest.images.values()
+        }
         sibling_candidate_names = (
             {c.name for c in eligible} | set(added) | {n for n, _ in renamed_pairs}
         )
@@ -641,11 +666,10 @@ def _build_comparison_plan(
                 continue
             head_meta = head_meta_by_hash[head_hash]
             head_size = ImageSize(head_meta.width, head_meta.height)
-            sibling_size = (
-                ImageSize(sibling_image.after_width, sibling_image.after_height)
-                if sibling_image.after_width is not None and sibling_image.after_height is not None
-                else head_size
-            )
+            sibling_meta = sibling_meta_by_hash.get(sibling_hash)
+            if sibling_meta is None:
+                continue
+            sibling_size = ImageSize(sibling_meta.width, sibling_meta.height)
             pixel_count = get_comparison_size(head_size, sibling_size).pixel_count
             if pixel_count > MAX_DIFF_PIXELS:
                 continue

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -940,7 +940,9 @@ def compare_snapshots(
     )
 
     try:
-        head_artifact = PreprodArtifact.objects.select_related("project__organization").get(
+        head_artifact = PreprodArtifact.objects.select_related(
+            "project__organization", "commit_comparison"
+        ).get(
             id=head_artifact_id,
             project__organization_id=org_id,
             project_id=project_id,

--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -6,7 +6,7 @@ import time
 from collections.abc import Callable
 from datetime import datetime
 from difflib import SequenceMatcher
-from typing import Any, NamedTuple
+from typing import Any, Literal, NamedTuple
 
 import orjson
 from django.contrib.postgres.fields import ArrayField
@@ -17,7 +17,7 @@ from objectstore_client import RequestError, Session
 from pydantic import BaseModel, ValidationError
 from taskbroker_client.retry import Retry
 
-from sentry import analytics
+from sentry import analytics, options
 from sentry.objectstore import UsecaseId, get_session
 from sentry.preprod.analytics import PreprodStatusCheckApprovalCreatedEvent
 from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
@@ -34,7 +34,7 @@ from sentry.preprod.snapshots.image_diff.compare import (
     read_image_size,
 )
 from sentry.preprod.snapshots.image_diff.odiff import OdiffServer
-from sentry.preprod.snapshots.image_diff.types import ImageSize
+from sentry.preprod.snapshots.image_diff.types import DiffResult, ImageSize
 from sentry.preprod.snapshots.manifest import (
     ChunkAssignment,
     ChunkCandidate,
@@ -164,6 +164,7 @@ class _DiffCandidate(NamedTuple):
     head_hash: str
     base_hash: str
     pixel_count: int
+    kind: Literal["base", "sibling"] = "base"
 
 
 class _ImageDiffResult(NamedTuple):
@@ -341,18 +342,61 @@ def _build_comparison_fingerprints(manifest: ComparisonManifest) -> set[ImageFin
     return fingerprints
 
 
-def _try_auto_approve_snapshot(
-    head_artifact: PreprodArtifact,
-    comparison_manifest: ComparisonManifest,
-    session: Session,
-) -> None:
+class _HashOnlyDiff(NamedTuple):
+    name: str
+    head_hash: str
+    sibling_hash: str
+
+
+def _hash_only_diffs(
+    head: set[ImageFingerprint], sibling: set[ImageFingerprint]
+) -> list[_HashOnlyDiff] | None:
+    # None: names or statuses differ (structural). []: identical. Otherwise the
+    # pairs that differ only by content hash and need a pixel diff.
+    head_by_name = {fp.name: fp for fp in head}
+    sibling_by_name = {fp.name: fp for fp in sibling}
+    if head_by_name.keys() != sibling_by_name.keys():
+        return None
+
+    diffs: list[_HashOnlyDiff] = []
+    for name in sorted(head_by_name):
+        head_fp = head_by_name[name]
+        sibling_fp = sibling_by_name[name]
+        if head_fp == sibling_fp:
+            continue
+        if head_fp._replace(head_hash=None) != sibling_fp._replace(head_hash=None):
+            return None
+        if head_fp.head_hash is None or sibling_fp.head_hash is None:
+            return None
+        diffs.append(_HashOnlyDiff(name, head_fp.head_hash, sibling_fp.head_hash))
+    return diffs
+
+
+def _effective_diff_threshold(manifest: SnapshotManifest, name: str) -> float:
+    image = manifest.images.get(name)
+    if image is not None and image.diff_threshold is not None:
+        return image.diff_threshold
+    if manifest.diff_threshold is not None:
+        return manifest.diff_threshold
+    return 0.0
+
+
+def _diff_ratio(result: DiffResult) -> float:
+    return result.changed_pixels / result.total_pixels if result.total_pixels > 0 else 0.0
+
+
+class SiblingComparison(NamedTuple):
+    artifact_id: int
+    comparison_key: str
+    manifest: ComparisonManifest
+
+
+def _find_approved_sibling(
+    head_artifact: PreprodArtifact, session: Session
+) -> SiblingComparison | None:
     cc = head_artifact.commit_comparison
     if not cc or not cc.pr_number or not cc.head_repo_name:
-        return
-
-    head_fingerprints = _build_comparison_fingerprints(comparison_manifest)
-    if not head_fingerprints:
-        return
+        return None
 
     approved_sibling = (
         PreprodArtifact.objects.filter(
@@ -363,15 +407,17 @@ def _try_auto_approve_snapshot(
             commit_comparison__head_repo_name=cc.head_repo_name,
             preprodcomparisonapproval__preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
             preprodcomparisonapproval__approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+            # Human approvals only: chaining through auto-approvals would let
+            # sub-threshold drift compound across rebuilds.
+            preprodcomparisonapproval__extras__auto_approval__isnull=True,
             preprodsnapshotmetrics__snapshot_comparisons_head_metrics__state=PreprodSnapshotComparison.State.SUCCESS,
         )
         .exclude(id=head_artifact.id)
         .order_by("-date_added")
         .first()
     )
-
     if not approved_sibling:
-        return
+        return None
 
     sibling_comparison = (
         PreprodSnapshotComparison.objects.filter(
@@ -381,40 +427,81 @@ def _try_auto_approve_snapshot(
         .order_by("-date_updated")
         .first()
     )
-
     if not sibling_comparison:
-        return
+        return None
 
-    sibling_comparison_key = (sibling_comparison.extras or {}).get("comparison_key")
-    if not sibling_comparison_key:
-        return
+    comparison_key = (sibling_comparison.extras or {}).get("comparison_key")
+    if not comparison_key:
+        return None
 
     try:
-        sibling_manifest = ComparisonManifest(
-            **orjson.loads(_read_objectstore(session, sibling_comparison_key))
-        )
+        manifest = _get_json(session, comparison_key, ComparisonManifest)
     except Exception:
         logger.exception(
             "auto_approve: failed to load sibling comparison manifest",
             extra={
                 "head_artifact_id": head_artifact.id,
                 "sibling_artifact_id": approved_sibling.id,
-                "comparison_key": sibling_comparison_key,
+                "comparison_key": comparison_key,
             },
+        )
+        return None
+    return SiblingComparison(approved_sibling.id, comparison_key, manifest)
+
+
+def _try_auto_approve_snapshot(
+    head_artifact: PreprodArtifact,
+    comparison_manifest: ComparisonManifest,
+    plan: ComparisonPlan,
+    sibling_images: dict[str, ComparisonImageResult],
+    session: Session,
+) -> None:
+    if plan.sibling_artifact_id is None or not plan.sibling_comparison_key:
+        return
+
+    head_fingerprints = _build_comparison_fingerprints(comparison_manifest)
+    if not head_fingerprints:
+        return
+
+    log_extra = {
+        "head_artifact_id": head_artifact.id,
+        "sibling_artifact_id": plan.sibling_artifact_id,
+    }
+    try:
+        sibling_manifest = _get_json(session, plan.sibling_comparison_key, ComparisonManifest)
+    except Exception:
+        logger.exception(
+            "auto_approve: failed to load sibling comparison manifest",
+            extra={**log_extra, "comparison_key": plan.sibling_comparison_key},
         )
         return
 
-    sibling_fingerprints = _build_comparison_fingerprints(sibling_manifest)
-
-    if head_fingerprints != sibling_fingerprints:
-        logger.info(
-            "auto_approve: fingerprints do not match",
-            extra={
-                "head_artifact_id": head_artifact.id,
-                "sibling_artifact_id": approved_sibling.id,
-            },
-        )
+    diffs = _hash_only_diffs(head_fingerprints, _build_comparison_fingerprints(sibling_manifest))
+    if diffs is None:
+        logger.info("auto_approve: fingerprints do not match", extra=log_extra)
         return
+
+    for diff in diffs:
+        result = sibling_images.get(diff.name)
+        if (
+            result is None
+            or result.status != "unchanged"
+            or result.head_hash != diff.head_hash
+            or result.base_hash != diff.sibling_hash
+        ):
+            metrics.incr("preprod.snapshots.auto_approve.threshold_mismatch")
+            logger.info(
+                "auto_approve: sibling diff rejected",
+                extra={
+                    **log_extra,
+                    "image_name": diff.name,
+                    "status": result.status if result else None,
+                },
+            )
+            return
+
+    if diffs:
+        metrics.incr("preprod.snapshots.auto_approve.threshold_match")
 
     PreprodComparisonApproval.objects.create(
         preprod_artifact=head_artifact,
@@ -423,7 +510,8 @@ def _try_auto_approve_snapshot(
         approved_at=timezone.now(),
         extras={
             "auto_approval": True,
-            "prev_approved_artifact_id": approved_sibling.id,
+            "prev_approved_artifact_id": plan.sibling_artifact_id,
+            "threshold_matched_image_count": len(diffs),
         },
     )
 
@@ -440,9 +528,10 @@ def _try_auto_approve_snapshot(
     logger.info(
         "auto_approve: snapshot auto-approved",
         extra={
-            "head_artifact_id": head_artifact.id,
-            "prev_approved_artifact_id": approved_sibling.id,
+            **log_extra,
+            "prev_approved_artifact_id": plan.sibling_artifact_id,
             "organization_slug": head_artifact.project.organization.slug,
+            "threshold_matched_image_count": len(diffs),
         },
     )
 
@@ -452,9 +541,9 @@ def _build_comparison_plan(
     base_manifest: SnapshotManifest,
     head_artifact_id: int,
     base_artifact_id: int,
+    sibling: SiblingComparison | None = None,
+    diff_sibling_images: bool = True,
 ) -> ComparisonPlan:
-    diff_threshold = head_manifest.diff_threshold
-
     head_images = head_manifest.images
     base_images = base_manifest.images
 
@@ -501,16 +590,8 @@ def _build_comparison_plan(
             )
             continue
 
-        specific_image_diff_threshold = head_images[name].diff_threshold
-        effective_threshold = (
-            specific_image_diff_threshold
-            if specific_image_diff_threshold is not None
-            else diff_threshold
-            if diff_threshold is not None
-            else 0.0
-        )
         eligible.append(_DiffCandidate(name, head_hash, base_hash, pixel_count))
-        eligible_thresholds[name] = effective_threshold
+        eligible_thresholds[name] = _effective_diff_threshold(head_manifest, name)
 
     for name in sorted(added):
         non_diff_images[name] = ComparisonImageResult(
@@ -545,6 +626,32 @@ def _build_comparison_plan(
             previous_image_file_name=old_name,
         )
 
+    # Diff hash-differing images against the approved sibling so finalize can auto-approve.
+    if sibling is not None and diff_sibling_images:
+        sibling_candidate_names = (
+            {c.name for c in eligible} | set(added) | {n for n, _ in renamed_pairs}
+        )
+        for name in sorted(sibling_candidate_names):
+            sibling_image = sibling.manifest.images.get(name)
+            if sibling_image is None or sibling_image.status not in ("changed", "added", "renamed"):
+                continue
+            head_hash = head_by_name[name]
+            sibling_hash = sibling_image.head_hash
+            if not sibling_hash or sibling_hash == head_hash:
+                continue
+            head_meta = head_meta_by_hash[head_hash]
+            head_size = ImageSize(head_meta.width, head_meta.height)
+            sibling_size = (
+                ImageSize(sibling_image.after_width, sibling_image.after_height)
+                if sibling_image.after_width is not None and sibling_image.after_height is not None
+                else head_size
+            )
+            pixel_count = get_comparison_size(head_size, sibling_size).pixel_count
+            if pixel_count > MAX_DIFF_PIXELS:
+                continue
+            eligible.append(_DiffCandidate(name, head_hash, sibling_hash, pixel_count, "sibling"))
+            eligible_thresholds[name] = _effective_diff_threshold(head_manifest, name)
+
     batches = _create_pixel_batches(eligible, MAX_PIXELS_PER_BATCH)
     chunks = [
         ChunkAssignment(
@@ -556,6 +663,7 @@ def _build_comparison_plan(
                     base_hash=candidate.base_hash,
                     pixel_count=candidate.pixel_count,
                     diff_threshold=eligible_thresholds[candidate.name],
+                    kind=candidate.kind,
                 )
                 for candidate in batch
             ],
@@ -568,6 +676,8 @@ def _build_comparison_plan(
         base_artifact_id=base_artifact_id,
         chunks=chunks,
         non_diff_images=non_diff_images,
+        sibling_artifact_id=sibling.artifact_id if sibling else None,
+        sibling_comparison_key=sibling.comparison_key if sibling else None,
     )
 
 
@@ -578,15 +688,17 @@ def _process_chunk(
     project_id: int,
     head_artifact_id: int,
     base_artifact_id: int,
-) -> dict[str, ComparisonImageResult]:
+) -> ChunkResult:
     image_key_prefix = f"{org_id}/{project_id}"
     images: dict[str, ComparisonImageResult] = {}
+    sibling_images: dict[str, ComparisonImageResult] = {}
+
+    def results_for(candidate: ChunkCandidate) -> dict[str, ComparisonImageResult]:
+        return sibling_images if candidate.kind == "sibling" else images
 
     with OdiffServer() as server:
         diff_pairs: list[tuple[bytes, bytes]] = []
-        batch_names: list[str] = []
-        batch_hashes: list[tuple[str, str]] = []
-        batch_thresholds: list[float] = []
+        batch_candidates: list[ChunkCandidate] = []
 
         unique_hashes: set[str] = set()
         for candidate in assignment.candidates:
@@ -615,13 +727,17 @@ def _process_chunk(
         current_batch_pixels = 0
         for candidate in assignment.candidates:
             if candidate.head_hash in failed_hashes or candidate.base_hash in failed_hashes:
-                images[candidate.name] = _errored_result(candidate, "image_fetch_failed")
+                results_for(candidate)[candidate.name] = _errored_result(
+                    candidate, "image_fetch_failed"
+                )
                 continue
 
             head_size = actual_sizes[candidate.head_hash]
             base_size = actual_sizes[candidate.base_hash]
             if head_size is None or base_size is None:
-                images[candidate.name] = _errored_result(candidate, "image_processing_failed")
+                results_for(candidate)[candidate.name] = _errored_result(
+                    candidate, "image_processing_failed"
+                )
                 continue
 
             head_data = fetch_cache[candidate.head_hash]
@@ -629,7 +745,9 @@ def _process_chunk(
             comparison_size = get_comparison_size(head_size, base_size)
             comparison_pixels = comparison_size.pixel_count
             if comparison_pixels > MAX_DIFF_PIXELS:
-                images[candidate.name] = _errored_result(candidate, "exceeds_pixel_limit")
+                results_for(candidate)[candidate.name] = _errored_result(
+                    candidate, "exceeds_pixel_limit"
+                )
                 metrics.incr("preprod.snapshots.image_diff.exceeds_pixel_limit")
                 logger.warning(
                     "preprod.snapshots.image_diff.exceeds_pixel_limit",
@@ -646,7 +764,9 @@ def _process_chunk(
 
             next_batch_pixels = current_batch_pixels + comparison_pixels
             if next_batch_pixels > MAX_PIXELS_PER_BATCH:
-                images[candidate.name] = _errored_result(candidate, "exceeds_batch_pixel_limit")
+                results_for(candidate)[candidate.name] = _errored_result(
+                    candidate, "exceeds_batch_pixel_limit"
+                )
                 metrics.incr("preprod.snapshots.image_diff.exceeds_batch_pixel_limit")
                 logger.warning(
                     "preprod.snapshots.image_diff.exceeds_batch_pixel_limit",
@@ -663,21 +783,36 @@ def _process_chunk(
 
             current_batch_pixels = next_batch_pixels
             diff_pairs.append((base_data, head_data))
-            batch_names.append(candidate.name)
-            batch_hashes.append((candidate.head_hash, candidate.base_hash))
-            batch_thresholds.append(candidate.diff_threshold)
+            batch_candidates.append(candidate)
 
         diff_results = compare_images_batch(diff_pairs, server=server)
 
-        for name, (head_hash, base_hash), threshold, diff_result in zip(
-            batch_names, batch_hashes, batch_thresholds, diff_results, strict=True
-        ):
+        for candidate, diff_result in zip(batch_candidates, diff_results, strict=True):
+            name = candidate.name
+            head_hash, base_hash, threshold = (
+                candidate.head_hash,
+                candidate.base_hash,
+                candidate.diff_threshold,
+            )
             if diff_result is None:
-                images[name] = ComparisonImageResult(
+                results_for(candidate)[name] = ComparisonImageResult(
                     status="errored",
                     head_hash=head_hash,
                     base_hash=base_hash,
                     reason="image_processing_failed",
+                )
+                continue
+
+            diff_pct = _diff_ratio(diff_result)
+            is_changed = diff_pct > threshold
+
+            if candidate.kind == "sibling":
+                sibling_images[name] = ComparisonImageResult(
+                    status="changed" if is_changed else "unchanged",
+                    head_hash=head_hash,
+                    base_hash=base_hash,
+                    changed_pixels=diff_result.changed_pixels,
+                    total_pixels=diff_result.total_pixels,
                 )
                 continue
 
@@ -687,13 +822,6 @@ def _process_chunk(
             )
             diff_mask_bytes = diff_result.diff_mask_png
             _put_diff_mask(session, diff_mask_key, diff_mask_bytes)
-
-            diff_pct = (
-                diff_result.changed_pixels / diff_result.total_pixels
-                if diff_result.total_pixels > 0
-                else 0
-            )
-            is_changed = diff_pct > threshold
 
             diff_mask_image_id = f"{head_artifact_id}/{base_artifact_id}/diff/{stem}.png"
 
@@ -728,7 +856,9 @@ def _process_chunk(
                 aligned_height=diff_result.aligned_height,
             )
 
-    return images
+    return ChunkResult(
+        chunk_index=assignment.chunk_index, images=images, sibling_images=sibling_images
+    )
 
 
 @instrumented_task(
@@ -757,13 +887,13 @@ def process_snapshot_comparison_chunk(
         plan = _get_json(session, plan_key, ComparisonPlan)
         assignment = next((c for c in plan.chunks if c.chunk_index == chunk_index), None)
         if assignment is not None:
-            images = _process_chunk(
+            result = _process_chunk(
                 session, assignment, org_id, project_id, head_artifact_id, base_artifact_id
             )
             result_key = _chunk_result_key(
                 org_id, project_id, head_artifact_id, base_artifact_id, chunk_index
             )
-            _put_json(session, result_key, ChunkResult(chunk_index=chunk_index, images=images))
+            _put_json(session, result_key, result)
     except Exception as e:
         # Record the chunk as terminally failed so the comparison can still
         # complete: finalize degrades a done chunk with no result blob to errored.
@@ -1058,8 +1188,15 @@ def compare_snapshots(
                 )
                 return
 
+        sibling = _find_approved_sibling(head_artifact, session)
+        diff_sibling_images = options.get("preprod.snapshots.auto-approve-sibling-diffs.enabled")
         plan = _build_comparison_plan(
-            head_manifest, base_manifest, head_artifact_id, base_artifact_id
+            head_manifest,
+            base_manifest,
+            head_artifact_id,
+            base_artifact_id,
+            sibling=sibling,
+            diff_sibling_images=diff_sibling_images,
         )
 
         plan_key = _plan_key(org_id, project_id, head_artifact_id, base_artifact_id)
@@ -1226,6 +1363,7 @@ def finalize_snapshot_comparison(
         return
 
     images: dict[str, ComparisonImageResult] = dict(plan.non_diff_images)
+    sibling_images: dict[str, ComparisonImageResult] = {}
     done_set = set(comparison.chunks_done_indices)
 
     for assignment in plan.chunks:
@@ -1251,12 +1389,15 @@ def finalize_snapshot_comparison(
                     extra={"comparison_id": comparison.id, "chunk_index": idx},
                 )
                 for candidate in assignment.candidates:
-                    images[candidate.name] = _errored_result(candidate, "chunk_result_unreadable")
+                    target = sibling_images if candidate.kind == "sibling" else images
+                    target[candidate.name] = _errored_result(candidate, "chunk_result_unreadable")
                 continue
             images.update(result.images)
+            sibling_images.update(result.sibling_images)
         else:
             for candidate in assignment.candidates:
-                images[candidate.name] = _errored_result(candidate, "chunk_failed")
+                target = sibling_images if candidate.kind == "sibling" else images
+                target[candidate.name] = _errored_result(candidate, "chunk_failed")
 
     counts = {
         s: 0 for s in ("changed", "unchanged", "added", "removed", "errored", "renamed", "skipped")
@@ -1366,7 +1507,9 @@ def finalize_snapshot_comparison(
             metrics.incr("preprod.snapshots.diff.zero_changes", sample_rate=1.0, tags=metric_tags)
 
         try:
-            _try_auto_approve_snapshot(head_artifact, comparison_manifest, session)
+            _try_auto_approve_snapshot(
+                head_artifact, comparison_manifest, plan, sibling_images, session
+            )
         except Exception:
             logger.exception(
                 "Auto-approve failed after successful comparison",

--- a/tests/sentry/preprod/snapshots/test_auto_approve.py
+++ b/tests/sentry/preprod/snapshots/test_auto_approve.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import orjson
 
@@ -11,6 +11,8 @@ from sentry.preprod.snapshots.manifest import (
     ComparisonManifest,
     ComparisonPlan,
     ComparisonSummary,
+    ImageMetadata,
+    SnapshotManifest,
 )
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.snapshots.tasks import (
@@ -211,6 +213,7 @@ class TryAutoApproveSnapshotTest(TestCase):
         super().setUp()
         self.organization = self.create_organization(owner=self.user)
         self.project = self.create_project(organization=self.organization)
+        self._object_store: dict[str, bytes] = {}
 
     def _create_approved_sibling(
         self,
@@ -230,9 +233,13 @@ class TryAutoApproveSnapshotTest(TestCase):
             app_id=app_id,
             build_configuration=build_configuration,
         )
+        snapshot_manifest_key = (
+            f"{self.organization.id}/{self.project.id}/{artifact.id}/snapshot_manifest.json"
+        )
         head_metrics = PreprodSnapshotMetrics.objects.create(
             preprod_artifact=artifact,
             image_count=10,
+            extras={"manifest_key": snapshot_manifest_key},
         )
         base_artifact = self.create_preprod_artifact(
             project=self.project,
@@ -242,6 +249,13 @@ class TryAutoApproveSnapshotTest(TestCase):
             preprod_artifact=base_artifact,
             image_count=10,
         )
+        snapshot_manifest = SnapshotManifest(
+            images={
+                name: ImageMetadata(content_hash=image.head_hash or name, width=10, height=10)
+                for name, image in comparison_images.items()
+            },
+        )
+        self._object_store[snapshot_manifest_key] = orjson.dumps(snapshot_manifest.dict())
         comparison_key = f"{self.organization.id}/{self.project.id}/{artifact.id}/{base_artifact.id}/comparison.json"
         PreprodSnapshotComparison.objects.create(
             head_snapshot_metrics=head_metrics,
@@ -338,7 +352,9 @@ class TryAutoApproveSnapshotTest(TestCase):
             extras={"auto_approval": True, "prev_approved_artifact_id": human_sibling.id}
         )
         head_artifact = self._create_head_artifact()
-        session = _mock_session_with_manifests({human_key: human_json, auto_key: auto_json})
+        session = _mock_session_with_manifests(
+            {human_key: human_json, auto_key: auto_json, **self._object_store}
+        )
 
         sibling = _find_approved_sibling(head_artifact, session)
 
@@ -346,7 +362,9 @@ class TryAutoApproveSnapshotTest(TestCase):
         assert sibling.artifact_id == human_sibling.id
         assert sibling.comparison_key == human_key
         assert set(sibling.manifest.images) == {"screen1.png"}
-        session.get.assert_called_once_with(human_key)
+        assert set(sibling.snapshot_manifest.images) == {"screen1.png"}
+        assert call(human_key) in session.get.call_args_list
+        assert call(auto_key) not in session.get.call_args_list
 
     def test_find_approved_sibling_returns_none_without_pr(self):
         cc = self.create_commit_comparison(organization=self.organization, pr_number=None)
@@ -354,6 +372,21 @@ class TryAutoApproveSnapshotTest(TestCase):
             project=self.project, commit_comparison=cc, app_id="com.example.app"
         )
         assert _find_approved_sibling(head_artifact, MagicMock()) is None
+
+    def test_find_approved_sibling_returns_none_without_snapshot_manifest_key(self):
+        images = {
+            "screen1.png": ComparisonImageResult(
+                status="changed", head_hash="abc", base_hash="old1"
+            ),
+        }
+        sibling, comp_key, comp_json = self._create_approved_sibling(
+            pr_number=42, comparison_images=images
+        )
+        PreprodSnapshotMetrics.objects.filter(preprod_artifact=sibling).update(extras={})
+        head_artifact = self._create_head_artifact()
+        session = _mock_session_with_manifests({comp_key: comp_json})
+
+        assert _find_approved_sibling(head_artifact, session) is None
 
     @patch("sentry.analytics.record")
     def test_auto_approves_when_fingerprints_match(self, mock_analytics):
@@ -894,12 +927,15 @@ class TryAutoApproveSnapshotTest(TestCase):
 
         head_artifact = self._create_head_artifact()
 
-        session = _mock_session_with_manifests({human_key: human_json, auto_key: auto_json})
+        session = _mock_session_with_manifests(
+            {human_key: human_json, auto_key: auto_json, **self._object_store}
+        )
         sibling = _find_approved_sibling(head_artifact, session)
 
         assert sibling is not None
         assert sibling.artifact_id == human_sibling.id
-        session.get.assert_called_once_with(human_key)
+        assert call(human_key) in session.get.call_args_list
+        assert call(auto_key) not in session.get.call_args_list
 
     def test_sibling_selection_keeps_human_approval_with_other_extras(self):
         images = {
@@ -916,9 +952,9 @@ class TryAutoApproveSnapshotTest(TestCase):
 
         head_artifact = self._create_head_artifact()
 
-        session = _mock_session_with_manifests({comp_key: comp_json})
+        session = _mock_session_with_manifests({comp_key: comp_json, **self._object_store})
         result = _find_approved_sibling(head_artifact, session)
 
         assert result is not None
         assert result.artifact_id == sibling.id
-        session.get.assert_called_once_with(comp_key)
+        assert call(comp_key) in session.get.call_args_list

--- a/tests/sentry/preprod/snapshots/test_auto_approve.py
+++ b/tests/sentry/preprod/snapshots/test_auto_approve.py
@@ -9,12 +9,16 @@ from sentry.preprod.models import PreprodArtifact, PreprodComparisonApproval
 from sentry.preprod.snapshots.manifest import (
     ComparisonImageResult,
     ComparisonManifest,
+    ComparisonPlan,
     ComparisonSummary,
 )
 from sentry.preprod.snapshots.models import PreprodSnapshotComparison, PreprodSnapshotMetrics
 from sentry.preprod.snapshots.tasks import (
     ImageFingerprint,
     _build_comparison_fingerprints,
+    _find_approved_sibling,
+    _hash_only_diffs,
+    _HashOnlyDiff,
     _try_auto_approve_snapshot,
 )
 from sentry.testutils.cases import TestCase
@@ -119,6 +123,73 @@ class BuildComparisonFingerprintsTest(TestCase):
         assert fps == {ImageFingerprint("valid.png", "renamed", "def", "old_valid.png")}
 
 
+class HashOnlyDiffsTest(TestCase):
+    def test_identical_sets_return_empty_list(self):
+        fps = {ImageFingerprint("a.png", "changed", "h1")}
+        assert _hash_only_diffs(fps, set(fps)) == []
+
+    def test_hash_only_difference_is_returned(self):
+        head = {
+            ImageFingerprint("a.png", "changed", "h1"),
+            ImageFingerprint("b.png", "added", "same"),
+        }
+        sibling = {
+            ImageFingerprint("a.png", "changed", "h2"),
+            ImageFingerprint("b.png", "added", "same"),
+        }
+        assert _hash_only_diffs(head, sibling) == [_HashOnlyDiff("a.png", "h1", "h2")]
+
+    def test_renamed_hash_only_difference_is_returned(self):
+        head = {ImageFingerprint("new.png", "renamed", "h1", "old.png")}
+        sibling = {ImageFingerprint("new.png", "renamed", "h2", "old.png")}
+        assert _hash_only_diffs(head, sibling) == [_HashOnlyDiff("new.png", "h1", "h2")]
+
+    def test_renamed_with_different_previous_name_is_structural(self):
+        head = {ImageFingerprint("new.png", "renamed", "h1", "old.png")}
+        sibling = {ImageFingerprint("new.png", "renamed", "h1", "other.png")}
+        assert _hash_only_diffs(head, sibling) is None
+
+    def test_status_difference_is_structural(self):
+        head = {ImageFingerprint("a.png", "changed", "h1")}
+        sibling = {ImageFingerprint("a.png", "added", "h1")}
+        assert _hash_only_diffs(head, sibling) is None
+
+    def test_extra_head_image_is_structural(self):
+        head = {
+            ImageFingerprint("a.png", "changed", "h1"),
+            ImageFingerprint("b.png", "changed", "h9"),
+        }
+        sibling = {ImageFingerprint("a.png", "changed", "h1")}
+        assert _hash_only_diffs(head, sibling) is None
+
+    def test_missing_head_image_is_structural(self):
+        head = {ImageFingerprint("a.png", "changed", "h1")}
+        sibling = {
+            ImageFingerprint("a.png", "changed", "h1"),
+            ImageFingerprint("b.png", "removed"),
+        }
+        assert _hash_only_diffs(head, sibling) is None
+
+    def test_removed_and_errored_never_produce_pairs(self):
+        head = {ImageFingerprint("a.png", "removed"), ImageFingerprint("b.png", "errored")}
+        sibling = {ImageFingerprint("a.png", "removed"), ImageFingerprint("b.png", "errored")}
+        assert _hash_only_diffs(head, sibling) == []
+
+    def test_pairs_are_sorted_by_name(self):
+        head = {
+            ImageFingerprint("z.png", "changed", "z1"),
+            ImageFingerprint("a.png", "changed", "a1"),
+        }
+        sibling = {
+            ImageFingerprint("z.png", "changed", "z2"),
+            ImageFingerprint("a.png", "changed", "a2"),
+        }
+        assert _hash_only_diffs(head, sibling) == [
+            _HashOnlyDiff("a.png", "a1", "a2"),
+            _HashOnlyDiff("z.png", "z1", "z2"),
+        ]
+
+
 def _mock_session_with_manifests(manifests_by_key: dict[str, bytes]) -> MagicMock:
     session = MagicMock()
 
@@ -217,6 +288,73 @@ class TryAutoApproveSnapshotTest(TestCase):
             images=images,
         )
 
+    def _create_head_artifact(self, pr_number: int = 42) -> PreprodArtifact:
+        cc = self.create_commit_comparison(
+            organization=self.organization,
+            pr_number=pr_number,
+            head_repo_name="owner/repo",
+        )
+        return self.create_preprod_artifact(
+            project=self.project,
+            commit_comparison=cc,
+            app_id="com.example.app",
+        )
+
+    def _plan(self, sibling: PreprodArtifact | None, comparison_key: str | None) -> ComparisonPlan:
+        return ComparisonPlan(
+            head_artifact_id=999,
+            base_artifact_id=998,
+            chunks=[],
+            non_diff_images={},
+            sibling_artifact_id=sibling.id if sibling else None,
+            sibling_comparison_key=comparison_key,
+        )
+
+    def _approve(
+        self,
+        head_artifact: PreprodArtifact,
+        head_manifest: ComparisonManifest,
+        plan: ComparisonPlan,
+        session: MagicMock,
+        sibling_images: dict[str, ComparisonImageResult] | None = None,
+    ) -> None:
+        _try_auto_approve_snapshot(
+            head_artifact, head_manifest, plan, sibling_images or {}, session
+        )
+
+    def test_find_approved_sibling_returns_human_sibling_manifest(self):
+        images = {
+            "screen1.png": ComparisonImageResult(
+                status="changed", head_hash="abc", base_hash="old1"
+            ),
+        }
+        human_sibling, human_key, human_json = self._create_approved_sibling(
+            pr_number=42, comparison_images=images
+        )
+        auto_sibling, auto_key, auto_json = self._create_approved_sibling(
+            pr_number=42, comparison_images=images
+        )
+        PreprodComparisonApproval.objects.filter(preprod_artifact=auto_sibling).update(
+            extras={"auto_approval": True, "prev_approved_artifact_id": human_sibling.id}
+        )
+        head_artifact = self._create_head_artifact()
+        session = _mock_session_with_manifests({human_key: human_json, auto_key: auto_json})
+
+        sibling = _find_approved_sibling(head_artifact, session)
+
+        assert sibling is not None
+        assert sibling.artifact_id == human_sibling.id
+        assert sibling.comparison_key == human_key
+        assert set(sibling.manifest.images) == {"screen1.png"}
+        session.get.assert_called_once_with(human_key)
+
+    def test_find_approved_sibling_returns_none_without_pr(self):
+        cc = self.create_commit_comparison(organization=self.organization, pr_number=None)
+        head_artifact = self.create_preprod_artifact(
+            project=self.project, commit_comparison=cc, app_id="com.example.app"
+        )
+        assert _find_approved_sibling(head_artifact, MagicMock()) is None
+
     @patch("sentry.analytics.record")
     def test_auto_approves_when_fingerprints_match(self, mock_analytics):
         shared_images = {
@@ -258,7 +396,7 @@ class TryAutoApproveSnapshotTest(TestCase):
         )
 
         session = _mock_session_with_manifests({comp_key: comp_json})
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
+        self._approve(head_artifact, head_manifest, self._plan(sibling, comp_key), session)
 
         approval = PreprodComparisonApproval.objects.get(
             preprod_artifact=head_artifact,
@@ -270,6 +408,7 @@ class TryAutoApproveSnapshotTest(TestCase):
         assert approval.extras is not None
         assert approval.extras["auto_approval"] is True
         assert approval.extras["prev_approved_artifact_id"] == sibling.id
+        assert approval.extras["threshold_matched_image_count"] == 0
 
         assert_any_analytics_event(
             mock_analytics,
@@ -289,7 +428,7 @@ class TryAutoApproveSnapshotTest(TestCase):
                 status="changed", head_hash="abc", base_hash="old1"
             ),
         }
-        _, comp_key, comp_json = self._create_approved_sibling(
+        sibling, comp_key, comp_json = self._create_approved_sibling(
             pr_number=42,
             comparison_images=sibling_images,
         )
@@ -310,11 +449,12 @@ class TryAutoApproveSnapshotTest(TestCase):
                 "screen1.png": ComparisonImageResult(
                     status="changed", head_hash="DIFFERENT", base_hash="old1"
                 ),
+                "screen2.png": ComparisonImageResult(status="added", head_hash="new"),
             }
         )
 
         session = _mock_session_with_manifests({comp_key: comp_json})
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
+        self._approve(head_artifact, head_manifest, self._plan(sibling, comp_key), session)
 
         assert not PreprodComparisonApproval.objects.filter(
             preprod_artifact=head_artifact,
@@ -338,7 +478,7 @@ class TryAutoApproveSnapshotTest(TestCase):
             }
         )
         session = MagicMock()
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
+        self._approve(head_artifact, head_manifest, self._plan(None, None), session)
         assert not PreprodComparisonApproval.objects.filter(
             preprod_artifact=head_artifact,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
@@ -361,22 +501,22 @@ class TryAutoApproveSnapshotTest(TestCase):
             }
         )
         session = MagicMock()
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
+        self._approve(head_artifact, head_manifest, self._plan(None, None), session)
         assert not PreprodComparisonApproval.objects.filter(
             preprod_artifact=head_artifact,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
         ).exists()
 
     def test_no_auto_approve_when_no_changes(self):
-        cc = self.create_commit_comparison(
-            organization=self.organization,
+        sibling, comp_key, comp_json = self._create_approved_sibling(
             pr_number=42,
-            head_repo_name="owner/repo",
+            comparison_images={
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="abc", base_hash="old1"
+                ),
+            },
         )
-        head_artifact = self.create_preprod_artifact(
-            project=self.project,
-            commit_comparison=cc,
-        )
+        head_artifact = self._create_head_artifact()
         head_manifest = self._create_head_manifest(
             {
                 "screen1.png": ComparisonImageResult(
@@ -385,33 +525,23 @@ class TryAutoApproveSnapshotTest(TestCase):
             }
         )
         session = MagicMock()
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
+        self._approve(head_artifact, head_manifest, self._plan(sibling, comp_key), session)
         assert not PreprodComparisonApproval.objects.filter(
             preprod_artifact=head_artifact,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
         ).exists()
+        session.get.assert_not_called()
 
     def test_handles_missing_comparison_manifest(self):
-        sibling_images = {
-            "screen1.png": ComparisonImageResult(
-                status="changed", head_hash="abc", base_hash="old1"
-            ),
-        }
-        _, comp_key, _ = self._create_approved_sibling(
+        sibling, comp_key, _ = self._create_approved_sibling(
             pr_number=42,
-            comparison_images=sibling_images,
+            comparison_images={
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="abc", base_hash="old1"
+                ),
+            },
         )
-
-        cc = self.create_commit_comparison(
-            organization=self.organization,
-            pr_number=42,
-            head_repo_name="owner/repo",
-        )
-        head_artifact = self.create_preprod_artifact(
-            project=self.project,
-            commit_comparison=cc,
-            app_id="com.example.app",
-        )
+        head_artifact = self._create_head_artifact()
         head_manifest = self._create_head_manifest(
             {
                 "screen1.png": ComparisonImageResult(status="changed", head_hash="abc"),
@@ -420,7 +550,7 @@ class TryAutoApproveSnapshotTest(TestCase):
 
         session = MagicMock()
         session.get.side_effect = Exception("Not found")
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
+        self._approve(head_artifact, head_manifest, self._plan(sibling, comp_key), session)
         assert not PreprodComparisonApproval.objects.filter(
             preprod_artifact=head_artifact,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
@@ -438,27 +568,9 @@ class TryAutoApproveSnapshotTest(TestCase):
             app_id="com.other.app",
         )
 
-        cc = self.create_commit_comparison(
-            organization=self.organization,
-            pr_number=42,
-            head_repo_name="owner/repo",
-        )
-        head_artifact = self.create_preprod_artifact(
-            project=self.project,
-            commit_comparison=cc,
-            app_id="com.example.app",
-        )
-        head_manifest = self._create_head_manifest(
-            {
-                "screen1.png": ComparisonImageResult(status="changed", head_hash="abc"),
-            }
-        )
-        session = MagicMock()
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
-        assert not PreprodComparisonApproval.objects.filter(
-            preprod_artifact=head_artifact,
-            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
-        ).exists()
+        head_artifact = self._create_head_artifact()
+
+        assert _find_approved_sibling(head_artifact, MagicMock()) is None
 
     def test_no_auto_approve_when_sibling_not_approved_for_snapshots(self):
         cc = self.create_commit_comparison(
@@ -495,27 +607,9 @@ class TryAutoApproveSnapshotTest(TestCase):
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
         )
 
-        cc2 = self.create_commit_comparison(
-            organization=self.organization,
-            pr_number=42,
-            head_repo_name="owner/repo",
-        )
-        head_artifact = self.create_preprod_artifact(
-            project=self.project,
-            commit_comparison=cc2,
-            app_id="com.example.app",
-        )
-        head_manifest = self._create_head_manifest(
-            {
-                "screen1.png": ComparisonImageResult(status="changed", head_hash="abc"),
-            }
-        )
-        session = MagicMock()
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
-        assert not PreprodComparisonApproval.objects.filter(
-            preprod_artifact=head_artifact,
-            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
-        ).exists()
+        head_artifact = self._create_head_artifact()
+
+        assert _find_approved_sibling(head_artifact, MagicMock()) is None
 
     def test_auto_approves_with_renamed_images(self):
         shared_images = {
@@ -523,7 +617,7 @@ class TryAutoApproveSnapshotTest(TestCase):
                 status="renamed", head_hash="abc", previous_image_file_name="old_name.png"
             ),
         }
-        _, comp_key, comp_json = self._create_approved_sibling(
+        sibling, comp_key, comp_json = self._create_approved_sibling(
             pr_number=42,
             comparison_images=shared_images,
         )
@@ -548,7 +642,7 @@ class TryAutoApproveSnapshotTest(TestCase):
         )
 
         session = _mock_session_with_manifests({comp_key: comp_json})
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
+        self._approve(head_artifact, head_manifest, self._plan(sibling, comp_key), session)
         assert PreprodComparisonApproval.objects.filter(
             preprod_artifact=head_artifact,
             approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
@@ -595,7 +689,7 @@ class TryAutoApproveSnapshotTest(TestCase):
         )
 
         session = _mock_session_with_manifests({comp_key: comp_json})
-        _try_auto_approve_snapshot(head_artifact, head_manifest, session)
+        self._approve(head_artifact, head_manifest, self._plan(sibling, comp_key), session)
 
         approval = PreprodComparisonApproval.objects.get(
             preprod_artifact=head_artifact,
@@ -605,3 +699,226 @@ class TryAutoApproveSnapshotTest(TestCase):
         assert approval.extras is not None
         assert approval.extras["auto_approval"] is True
         assert approval.extras["prev_approved_artifact_id"] == sibling.id
+
+    @patch("sentry.analytics.record")
+    def test_auto_approves_when_sibling_results_unchanged(self, mock_analytics):
+        sibling, comp_key, comp_json = self._create_approved_sibling(
+            pr_number=42,
+            comparison_images={
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="sibling-hash", base_hash="old1"
+                ),
+            },
+        )
+        head_artifact = self._create_head_artifact()
+        head_manifest = self._create_head_manifest(
+            {
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="head-hash", base_hash="old1"
+                ),
+            }
+        )
+        sibling_images = {
+            "screen1.png": ComparisonImageResult(
+                status="unchanged",
+                head_hash="head-hash",
+                base_hash="sibling-hash",
+                changed_pixels=3,
+                total_pixels=10000,
+            )
+        }
+        session = _mock_session_with_manifests({comp_key: comp_json})
+
+        self._approve(
+            head_artifact, head_manifest, self._plan(sibling, comp_key), session, sibling_images
+        )
+
+        approval = PreprodComparisonApproval.objects.get(preprod_artifact=head_artifact)
+        assert approval.extras is not None
+        assert approval.extras["auto_approval"] is True
+        assert approval.extras["prev_approved_artifact_id"] == sibling.id
+        assert approval.extras["threshold_matched_image_count"] == 1
+        session.get.assert_called_once_with(comp_key)
+        assert_any_analytics_event(
+            mock_analytics,
+            PreprodStatusCheckApprovalCreatedEvent(
+                organization_id=self.organization.id,
+                project_id=self.project.id,
+                artifact_id=head_artifact.id,
+                product="snapshots",
+                source="auto",
+            ),
+        )
+
+    def test_no_auto_approve_when_sibling_result_changed(self):
+        sibling, comp_key, comp_json = self._create_approved_sibling(
+            pr_number=42,
+            comparison_images={
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="sibling-hash", base_hash="old1"
+                ),
+            },
+        )
+        head_artifact = self._create_head_artifact()
+        head_manifest = self._create_head_manifest(
+            {
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="head-hash", base_hash="old1"
+                ),
+            }
+        )
+        sibling_images = {
+            "screen1.png": ComparisonImageResult(
+                status="changed", head_hash="head-hash", base_hash="sibling-hash"
+            )
+        }
+        self._approve(
+            head_artifact,
+            head_manifest,
+            self._plan(sibling, comp_key),
+            _mock_session_with_manifests({comp_key: comp_json}),
+            sibling_images,
+        )
+        assert not PreprodComparisonApproval.objects.filter(preprod_artifact=head_artifact).exists()
+
+    def test_no_auto_approve_when_sibling_result_missing(self):
+        sibling, comp_key, comp_json = self._create_approved_sibling(
+            pr_number=42,
+            comparison_images={
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="sibling-hash", base_hash="old1"
+                ),
+            },
+        )
+        head_artifact = self._create_head_artifact()
+        head_manifest = self._create_head_manifest(
+            {
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="head-hash", base_hash="old1"
+                ),
+            }
+        )
+        self._approve(
+            head_artifact,
+            head_manifest,
+            self._plan(sibling, comp_key),
+            _mock_session_with_manifests({comp_key: comp_json}),
+            {},
+        )
+        assert not PreprodComparisonApproval.objects.filter(preprod_artifact=head_artifact).exists()
+
+    def test_no_auto_approve_when_sibling_result_hashes_mismatch(self):
+        sibling, comp_key, comp_json = self._create_approved_sibling(
+            pr_number=42,
+            comparison_images={
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="sibling-hash", base_hash="old1"
+                ),
+            },
+        )
+        head_artifact = self._create_head_artifact()
+        head_manifest = self._create_head_manifest(
+            {
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="head-hash", base_hash="old1"
+                ),
+            }
+        )
+        sibling_images = {
+            "screen1.png": ComparisonImageResult(
+                status="unchanged", head_hash="stale-head", base_hash="sibling-hash"
+            )
+        }
+        self._approve(
+            head_artifact,
+            head_manifest,
+            self._plan(sibling, comp_key),
+            _mock_session_with_manifests({comp_key: comp_json}),
+            sibling_images,
+        )
+        assert not PreprodComparisonApproval.objects.filter(preprod_artifact=head_artifact).exists()
+
+    def test_no_auto_approve_when_plan_has_no_sibling(self):
+        head_artifact = self._create_head_artifact()
+        head_manifest = self._create_head_manifest(
+            {"screen1.png": ComparisonImageResult(status="changed", head_hash="h", base_hash="b")}
+        )
+        session = MagicMock()
+        self._approve(head_artifact, head_manifest, self._plan(None, None), session)
+        assert not PreprodComparisonApproval.objects.filter(preprod_artifact=head_artifact).exists()
+        session.get.assert_not_called()
+
+    def test_no_auto_approve_when_status_differs_even_if_pixels_match(self):
+        sibling, comp_key, comp_json = self._create_approved_sibling(
+            pr_number=42,
+            comparison_images={
+                "screen1.png": ComparisonImageResult(status="added", head_hash="sibling-hash"),
+            },
+        )
+        head_artifact = self._create_head_artifact()
+        head_manifest = self._create_head_manifest(
+            {
+                "screen1.png": ComparisonImageResult(
+                    status="changed", head_hash="head-hash", base_hash="old1"
+                ),
+            }
+        )
+        sibling_images = {
+            "screen1.png": ComparisonImageResult(
+                status="unchanged", head_hash="head-hash", base_hash="sibling-hash"
+            )
+        }
+        session = _mock_session_with_manifests({comp_key: comp_json})
+        self._approve(
+            head_artifact, head_manifest, self._plan(sibling, comp_key), session, sibling_images
+        )
+
+        assert not PreprodComparisonApproval.objects.filter(preprod_artifact=head_artifact).exists()
+        session.get.assert_called_once_with(comp_key)
+
+    def test_sibling_selection_skips_auto_approved_builds(self):
+        images = {
+            "screen1.png": ComparisonImageResult(
+                status="changed", head_hash="abc", base_hash="old1"
+            ),
+        }
+        human_sibling, human_key, human_json = self._create_approved_sibling(
+            pr_number=42, comparison_images=images
+        )
+        auto_sibling, auto_key, auto_json = self._create_approved_sibling(
+            pr_number=42, comparison_images=images
+        )
+        PreprodComparisonApproval.objects.filter(preprod_artifact=auto_sibling).update(
+            extras={"auto_approval": True, "prev_approved_artifact_id": human_sibling.id}
+        )
+
+        head_artifact = self._create_head_artifact()
+
+        session = _mock_session_with_manifests({human_key: human_json, auto_key: auto_json})
+        sibling = _find_approved_sibling(head_artifact, session)
+
+        assert sibling is not None
+        assert sibling.artifact_id == human_sibling.id
+        session.get.assert_called_once_with(human_key)
+
+    def test_sibling_selection_keeps_human_approval_with_other_extras(self):
+        images = {
+            "screen1.png": ComparisonImageResult(
+                status="changed", head_hash="abc", base_hash="old1"
+            ),
+        }
+        sibling, comp_key, comp_json = self._create_approved_sibling(
+            pr_number=42, comparison_images=images
+        )
+        PreprodComparisonApproval.objects.filter(preprod_artifact=sibling).update(
+            extras={"github_user_info": {"login": "reviewer"}}
+        )
+
+        head_artifact = self._create_head_artifact()
+
+        session = _mock_session_with_manifests({comp_key: comp_json})
+        result = _find_approved_sibling(head_artifact, session)
+
+        assert result is not None
+        assert result.artifact_id == sibling.id
+        session.get.assert_called_once_with(comp_key)

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -1003,7 +1003,13 @@ class CompareSnapshotsOrchestratorTest(TestCase):
                 )
             },
         )
-        sibling = SiblingComparison(77, "sib/comparison.json", sibling_manifest)
+        sibling_snapshot_manifest = SnapshotManifest(
+            images={"changed.png": ImageMetadata(content_hash="hsib", width=100, height=100)},
+            diff_threshold=None,
+        )
+        sibling = SiblingComparison(
+            77, "sib/comparison.json", sibling_manifest, sibling_snapshot_manifest
+        )
 
         with (
             self.options({"preprod.snapshots.auto-approve-sibling-diffs.enabled": True}),
@@ -1088,7 +1094,13 @@ class CompareSnapshotsOrchestratorTest(TestCase):
                 )
             },
         )
-        sibling = SiblingComparison(77, "sib/comparison.json", sibling_manifest)
+        sibling_snapshot_manifest = SnapshotManifest(
+            images={"changed.png": ImageMetadata(content_hash="hsib", width=100, height=100)},
+            diff_threshold=None,
+        )
+        sibling = SiblingComparison(
+            77, "sib/comparison.json", sibling_manifest, sibling_snapshot_manifest
+        )
 
         with (
             self.options({"preprod.snapshots.auto-approve-sibling-diffs.enabled": False}),
@@ -2094,7 +2106,13 @@ class EndToEndFanoutTest(TestCase):
             ),
             images={"added.png": ComparisonImageResult(status="added", head_hash="sib1")},
         )
-        sibling = SiblingComparison(777, sibling_comparison_key, sibling_manifest)
+        sibling_snapshot_manifest = SnapshotManifest(
+            images={"added.png": ImageMetadata(content_hash="sib1", width=10, height=10)},
+            diff_threshold=None,
+        )
+        sibling = SiblingComparison(
+            777, sibling_comparison_key, sibling_manifest, sibling_snapshot_manifest
+        )
 
         stored = {
             "head_manifest": orjson.dumps(head_manifest.dict()),
@@ -2229,7 +2247,13 @@ class EndToEndFanoutTest(TestCase):
             ),
             images={"added.png": ComparisonImageResult(status="added", head_hash="ha1")},
         )
-        sibling = SiblingComparison(777, sibling_comparison_key, sibling_manifest)
+        sibling_snapshot_manifest = SnapshotManifest(
+            images={"added.png": ImageMetadata(content_hash="ha1", width=10, height=10)},
+            diff_threshold=None,
+        )
+        sibling = SiblingComparison(
+            777, sibling_comparison_key, sibling_manifest, sibling_snapshot_manifest
+        )
 
         stored = {
             "head_manifest": orjson.dumps(head_manifest.dict()),

--- a/tests/sentry/preprod/snapshots/test_compare_snapshots.py
+++ b/tests/sentry/preprod/snapshots/test_compare_snapshots.py
@@ -224,6 +224,85 @@ class ProcessChunkTest(TestCase):
             comparison.refresh_from_db()
             assert comparison.chunks_done_indices == [0]
 
+    def test_chunk_writes_sibling_results_separately(self):
+        from sentry.preprod.snapshots.image_diff.types import DiffResult
+        from sentry.preprod.snapshots.manifest import (
+            ChunkAssignment,
+            ChunkCandidate,
+            ChunkResult,
+            ComparisonPlan,
+        )
+        from sentry.preprod.snapshots.tasks import process_snapshot_comparison_chunk
+
+        head_artifact = self.create_preprod_artifact(project=self.project)
+        base_artifact = self.create_preprod_artifact(project=self.project)
+        head = self.create_preprod_snapshot_metrics(head_artifact)
+        base = self.create_preprod_snapshot_metrics(base_artifact)
+        comparison = self.create_preprod_snapshot_comparison(
+            head_snapshot_metrics=head,
+            base_snapshot_metrics=base,
+            state=PreprodSnapshotComparison.State.PROCESSING,
+        )
+
+        plan = ComparisonPlan(
+            head_artifact_id=head_artifact.id,
+            base_artifact_id=base_artifact.id,
+            chunks=[
+                ChunkAssignment(
+                    chunk_index=0,
+                    candidates=[
+                        ChunkCandidate(
+                            name="a.png",
+                            head_hash="h",
+                            base_hash="b",
+                            pixel_count=10,
+                            diff_threshold=0.0,
+                            kind="sibling",
+                        )
+                    ],
+                )
+            ],
+            non_diff_images={},
+        )
+        prefix = f"{self.organization.id}/{self.project.id}/{head_artifact.id}/{base_artifact.id}"
+        stored = {f"{prefix}/plan.json": orjson.dumps(plan.dict())}
+        session = _dict_backed_session(stored)
+
+        diff = DiffResult(
+            diff_mask_png=b"png",
+            changed_pixels=5,
+            total_pixels=100,
+            aligned_height=10,
+            before_width=10,
+            before_height=10,
+            after_width=10,
+            after_height=10,
+        )
+
+        with (
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks.OdiffServer"),
+            patch(
+                "sentry.preprod.snapshots.tasks._fetch_batch_images",
+                return_value=({"h": b"img", "b": b"img"}, set()),
+            ),
+            patch("sentry.preprod.snapshots.tasks.read_image_size", return_value=ImageSize(1, 1)),
+            patch("sentry.preprod.snapshots.tasks.compare_images_batch", return_value=[diff]),
+        ):
+            process_snapshot_comparison_chunk(
+                comparison_id=comparison.id,
+                chunk_index=0,
+                org_id=self.organization.id,
+                project_id=self.project.id,
+                head_artifact_id=head_artifact.id,
+                base_artifact_id=base_artifact.id,
+            )
+
+        result_key = f"{prefix}/chunks/0.json"
+        stored_result = ChunkResult(**orjson.loads(stored[result_key]))
+        assert stored_result.images == {}
+        assert set(stored_result.sibling_images) == {"a.png"}
+
     def _comparison(self, chunks_total, done_indices=None):
         head_artifact = self.create_preprod_artifact(project=self.project)
         base_artifact = self.create_preprod_artifact(project=self.project)
@@ -610,10 +689,75 @@ class FinalizeSnapshotComparisonTest(TestCase):
         assert comparison.images_changed == 1
         assert f"{prefix}/comparison.json" in stored
         assert mock_auto_approve.call_count == 1
-        called_head_artifact, called_manifest, called_session = mock_auto_approve.call_args.args
+        (
+            called_head_artifact,
+            called_manifest,
+            called_plan,
+            called_sibling_images,
+            called_session,
+        ) = mock_auto_approve.call_args.args
         assert called_head_artifact.id == h.id
         assert called_manifest.head_artifact_id == h.id
         assert called_session is session
+
+    def test_finalize_passes_sibling_results_to_auto_approve(self):
+        from sentry.preprod.snapshots.manifest import (
+            ChunkAssignment,
+            ChunkCandidate,
+            ChunkResult,
+            ComparisonImageResult,
+            ComparisonPlan,
+        )
+        from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
+
+        comparison, h, b = self._comparison(1, done_indices=[0])
+        plan = ComparisonPlan(
+            head_artifact_id=h.id,
+            base_artifact_id=b.id,
+            chunks=[
+                ChunkAssignment(
+                    chunk_index=0,
+                    candidates=[
+                        ChunkCandidate(
+                            name="a.png",
+                            head_hash="a-head",
+                            base_hash="a-sib",
+                            pixel_count=10,
+                            diff_threshold=0.0,
+                            kind="sibling",
+                        )
+                    ],
+                )
+            ],
+            non_diff_images={},
+            sibling_artifact_id=77,
+            sibling_comparison_key="sib/comparison.json",
+        )
+        sibling_images = {
+            "a.png": ComparisonImageResult(
+                status="unchanged", head_hash="a-head", base_hash="a-sib"
+            )
+        }
+        result = ChunkResult(chunk_index=0, images={}, sibling_images=sibling_images)
+        prefix = f"{self.organization.id}/{self.project.id}/{h.id}/{b.id}"
+        stored = {
+            f"{prefix}/plan.json": orjson.dumps(plan.dict()),
+            f"{prefix}/chunks/0.json": orjson.dumps(result.dict()),
+        }
+        session = _dict_backed_session(stored)
+        with (
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks._try_auto_approve_snapshot") as mock_auto_approve,
+        ):
+            finalize_snapshot_comparison(**self._kwargs(comparison, h, b))
+        comparison.refresh_from_db()
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
+        assert mock_auto_approve.call_count == 1
+        (_head, _manifest, called_plan, called_sibling_images, _session) = (
+            mock_auto_approve.call_args.args
+        )
+        assert called_sibling_images == sibling_images
+        assert called_plan.sibling_artifact_id == 77
 
     def test_finalize_writes_images_errored_column(self):
         from sentry.preprod.snapshots.tasks import finalize_snapshot_comparison
@@ -807,6 +951,173 @@ class CompareSnapshotsOrchestratorTest(TestCase):
             comparison.state == PreprodSnapshotComparison.State.PROCESSING
         )  # finalizer sets SUCCESS, not orchestrator
         assert dispatch.call_count == 1
+
+    def test_orchestrator_records_sibling_in_plan(self):
+        import orjson
+
+        from sentry.preprod.snapshots.manifest import (
+            ComparisonImageResult,
+            ComparisonManifest,
+            ComparisonPlan,
+            ComparisonSummary,
+            ImageMetadata,
+            SnapshotManifest,
+        )
+        from sentry.preprod.snapshots.tasks import (
+            SiblingComparison,
+            _plan_key,
+            compare_snapshots,
+        )
+
+        head_artifact, base_artifact = self._setup()
+        head_manifest = SnapshotManifest(
+            images={"changed.png": ImageMetadata(content_hash="h1", width=100, height=100)},
+            diff_threshold=None,
+        )
+        base_manifest = SnapshotManifest(
+            images={"changed.png": ImageMetadata(content_hash="h0", width=100, height=100)},
+            diff_threshold=None,
+        )
+        stored = {
+            "head_manifest": orjson.dumps(head_manifest.dict()),
+            "base_manifest": orjson.dumps(base_manifest.dict()),
+        }
+        session = _dict_backed_session(stored)
+
+        sibling_manifest = ComparisonManifest(
+            head_artifact_id=77,
+            base_artifact_id=0,
+            summary=ComparisonSummary(
+                total=1,
+                changed=1,
+                unchanged=0,
+                added=0,
+                removed=0,
+                errored=0,
+                renamed=0,
+                skipped=0,
+            ),
+            images={
+                "changed.png": ComparisonImageResult(
+                    status="changed", head_hash="hsib", base_hash="hsib_base"
+                )
+            },
+        )
+        sibling = SiblingComparison(77, "sib/comparison.json", sibling_manifest)
+
+        with (
+            self.options({"preprod.snapshots.auto-approve-sibling-diffs.enabled": True}),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
+            patch(
+                "sentry.preprod.snapshots.tasks._find_approved_sibling", return_value=sibling
+            ) as mock_find_sibling,
+            patch("sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"),
+            patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
+        ):
+            compare_snapshots(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                head_artifact_id=head_artifact.id,
+                base_artifact_id=base_artifact.id,
+            )
+
+        plan_key = _plan_key(
+            self.organization.id, self.project.id, head_artifact.id, base_artifact.id
+        )
+        plan = ComparisonPlan(**orjson.loads(stored[plan_key]))
+        assert plan.sibling_artifact_id == 77
+        assert plan.sibling_comparison_key == "sib/comparison.json"
+        sibling_candidates = [
+            c for chunk in plan.chunks for c in chunk.candidates if c.kind == "sibling"
+        ]
+        assert len(sibling_candidates) == 1
+
+        mock_find_sibling.assert_called_once()
+        called_head, called_session = mock_find_sibling.call_args.args
+        assert called_head.id == head_artifact.id
+        assert called_session is session
+
+    def test_orchestrator_records_sibling_without_candidates_when_disabled(self):
+        import orjson
+
+        from sentry.preprod.snapshots.manifest import (
+            ComparisonImageResult,
+            ComparisonManifest,
+            ComparisonPlan,
+            ComparisonSummary,
+            ImageMetadata,
+            SnapshotManifest,
+        )
+        from sentry.preprod.snapshots.tasks import (
+            SiblingComparison,
+            _plan_key,
+            compare_snapshots,
+        )
+
+        head_artifact, base_artifact = self._setup()
+        head_manifest = SnapshotManifest(
+            images={"changed.png": ImageMetadata(content_hash="h1", width=100, height=100)},
+            diff_threshold=None,
+        )
+        base_manifest = SnapshotManifest(
+            images={"changed.png": ImageMetadata(content_hash="h0", width=100, height=100)},
+            diff_threshold=None,
+        )
+        stored = {
+            "head_manifest": orjson.dumps(head_manifest.dict()),
+            "base_manifest": orjson.dumps(base_manifest.dict()),
+        }
+        session = _dict_backed_session(stored)
+
+        sibling_manifest = ComparisonManifest(
+            head_artifact_id=77,
+            base_artifact_id=0,
+            summary=ComparisonSummary(
+                total=1,
+                changed=1,
+                unchanged=0,
+                added=0,
+                removed=0,
+                errored=0,
+                renamed=0,
+                skipped=0,
+            ),
+            images={
+                "changed.png": ComparisonImageResult(
+                    status="changed", head_hash="hsib", base_hash="hsib_base"
+                )
+            },
+        )
+        sibling = SiblingComparison(77, "sib/comparison.json", sibling_manifest)
+
+        with (
+            self.options({"preprod.snapshots.auto-approve-sibling-diffs.enabled": False}),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
+            patch(
+                "sentry.preprod.snapshots.tasks._find_approved_sibling", return_value=sibling
+            ) as mock_find_sibling,
+            patch("sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async"),
+            patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
+        ):
+            compare_snapshots(
+                project_id=self.project.id,
+                org_id=self.organization.id,
+                head_artifact_id=head_artifact.id,
+                base_artifact_id=base_artifact.id,
+            )
+
+        mock_find_sibling.assert_called_once()
+
+        plan_key = _plan_key(
+            self.organization.id, self.project.id, head_artifact.id, base_artifact.id
+        )
+        plan = ComparisonPlan(**orjson.loads(stored[plan_key]))
+        assert plan.sibling_artifact_id == sibling.artifact_id
+        assert plan.sibling_comparison_key == sibling.comparison_key
+        sibling_candidates = [
+            c for chunk in plan.chunks for c in chunk.candidates if c.kind == "sibling"
+        ]
+        assert sibling_candidates == []
 
     def test_orchestrator_finalizes_when_no_diff_chunks(self):
         import orjson
@@ -1724,3 +2035,273 @@ class EndToEndFanoutTest(TestCase):
             sample_rate=1.0,
             tags={"app_id_temp": head_artifact.app_id or ""},
         )
+
+    def test_full_flow_auto_approves_via_sibling_results(self):
+        from sentry.preprod.models import PreprodComparisonApproval
+        from sentry.preprod.snapshots.image_diff.types import DiffResult
+        from sentry.preprod.snapshots.manifest import (
+            ComparisonImageResult,
+            ComparisonManifest,
+            ComparisonSummary,
+            ImageMetadata,
+            SnapshotManifest,
+        )
+        from sentry.preprod.snapshots.tasks import (
+            SiblingComparison,
+            compare_snapshots,
+            finalize_snapshot_comparison,
+            process_snapshot_comparison_chunk,
+        )
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, pr_number=42, head_repo_name="owner/repo"
+        )
+        head_artifact = self.create_preprod_artifact(
+            project=self.project, commit_comparison=commit_comparison
+        )
+        base_artifact = self.create_preprod_artifact(project=self.project)
+        head = self.create_preprod_snapshot_metrics(head_artifact)
+        head.extras = {"manifest_key": "head_manifest"}
+        head.save()
+        base = self.create_preprod_snapshot_metrics(base_artifact)
+        base.extras = {"manifest_key": "base_manifest"}
+        base.save()
+
+        head_manifest = SnapshotManifest(
+            images={
+                "added.png": ImageMetadata(content_hash="ha1", width=10, height=10),
+                "unchanged.png": ImageMetadata(content_hash="hsame", width=10, height=10),
+            },
+            diff_threshold=None,
+        )
+        base_manifest = SnapshotManifest(
+            images={"unchanged.png": ImageMetadata(content_hash="hsame", width=10, height=10)},
+            diff_threshold=None,
+        )
+        sibling_comparison_key = "sib/comparison.json"
+        sibling_manifest = ComparisonManifest(
+            head_artifact_id=777,
+            base_artifact_id=0,
+            summary=ComparisonSummary(
+                total=1,
+                changed=0,
+                unchanged=0,
+                added=1,
+                removed=0,
+                errored=0,
+                renamed=0,
+                skipped=0,
+            ),
+            images={"added.png": ComparisonImageResult(status="added", head_hash="sib1")},
+        )
+        sibling = SiblingComparison(777, sibling_comparison_key, sibling_manifest)
+
+        stored = {
+            "head_manifest": orjson.dumps(head_manifest.dict()),
+            "base_manifest": orjson.dumps(base_manifest.dict()),
+            sibling_comparison_key: orjson.dumps(sibling_manifest.dict()),
+        }
+        session = _dict_backed_session(stored)
+        dispatched: list[dict] = []
+
+        kwargs = dict(
+            project_id=self.project.id,
+            org_id=self.organization.id,
+            head_artifact_id=head_artifact.id,
+            base_artifact_id=base_artifact.id,
+        )
+
+        unchanged_diff = DiffResult(
+            diff_mask_png=b"png",
+            changed_pixels=0,
+            total_pixels=100,
+            aligned_height=10,
+            before_width=10,
+            before_height=10,
+            after_width=10,
+            after_height=10,
+        )
+
+        with (
+            self.options({"preprod.snapshots.auto-approve-sibling-diffs.enabled": True}),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks._find_approved_sibling", return_value=sibling),
+            patch(
+                "sentry.preprod.snapshots.tasks._fetch_batch_images", side_effect=self._fake_fetch
+            ),
+            patch("sentry.preprod.snapshots.tasks.read_image_size", return_value=ImageSize(1, 1)),
+            patch(
+                "sentry.preprod.snapshots.tasks.compare_images_batch",
+                side_effect=lambda pairs, server: [unchanged_diff for _ in pairs],
+            ),
+            patch("sentry.preprod.snapshots.tasks.OdiffServer"),
+            patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
+            patch("sentry.analytics.record"),
+            patch(
+                "sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async",
+                side_effect=lambda kwargs, **_: dispatched.append(kwargs),
+            ),
+            patch("sentry.preprod.snapshots.tasks.finalize_snapshot_comparison.apply_async"),
+        ):
+            compare_snapshots(**kwargs)
+
+            comparison = PreprodSnapshotComparison.objects.get(
+                head_snapshot_metrics__preprod_artifact=head_artifact
+            )
+            for chunk_kwargs in dispatched:
+                process_snapshot_comparison_chunk(**chunk_kwargs)
+
+            finalize_snapshot_comparison(
+                comparison_id=comparison.id,
+                org_id=self.organization.id,
+                project_id=self.project.id,
+                head_artifact_id=head_artifact.id,
+                base_artifact_id=base_artifact.id,
+            )
+
+        comparison.refresh_from_db()
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
+
+        approval = PreprodComparisonApproval.objects.get(
+            preprod_artifact=head_artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        )
+        assert approval.extras is not None
+        assert approval.extras["prev_approved_artifact_id"] == 777
+        assert approval.extras["threshold_matched_image_count"] == 1
+
+    def test_full_flow_auto_approves_exact_match_when_disabled(self):
+        from sentry.preprod.models import PreprodComparisonApproval
+        from sentry.preprod.snapshots.image_diff.types import DiffResult
+        from sentry.preprod.snapshots.manifest import (
+            ComparisonImageResult,
+            ComparisonManifest,
+            ComparisonSummary,
+            ImageMetadata,
+            SnapshotManifest,
+        )
+        from sentry.preprod.snapshots.tasks import (
+            SiblingComparison,
+            compare_snapshots,
+            finalize_snapshot_comparison,
+            process_snapshot_comparison_chunk,
+        )
+
+        commit_comparison = self.create_commit_comparison(
+            organization=self.organization, pr_number=42, head_repo_name="owner/repo"
+        )
+        head_artifact = self.create_preprod_artifact(
+            project=self.project, commit_comparison=commit_comparison
+        )
+        base_artifact = self.create_preprod_artifact(project=self.project)
+        head = self.create_preprod_snapshot_metrics(head_artifact)
+        head.extras = {"manifest_key": "head_manifest"}
+        head.save()
+        base = self.create_preprod_snapshot_metrics(base_artifact)
+        base.extras = {"manifest_key": "base_manifest"}
+        base.save()
+
+        head_manifest = SnapshotManifest(
+            images={
+                "added.png": ImageMetadata(content_hash="ha1", width=10, height=10),
+                "unchanged.png": ImageMetadata(content_hash="hsame", width=10, height=10),
+            },
+            diff_threshold=None,
+        )
+        base_manifest = SnapshotManifest(
+            images={"unchanged.png": ImageMetadata(content_hash="hsame", width=10, height=10)},
+            diff_threshold=None,
+        )
+        sibling_comparison_key = "sib/comparison.json"
+        sibling_manifest = ComparisonManifest(
+            head_artifact_id=777,
+            base_artifact_id=0,
+            summary=ComparisonSummary(
+                total=1,
+                changed=0,
+                unchanged=0,
+                added=1,
+                removed=0,
+                errored=0,
+                renamed=0,
+                skipped=0,
+            ),
+            images={"added.png": ComparisonImageResult(status="added", head_hash="ha1")},
+        )
+        sibling = SiblingComparison(777, sibling_comparison_key, sibling_manifest)
+
+        stored = {
+            "head_manifest": orjson.dumps(head_manifest.dict()),
+            "base_manifest": orjson.dumps(base_manifest.dict()),
+            sibling_comparison_key: orjson.dumps(sibling_manifest.dict()),
+        }
+        session = _dict_backed_session(stored)
+        dispatched: list[dict] = []
+
+        kwargs = dict(
+            project_id=self.project.id,
+            org_id=self.organization.id,
+            head_artifact_id=head_artifact.id,
+            base_artifact_id=base_artifact.id,
+        )
+
+        unchanged_diff = DiffResult(
+            diff_mask_png=b"png",
+            changed_pixels=0,
+            total_pixels=100,
+            aligned_height=10,
+            before_width=10,
+            before_height=10,
+            after_width=10,
+            after_height=10,
+        )
+
+        with (
+            self.options({"preprod.snapshots.auto-approve-sibling-diffs.enabled": False}),
+            patch("sentry.preprod.snapshots.tasks.get_session", return_value=session),
+            patch("sentry.preprod.snapshots.tasks._find_approved_sibling", return_value=sibling),
+            patch(
+                "sentry.preprod.snapshots.tasks._fetch_batch_images", side_effect=self._fake_fetch
+            ),
+            patch("sentry.preprod.snapshots.tasks.read_image_size", return_value=ImageSize(1, 1)),
+            patch(
+                "sentry.preprod.snapshots.tasks.compare_images_batch",
+                side_effect=lambda pairs, server: [unchanged_diff for _ in pairs],
+            ),
+            patch("sentry.preprod.snapshots.tasks.OdiffServer"),
+            patch("sentry.preprod.snapshots.tasks.update_preprod_snapshot_vcs"),
+            patch("sentry.analytics.record"),
+            patch(
+                "sentry.preprod.snapshots.tasks.process_snapshot_comparison_chunk.apply_async",
+                side_effect=lambda kwargs, **_: dispatched.append(kwargs),
+            ),
+            patch("sentry.preprod.snapshots.tasks.finalize_snapshot_comparison.apply_async"),
+        ):
+            compare_snapshots(**kwargs)
+
+            comparison = PreprodSnapshotComparison.objects.get(
+                head_snapshot_metrics__preprod_artifact=head_artifact
+            )
+            for chunk_kwargs in dispatched:
+                process_snapshot_comparison_chunk(**chunk_kwargs)
+
+            finalize_snapshot_comparison(
+                comparison_id=comparison.id,
+                org_id=self.organization.id,
+                project_id=self.project.id,
+                head_artifact_id=head_artifact.id,
+                base_artifact_id=base_artifact.id,
+            )
+
+        comparison.refresh_from_db()
+        assert comparison.state == PreprodSnapshotComparison.State.SUCCESS
+
+        approval = PreprodComparisonApproval.objects.get(
+            preprod_artifact=head_artifact,
+            preprod_feature_type=PreprodComparisonApproval.FeatureType.SNAPSHOTS,
+            approval_status=PreprodComparisonApproval.ApprovalStatus.APPROVED,
+        )
+        assert approval.extras is not None
+        assert approval.extras["prev_approved_artifact_id"] == 777
+        assert approval.extras["threshold_matched_image_count"] == 0

--- a/tests/sentry/preprod/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_tasks.py
@@ -3,12 +3,25 @@ from unittest.mock import MagicMock, patch
 
 from PIL import Image, PngImagePlugin
 
-from sentry.preprod.snapshots.manifest import ImageMetadata, SnapshotManifest
+from sentry.preprod.snapshots.image_diff.types import DiffResult
+from sentry.preprod.snapshots.manifest import (
+    ChunkAssignment,
+    ChunkCandidate,
+    ComparisonImageResult,
+    ComparisonManifest,
+    ComparisonSummary,
+    ImageMetadata,
+    SnapshotManifest,
+)
 from sentry.preprod.snapshots.tasks import (
+    SiblingComparison,
+    _build_comparison_plan,
     _chunk_result_key,
     _comparison_key,
     _diff_mask_key,
+    _effective_diff_threshold,
     _plan_key,
+    _process_chunk,
     categorize_image_diff,
 )
 
@@ -381,9 +394,6 @@ def test_build_comparison_plan_detects_rename():
 
 
 def test_process_chunk_enforces_actual_batch_pixel_limit():
-    from sentry.preprod.snapshots.manifest import ChunkAssignment, ChunkCandidate
-    from sentry.preprod.snapshots.tasks import _process_chunk
-
     assignment = ChunkAssignment(
         chunk_index=0,
         candidates=[
@@ -417,9 +427,323 @@ def test_process_chunk_enforces_actual_batch_pixel_limit():
         patch.object(PngImagePlugin.PngImageFile, "load") as load,
         patch("sentry.preprod.snapshots.tasks.OdiffServer"),
     ):
-        results = _process_chunk(MagicMock(), assignment, 1, 2, 3, 4)
+        result = _process_chunk(MagicMock(), assignment, 1, 2, 3, 4)
 
-    assert results["first"].reason == "image_processing_failed"
-    assert results["second"].reason == "exceeds_batch_pixel_limit"
+    assert result.images["first"].reason == "image_processing_failed"
+    assert result.images["second"].reason == "exceeds_batch_pixel_limit"
     assert len(compare.call_args.args[0]) == 1
     load.assert_not_called()
+
+
+def test_process_chunk_routes_sibling_candidates_without_diff_mask() -> None:
+    assignment = ChunkAssignment(
+        chunk_index=0,
+        candidates=[
+            ChunkCandidate(
+                name="a.png",
+                head_hash="a-head",
+                base_hash="a-base",
+                pixel_count=1,
+                diff_threshold=0.0,
+            ),
+            ChunkCandidate(
+                name="a.png",
+                head_hash="a-head",
+                base_hash="a-sib",
+                pixel_count=1,
+                diff_threshold=0.5,
+                kind="sibling",
+            ),
+        ],
+    )
+    buffer = io.BytesIO()
+    Image.new("RGBA", (10, 10)).save(buffer, format="PNG")
+    fetched = {h: buffer.getvalue() for h in ("a-head", "a-base", "a-sib")}
+    diff_result = DiffResult(
+        diff_mask_png=b"png",
+        changed_pixels=10,
+        total_pixels=100,
+        aligned_height=10,
+        before_width=10,
+        before_height=10,
+        after_width=10,
+        after_height=10,
+    )
+    session = MagicMock()
+    with (
+        patch("sentry.preprod.snapshots.tasks._fetch_batch_images", return_value=(fetched, set())),
+        patch(
+            "sentry.preprod.snapshots.tasks.compare_images_batch",
+            return_value=[diff_result, diff_result],
+        ),
+        patch("sentry.preprod.snapshots.tasks.OdiffServer"),
+        patch("sentry.preprod.snapshots.tasks._put_diff_mask") as put_mask,
+    ):
+        result = _process_chunk(session, assignment, 1, 2, 3, 4)
+
+    assert set(result.images) == {"a.png"}
+    assert result.images["a.png"].status == "changed"
+    assert result.images["a.png"].diff_mask_key is not None
+    assert set(result.sibling_images) == {"a.png"}
+    sibling = result.sibling_images["a.png"]
+    assert sibling.status == "unchanged"
+    assert sibling.head_hash == "a-head"
+    assert sibling.base_hash == "a-sib"
+    assert sibling.changed_pixels == 10
+    assert sibling.diff_mask_key is None
+    assert put_mask.call_count == 1
+
+
+def test_process_chunk_sibling_fetch_failure_is_errored_in_sibling_images() -> None:
+    assignment = ChunkAssignment(
+        chunk_index=0,
+        candidates=[
+            ChunkCandidate(
+                name="a.png",
+                head_hash="a-head",
+                base_hash="a-sib",
+                pixel_count=1,
+                diff_threshold=0.0,
+                kind="sibling",
+            ),
+        ],
+    )
+    with (
+        patch("sentry.preprod.snapshots.tasks._fetch_batch_images", return_value=({}, {"a-sib"})),
+        patch("sentry.preprod.snapshots.tasks.compare_images_batch", return_value=[]),
+        patch("sentry.preprod.snapshots.tasks.OdiffServer"),
+    ):
+        result = _process_chunk(MagicMock(), assignment, 1, 2, 3, 4)
+
+    assert result.images == {}
+    assert result.sibling_images["a.png"].status == "errored"
+    assert result.sibling_images["a.png"].reason == "image_fetch_failed"
+
+
+def _threshold_manifest(
+    image_threshold: float | None, manifest_threshold: float | None
+) -> SnapshotManifest:
+    return SnapshotManifest(
+        images={
+            "screen.png": ImageMetadata(
+                content_hash="abc", width=10, height=10, diff_threshold=image_threshold
+            )
+        },
+        diff_threshold=manifest_threshold,
+    )
+
+
+def test_effective_diff_threshold_prefers_image_value() -> None:
+    manifest = _threshold_manifest(image_threshold=0.2, manifest_threshold=0.5)
+    assert _effective_diff_threshold(manifest, "screen.png") == 0.2
+
+
+def test_effective_diff_threshold_falls_back_to_manifest_value() -> None:
+    manifest = _threshold_manifest(image_threshold=None, manifest_threshold=0.5)
+    assert _effective_diff_threshold(manifest, "screen.png") == 0.5
+
+
+def test_effective_diff_threshold_defaults_to_zero() -> None:
+    manifest = _threshold_manifest(image_threshold=None, manifest_threshold=None)
+    assert _effective_diff_threshold(manifest, "screen.png") == 0.0
+
+
+def test_effective_diff_threshold_unknown_image_uses_manifest_value() -> None:
+    manifest = _threshold_manifest(image_threshold=0.2, manifest_threshold=0.5)
+    assert _effective_diff_threshold(manifest, "missing.png") == 0.5
+
+
+def test_chunk_candidate_kind_defaults_to_base() -> None:
+    candidate = ChunkCandidate(
+        name="a.png", head_hash="h", base_hash="b", pixel_count=1, diff_threshold=0.0
+    )
+    assert candidate.kind == "base"
+
+
+def test_plan_and_chunk_result_parse_without_sibling_fields() -> None:
+    from sentry.preprod.snapshots.manifest import ChunkResult, ComparisonPlan
+
+    plan = ComparisonPlan(head_artifact_id=1, base_artifact_id=2, chunks=[], non_diff_images={})
+    assert plan.sibling_artifact_id is None
+    assert plan.sibling_comparison_key is None
+    result = ChunkResult(chunk_index=0, images={})
+    assert result.sibling_images == {}
+
+
+def _sibling(artifact_id: int, images: dict[str, ComparisonImageResult]) -> SiblingComparison:
+    manifest = ComparisonManifest(
+        head_artifact_id=artifact_id,
+        base_artifact_id=0,
+        summary=ComparisonSummary(
+            total=len(images), changed=0, unchanged=0, added=0, removed=0, errored=0, renamed=0
+        ),
+        images=images,
+    )
+    return SiblingComparison(artifact_id, f"key/{artifact_id}/comparison.json", manifest)
+
+
+def _manifest(
+    images: dict[str, tuple[str, int, int]], diff_threshold: float | None = None
+) -> SnapshotManifest:
+    return SnapshotManifest(
+        images={
+            name: ImageMetadata(content_hash=h, width=w, height=hgt)
+            for name, (h, w, hgt) in images.items()
+        },
+        diff_threshold=diff_threshold,
+    )
+
+
+def test_build_comparison_plan_without_sibling_has_no_sibling_candidates() -> None:
+    head = _manifest({"a.png": ("a2", 10, 10)})
+    base = _manifest({"a.png": ("a1", 10, 10)})
+    plan = _build_comparison_plan(head, base, 1, 2)
+    assert plan.sibling_artifact_id is None
+    assert plan.sibling_comparison_key is None
+    kinds = [c.kind for chunk in plan.chunks for c in chunk.candidates]
+    assert kinds == ["base"]
+
+
+def test_build_comparison_plan_adds_sibling_candidates_for_hash_differing_interesting_images() -> (
+    None
+):
+    head = _manifest(
+        {
+            "changed.png": ("c-head", 10, 10),
+            "added.png": ("add-head", 20, 20),
+            "renamed.png": ("ren-head", 10, 10),
+            "same.png": ("same", 10, 10),
+        },
+        diff_threshold=0.05,
+    )
+    base = _manifest(
+        {
+            "changed.png": ("c-base", 10, 10),
+            "old.png": ("ren-head", 10, 10),
+            "same.png": ("same", 10, 10),
+        }
+    )
+    sibling = _sibling(
+        7,
+        {
+            "changed.png": ComparisonImageResult(
+                status="changed", head_hash="c-sib", base_hash="c-base"
+            ),
+            "added.png": ComparisonImageResult(status="added", head_hash="add-head"),
+            "renamed.png": ComparisonImageResult(
+                status="renamed", head_hash="ren-sib", previous_image_file_name="old.png"
+            ),
+            "same.png": ComparisonImageResult(
+                status="unchanged", head_hash="same", base_hash="same"
+            ),
+        },
+    )
+    plan = _build_comparison_plan(head, base, 1, 2, sibling=sibling)
+    assert plan.sibling_artifact_id == 7
+    assert plan.sibling_comparison_key == "key/7/comparison.json"
+    sibling_candidates = {
+        c.name: c for chunk in plan.chunks for c in chunk.candidates if c.kind == "sibling"
+    }
+    assert set(sibling_candidates) == {"changed.png", "renamed.png"}
+    assert sibling_candidates["changed.png"].head_hash == "c-head"
+    assert sibling_candidates["changed.png"].base_hash == "c-sib"
+    assert sibling_candidates["changed.png"].pixel_count == 100
+    assert sibling_candidates["changed.png"].diff_threshold == 0.05
+    assert sibling_candidates["renamed.png"].base_hash == "ren-sib"
+    base_names = {c.name for chunk in plan.chunks for c in chunk.candidates if c.kind == "base"}
+    assert base_names == {"changed.png"}
+
+
+def test_build_comparison_plan_sibling_pixel_count_uses_larger_dimensions() -> None:
+    head = _manifest({"changed.png": ("c-head", 10, 10)})
+    base = _manifest({"changed.png": ("c-base", 10, 10)})
+    sibling = _sibling(
+        7,
+        {
+            "changed.png": ComparisonImageResult(
+                status="changed",
+                head_hash="c-sib",
+                base_hash="c-base",
+                after_width=30,
+                after_height=20,
+            ),
+        },
+    )
+    plan = _build_comparison_plan(head, base, 1, 2, sibling=sibling)
+    candidates = {(c.kind, c.name): c for chunk in plan.chunks for c in chunk.candidates}
+    assert candidates[("sibling", "changed.png")].pixel_count == 600
+    assert candidates[("base", "changed.png")].pixel_count == 100
+
+
+def test_build_comparison_plan_sibling_pixel_count_falls_back_to_head_dimensions() -> None:
+    head = _manifest({"changed.png": ("c-head", 10, 10)})
+    base = _manifest({"changed.png": ("c-base", 10, 10)})
+    sibling = _sibling(
+        7,
+        {"changed.png": ComparisonImageResult(status="added", head_hash="c-sib")},
+    )
+    plan = _build_comparison_plan(head, base, 1, 2, sibling=sibling)
+    sibling_candidates = {
+        c.name: c for chunk in plan.chunks for c in chunk.candidates if c.kind == "sibling"
+    }
+    assert sibling_candidates["changed.png"].pixel_count == 100
+
+
+def test_build_comparison_plan_records_sibling_without_candidates_when_disabled() -> None:
+    head = _manifest(
+        {
+            "changed.png": ("c-head", 10, 10),
+            "added.png": ("add-head", 20, 20),
+            "renamed.png": ("ren-head", 10, 10),
+            "same.png": ("same", 10, 10),
+        },
+        diff_threshold=0.05,
+    )
+    base = _manifest(
+        {
+            "changed.png": ("c-base", 10, 10),
+            "old.png": ("ren-head", 10, 10),
+            "same.png": ("same", 10, 10),
+        }
+    )
+    sibling = _sibling(
+        7,
+        {
+            "changed.png": ComparisonImageResult(
+                status="changed", head_hash="c-sib", base_hash="c-base"
+            ),
+            "added.png": ComparisonImageResult(status="added", head_hash="add-head"),
+            "renamed.png": ComparisonImageResult(
+                status="renamed", head_hash="ren-sib", previous_image_file_name="old.png"
+            ),
+            "same.png": ComparisonImageResult(
+                status="unchanged", head_hash="same", base_hash="same"
+            ),
+        },
+    )
+    plan = _build_comparison_plan(head, base, 1, 2, sibling=sibling, diff_sibling_images=False)
+    assert plan.sibling_artifact_id == 7
+    assert plan.sibling_comparison_key == "key/7/comparison.json"
+    kinds = [c.kind for chunk in plan.chunks for c in chunk.candidates]
+    assert "sibling" not in kinds
+
+
+def test_build_comparison_plan_skips_sibling_candidate_for_unchanged_head_image() -> None:
+    head = _manifest({"same.png": ("same", 10, 10)})
+    base = _manifest({"same.png": ("same", 10, 10)})
+    sibling = _sibling(
+        7, {"same.png": ComparisonImageResult(status="changed", head_hash="other", base_hash="x")}
+    )
+    plan = _build_comparison_plan(head, base, 1, 2, sibling=sibling)
+    assert plan.chunks == []
+
+
+def test_build_comparison_plan_skips_sibling_candidate_over_pixel_limit() -> None:
+    head = _manifest({"big.png": ("b-head", 7000, 7000)})
+    base = _manifest({"big.png": ("b-base", 10, 10)})
+    sibling = _sibling(
+        7, {"big.png": ComparisonImageResult(status="changed", head_hash="b-sib", base_hash="x")}
+    )
+    plan = _build_comparison_plan(head, base, 1, 2, sibling=sibling)
+    assert all(c.kind == "base" for chunk in plan.chunks for c in chunk.candidates)
+    assert plan.non_diff_images["big.png"].reason == "exceeds_pixel_limit"

--- a/tests/sentry/preprod/snapshots/test_tasks.py
+++ b/tests/sentry/preprod/snapshots/test_tasks.py
@@ -3,7 +3,8 @@ from unittest.mock import MagicMock, patch
 
 from PIL import Image, PngImagePlugin
 
-from sentry.preprod.snapshots.image_diff.types import DiffResult
+from sentry.preprod.snapshots.image_diff.compare import get_comparison_size
+from sentry.preprod.snapshots.image_diff.types import DiffResult, ImageSize
 from sentry.preprod.snapshots.manifest import (
     ChunkAssignment,
     ChunkCandidate,
@@ -570,7 +571,11 @@ def test_plan_and_chunk_result_parse_without_sibling_fields() -> None:
     assert result.sibling_images == {}
 
 
-def _sibling(artifact_id: int, images: dict[str, ComparisonImageResult]) -> SiblingComparison:
+def _sibling(
+    artifact_id: int,
+    images: dict[str, ComparisonImageResult],
+    snapshot_manifest: SnapshotManifest | None = None,
+) -> SiblingComparison:
     manifest = ComparisonManifest(
         head_artifact_id=artifact_id,
         base_artifact_id=0,
@@ -579,7 +584,21 @@ def _sibling(artifact_id: int, images: dict[str, ComparisonImageResult]) -> Sibl
         ),
         images=images,
     )
-    return SiblingComparison(artifact_id, f"key/{artifact_id}/comparison.json", manifest)
+    if snapshot_manifest is None:
+        snapshot_manifest = SnapshotManifest(
+            images={
+                name: ImageMetadata(
+                    content_hash=image.head_hash,
+                    width=image.after_width if image.after_width is not None else 10,
+                    height=image.after_height if image.after_height is not None else 10,
+                )
+                for name, image in images.items()
+                if image.head_hash
+            }
+        )
+    return SiblingComparison(
+        artifact_id, f"key/{artifact_id}/comparison.json", manifest, snapshot_manifest
+    )
 
 
 def _manifest(
@@ -675,18 +694,20 @@ def test_build_comparison_plan_sibling_pixel_count_uses_larger_dimensions() -> N
     assert candidates[("base", "changed.png")].pixel_count == 100
 
 
-def test_build_comparison_plan_sibling_pixel_count_falls_back_to_head_dimensions() -> None:
-    head = _manifest({"changed.png": ("c-head", 10, 10)})
-    base = _manifest({"changed.png": ("c-base", 10, 10)})
+def test_build_comparison_plan_sibling_added_uses_snapshot_manifest_dimensions() -> None:
+    head = _manifest({"added.png": ("add-head", 10, 10)})
+    base = _manifest({})
     sibling = _sibling(
         7,
-        {"changed.png": ComparisonImageResult(status="added", head_hash="c-sib")},
+        {"added.png": ComparisonImageResult(status="added", head_hash="add-sib")},
+        snapshot_manifest=_manifest({"added.png": ("add-sib", 40, 30)}),
     )
     plan = _build_comparison_plan(head, base, 1, 2, sibling=sibling)
     sibling_candidates = {
         c.name: c for chunk in plan.chunks for c in chunk.candidates if c.kind == "sibling"
     }
-    assert sibling_candidates["changed.png"].pixel_count == 100
+    expected = get_comparison_size(ImageSize(10, 10), ImageSize(40, 30)).pixel_count
+    assert sibling_candidates["added.png"].pixel_count == expected
 
 
 def test_build_comparison_plan_records_sibling_without_candidates_when_disabled() -> None:


### PR DESCRIPTION
Snapshot auto-approval required the head build and the approved sibling to match by exact content hash, so a rebuild that re-encoded an image or drifted a few pixels lost its approval and forced a re-review.

Now, when the two builds differ only by content hash, those head-vs-sibling pairs are added to the comparison plan and diffed by the same chunk workers as the head-vs-base pairs, with no diff mask and outside the comparison manifest. Finalize approves if every pair is within that image's `diff_threshold`. Any name or status difference, missing or errored sibling result, or over-threshold pair still rejects. Sibling selection ignores auto-approved builds so drift cannot chain.

Sibling candidate emission is gated by the option `preprod.snapshots.auto-approve-sibling-diffs.enabled`, default off. It must stay off until this PR is fully deployed: a chunk worker on the old code does not know the `kind` field and would treat a sibling pair as a base pair, writing a wrong comparison result. Once every worker is on the new code, getsentry/sentry-options-automator#9689 turns it on. Set it back to off before any code rollback for the same reason. With the option off, behaviour is today's exact-match rule.

If an upload doesn't set a `diff_threshold`, the sibling comparison requires a pixel-exact match. That still fixes the common case where a rebuild re-encodes an image into different bytes that render identically; tolerating small pixel drift requires the client to send a threshold. An image that flips from changed to unchanged after a rebase is still a structural difference and still rejects; allowing that is a follow-up.
