### PR TITLE
ref(issues): Clean up event grouping details

### DIFF
--- a/static/app/components/events/groupingInfo/groupingComponent.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.spec.tsx
@@ -1,0 +1,83 @@
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import type {EventGroupComponent} from 'sentry/types/event';
+
+import {GroupingComponent} from './groupingComponent';
+
+function component(
+  id: string,
+  values: EventGroupComponent['values'],
+  contributes = true
+): EventGroupComponent {
+  return {id, values, contributes, name: null, hint: null};
+}
+
+describe('GroupingComponent', () => {
+  it('preserves nested disclosure state when its parent is collapsed', async () => {
+    render(
+      <GroupingComponent
+        component={component('exception', [
+          component('frame', [component('function', ['handleRequest'])]),
+        ])}
+        showNonContributing={false}
+      />
+    );
+    const frame = screen.getByRole('button', {name: 'frame'});
+    await userEvent.click(frame);
+    expect(frame).toHaveAttribute('aria-expanded', 'false');
+    const exception = screen.getByRole('button', {name: 'exception'});
+    await userEvent.click(exception);
+    expect(exception).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(exception);
+    expect(screen.getByRole('button', {name: 'frame'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+    await userEvent.click(screen.getByRole('button', {name: 'frame'}));
+    expect(screen.getByText('handleRequest')).toBeVisible();
+  });
+
+  it('preserves a contributing sibling’s state when filtering other values', async () => {
+    const tree = component('exception', [
+      component('ignored', ['unused'], false),
+      component('frame', [component('function', ['handleRequest'])]),
+    ]);
+    const {rerender} = render(
+      <GroupingComponent component={tree} showNonContributing={false} />
+    );
+    expect(screen.queryByText('unused')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'frame'}));
+    rerender(<GroupingComponent component={tree} showNonContributing />);
+    expect(screen.getByText('unused')).toBeVisible();
+    expect(screen.getByRole('button', {name: 'frame'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
+
+  it('expands similar frames and resets their default when the filter changes', async () => {
+    const tree = component(
+      'stacktrace',
+      ['first', 'second', 'third', 'fourth'].map(name =>
+        component('frame', [component('function', [name])])
+      )
+    );
+    const {rerender} = render(
+      <GroupingComponent component={tree} showNonContributing={false} />
+    );
+    expect(screen.getByText('first')).toBeVisible();
+    expect(screen.getByText('second')).toBeVisible();
+    const expand = screen.getByRole('button', {name: 'show 2 similar'});
+    expect(expand).toHaveAttribute('aria-expanded', 'false');
+    await userEvent.click(expand);
+    expect(screen.getByText('third')).toBeVisible();
+    await userEvent.click(screen.getByRole('button', {name: 'collapse 2 similar'}));
+    rerender(<GroupingComponent component={tree} showNonContributing />);
+    expect(screen.getByText('third')).toBeVisible();
+    rerender(<GroupingComponent component={tree} showNonContributing={false} />);
+    expect(screen.getByRole('button', {name: 'show 2 similar'})).toHaveAttribute(
+      'aria-expanded',
+      'false'
+    );
+  });
+});

--- a/static/app/components/events/groupingInfo/groupingComponent.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponent.tsx
@@ -1,11 +1,10 @@
-import {Activity, useState} from 'react';
+import {Activity, useId, useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 
 import {IconChevron} from 'sentry/icons';
-import {t} from 'sentry/locale';
 import type {EventGroupComponent} from 'sentry/types/event';
 
 import {GroupingComponentChildren} from './groupingComponentChildren';
@@ -18,6 +17,7 @@ type Props = {
 };
 
 export function GroupingComponent({component, showNonContributing}: Props) {
+  const contentId = useId();
   const shouldInlineValue = shouldInlineComponentValue(component);
   const GroupingComponentListItems =
     component.id === 'stacktrace'
@@ -36,7 +36,9 @@ export function GroupingComponent({component, showNonContributing}: Props) {
           variant="link"
           icon={<IconChevron direction={folded ? 'right' : 'down'} legacySize="10px" />}
           onClick={() => setFolded(!folded)}
-          aria-label={folded ? t('expand') : t('collapse')}
+          aria-label={component.name || component.id}
+          aria-expanded={!folded}
+          aria-controls={contentId}
         />
       )}
 
@@ -47,7 +49,11 @@ export function GroupingComponent({component, showNonContributing}: Props) {
         </span>
 
         <Activity mode={folded ? 'hidden' : 'visible'}>
-          <GroupingComponentList isInline={shouldInlineValue} hasFold={canFold}>
+          <GroupingComponentList
+            id={contentId}
+            isInline={shouldInlineValue}
+            hasFold={canFold}
+          >
             <GroupingComponentListItems
               component={component}
               showNonContributing={showNonContributing}
@@ -68,7 +74,7 @@ const CollapseButtonWrapper = styled('div')`
 const CollapseButton = styled(Button)<{folded: boolean}>`
   grid-column: 1;
   border: none;
-  opacity: ${p => (p.folded ? 1 : 0.25)};
+  opacity: ${p => (p.folded ? 1 : 0.65)};
   transition: opacity 0.2s ease;
   align-self: ${p => (p.folded ? 'center' : 'baseline')};
   color: ${p =>

--- a/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentChildren.tsx
@@ -16,14 +16,17 @@ type Props = {
 export function GroupingComponentChildren({component, showNonContributing}: Props) {
   return (
     <Fragment>
-      {component.values
-        .filter((value: any) => groupingComponentFilter(value, showNonContributing))
-        .map((value: any, index: number) => (
+      {component.values.map((value, index) =>
+        groupingComponentFilter(value, showNonContributing) ? (
           <GroupingComponentListItem
             // value.id is not a unique value
-            key={typeof value === 'object' ? `${value.id}-${index}` : `${value}-${index}`}
+            key={
+              typeof value === 'object' && value !== null
+                ? `${value.id}-${index}`
+                : `${value}-${index}`
+            }
           >
-            {typeof value === 'object' ? (
+            {typeof value === 'object' && value !== null ? (
               <GroupingComponent
                 component={value}
                 showNonContributing={showNonContributing}
@@ -39,7 +42,8 @@ export function GroupingComponentChildren({component, showNonContributing}: Prop
               </GroupingValue>
             )}
           </GroupingComponentListItem>
-        ))}
+        ) : null
+      )}
     </Fragment>
   );
 }

--- a/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentFrames.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useState} from 'react';
+import {Fragment, useState} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
@@ -17,11 +17,6 @@ export function GroupingComponentFrames({
 }: GroupingComponentFramesProps) {
   const [collapsed, setCollapsed] = useState(initialCollapsed);
   const isCollapsible = items.length > 2;
-
-  useEffect(() => {
-    // eslint-disable-next-line react-you-might-not-need-an-effect/no-derived-state
-    setCollapsed(initialCollapsed);
-  }, [initialCollapsed]);
 
   return (
     <Fragment>
@@ -42,6 +37,7 @@ export function GroupingComponentFrames({
                 variant="link"
                 icon={<IconAdd legacySize="8px" />}
                 onClick={() => setCollapsed(false)}
+                aria-expanded={false}
               >
                 {tct('show [numberOfFrames] similar', {
                   numberOfFrames: items.length - 2,
@@ -61,6 +57,7 @@ export function GroupingComponentFrames({
             variant="link"
             icon={<IconSubtract legacySize="8px" />}
             onClick={() => setCollapsed(true)}
+            aria-expanded
           >
             {tct('collapse [numberOfFrames] similar', {
               numberOfFrames: items.length - 2,

--- a/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
+++ b/static/app/components/events/groupingInfo/groupingComponentStacktrace.tsx
@@ -16,7 +16,7 @@ export function GroupingComponentStacktrace({component, showNonContributing}: Pr
     <Fragment>
       {getFrameGroups(component, showNonContributing).map((group, index) => (
         <GroupingComponentFrames
-          key={index}
+          key={`${showNonContributing}-${index}`}
           items={group.data.map((v, idx) => (
             <GroupingComponent
               key={idx}

--- a/static/app/components/events/groupingInfo/groupingInfo.spec.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.spec.tsx
@@ -1,7 +1,7 @@
 import {EventFixture} from 'sentry-fixture/event';
 import {GroupFixture} from 'sentry-fixture/group';
 
-import {render, screen} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
 
 import {EventGroupVariantType} from 'sentry/types/event';
 import {IssueCategory} from 'sentry/types/group';
@@ -82,34 +82,65 @@ describe('EventGroupingInfo', () => {
     expect(await screen.findByText('variant description')).toBeInTheDocument();
     expect(screen.getByText('123')).toBeInTheDocument();
   });
-  it('gets performance new grouping info from group/event data', async () => {
-    groupingInfoRequest = MockApiClient.addMockResponse({
+  it('filters non-contributing variants and keeps the summary unchanged', async () => {
+    MockApiClient.addMockResponse({
       url: `/projects/org-slug/project-slug/events/${event.id}/grouping-info/`,
       body: {
-        grouping_config: null,
+        grouping_config: 'default:XXXX',
         variants: {
           app: {
-            contributes: true,
-            description: 'variant description',
-            hash: '123',
-            hashMismatch: false,
-            key: 'key',
+            key: 'app',
             type: EventGroupVariantType.CHECKSUM,
+            contributes: true,
+            description: 'stacktrace',
+            hash: '123',
+          },
+          fallback: {
+            key: 'fallback',
+            type: EventGroupVariantType.CHECKSUM,
+            contributes: false,
+            description: 'message',
+            hash: null,
           },
         },
       },
     });
-    const perfEvent = EventFixture({
-      type: 'transaction',
-      occurrence: {fingerprint: ['123'], evidenceData: {op: 'bad-op'}},
+    render(<GroupingInfo {...defaultProps} showGroupingConfig />);
+
+    expect(await screen.findByTestId('loaded-grouping-info')).toHaveTextContent(
+      'Grouped by: stacktrace'
+    );
+    expect(screen.getByTestId('loaded-grouping-info')).toHaveTextContent(
+      'Grouping Config: default:XXXX'
+    );
+    expect(screen.queryByRole('heading', {name: 'Message'})).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('radio', {name: 'All Values'}));
+    expect(screen.getByRole('heading', {name: 'Message'})).toBeInTheDocument();
+    expect(screen.getByTestId('loaded-grouping-info')).toHaveTextContent(
+      'Grouped by: stacktrace'
+    );
+    await userEvent.click(screen.getByRole('radio', {name: 'Contributing Values'}));
+    expect(screen.queryByRole('heading', {name: 'Message'})).not.toBeInTheDocument();
+  });
+
+  it('shows an empty summary when no variants contribute', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/events/${event.id}/grouping-info/`,
+      body: {grouping_config: null, variants: {}},
     });
-    const perfGroup = GroupFixture({issueCategory: IssueCategory.PERFORMANCE});
+    render(<GroupingInfo {...defaultProps} />);
+    expect(await screen.findByTestId('loaded-grouping-info')).toHaveTextContent(
+      'Grouped by: nothing'
+    );
+  });
 
-    render(<GroupingInfo {...defaultProps} event={perfEvent} group={perfGroup} />);
-
-    expect(await screen.findByText('performance problem')).toBeInTheDocument();
-    expect(screen.getByText('123')).toBeInTheDocument();
-    // Should not make grouping-info request
-    expect(groupingInfoRequest).not.toHaveBeenCalled();
+  it('shows a fetch error without a misleading grouping summary', async () => {
+    MockApiClient.addMockResponse({
+      url: `/projects/org-slug/project-slug/events/${event.id}/grouping-info/`,
+      statusCode: 500,
+    });
+    render(<GroupingInfo {...defaultProps} />);
+    expect(await screen.findByText('Failed to fetch grouping info.')).toBeInTheDocument();
+    expect(screen.queryByTestId('loaded-grouping-info')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/groupingInfo/groupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/groupingInfo.tsx
@@ -15,7 +15,7 @@ import type {Group} from 'sentry/types/group';
 
 import {GroupingVariant} from './groupingVariant';
 
-interface GroupingSummaryProps {
+interface GroupingInfoProps {
   event: Event;
   group: Group | undefined;
   projectSlug: string;
@@ -27,15 +27,21 @@ export default function GroupingInfo({
   projectSlug,
   showGroupingConfig,
   group,
-}: GroupingSummaryProps) {
+}: GroupingInfoProps) {
   const [showNonContributing, setShowNonContributing] = useState(false);
 
-  const {groupInfo, isPending, isError, isSuccess, hasPerformanceGrouping} =
-    useEventGroupingInfo({
-      event,
-      group,
-      projectSlug,
-    });
+  const {groupInfo, isPending, isError} = useEventGroupingInfo({
+    event,
+    group,
+    projectSlug,
+  });
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+  if (isError) {
+    return <LoadingError message={t('Failed to fetch grouping info.')} />;
+  }
 
   const variants = groupInfo?.variants
     ? Object.values(groupInfo.variants).sort((a, b) => {
@@ -69,12 +75,7 @@ export default function GroupingInfo({
   return (
     <Fragment>
       <Flex justify="between" marginBottom="2xs" gap="md">
-        <GroupInfoSummary
-          event={event}
-          group={group}
-          projectSlug={projectSlug}
-          showGroupingConfig={showGroupingConfig}
-        />
+        <GroupInfoSummary groupInfo={groupInfo} showGroupingConfig={showGroupingConfig} />
         {feedbackComponent}
       </Flex>
       <ToggleContainer>
@@ -90,22 +91,18 @@ export default function GroupingInfo({
           <SegmentedControl.Item key="all">{t('All Values')}</SegmentedControl.Item>
         </SegmentedControl>
       </ToggleContainer>
-      {isError ? <LoadingError message={t('Failed to fetch grouping info.')} /> : null}
-      {isPending && !hasPerformanceGrouping ? <LoadingIndicator /> : null}
-      {hasPerformanceGrouping || isSuccess
-        ? variants
-            .filter(variant => variant.contributes || showNonContributing)
-            .map((variant, index, filteredVariants) => (
-              <Fragment key={variant.key}>
-                <GroupingVariant
-                  event={event}
-                  variant={variant}
-                  showNonContributing={showNonContributing}
-                />
-                {index < filteredVariants.length - 1 && <VariantDivider />}
-              </Fragment>
-            ))
-        : null}
+      {variants
+        .filter(variant => variant.contributes || showNonContributing)
+        .map((variant, index, filteredVariants) => (
+          <Fragment key={variant.key}>
+            <GroupingVariant
+              event={event}
+              variant={variant}
+              showNonContributing={showNonContributing}
+            />
+            {index < filteredVariants.length - 1 && <VariantDivider />}
+          </Fragment>
+        ))}
     </Fragment>
   );
 }

--- a/static/app/components/events/groupingInfo/groupingSummary.tsx
+++ b/static/app/components/events/groupingInfo/groupingSummary.tsx
@@ -1,54 +1,30 @@
 import {Fragment} from 'react';
 
-import {useEventGroupingInfo} from 'sentry/components/events/groupingInfo/useEventGroupingInfo';
-import {Placeholder} from 'sentry/components/placeholder';
 import {t} from 'sentry/locale';
-import type {Event} from 'sentry/types/event';
-import type {Group} from 'sentry/types/group';
+
+import type {EventGroupingInfoResponse} from './useEventGroupingInfo';
 
 export function GroupInfoSummary({
-  event,
-  group,
-  projectSlug,
+  groupInfo,
   showGroupingConfig,
 }: {
-  event: Event;
-  group: Group | undefined;
-  projectSlug: string;
+  groupInfo: EventGroupingInfoResponse | null;
   showGroupingConfig: boolean;
 }) {
-  const {groupInfo, isPending, hasPerformanceGrouping} = useEventGroupingInfo({
-    event,
-    group,
-    projectSlug,
-  });
-  const groupedBy = groupInfo?.variants
-    ? Object.values(groupInfo.variants)
-        .filter(variant => variant.contributes && variant.description !== null)
-        .map(variant => variant.description!)
-        .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
-        .join(', ')
-    : t('nothing');
-
-  const groupingConfig = showGroupingConfig && groupInfo?.grouping_config;
-
-  if (isPending && !hasPerformanceGrouping) {
-    return (
-      <Placeholder
-        height="20px"
-        width="unset"
-        style={{flexGrow: 1, marginBottom: '20px'}}
-      />
-    );
-  }
+  const groupedBy =
+    Object.values(groupInfo?.variants ?? {})
+      .filter(variant => variant.contributes)
+      .flatMap(variant => (variant.description ? [variant.description] : []))
+      .sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()))
+      .join(', ') || t('nothing');
 
   return (
     <p data-test-id="loaded-grouping-info">
       <strong>{t('Grouped by:')}</strong> {groupedBy}
-      {groupingConfig && (
+      {showGroupingConfig && groupInfo?.grouping_config && (
         <Fragment>
           <br />
-          <strong>{t('Grouping Config:')}</strong> {groupingConfig}
+          <strong>{t('Grouping Config:')}</strong> {groupInfo.grouping_config}
         </Fragment>
       )}
     </p>

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {InfoTip} from '@sentry/scraps/info';
+import {Flex} from '@sentry/scraps/layout';
 
 import {KeyValueList} from 'sentry/components/events/interfaces/keyValueList';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
@@ -74,26 +75,16 @@ export function GroupingVariant({
   variant,
   showNonContributing,
 }: GroupingVariantProps) {
-  const getVariantData = (): [VariantData, EventGroupComponent | undefined] => {
+  const getVariantData = (): VariantData => {
     const data: VariantData = [];
     let component: EventGroupComponent | undefined;
 
     if (!showNonContributing && !variant.contributes) {
-      return [data, component];
+      return data;
     }
 
     if (variant.hash !== null) {
-      data.push([
-        t('Hash'),
-        <TextWithQuestionTooltip key="hash">
-          <Hash>{variant.hash}</Hash>
-          <InfoTip
-            size="xs"
-            position="top"
-            title={t('Events with the same hash are grouped together')}
-          />
-        </TextWithQuestionTooltip>,
-      ]);
+      data.push([t('Hash'), <Hash key="hash">{variant.hash}</Hash>]);
     }
 
     if (variant.hashMismatch) {
@@ -155,7 +146,7 @@ export function GroupingVariant({
       ]);
     }
 
-    return [data, component];
+    return data;
   };
 
   const renderTitle = () => {
@@ -175,16 +166,27 @@ export function GroupingVariant({
     );
   };
 
-  const [data] = getVariantData();
+  const data = getVariantData();
   return (
     <VariantWrapper>
       <Header>{renderTitle()}</Header>
 
       <KeyValueList
-        data={data.map(d => ({
-          key: d[0],
-          subject: d[0],
-          value: d[1],
+        data={data.map(([subject, value]) => ({
+          key: subject,
+          subject,
+          subjectNode:
+            subject === t('Hash') ? (
+              <Flex align="center" gap="xs">
+                {subject}
+                <InfoTip
+                  size="xs"
+                  position="top"
+                  title={t('Events with the same hash are grouped together')}
+                />
+              </Flex>
+            ) : undefined,
+          value,
         }))}
         isContextData
         shouldSort={false}
@@ -221,12 +223,13 @@ const VariantHint = styled('span')`
   color: ${p => p.theme.tokens.content.secondary};
 `;
 
-const ContributionIcon = styled(({isContributing, ...p}: any) =>
-  isContributing ? (
-    <IconCheckmark size="sm" variant="success" {...p} />
-  ) : (
-    <IconClose size="sm" variant="danger" {...p} />
-  )
+const ContributionIcon = styled(
+  ({isContributing, ...p}: {isContributing: boolean; className?: string}) =>
+    isContributing ? (
+      <IconCheckmark size="sm" variant="success" {...p} />
+    ) : (
+      <IconClose size="sm" variant="danger" {...p} />
+    )
 )`
   margin-right: ${p => p.theme.space.md};
 `;

--- a/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
+++ b/static/app/components/events/groupingInfo/useEventGroupingInfo.tsx
@@ -1,3 +1,5 @@
+import {skipToken, useQuery} from '@tanstack/react-query';
+
 import {t} from 'sentry/locale';
 import {
   EventGroupVariantType,
@@ -5,11 +7,10 @@ import {
   type EventGroupVariant,
 } from 'sentry/types/event';
 import type {Group} from 'sentry/types/group';
-import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
+import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
-type EventGroupingInfoResponse = {
+export type EventGroupingInfoResponse = {
   grouping_config: string | null;
   variants: Record<string, EventGroupVariant>;
 };
@@ -36,7 +37,7 @@ function generatePerformanceGroupInfo({
           [group.issueType]: {
             contributes: true,
             description: t('performance problem'),
-            hash: event.occurrence?.fingerprint[0] || '',
+            hash,
             hashMismatch: false,
             hint: null,
             key: group.issueType,
@@ -66,25 +67,24 @@ export function useEventGroupingInfo({
 }) {
   const organization = useOrganization();
 
-  const hasPerformanceGrouping = event.occurrence && event.type === 'transaction';
+  const hasPerformanceGrouping = Boolean(
+    event.occurrence && event.type === 'transaction'
+  );
 
-  const {data, isPending, isError, isSuccess} = useApiQuery<EventGroupingInfoResponse>(
-    [
-      getApiUrl(
-        '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/grouping-info/',
-        {
-          path: {
-            organizationIdOrSlug: organization.slug,
-            projectIdOrSlug: projectSlug,
-            eventId: event.id,
-          },
-        }
-      ),
-    ],
-    {
-      enabled: !hasPerformanceGrouping,
-      staleTime: Infinity,
-    }
+  const {data, isPending, isError} = useQuery(
+    apiOptions.as<EventGroupingInfoResponse>()(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/events/$eventId/grouping-info/',
+      {
+        path: hasPerformanceGrouping
+          ? skipToken
+          : {
+              organizationIdOrSlug: organization.slug,
+              projectIdOrSlug: projectSlug,
+              eventId: event.id,
+            },
+        staleTime: Infinity,
+      }
+    )
   );
 
   const groupInfo = hasPerformanceGrouping
@@ -93,9 +93,7 @@ export function useEventGroupingInfo({
 
   return {
     groupInfo,
-    isPending,
-    isError,
-    isSuccess,
-    hasPerformanceGrouping,
+    isPending: isPending && !hasPerformanceGrouping,
+    isError: isError && !hasPerformanceGrouping,
   };
 }

--- a/static/app/components/events/groupingInfo/utils.tsx
+++ b/static/app/components/events/groupingInfo/utils.tsx
@@ -1,9 +1,7 @@
 import type {EventGroupComponent} from 'sentry/types/event';
 
 export function shouldInlineComponentValue(component: EventGroupComponent) {
-  return (component.values as EventGroupComponent[]).every(
-    value => !value || typeof value !== 'object'
-  );
+  return component.values.every(value => !value || typeof value !== 'object');
 }
 
 export function groupingComponentFilter(

--- a/static/app/components/events/interfaces/keyValueList/index.tsx
+++ b/static/app/components/events/interfaces/keyValueList/index.tsx
@@ -40,6 +40,7 @@ export function KeyValueList({
             {
               key,
               subject,
+              subjectNode,
               value = null,
               meta,
               subjectIcon,
@@ -74,7 +75,7 @@ export function KeyValueList({
 
             return (
               <tr key={`${key}-${idx}`}>
-                <td className="key">{subject}</td>
+                <td className="key">{subjectNode ?? subject}</td>
                 <td className="val" data-test-id={subjectDataTestId}>
                   <Tablevalue>
                     {actionButton ? (


### PR DESCRIPTION
Clean up event grouping on issue details. Migrate to the current query API and share the result with the summary, tighten types, and simplify collapse state.

Keep the existing styling, make the caret easier to see, and move the hash tooltip beside its label. Adds toggle accessibility and coverage for filtering, expansion, and empty/error states.
