### PR TITLE
test(dashboards): Drive widget builder specs through the real router

### DIFF
--- a/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/newWidgetBuilder.spec.tsx
@@ -205,7 +205,7 @@ describe('NewWidgetBuilder', () => {
     });
     // add a field and see if delete buttons are there
     await userEvent.click(screen.getByText('+ Add Filter'));
-    expect(screen.getAllByLabelText('Remove this filter')).toHaveLength(2);
+    expect(await screen.findAllByLabelText('Remove this filter')).toHaveLength(2);
   });
 
   it('does not render the filter alias field and add filter button on other widgets', async () => {

--- a/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/sortBySelector.spec.tsx
@@ -1,19 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 import type {RouterConfig} from 'sentry-test/reactTestingLibrary';
 
 import type {Organization} from 'sentry/types/organization';
 import {ELLIPSIS} from 'sentry/utils/string/unicode';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {WidgetBuilderSortBySelector} from 'sentry/views/dashboards/widgetBuilder/components/sortBySelector';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
-
-jest.mock('sentry/utils/useNavigate', () => ({
-  useNavigate: jest.fn(),
-}));
-
-const mockUseNavigate = jest.mocked(useNavigate);
 
 describe('WidgetBuilderSortBySelector', () => {
   let organization: Organization;
@@ -99,10 +92,7 @@ describe('WidgetBuilderSortBySelector', () => {
   });
 
   it('renders and functions correctly', async () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <WidgetBuilderSortBySelector />
       </WidgetBuilderProvider>,
@@ -120,21 +110,15 @@ describe('WidgetBuilderSortBySelector', () => {
     await userEvent.click(sortFieldSelector);
     await userEvent.click(await screen.findByText('count()'));
 
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({sort: ['-count()']}),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).toEqual(expect.objectContaining({sort: '-count()'}));
+    });
 
     await userEvent.click(sortDirectionSelector);
     await userEvent.click(await screen.findByText('Low to high'));
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({sort: ['count()']}),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).toEqual(expect.objectContaining({sort: 'count()'}));
+    });
   });
 
   it('renders the correct limit options', async () => {
@@ -175,10 +159,7 @@ describe('WidgetBuilderSortBySelector', () => {
   });
 
   it('correctly handles limit changes', async () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <WidgetBuilderSortBySelector />
       </WidgetBuilderProvider>,
@@ -192,17 +173,12 @@ describe('WidgetBuilderSortBySelector', () => {
     await userEvent.click(limitSelector);
     await userEvent.click(await screen.findByText('Limit to 3 results'));
 
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({limit: 3}),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).toEqual(expect.objectContaining({limit: '3'}));
+    });
   });
 
   it('switches the default value for count_unique functions', async () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/trace-items/attributes/',
       body: [{key: 'span.duration', name: 'span.duration'}],
@@ -213,7 +189,7 @@ describe('WidgetBuilderSortBySelector', () => {
       ],
     });
 
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <WidgetBuilderSortBySelector />
       </WidgetBuilderProvider>,
@@ -240,23 +216,19 @@ describe('WidgetBuilderSortBySelector', () => {
     await userEvent.click(screen.getByText(`count(${ELLIPSIS})`));
     await userEvent.click(screen.getByText(`count_unique(${ELLIPSIS})`));
 
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({sort: ['-count_unique(span.op)']}),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).toEqual(
+        expect.objectContaining({sort: '-count_unique(span.op)'})
+      );
+    });
   });
 
   it('sorts by equations line chart', async () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
     const organizationWithFlag = OrganizationFixture({
       features: ['open-membership', 'visibility-explore-view'],
     });
 
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <WidgetBuilderSortBySelector />
       </WidgetBuilderProvider>,
@@ -285,21 +257,19 @@ describe('WidgetBuilderSortBySelector', () => {
       await screen.findByText('count_unique(transaction.duration) + 100')
     );
 
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({sort: ['-equation[0]']}),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).toEqual(
+        expect.objectContaining({sort: '-equation[0]'})
+      );
+    });
 
     await userEvent.click(sortDirectionSelector);
     await userEvent.click(await screen.findByText('Low to high'));
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({sort: ['equation[0]']}),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).toEqual(
+        expect.objectContaining({sort: 'equation[0]'})
+      );
+    });
   });
   it('renders a limit selector for categorical bar widgets', async () => {
     render(
@@ -351,10 +321,7 @@ describe('WidgetBuilderSortBySelector', () => {
   });
 
   it('correctly handles categorical bar limit changes', async () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <WidgetBuilderSortBySelector />
       </WidgetBuilderProvider>,
@@ -379,23 +346,17 @@ describe('WidgetBuilderSortBySelector', () => {
     await userEvent.click(limitSelector);
     await userEvent.click(await screen.findByText('Limit to 15 results'));
 
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({limit: 15}),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).toEqual(expect.objectContaining({limit: '15'}));
+    });
   });
 
   it('sorts by equations table', async () => {
-    const mockNavigate = jest.fn();
-    mockUseNavigate.mockReturnValue(mockNavigate);
-
     const organizationWithFlag = OrganizationFixture({
       features: ['open-membership', 'visibility-explore-view'],
     });
 
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <WidgetBuilderSortBySelector />
       </WidgetBuilderProvider>,
@@ -425,20 +386,18 @@ describe('WidgetBuilderSortBySelector', () => {
       await screen.findByText('count_unique(transaction.duration) + 100')
     );
 
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({sort: ['-equation[0]']}),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).toEqual(
+        expect.objectContaining({sort: '-equation[0]'})
+      );
+    });
 
     await userEvent.click(sortDirectionSelector);
     await userEvent.click(await screen.findByText('Low to high'));
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({sort: ['equation[0]']}),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).toEqual(
+        expect.objectContaining({sort: 'equation[0]'})
+      );
+    });
   });
 });

