### PR TITLE
test(url): avoid mocking router hooks in useQueryParamState

### DIFF
--- a/static/app/utils/url/useQueryParamState.spec.tsx
+++ b/static/app/utils/url/useQueryParamState.spec.tsx
@@ -1,49 +1,36 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-
-import {act, renderHook} from 'sentry-test/reactTestingLibrary';
+import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import type {Sort} from 'sentry/utils/discover/fields';
 import {decodeSorts} from 'sentry/utils/queryString';
 import {UrlParamBatchProvider} from 'sentry/utils/url/urlParamBatchContext';
 import {useQueryParamState} from 'sentry/utils/url/useQueryParamState';
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {formatSort} from 'sentry/views/explore/contexts/pageParamsContext/sortBys';
 
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
-
-const mockedUseLocation = jest.mocked(useLocation);
-const mockedUseNavigate = jest.mocked(useNavigate);
-
 describe('useQueryParamState', () => {
-  beforeEach(() => {
-    jest.useFakeTimers();
-  });
-
-  afterEach(() => {
-    jest.useRealTimers();
-  });
-
   it('should get the initial value from the query param', () => {
-    mockedUseLocation.mockReturnValue(
-      LocationFixture({query: {testField: 'initial state'}})
+    const {result} = renderHookWithProviders(
+      () => useQueryParamState({fieldName: 'testField'}),
+      {
+        additionalWrapper: UrlParamBatchProvider,
+        initialRouterConfig: {
+          location: {pathname: '/', query: {testField: 'initial state'}},
+        },
+      }
     );
-
-    const {result} = renderHook(() => useQueryParamState({fieldName: 'testField'}), {
-      wrapper: UrlParamBatchProvider,
-    });
 
     expect(result.current[0]).toBe('initial state');
   });
 
   it('should update the local state and the query param', () => {
-    const mockedNavigate = jest.fn();
-    mockedUseNavigate.mockReturnValue(mockedNavigate);
-
-    const {result} = renderHook(() => useQueryParamState({fieldName: 'testField'}), {
-      wrapper: UrlParamBatchProvider,
-    });
+    const {result, router} = renderHookWithProviders(
+      () => useQueryParamState({fieldName: 'testField'}),
+      {
+        additionalWrapper: UrlParamBatchProvider,
+        initialRouterConfig: {
+          location: {pathname: '/', query: {testField: 'initial state'}},
+        },
+      }
+    );
 
     act(() => {
       result.current[1]('newValue');
@@ -52,42 +39,26 @@ describe('useQueryParamState', () => {
     // The local state should be updated
     expect(result.current[0]).toBe('newValue');
 
-    // The query param should not be updated yet
-    expect(mockedNavigate).not.toHaveBeenCalledWith(
-      {
-        pathname: '/',
-        query: {testField: 'initial state'},
-      },
-      {replace: true, preventScrollReset: true}
-    );
-
-    // Run the timers to trigger queued updates
-    jest.runAllTimers();
-
     // The query param should be updated
-    expect(mockedNavigate).toHaveBeenCalledWith(
-      {
-        pathname: '/',
-        query: {testField: 'newValue'},
-      },
-      {replace: true, preventScrollReset: true}
-    );
+    expect(router.location).toMatchObject({
+      pathname: '/',
+      query: {testField: 'newValue'},
+    });
 
     // The local state should be still reflect the new value
     expect(result.current[0]).toBe('newValue');
   });
 
   it('should use the decoder function to decode the query param value if provided', () => {
-    mockedUseLocation.mockReturnValue(
-      LocationFixture({query: {testField: 'initial state'}})
-    );
-
     const testDeserializer = (value: string) => `${value.toUpperCase()} - decoded`;
 
-    const {result} = renderHook(
+    const {result} = renderHookWithProviders(
       () => useQueryParamState({fieldName: 'testField', deserializer: testDeserializer}),
       {
-        wrapper: UrlParamBatchProvider,
+        additionalWrapper: UrlParamBatchProvider,
+        initialRouterConfig: {
+          location: {pathname: '/', query: {testField: 'initial state'}},
+        },
       }
     );
 
@@ -101,16 +72,13 @@ describe('useQueryParamState', () => {
       value: string;
     };
 
-    const mockedNavigate = jest.fn();
-    mockedUseNavigate.mockReturnValue(mockedNavigate);
-
     const testSerializer = (value: TestType) =>
       `${value.value} - ${value.count} - ${value.isActive}`;
 
-    const {result} = renderHook(
+    const {result, router} = renderHookWithProviders(
       () => useQueryParamState({fieldName: 'testField', serializer: testSerializer}),
       {
-        wrapper: UrlParamBatchProvider,
+        additionalWrapper: UrlParamBatchProvider,
       }
     );
 
@@ -118,22 +86,14 @@ describe('useQueryParamState', () => {
       result.current[1]({value: 'newValue', count: 2, isActive: true});
     });
 
-    expect(mockedNavigate).toHaveBeenCalledWith(
-      {
-        pathname: '/',
-        query: {testField: 'newValue - 2 - true'},
-      },
-      {replace: true, preventScrollReset: true}
-    );
+    expect(router.location).toMatchObject({
+      pathname: '/',
+      query: {testField: 'newValue - 2 - true'},
+    });
   });
 
   it('can decode and update sorts', () => {
-    mockedUseLocation.mockReturnValue(LocationFixture({query: {sort: '-testField'}}));
-
-    const mockedNavigate = jest.fn();
-    mockedUseNavigate.mockReturnValue(mockedNavigate);
-
-    const {result} = renderHook(
+    const {result, router} = renderHookWithProviders(
       () =>
         useQueryParamState<Sort[]>({
           fieldName: 'sort',
@@ -141,7 +101,10 @@ describe('useQueryParamState', () => {
           serializer: value => value.map(formatSort),
         }),
       {
-        wrapper: UrlParamBatchProvider,
+        additionalWrapper: UrlParamBatchProvider,
+        initialRouterConfig: {
+          location: {pathname: '/', query: {sort: '-testField'}},
+        },
       }
     );
 
@@ -151,60 +114,47 @@ describe('useQueryParamState', () => {
       result.current[1]([{field: 'testField', kind: 'asc'}]);
     });
 
-    expect(mockedNavigate).toHaveBeenCalledWith(
-      {
-        pathname: '/',
-        query: {sort: ['testField']},
-      },
-      {replace: true, preventScrollReset: true}
-    );
+    expect(router.location).toMatchObject({
+      pathname: '/',
+      query: {sort: 'testField'},
+    });
   });
 
   it('should not sync local state when URL changes if syncStateWithUrl is false', () => {
-    mockedUseLocation.mockReturnValue(
-      LocationFixture({query: {testField: 'initial state'}})
-    );
-
-    const {result, rerender} = renderHook(
+    const {result, router} = renderHookWithProviders(
       () => useQueryParamState({fieldName: 'testField'}),
       {
-        wrapper: UrlParamBatchProvider,
+        additionalWrapper: UrlParamBatchProvider,
+        initialRouterConfig: {
+          location: {pathname: '/', query: {testField: 'initial state'}},
+        },
       }
     );
 
     expect(result.current[0]).toBe('initial state');
 
     // Simulate URL change (e.g., browser back/forward navigation)
-    mockedUseLocation.mockReturnValue(
-      LocationFixture({query: {testField: 'changed via URL'}})
-    );
-
-    rerender();
+    router.navigate('/?testField=changed%20via%20URL');
 
     // Local state should NOT be updated because syncStateWithUrl is false
     expect(result.current[0]).toBe('initial state');
   });
 
   it('should sync local state when URL changes if syncStateWithUrl is true', () => {
-    mockedUseLocation.mockReturnValue(
-      LocationFixture({query: {testField: 'initial state'}})
-    );
-
-    const {result, rerender} = renderHook(
+    const {result, router} = renderHookWithProviders(
       () => useQueryParamState({fieldName: 'testField', syncStateWithUrl: true}),
       {
-        wrapper: UrlParamBatchProvider,
+        additionalWrapper: UrlParamBatchProvider,
+        initialRouterConfig: {
+          location: {pathname: '/', query: {testField: 'initial state'}},
+        },
       }
     );
 
     expect(result.current[0]).toBe('initial state');
 
     // Simulate URL change (e.g., browser back/forward navigation)
-    mockedUseLocation.mockReturnValue(
-      LocationFixture({query: {testField: 'changed via URL'}})
-    );
-
-    rerender();
+    router.navigate('/?testField=changed%20via%20URL');
 
     // Local state should be updated because syncStateWithUrl is true
     expect(result.current[0]).toBe('changed via URL');


### PR DESCRIPTION
I am attempting to add a lint rule to disallow these kind of module mocks - this is one change of many to ensure those lint rules pass when added.