### PR TITLE
fix(derived): Narrow the child duplication window in generate_project_derived_data

### DIFF
--- a/src/sentry/issues/derived/tasks.py
+++ b/src/sentry/issues/derived/tasks.py
@@ -232,19 +232,18 @@ def generate_project_derived_data(
 
     from sentry import options
     from sentry.issues.derived.processing import PIPELINE
+    from sentry.issues.derived.tasks_util import SpawnState
     from sentry.models.group import Group
-    from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 
-    task_state = current_task()
-    activation_id = task_state.id if task_state else None
-    if activation_id and already_spawned(_GENERATE_PROJECT_TASK_KEY, activation_id):
+    spawn = SpawnState(current_task(), _GENERATE_PROJECT_TASK_KEY)
+    if spawn.already_spawned():
         logger.info(
             "generate_project_derived_data.duplicate_redelivery.skipped",
-            extra={"project_id": project_id, "activation_id": activation_id},
+            extra={"project_id": project_id, "activation_id": spawn.activation_id},
         )
         metrics.incr(
             "taskworker.selfchain.duplicate_skipped",
-            tags={"task": _GENERATE_PROJECT_TASK_KEY},
+            tags={"task": spawn.task_key},
         )
         return
 
@@ -282,16 +281,28 @@ def generate_project_derived_data(
         )
 
     if next_cursor_group_id is not None:
-        generate_project_derived_data.apply_async(
-            kwargs={
-                "project_id": project_id,
-                "cursor_group_id": next_cursor_group_id,
-                "stale_only": stale_only,
-            },
-            headers={"sentry-propagate-traces": False},
-        )
-        if activation_id:
-            mark_spawned(_GENERATE_PROJECT_TASK_KEY, activation_id)
+        # Check just before self-spawn and mark after: narrowest race window without going
+        # at-most-once. Still best-effort — concurrent deliveries can both pass this check and
+        # double-spawn; we only shrink the window so that is less likely.
+        if spawn.already_spawned():
+            logger.info(
+                "generate_project_derived_data.duplicate_redelivery.skipped_before_spawn",
+                extra={"project_id": project_id, "activation_id": spawn.activation_id},
+            )
+            metrics.incr(
+                "taskworker.selfchain.duplicate_skipped",
+                tags={"task": spawn.task_key},
+            )
+        else:
+            generate_project_derived_data.apply_async(
+                kwargs={
+                    "project_id": project_id,
+                    "cursor_group_id": next_cursor_group_id,
+                    "stale_only": stale_only,
+                },
+                headers={"sentry-propagate-traces": False},
+            )
+            spawn.mark_spawned()
 
     logger.info(
         "generate_project_derived_data.scheduled",

--- a/src/sentry/issues/derived/tasks_util.py
+++ b/src/sentry/issues/derived/tasks_util.py
@@ -1,12 +1,16 @@
+from __future__ import annotations
+
 import logging
 import random
 from datetime import datetime, timezone
+from typing import Protocol
 
 from django.db import connections, router
 from django.db.models import Max, Min
 
 from sentry.issues.derived.check import CheckFailure, CheckId, CheckInvalidated, CheckResult
 from sentry.issues.models.groupderiveddata import GroupDerivedData
+from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
@@ -16,6 +20,32 @@ _MAX_CHECK_GROUPS = 10_000
 # Safety valve on the number of group IDs one ``group_id_ranges_for_hash`` call may
 # walk, however large the requested chunking is.
 _MAX_SCANNED_GROUP_IDS = 2_000_000
+
+
+class _TaskState(Protocol):
+    id: str
+
+
+class SpawnState:
+    """Ergonomic wrapper around self-chain ``already_spawned`` / ``mark_spawned``.
+
+    Construct once from ``current_task()`` and the task's self-chain key. Methods are no-ops when
+    there is no activation (eager/sync calls).
+    """
+
+    def __init__(self, task_state: _TaskState | None, task_key: str) -> None:
+        self.task_key = task_key
+        self.activation_id: str | None = task_state.id if task_state is not None else None
+
+    def already_spawned(self) -> bool:
+        if self.activation_id is None:
+            return False
+        return already_spawned(self.task_key, self.activation_id)
+
+    def mark_spawned(self) -> None:
+        if self.activation_id is None:
+            return
+        mark_spawned(self.task_key, self.activation_id)
 
 
 def _record_check_result(result: CheckResult) -> None:

--- a/tests/sentry/issues/derived/test_tasks.py
+++ b/tests/sentry/issues/derived/test_tasks.py
@@ -1,6 +1,8 @@
 from collections.abc import Sequence
 from datetime import datetime, timezone
-from unittest.mock import call, patch
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, call, patch
 
 from sentry.issues.action_log.publish import publish_action
 from sentry.issues.action_log.types import ActionSource, GroupActionActor, ViewAction
@@ -17,11 +19,13 @@ from sentry.issues.derived.tasks import (
     regenerate_stale_derived_data_batch,
 )
 from sentry.issues.derived.tasks_util import (
+    SpawnState,
     _pick_random_fresh_group_ranges,
     group_id_ranges_for_hash,
 )
 from sentry.issues.models.groupderiveddata import GroupDerivedData
 from sentry.models.group import Group, GroupStatus
+from sentry.taskworker.selfchain_idempotency import already_spawned, mark_spawned
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.helpers.options import override_options
@@ -234,6 +238,89 @@ class GenerateProjectDerivedDataPaginationTest(DerivedDataTaskTestBase):
             stale_only=False,
         )
         mock_project_delay.assert_not_called()
+
+    @patch("taskbroker_client.state.current_task")
+    def test_selfchain_skips_self_schedule_when_marked_during_work(
+        self, mock_current_task: MagicMock
+    ) -> None:
+        # Entry guard passes; a concurrent delivery marks before we self-schedule the next page.
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(group.id for group in groups)
+        mock_current_task.return_value = SimpleNamespace(id="proj-act-race")
+
+        def mark_during_chunk(
+            chunk_group_ids: Sequence[int], batch_size: int
+        ) -> list[tuple[int, int]]:
+            mark_spawned("generate_project_derived_data", "proj-act-race")
+            return [(chunk_group_ids[0], chunk_group_ids[-1] + 1)]
+
+        with (
+            override_options(
+                {
+                    "issues.derived.project-batch-size": 2,
+                    "issues.derived.project-max-tasks": 1,
+                }
+            ),
+            patch(
+                "sentry.issues.derived.tasks._chunk_group_ids_into_ranges",
+                side_effect=mark_during_chunk,
+            ),
+            patch.object(generate_project_derived_data_batch, "delay") as mock_batch_delay,
+            patch.object(generate_project_derived_data, "apply_async") as mock_project_delay,
+        ):
+            generate_project_derived_data(project_id=self.project.id)
+
+        mock_batch_delay.assert_called_once_with(
+            project_id=self.project.id,
+            group_id_start=group_ids[0],
+            group_id_end=group_ids[1] + 1,
+            stale_only=False,
+        )
+        mock_project_delay.assert_not_called()
+
+    @patch("taskbroker_client.state.current_task")
+    def test_selfchain_marks_after_self_schedule(self, mock_current_task: MagicMock) -> None:
+        groups = self.create_unprocessed_groups(3)
+        group_ids = sorted(group.id for group in groups)
+        mock_current_task.return_value = SimpleNamespace(id="proj-act-mark")
+
+        with (
+            override_options(
+                {
+                    "issues.derived.project-batch-size": 2,
+                    "issues.derived.project-max-tasks": 1,
+                }
+            ),
+            patch.object(generate_project_derived_data_batch, "delay"),
+            patch.object(generate_project_derived_data, "apply_async") as mock_project_delay,
+        ):
+            generate_project_derived_data(project_id=self.project.id)
+
+        mock_project_delay.assert_called_once()
+        assert already_spawned("generate_project_derived_data", "proj-act-mark") is True
+        call_kwargs: dict[str, Any] = mock_project_delay.call_args.kwargs["kwargs"]
+        assert group_ids[1] == call_kwargs["cursor_group_id"]
+
+
+class SpawnStateTest(TestCase):
+    def test_roundtrip(self) -> None:
+        spawn = SpawnState(SimpleNamespace(id="act-spawn-state"), "merge_groups")
+        assert spawn.task_key == "merge_groups"
+        assert spawn.activation_id == "act-spawn-state"
+        assert spawn.already_spawned() is False
+
+        spawn.mark_spawned()
+
+        assert spawn.already_spawned() is True
+        assert already_spawned(spawn.task_key, "act-spawn-state") is True
+
+    def test_noop_without_activation(self) -> None:
+        spawn = SpawnState(None, "merge_groups")
+        assert spawn.task_key == "merge_groups"
+        assert spawn.activation_id is None
+        assert spawn.already_spawned() is False
+        spawn.mark_spawned()
+        assert already_spawned(spawn.task_key, "act-none") is False
 
 
 @with_feature("projects:issue-action-log-write-to-db")


### PR DESCRIPTION
We've seen a number of significant cases of generate_project_derived_data generating duplicate children, who in turn can create duplicate children, resulting in lots of extra load and contention we don't need or want.

This adds a spawn check just before the self-schedule in an aim to reduce the window of possibility for this issue, and to make it less messy looking introduces a SpawnState helper.
