### PR TITLE
fix: Missing next bill card for platform orgs

### DIFF
--- a/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
+++ b/static/gsApp/views/subscriptionPage/headerCards/headerCards.tsx
@@ -23,13 +23,15 @@ function getCards(organization: Organization, subscription: Subscription) {
   const isTrialOrFreePlan =
     subscription.onTrialPlan || isDeveloperPlan(subscription.planDetails);
 
+  const isPaidPlan = subscription.planDetails.totalPrice > 0;
+
   // the organization can use PAYG
   const canUsePayg = supportsPayg(subscription);
 
   // the user can update the PAYG budget
   const canUpdatePayg = canUsePayg && hasBillingPerms;
 
-  if (subscription.canSelfServe && !isTrialOrFreePlan && hasBillingPerms) {
+  if (subscription.canSelfServe && isPaidPlan && hasBillingPerms) {
     cards.push(
       <NextBillCard
         key="next-bill"


### PR DESCRIPTION
Fixes https://linear.app/getsentry/issue/REVENG-503/missing-next-bill-card

This check was looking at trial and isFree. The trial check was useless for legacy orgs and for platform orgs it was causing trouble because a platform org can be on a paid plan while a trial is still running