### PR TITLE
ref(issue details): Fix small span evidence bugs

### DIFF
--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -185,14 +185,16 @@ function NPlusOneDBQueriesSpanEvidence({
   location,
 }: SpanEvidenceKeyValueListProps) {
   const dbSpans = offendingSpans.filter(span => (span.op || '').startsWith('db'));
-  const repeatingSpanRows = dbSpans
-    .filter(span => offendingSpans.find(s => s.hash === span.hash) === span)
-    .map((span, i) =>
-      makeRow(
-        i === 0 ? t('Repeating Spans (%s)', dbSpans.length) : '',
-        getSpanEvidenceValue(span)
-      )
-    );
+  // Our hashing calculation parameterizes query literals, so two spans running the same query with
+  // different values will share a hash value. Dedupe by hash so we only get one representative of
+  // each query.
+  const repeatingSpanRows = dedupeSpansByHash(dbSpans).map((span, i) =>
+    makeRow(
+      // Only the first row carries the label; the rest render bare beneath it.
+      i === 0 ? t('Repeating Spans (%s)', dbSpans.length) : '',
+      getSpanEvidenceValue(span)
+    )
+  );
   const evidenceData = event?.occurrence?.evidenceData ?? {};
   const patternSize = evidenceData.patternSize ?? 0;
 
@@ -748,6 +750,24 @@ const StyledCodeSnippet = styled(CodeBlock)`
 
   z-index: 0;
 `;
+
+function dedupeSpansByHash(spans: Span[]): Span[] {
+  const hashesSeen = new Set<Span['hash']>();
+
+  // Only keep spans whose hashes we haven't yet seen, tracking the ones we have seen as we go
+  const shouldKeepSpan = (span: Span) => {
+    const hash = span.hash;
+
+    if (hashesSeen.has(hash)) {
+      return false;
+    }
+
+    hashesSeen.add(hash);
+    return true;
+  };
+
+  return spans.filter(shouldKeepSpan);
+}
 
 const getConsecutiveDbTimeSaved = (
   consecutiveSpans: Span[],

--- a/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
+++ b/static/app/components/events/interfaces/performance/spanEvidenceKeyValueList.tsx
@@ -505,7 +505,6 @@ function SlowDBQueryEvidence({
 }: SpanEvidenceKeyValueListProps) {
   const span = offendingSpans[0]!;
   const sentryTags = 'sentry_tags' in span ? span.sentry_tags : undefined;
-  const groupHash = sentryTags?.group ?? span.hash ?? '';
   const hasExplore = organization.features.includes('visibility-explore-view');
 
   const codeFilepath = getAttributeValue(span.data ?? {}, 'code.file.path', 'string');
@@ -538,7 +537,7 @@ function SlowDBQueryEvidence({
         <SpanSummaryLink
           op={span.op}
           category={sentryTags?.category}
-          group={groupHash}
+          group={sentryTags?.group}
           organization={organization}
         />
         {hasExplore && span.description && (


### PR DESCRIPTION
This includes a few small fixes/refactors to our span evidence issue details components, pulled out of an upcoming PR to keep it focused.

- In the `SlowDBQueryEvidence` component, remove fallbacks from the `SpanSummaryLink` component's `group` prop. The `span.hash` fallback is incorrect - that link creates an EAP filter from the `group` prop, but EAP doesn't index span hash values, only the `sentryTags.group` value added by Relay, so using `hash` won't work there. And the empty string callback is unnecessary, since the component only renders if the `group` prop is truthy, so an empty string and a null value are functionally identical.

- In the `NPlusOneDBQueriesSpanEvidence` component, use a helper for deduping query spans based on hash value. This not only allows the code to be more readable, but also allows us to decrease the runtime of the filtering from quadratic to linear.