--- a/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/components/thresholds.spec.tsx
@@ -1,23 +1,14 @@
-import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {ThresholdsSection as Thresholds} from 'sentry/views/dashboards/widgetBuilder/components/thresholds';
 import {
   useWidgetBuilderContext,
   WidgetBuilderProvider,
 } from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 
-jest.mock('sentry/utils/useNavigate');
 describe('Thresholds', () => {
-  let mockNavigate!: jest.Mock;
-
-  beforeEach(() => {
-    mockNavigate = jest.fn();
-    jest.mocked(useNavigate).mockReturnValue(mockNavigate);
-  });
-
   it('sets thresholds to undefined if the thresholds are fully wiped', async () => {
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <Thresholds dataType="duration" dataUnit="millisecond" />
       </WidgetBuilderProvider>,
@@ -35,18 +26,13 @@ describe('Thresholds', () => {
 
     await userEvent.clear(screen.getByLabelText('First Maximum'));
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({
-          thresholds: undefined,
-        }),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query).not.toHaveProperty('thresholds');
+    });
   });
 
   it('sets a threshold when applied', async () => {
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <Thresholds dataType="duration" dataUnit="millisecond" />
       </WidgetBuilderProvider>
@@ -56,18 +42,15 @@ describe('Thresholds', () => {
     await userEvent.type(screen.getByLabelText('Second Maximum'), '200');
     await userEvent.tab();
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({
-          thresholds: '{"max_values":{"max1":100,"max2":200},"unit":null}',
-        }),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query.thresholds).toBe(
+        '{"max_values":{"max1":100,"max2":200},"unit":null}'
+      );
+    });
   });
 
   it('updates the unit when applied', async () => {
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <Thresholds dataType="duration" dataUnit="millisecond" />
       </WidgetBuilderProvider>,
@@ -86,14 +69,11 @@ describe('Thresholds', () => {
     await userEvent.click(screen.getAllByText('millisecond')[0]!);
     await userEvent.click(screen.getByText('second'));
 
-    expect(mockNavigate).toHaveBeenCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({
-          thresholds: '{"max_values":{"max1":100,"max2":200},"unit":"second"}',
-        }),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query.thresholds).toBe(
+        '{"max_values":{"max1":100,"max2":200},"unit":"second"}'
+      );
+    });
   });
 
   it('displays error', async () => {
@@ -122,7 +102,7 @@ describe('Thresholds', () => {
   });
 
   it('accepts decimal values', async () => {
-    render(
+    const {router} = render(
       <WidgetBuilderProvider>
         <Thresholds dataType="duration" dataUnit="millisecond" />
       </WidgetBuilderProvider>
@@ -134,14 +114,11 @@ describe('Thresholds', () => {
     expect((await screen.findAllByDisplayValue('0.5'))[0]).toBeInTheDocument();
     expect((await screen.findAllByDisplayValue('100.5456'))[0]).toBeInTheDocument();
 
-    expect(mockNavigate).toHaveBeenLastCalledWith(
-      expect.objectContaining({
-        query: expect.objectContaining({
-          thresholds: '{"max_values":{"max1":0.5,"max2":100.5456},"unit":null}',
-        }),
-      }),
-      expect.anything()
-    );
+    await waitFor(() => {
+      expect(router.location.query.thresholds).toBe(
+        '{"max_values":{"max1":0.5,"max2":100.5456},"unit":null}'
+      );
+    });
   });
 
   it('preserves preferred polarity when thresholds are cleared', async () => {

--- a/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.spec.tsx
+++ b/static/app/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig.spec.tsx
@@ -1,44 +1,18 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
-import {useLocation} from 'sentry/utils/useLocation';
-import {useNavigate} from 'sentry/utils/useNavigate';
 import {WidgetType} from 'sentry/views/dashboards/types';
 import {WidgetBuilderProvider} from 'sentry/views/dashboards/widgetBuilder/contexts/widgetBuilderContext';
 import {useWidgetBuilderTraceItemConfig} from 'sentry/views/dashboards/widgetBuilder/hooks/useWidgetBuilderTraceItemConfig';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
-jest.mock('sentry/utils/useLocation');
-jest.mock('sentry/utils/useNavigate');
-
-const mockedUseLocation = jest.mocked(useLocation);
-const mockedUseNavigate = jest.mocked(useNavigate);
-
 describe('useWidgetBuilderTraceItemConfig', () => {
-  beforeEach(() => {
-    mockedUseNavigate.mockReturnValue(jest.fn());
-  });
-
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('returns undefined query when multiple metrics are selected', () => {
-    mockedUseLocation.mockReturnValue(
-      LocationFixture({
-        query: {
-          dataset: WidgetType.TRACEMETRICS,
-          displayType: 'line',
-          yAxis: [
-            'avg(value,metric_one,gauge,none)',
-            'sum(value,metric_two,counter,none)',
-          ],
-        },
-      })
-    );
-
     const organization = OrganizationFixture({
       features: [
         'visibility-explore-view',
@@ -49,6 +23,19 @@ describe('useWidgetBuilderTraceItemConfig', () => {
     const {result} = renderHookWithProviders(() => useWidgetBuilderTraceItemConfig(), {
       organization,
       additionalWrapper: WidgetBuilderProvider,
+      initialRouterConfig: {
+        location: {
+          pathname: '/mock-pathname/',
+          query: {
+            dataset: WidgetType.TRACEMETRICS,
+            displayType: 'line',
+            yAxis: [
+              'avg(value,metric_one,gauge,none)',
+              'sum(value,metric_two,counter,none)',
+            ],
+          },
+        },
+      },
     });
 
     expect(result.current.traceItemType).toBe(TraceItemDataset.TRACEMETRICS);
@@ -57,16 +44,6 @@ describe('useWidgetBuilderTraceItemConfig', () => {
   });
 
   it('returns a query when a single metric is selected', () => {
-    mockedUseLocation.mockReturnValue(
-      LocationFixture({
-        query: {
-          dataset: WidgetType.TRACEMETRICS,
-          displayType: 'line',
-          yAxis: ['avg(value,metric_one,gauge,none)', 'max(value,metric_one,gauge,none)'],
-        },
-      })
-    );
-
     const organization = OrganizationFixture({
       features: [
         'visibility-explore-view',
@@ -77,6 +54,19 @@ describe('useWidgetBuilderTraceItemConfig', () => {
     const {result} = renderHookWithProviders(() => useWidgetBuilderTraceItemConfig(), {
       organization,
       additionalWrapper: WidgetBuilderProvider,
+      initialRouterConfig: {
+        location: {
+          pathname: '/mock-pathname/',
+          query: {
+            dataset: WidgetType.TRACEMETRICS,
+            displayType: 'line',
+            yAxis: [
+              'avg(value,metric_one,gauge,none)',
+              'max(value,metric_one,gauge,none)',
+            ],
+          },
+        },
+      },
     });
 
     expect(result.current.traceItemType).toBe(TraceItemDataset.TRACEMETRICS);


### PR DESCRIPTION
Four widget builder specs mocked `useNavigate` and asserted on the payload it was called with. That checks what the code *intended* to write, not what the app reads back — and it quietly encodes the wrong shapes, since a single-valued param comes out of a query string as a string rather than a one-element array, and a limit comes out as a string rather than a number.

They now render with the real test router and assert on `router.location.query`.

`newWidgetBuilder` also moves one `getAllByLabelText` to `findAllByLabelText`. The filter rows it looks for appear after a state update, so the synchronous query was passing on timing luck.

No source changes. This is groundwork for migrating the widget builder off `useQueryParamState` to nuqs, split out because it stands on its own — these four are the specs that pass against the current source unchanged. The rest of that suite can't be converted this way yet: `UrlParamBatchProvider` navigates to `window.location.pathname` and merges over `window.location.search` rather than the router's location, so with a real router those specs either land on a non-matching route or lose all but the last batched write. That's why they still mock `useNavigate`, and it's fixed by the nuqs swap rather than by a test change.

Stacked below: the nuqs migration itself, then removal of the now-dead `urlParamBatchContext`.

https://claude.ai/code/session_01L7oFLFXkMGMwV7xvPiPh5j
