### PR TITLE
test(dashboards): avoid mocking useNavigate

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/widgetTemplatesList.spec.tsx
@@ -1,18 +1,14 @@
 import debounce from 'lodash/debounce';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {act, render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {testableDebounce} from 'sentry/utils/url/testUtils';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {WidgetTemplatesList} from 'sentry/views/dashboards/widgetBuilder/components/widgetTemplatesList';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {getDefaultWidgets} from 'sentry/views/dashboards/widgetLibrary/data';
 import type {WidgetTemplate} from 'sentry/views/dashboards/widgetLibrary/types';
 
-jest.mock('sentry/utils/useNavigate', () => ({
-  useNavigate: jest.fn(),
-}));
 jest.mock('lodash/debounce');
 
 jest.mock('sentry/views/dashboards/widgetLibrary/data', () => ({
@@ -29,7 +25,6 @@ jest.mock('sentry/views/dashboards/widgetLibrary/data', () => ({
   ]),
 }));
 
-const mockUseNavigate = jest.mocked(useNavigate);
 const mockGetDefaultWidgets = jest.mocked(getDefaultWidgets);
 
 jest.mock('sentry/actionCreators/indicator');
@@ -39,9 +34,6 @@ describe('WidgetTemplatesList', () => {
 
   beforeEach(() => {
     jest.useFakeTimers();
-
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
 
     jest.mocked(debounce).mockImplementation(testableDebounce);
 
@@ -55,7 +47,7 @@ describe('WidgetTemplatesList', () => {
 
   afterEach(() => {
     jest.clearAllMocks();
-    jest.runOnlyPendingTimers();
+    act(() => jest.runOnlyPendingTimers());
     jest.useRealTimers();
   });
 
@@ -92,7 +84,7 @@ describe('WidgetTemplatesList', () => {
     const widgetTemplate = await screen.findByText('Duration Distribution');
     await user.click(widgetTemplate);
 
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     expect(await screen.findByText('Customize')).toBeInTheDocument();
     expect(await screen.findByText('Add to dashboard')).toBeInTheDocument();
@@ -101,10 +93,7 @@ describe('WidgetTemplatesList', () => {
   it('should put widget in url when clicking a template', async () => {
     const user = userEvent.setup({advanceTimers: jest.advanceTimersByTime});
 
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <WidgetTemplatesList
           onSave={onSave}
@@ -118,9 +107,9 @@ describe('WidgetTemplatesList', () => {
     const widgetTemplate = screen.getByText('Duration Distribution');
     await user.click(widgetTemplate);
 
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
-    expect(mockNavigate).toHaveBeenLastCalledWith(
+    expect(router.location).toEqual(
       expect.objectContaining({
         query: expect.objectContaining({
           description: 'some description',
@@ -128,8 +117,7 @@ describe('WidgetTemplatesList', () => {
           displayType: 'line',
           dataset: 'transactions-like',
         }),
-      }),
-      expect.anything()
+      })
     );
   });
 
@@ -152,7 +140,7 @@ describe('WidgetTemplatesList', () => {
 
     await user.click(await screen.findByText('Add to dashboard'));
 
-    jest.runAllTimers();
+    act(() => jest.runAllTimers());
 
     await waitFor(() => {
       expect(addErrorMessage).toHaveBeenCalledWith('Unable to add widget');


### PR DESCRIPTION
I am attempting to add a lint rule to disallow these kind of module mocks - this is one change of many to ensure those lint rules pass when added.