### PR TITLE
feat(gal): enable database writes by default

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -501,7 +501,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable using issue action log entries as the activity source in group details
     manager.add("projects:issue-action-log-activity", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable writing issue action log entries to the database
-    manager.add("projects:issue-action-log-write-to-db", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
+    manager.add("projects:issue-action-log-write-to-db", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, default=True, api_expose=False)
     manager.add("projects:issue-status-reconciliation", ProjectFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable similarity embeddings API call
     # This feature is only available on the frontend using project details since the handler gets

--- a/tests/sentry/issues/action_log/test_backfill.py
+++ b/tests/sentry/issues/action_log/test_backfill.py
@@ -29,6 +29,7 @@ from sentry.models.group import Group
 from sentry.models.grouplink import GroupLink
 from sentry.models.pullrequest import PullRequest, PullRequestLifecycleState
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.types.activity import ActivityType
 
 
@@ -156,6 +157,7 @@ class BackfillActionsTest(TestCase):
         mock_invalidate.assert_not_called()
 
 
+@with_feature({"projects:issue-action-log-write-to-db": False})
 class BackfillGroupActivitiesTest(TestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/issues/endpoints/test_group_notes_details.py
+++ b/tests/sentry/issues/endpoints/test_group_notes_details.py
@@ -19,6 +19,8 @@ from sentry.testutils.silo import assume_test_silo_mode
 from sentry.types.activity import ActivityType
 
 
+# The default Activity fixture represents a comment created before GALE dual writes.
+@with_feature({"projects:issue-action-log-write-to-db": False})
 class GroupNotesDetailsTest(APITestCase):
     def setUp(self) -> None:
         super().setUp()

--- a/tests/sentry/issues/test_action_log.py
+++ b/tests/sentry/issues/test_action_log.py
@@ -839,17 +839,6 @@ class TestPublishActionWrite(TestCase):
         assert len(entries) == 1
         assert entries[0].type == GroupActionType.VIEW
 
-    def test_feature_disabled_skips_write(self) -> None:
-        publish_action(
-            ViewAction(),
-            source=ActionSource.API,
-            group_id=self.group.id,
-            project=self.group.project,
-            actor=GroupActionActor.user(self.user.id),
-        )
-
-        assert GroupActionLogEntry.objects.filter(group_id=self.group.id).count() == 0
-
     def test_flush_false_defers_drain(self) -> None:
         with self.feature("projects:issue-action-log-write-to-db"):
             with outbox_context(flush=False):

--- a/tests/sentry/tasks/test_backfill_group_action_log.py
+++ b/tests/sentry/tasks/test_backfill_group_action_log.py
@@ -25,12 +25,14 @@ from sentry.tasks.backfill_group_action_log import (
     reset_and_backfill_group_action_log,
 )
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
 from sentry.types.activity import ActivityType
 
 TEST_BATCH_SIZE = 5
 
 
+@with_feature({"projects:issue-action-log-write-to-db": False})
 class BackfillGroupActionLogForGroupTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -155,6 +157,7 @@ class BackfillGroupActionLogForGroupTest(TestCase):
             backfill_group_action_log_for_group(self.group.id)
 
 
+@with_feature({"projects:issue-action-log-write-to-db": False})
 class ResetAndBackfillGroupActionLogTest(TestCase):
     def setUp(self) -> None:
         super().setUp()


### PR DESCRIPTION
Now that we're fully rolled out, we can enable this feature flag by default. This will be the first step to rolling this out for self-hosted / all customers.