### PR TITLE
feat(seer): Render and announce pull requests the Seer agent opens from chat

### DIFF
--- a/src/sentry/notifications/platform/slack/renderers/seer.py
+++ b/src/sentry/notifications/platform/slack/renderers/seer.py
@@ -25,6 +25,7 @@ from sentry.notifications.platform.renderer import NotificationRenderer
 from sentry.notifications.platform.slack.provider import SlackRenderable
 from sentry.notifications.platform.templates.seer import (
     SeerAgentError,
+    SeerAgentPullRequests,
     SeerAgentResponse,
     SeerAutofixError,
     SeerAutofixTrigger,
@@ -104,6 +105,8 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
             return cls._render_agent_error(data)
         elif isinstance(data, SeerAgentResponse):
             return cls._render_agent_response(data)
+        elif isinstance(data, SeerAgentPullRequests):
+            return cls._render_agent_pull_requests(data)
         else:
             raise ValueError(f"SeerSlackRenderer does not support {data.__class__.__name__}")
 
@@ -282,6 +285,22 @@ class SeerSlackRenderer(NotificationRenderer[SlackRenderable]):
             blocks.extend(cls.render_missing_scope_footer(data.missing_scope_settings_url))
 
         return SlackRenderable(blocks=blocks, text="Seer Agent has finished")
+
+    @classmethod
+    def _render_agent_pull_requests(cls, data: SeerAgentPullRequests) -> SlackRenderable:
+        # Plain mrkdwn links rather than link buttons: a button posts a block action back
+        # to Sentry, which would need a routed action id to be acknowledged, and there is
+        # nothing for Sentry to do with the click.
+        heading = AUTOFIX_CONFIG[AutofixStoppingPoint.OPEN_PR]["heading"]
+        lines = [
+            f"Seer opened <{pr['pr_url']}|{pr['repo_name']}#{pr['pr_number']}>"
+            for pr in data.pull_requests[:MAX_PRS]
+        ]
+        blocks: list[Block] = [
+            SectionBlock(text=MarkdownTextObject(text=heading)),
+            SectionBlock(text=MarkdownTextObject(text="\n".join(lines))),
+        ]
+        return SlackRenderable(blocks=blocks, text="Seer has summoned your pull request")
 
     @classmethod
     def _render_link_button(

--- a/src/sentry/notifications/platform/templates/seer.py
+++ b/src/sentry/notifications/platform/templates/seer.py
@@ -233,3 +233,42 @@ class SeerAgentWriteApprovalTemplate(NotificationTemplate[SeerAgentWriteApproval
 
     def render(self, data: SeerAgentWriteApproval) -> NotificationRenderedTemplate:
         return NotificationRenderedTemplate(subject="Seer Agent Write Approval", body=[])
+
+
+class SeerAgentPullRequest(TypedDict):
+    repo_name: str
+    pr_number: int
+    pr_url: str
+
+
+class SeerAgentPullRequests(NotificationData):
+    """The pull requests an agent run opened after its reply already went out.
+
+    Separate from ``SeerAgentResponse`` because the PR is created asynchronously by
+    Seer's PR step, so it does not exist yet when the completion hook posts the reply.
+    """
+
+    run_id: int
+    organization_id: int
+    pull_requests: list[SeerAgentPullRequest]
+    source: NotificationSource = NotificationSource.SEER_AGENT_PULL_REQUESTS
+
+
+@template_registry.register(NotificationSource.SEER_AGENT_PULL_REQUESTS)
+class SeerAgentPullRequestsTemplate(NotificationTemplate[SeerAgentPullRequests]):
+    category = NotificationCategory.SEER
+    example_data = SeerAgentPullRequests(
+        run_id=12345,
+        organization_id=1,
+        pull_requests=[
+            {
+                "repo_name": "getsentry/sentry",
+                "pr_number": 123,
+                "pr_url": "https://github.com/getsentry/sentry/pull/123",
+            }
+        ],
+    )
+    hide_from_debugger = True
+
+    def render(self, data: SeerAgentPullRequests) -> NotificationRenderedTemplate:
+        return NotificationRenderedTemplate(subject="Seer Agent Pull Requests", body=[])

--- a/src/sentry/notifications/platform/types.py
+++ b/src/sentry/notifications/platform/types.py
@@ -71,6 +71,7 @@ class NotificationSource(StrEnum):
     SEER_AGENT_RESPONSE = "seer-agent-response"
     SEER_AGENT_ERROR = "seer-agent-error"
     SEER_AGENT_WRITE_APPROVAL = "seer-agent-write-approval"
+    SEER_AGENT_PULL_REQUESTS = "seer-agent-pull-requests"
 
     # SENTRY_APP
     SENTRY_APP_WEBHOOK_DISABLED = "sentry-app-webhook-disabled"
@@ -135,6 +136,7 @@ NOTIFICATION_SOURCE_MAP: dict[NotificationCategory, list[NotificationSource]] = 
         NotificationSource.SEER_AGENT_RESPONSE,
         NotificationSource.SEER_AGENT_ERROR,
         NotificationSource.SEER_AGENT_WRITE_APPROVAL,
+        NotificationSource.SEER_AGENT_PULL_REQUESTS,
     ],
     NotificationCategory.SENTRY_APP: [
         NotificationSource.SENTRY_APP_WEBHOOK_DISABLED,

--- a/src/sentry/seer/endpoints/organization_seer_agent_chat.py
+++ b/src/sentry/seer/endpoints/organization_seer_agent_chat.py
@@ -331,6 +331,9 @@ class OrganizationSeerAgentChatEndpoint(OrganizationEndpoint):
                 is_interactive=True,
                 enable_bash_tools=override_bash_mode_enabled,
                 enable_coding=enable_coding,
+                # A run that can open pull requests has to read them back — status,
+                # reviews, failed CI — to iterate on what it opened.
+                enable_pr_context_tools=enable_coding,
                 enable_code_mode_tools=enable_code_mode_tools,
                 reasoning_effort="medium",
             )

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Any, NotRequired, TypedDict
+from collections.abc import Mapping, Sequence
+from typing import TYPE_CHECKING, Any, NotRequired, TypedDict
 
 from sentry import features, options
 from sentry.constants import DataCategory
@@ -39,6 +40,9 @@ from sentry.taskworker.namespaces import seer_tasks
 from sentry.types.activity import ActivityType
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
+
+if TYPE_CHECKING:
+    from sentry.notifications.platform.templates.seer import SeerAgentPullRequest
 
 SEER_EVENT_TO_ACTIVITY_TYPE: dict[SentryAppEventType, ActivityType] = {
     SentryAppEventType.SEER_ROOT_CAUSE_STARTED: ActivityType.SEER_RCA_STARTED,
@@ -851,6 +855,65 @@ def get_autofix_explorer_status(
     # no block matching the stopping point found, so return None
     # to indicate the step has not run before
     return None
+
+
+def notify_agent_entrypoints_of_pull_requests(
+    *,
+    organization: Organization,
+    run_id: int,
+    pull_requests: Sequence[Mapping[str, Any]],
+) -> None:
+    """Tell every entrypoint holding a cached payload for ``run_id`` which PRs it opened.
+
+    The same fan-out as ``SeerOperatorCompletionHook``, fired from the pr_created RPC
+    instead of the completion hook: the PR is opened by a Seer step that outlives the
+    agent's turn, so when the reply goes out there is nothing to link yet. Best-effort
+    throughout — a failed notification never fails the RPC that reported the PR.
+    """
+    if not SeerAgentOperator.has_access(organization=organization):
+        return
+
+    normalized: list[SeerAgentPullRequest] = []
+    for entry in pull_requests:
+        pr_payload = entry.get("pull_request") or {}
+        repo_name = entry.get("repo_name")
+        pr_number = pr_payload.get("pr_number")
+        pr_url = pr_payload.get("pr_url")
+        if not repo_name or pr_number is None or not pr_url:
+            continue
+        normalized.append({"repo_name": repo_name, "pr_number": int(pr_number), "pr_url": pr_url})
+    if not normalized:
+        return
+
+    for entrypoint_key, entrypoint_cls in agent_entrypoint_registry.registrations.items():
+        if not entrypoint_cls.has_access(organization=organization):
+            continue
+
+        cache_payload = SeerOperatorAgentCache[dict[str, Any]].get(
+            entrypoint_key=str(entrypoint_key), run_id=run_id
+        )
+        if not cache_payload:
+            continue
+        if cache_payload.get("organization_id") != organization.id:
+            # run_id is globally unique in Seer, so a payload for another org is a bug,
+            # not a routing choice; refuse rather than post into someone else's thread.
+            logger.error(
+                "seer.entrypoint.pull_requests.org_mismatch",
+                extra={"run_id": run_id, "organization_id": organization.id},
+            )
+            return
+
+        try:
+            entrypoint_cls.on_agent_pull_requests_created(
+                cache_payload=cache_payload,
+                run_id=run_id,
+                pull_requests=normalized,
+            )
+        except Exception:
+            logger.exception(
+                "seer.entrypoint.pull_requests.notify_failed",
+                extra={"entrypoint_key": str(entrypoint_key), "run_id": run_id},
+            )
 
 
 class SeerOperatorCompletionHook(AgentOnCompletionHook):

--- a/src/sentry/seer/entrypoints/slack/entrypoint.py
+++ b/src/sentry/seer/entrypoints/slack/entrypoint.py
@@ -10,6 +10,8 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.notifications.platform.templates.seer import (
     SeerAgentError,
+    SeerAgentPullRequest,
+    SeerAgentPullRequests,
     SeerAgentResponse,
     SeerAgentWriteApproval,
     SeerAutofixError,
@@ -649,6 +651,24 @@ class SlackAgentEntrypoint(
             integration_id=integration_id,
             organization_id=organization_id,
             data=response_data,
+        )
+
+    @staticmethod
+    def on_agent_pull_requests_created(
+        cache_payload: SlackAgentCachePayload,
+        run_id: int,
+        pull_requests: list[SeerAgentPullRequest],
+    ) -> None:
+        organization_id = cache_payload["organization_id"]
+        schedule_all_thread_updates(
+            threads=[cache_payload["thread"]],
+            integration_id=cache_payload["integration_id"],
+            organization_id=organization_id,
+            data=SeerAgentPullRequests(
+                run_id=run_id,
+                organization_id=organization_id,
+                pull_requests=pull_requests,
+            ),
         )
 
 

--- a/src/sentry/seer/entrypoints/types.py
+++ b/src/sentry/seer/entrypoints/types.py
@@ -1,11 +1,14 @@
 from enum import StrEnum
-from typing import Any, Literal, Protocol, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypedDict
 
 from sentry.models.organization import Organization
 from sentry.organizations.services.organization.model import RpcOrganization
 from sentry.seer.agent.client_models import PendingUserInput
 from sentry.seer.autofix.utils import CodingAgentProviderType
 from sentry.sentry_apps.event_types import SentryAppEventType
+
+if TYPE_CHECKING:
+    from sentry.notifications.platform.templates.seer import SeerAgentPullRequest
 
 
 class SeerEntrypointKey(StrEnum):
@@ -153,6 +156,22 @@ class SeerAgentEntrypoint[CachePayloadT](Protocol):
 
         Note: This is a static method. The entrypoint instance is NOT persisted between
         trigger and completion, so leverage the cached payload to persist any state.
+        """
+        ...
+
+    @staticmethod
+    def on_agent_pull_requests_created(
+        cache_payload: CachePayloadT,
+        run_id: int,
+        pull_requests: "list[SeerAgentPullRequest]",
+    ) -> None:
+        """
+        Called when Seer reports that an Agent run opened pull requests.
+
+        Arrives after on_agent_update: the reply goes out when the agent's turn ends, but
+        the pull request is opened by a separate Seer step that reports back through the
+        pr_created RPC once the PR exists. Static for the same reason as on_agent_update —
+        only the cached payload survives between trigger and this call.
         """
         ...
 

--- a/src/sentry/seer/pull_requests.py
+++ b/src/sentry/seer/pull_requests.py
@@ -258,4 +258,20 @@ def notify_seer_pr_created(
         group_id=group_id,
     )
 
+    if group_id is None:
+        # Issue-anchored runs already announce their PR through the autofix thread
+        # updates, keyed by group. A run with no issue has no group to key on, so
+        # the chat entrypoints hear about its PR from here instead.
+        from sentry.seer.entrypoints.operator import notify_agent_entrypoints_of_pull_requests
+
+        try:
+            notify_agent_entrypoints_of_pull_requests(
+                organization=organization, run_id=run_id, pull_requests=pull_requests
+            )
+        except Exception:
+            logger.exception(
+                "seer.pr_created_notify.entrypoint_notify_failed",
+                extra={"organization_id": organization_id, "run_id": run_id},
+            )
+
     return NotifySeerPrCreatedSuccessResponse()

--- a/static/app/components/seer/markdown/embeds/components/pullRequestRef.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/pullRequestRef.spec.tsx
@@ -1,0 +1,121 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {SeerRepoPRStatesProvider} from 'sentry/components/seer/markdown/embeds/components/pullRequestRef';
+import type {RepoPRState} from 'sentry/views/seerExplorer/types';
+
+const REPO = 'acme/web';
+const PR_URL = 'https://github.com/acme/web/pull/482';
+
+function makeState(overrides: Partial<RepoPRState> = {}): RepoPRState {
+  return {
+    repo_name: REPO,
+    branch_name: 'seer/add-cart-logging',
+    commit_sha: 'abc123',
+    pr_creation_error: null,
+    pr_creation_status: 'completed',
+    pr_id: 999,
+    pr_number: 482,
+    pr_url: PR_URL,
+    title: 'Add cart total logging',
+    ...overrides,
+  };
+}
+
+function renderCard({
+  states,
+  body = {repoName: REPO, runId: 42},
+}: {
+  states: Record<string, RepoPRState> | null;
+  body?: Record<string, unknown>;
+}) {
+  return render(
+    <SeerRepoPRStatesProvider repoPRStates={states}>
+      <SeerMarkdown
+        raw="{% pullRequestRef /%}"
+        structuredContent={{pullRequestRef: body}}
+      />
+    </SeerRepoPRStatesProvider>
+  );
+}
+
+describe('pullRequestRef embed', () => {
+  it('shows progress while the pull request is being opened', () => {
+    renderCard({
+      states: {
+        [REPO]: makeState({
+          pr_creation_status: 'creating',
+          pr_number: null,
+          pr_url: null,
+        }),
+      },
+    });
+
+    expect(screen.getByText(REPO)).toBeInTheDocument();
+    expect(screen.getByText('Opening a pull request in acme/web…')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('shows progress against the existing pull request when pushing to one', () => {
+    renderCard({
+      states: {[REPO]: makeState({pr_creation_status: 'creating'})},
+    });
+
+    expect(screen.getByText('Pushing changes to acme/web#482…')).toBeInTheDocument();
+  });
+
+  it('links the pull request once the push completes', () => {
+    renderCard({states: {[REPO]: makeState()}});
+
+    const link = screen.getByRole('button', {name: 'View acme/web#482'});
+    expect(link).toHaveAttribute('href', PR_URL);
+    expect(screen.getByText('Add cart total logging')).toBeInTheDocument();
+  });
+
+  it('reports a failed push with the error Seer recorded', () => {
+    renderCard({
+      states: {
+        [REPO]: makeState({
+          pr_creation_status: 'error',
+          pr_number: null,
+          pr_url: null,
+          pr_creation_error: 'No write access to repository',
+        }),
+      },
+    });
+
+    expect(screen.getByText('Seer could not push to acme/web.')).toBeInTheDocument();
+    expect(screen.getByText('No write access to repository')).toBeInTheDocument();
+  });
+
+  it('falls back to the pull request pinned in the body when the host has no run state', () => {
+    renderCard({
+      states: null,
+      body: {
+        repoName: REPO,
+        prNumber: 482,
+        prUrl: PR_URL,
+        title: 'Add cart total logging',
+      },
+    });
+
+    expect(screen.getByRole('button', {name: 'View acme/web#482'})).toHaveAttribute(
+      'href',
+      PR_URL
+    );
+  });
+
+  it('waits when neither the host nor the body knows the pull request yet', () => {
+    renderCard({states: {}});
+
+    expect(
+      screen.getByText('Waiting for the pull request in acme/web…')
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing for a body without a repository', () => {
+    renderCard({states: {}, body: {runId: 42}});
+
+    expect(screen.queryByTestId('pull-request-ref-embed')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/components/seer/markdown/embeds/components/pullRequestRef.tsx
+++ b/static/app/components/seer/markdown/embeds/components/pullRequestRef.tsx
@@ -1,0 +1,148 @@
+import {createContext, useContext, type ReactNode} from 'react';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {getRepoPullRequestLink} from 'sentry/components/events/autofix/pullRequests';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconOpen} from 'sentry/icons/iconOpen';
+import {IconPullRequest} from 'sentry/icons/iconPullRequest';
+import {t} from 'sentry/locale';
+import type {RepoPRState} from 'sentry/views/seerExplorer/types';
+
+/**
+ * The run's per-repository PR state, supplied by the host that already polls the run.
+ * The card reads it from here instead of fetching on its own: the explorer polls the
+ * session every 500ms while a push is in flight, so a second poller per card would only
+ * add load and could disagree with the header widget.
+ */
+const SeerRepoPRStatesContext = createContext<Record<string, RepoPRState> | null>(null);
+
+export function SeerRepoPRStatesProvider({
+  children,
+  repoPRStates,
+}: {
+  children: ReactNode;
+  repoPRStates: Record<string, RepoPRState> | null | undefined;
+}) {
+  return (
+    <SeerRepoPRStatesContext.Provider value={repoPRStates ?? null}>
+      {children}
+    </SeerRepoPRStatesContext.Provider>
+  );
+}
+
+export const PullRequestRefEmbed = defineSeerEmbed({
+  name: 'pullRequestRef',
+  render(props) {
+    return <PullRequestRefContent {...props} />;
+  },
+});
+
+interface PullRequestLink {
+  label: string;
+  url: string;
+}
+
+/**
+ * Seer emits the card before the PR exists, so the body carries the PR only when the
+ * push updates one that is already open. The live state wins whenever the host has it;
+ * the body is what keeps an old conversation's card linked once the host stops polling.
+ */
+function resolveLink(
+  state: RepoPRState | undefined,
+  {repoName, prNumber, prUrl}: EmbedOutput<'pullRequestRef'>
+): PullRequestLink | null {
+  const live = state ? getRepoPullRequestLink(state) : null;
+  if (live) {
+    return live;
+  }
+  if (prUrl && prNumber) {
+    return {label: t('View %s#%s', repoName, prNumber), url: prUrl};
+  }
+  return null;
+}
+
+function PullRequestRefContent(props: EmbedOutput<'pullRequestRef'>) {
+  const {repoName, prNumber, title} = props;
+  const repoPRStates = useContext(SeerRepoPRStatesContext);
+  const state = repoPRStates?.[repoName];
+  const link = resolveLink(state, props);
+  const displayTitle = state?.title ?? title;
+  const targetNumber = state?.pr_number ?? prNumber;
+
+  let body: ReactNode;
+  if (state?.pr_creation_status === 'creating') {
+    body = (
+      <Flex gap="md" align="center">
+        <LoadingIndicator size={16} style={{margin: 0}} />
+        <Text variant="muted" size="sm">
+          {targetNumber
+            ? t('Pushing changes to %s#%s…', repoName, targetNumber)
+            : t('Opening a pull request in %s…', repoName)}
+        </Text>
+      </Flex>
+    );
+  } else if (state?.pr_creation_status === 'error') {
+    body = (
+      <Stack gap="2xs">
+        <Text variant="danger" size="sm">
+          {t('Seer could not push to %s.', repoName)}
+        </Text>
+        {state.pr_creation_error && (
+          <Text variant="muted" size="sm">
+            {state.pr_creation_error}
+          </Text>
+        )}
+      </Stack>
+    );
+  } else if (link) {
+    body = (
+      <Flex>
+        <LinkButton size="sm" icon={<IconOpen />} href={link.url} external>
+          {link.label}
+        </LinkButton>
+      </Flex>
+    );
+  } else {
+    body = (
+      <Text variant="muted" size="sm">
+        {t('Waiting for the pull request in %s…', repoName)}
+      </Text>
+    );
+  }
+
+  return (
+    <Container
+      data-test-id="pull-request-ref-embed"
+      width="fit-content"
+      maxWidth="100%"
+      padding="md"
+      border="primary"
+      radius="md"
+      background="secondary"
+    >
+      <Flex gap="md" align="start">
+        <IconPullRequest size="sm" />
+        <Stack gap="sm">
+          <Stack gap="2xs">
+            <Text bold size="sm">
+              {repoName}
+            </Text>
+            {displayTitle && (
+              <Text variant="muted" size="sm">
+                {displayTitle}
+              </Text>
+            )}
+          </Stack>
+          {body}
+        </Stack>
+      </Flex>
+    </Container>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/index.ts
+++ b/static/app/components/seer/markdown/embeds/index.ts
@@ -16,6 +16,7 @@ import {LogsQuery} from './components/logsQuery';
 import {MetricsQuery} from './components/metricsQuery';
 import {Monitor} from './components/monitor/monitor';
 import {Profile} from './components/profile/profile';
+import {PullRequestRefEmbed} from './components/pullRequestRef';
 import {Release} from './components/release';
 import {Replay} from './components/replay';
 import {ReplaysQuery} from './components/replaysQuery';
@@ -47,6 +48,7 @@ const embeds = [
   MetricsQuery,
   Monitor,
   Profile,
+  PullRequestRefEmbed,
   Release,
   Replay,
   ReplaysQuery,

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -1079,6 +1079,25 @@ export const STRUCTURED_SEER_EMBED_SCHEMAS = {
       status: z.enum(['pending', 'approved', 'rejected']),
     }),
   },
+  /**
+   * Published by Seer's pull request lib when the agent opens or updates a PR from
+   * the run's own edits. Structured-only so the agent is never told to write the
+   * tag itself: the card follows the run's `repo_pr_states`, which the host that
+   * polls the run supplies, and the body only pins the PR the push targets when
+   * one already exists.
+   */
+  pullRequestRef: {
+    description:
+      'Follow the pull request Seer is opening or updating for a repository from the run state.',
+    level: ['block'],
+    schema: z.object({
+      repoName: z.string().min(1),
+      runId: z.union([z.string(), z.number()]).optional(),
+      prNumber: z.number().optional(),
+      prUrl: z.string().optional(),
+      title: z.string().optional(),
+    }),
+  },
 } as const satisfies Record<string, SeerEmbedSchema>;
 
 export const ALL_SEER_EMBED_SCHEMAS = {

--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef, type ReactNode} from 'react';
+import {useCallback, useEffect, useMemo, useRef, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
@@ -13,6 +13,7 @@ import {
   AutofixChatProvider,
   type SendMessageOptions,
 } from 'sentry/components/seer/autofixChatContext';
+import {SeerRepoPRStatesProvider} from 'sentry/components/seer/markdown/embeds/components/pullRequestRef';
 import {SEER_AGENTS_PROJECT_ID} from 'sentry/constants';
 import {IconClose, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -624,7 +625,7 @@ export function SeerExplorerContent({
               onSuggestionClick={readOnly ? undefined : sendMessage}
             />
           ) : (
-            <Fragment>
+            <SeerRepoPRStatesProvider repoPRStates={repoPRStates}>
               {groupTranscript(blocks).map(segment => {
                 const interactionPending =
                   isFileApprovalPending ||
@@ -701,7 +702,7 @@ export function SeerExplorerContent({
                   }
                 />
               )}
-            </Fragment>
+            </SeerRepoPRStatesProvider>
           )}
         </BlocksContainer>
         {isTimedOut && (

--- a/tests/sentry/notifications/platform/slack/renderers/test_seer.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_seer.py
@@ -22,6 +22,7 @@ from sentry.notifications.platform.slack.renderers.seer_agent_write_approval imp
 )
 from sentry.notifications.platform.templates.seer import (
     SeerAgentError,
+    SeerAgentPullRequests,
     SeerAgentResponse,
     SeerAgentWriteApproval,
     SeerAutofixCodeChange,
@@ -427,3 +428,36 @@ class SeerAgentWriteApprovalSlackRendererTest(TestCase):
         assert [reject_button.text.text, approve_button.text.text] == ["Reject", "Approve"]
         assert reject_button.value == "link_clicked"
         assert approve_button.value == "link_clicked"
+
+
+class SeerSlackRendererAgentPullRequestsTest(TestCase):
+    def test_render_agent_pull_requests_links_each_pull_request(self) -> None:
+        data = SeerAgentPullRequests(
+            run_id=12345,
+            organization_id=self.organization.id,
+            pull_requests=[
+                {
+                    "repo_name": "acme/web",
+                    "pr_number": 482,
+                    "pr_url": "https://gh/acme/web/pull/482",
+                },
+                {"repo_name": "acme/api", "pr_number": 7, "pr_url": "https://gh/acme/api/pull/7"},
+            ],
+        )
+
+        renderable = SeerSlackRenderer.render(
+            data=data, rendered_template=NotificationRenderedTemplate(subject="x", body=[])
+        )
+
+        assert renderable["text"] == "Seer has summoned your pull request"
+        blocks = renderable["blocks"]
+        assert len(blocks) == 2
+        assert isinstance(blocks[0], SectionBlock)
+        assert isinstance(blocks[1], SectionBlock)
+        assert isinstance(blocks[1].text, MarkdownTextObject)
+        assert blocks[1].text.text == (
+            "Seer opened <https://gh/acme/web/pull/482|acme/web#482>\n"
+            "Seer opened <https://gh/acme/api/pull/7|acme/api#7>"
+        )
+        # Links, not buttons: nothing here posts an action back to Sentry.
+        assert not any(isinstance(block, ActionsBlock) for block in blocks)

--- a/tests/sentry/seer/entrypoints/slack/test_slack.py
+++ b/tests/sentry/seer/entrypoints/slack/test_slack.py
@@ -8,6 +8,7 @@ from sentry.notifications.platform.service import serialize_notification_data
 from sentry.notifications.platform.slack.provider import SlackRenderable
 from sentry.notifications.platform.templates.seer import (
     SeerAgentError,
+    SeerAgentPullRequests,
     SeerAgentResponse,
     SeerAgentWriteApproval,
     SeerAutofixUpdate,
@@ -716,6 +717,31 @@ class SlackAgentEntrypointTest(TestCase):
         call_data = mock_schedule_all_thread_updates.call_args.kwargs["data"]
         assert isinstance(call_data, SeerAgentError)
         assert call_data.error_message == "Seer was unable to generate a response."
+
+    @patch("sentry.seer.entrypoints.slack.entrypoint.schedule_all_thread_updates")
+    def test_on_agent_pull_requests_created(self, mock_schedule_all_thread_updates):
+        ep = self._get_entrypoint()
+        cache_payload = ep.create_agent_cache_payload()
+        pull_requests = [
+            {"repo_name": "acme/web", "pr_number": 482, "pr_url": "https://gh/acme/web/pull/482"}
+        ]
+
+        SlackAgentEntrypoint.on_agent_pull_requests_created(
+            cache_payload=cache_payload,
+            run_id=12345,
+            pull_requests=pull_requests,
+        )
+
+        mock_schedule_all_thread_updates.assert_called_once_with(
+            threads=[cache_payload["thread"]],
+            integration_id=self.integration.id,
+            organization_id=self.organization.id,
+            data=ANY,
+        )
+        call_data = mock_schedule_all_thread_updates.call_args.kwargs["data"]
+        assert isinstance(call_data, SeerAgentPullRequests)
+        assert call_data.run_id == 12345
+        assert call_data.pull_requests == pull_requests
 
     @patch("sentry.seer.entrypoints.slack.entrypoint.schedule_all_thread_updates")
     @patch("sentry.seer.entrypoints.slack.entrypoint._send_agent_write_approval")

--- a/tests/sentry/seer/entrypoints/test_operator.py
+++ b/tests/sentry/seer/entrypoints/test_operator.py
@@ -934,6 +934,14 @@ class MockAgentEntrypoint(SeerAgentEntrypoint[MockCachePayload]):
     ) -> None:
         return None
 
+    @staticmethod
+    def on_agent_pull_requests_created(
+        cache_payload: MockCachePayload,
+        run_id: int,
+        pull_requests: list,
+    ) -> None:
+        return None
+
 
 class TestSeerAgentOperatorAccess(TestCase):
     def setUp(self) -> None:
@@ -1344,3 +1352,78 @@ class TestSeerAgentOperatorCodeMode(TestCase):
 
         mock_client_cls.assert_called_once()
         assert mock_client_cls.call_args.kwargs["enable_code_mode_tools"] == "off"
+
+
+class TestNotifyAgentEntrypointsOfPullRequests(TestCase):
+    _PAYLOAD = [
+        {
+            "provider": "github",
+            "repo_name": "acme/web",
+            "repo_external_id": "1",
+            "pull_request": {
+                "pr_id": 999,
+                "pr_number": 482,
+                "pr_url": "https://gh/acme/web/pull/482",
+            },
+        }
+    ]
+
+    def _notify(self, *, cache_payload: dict | None, payload: list | None = None) -> Mock:
+        from sentry.seer.entrypoints.operator import notify_agent_entrypoints_of_pull_requests
+
+        mock_entrypoint_cls = Mock(spec=SeerAgentEntrypoint)
+        mock_entrypoint_cls.has_access.return_value = True
+        with (
+            patch.dict(
+                "sentry.seer.entrypoints.operator.agent_entrypoint_registry.registrations",
+                {MockAgentEntrypoint.key: mock_entrypoint_cls},
+                clear=True,
+            ),
+            patch(
+                "sentry.seer.entrypoints.operator.SeerOperatorAgentCache.get",
+                return_value=cache_payload,
+            ),
+            patch(
+                "sentry.seer.entrypoints.operator.SeerAgentOperator.has_access",
+                return_value=True,
+            ),
+        ):
+            notify_agent_entrypoints_of_pull_requests(
+                organization=self.organization,
+                run_id=MOCK_RUN_ID,
+                pull_requests=self._PAYLOAD if payload is None else payload,
+            )
+        return mock_entrypoint_cls
+
+    def test_notifies_the_entrypoint_with_the_normalized_pull_requests(self):
+        cache_payload = {"thread_id": "abc", "organization_id": self.organization.id}
+        mock_entrypoint_cls = self._notify(cache_payload=cache_payload)
+
+        mock_entrypoint_cls.on_agent_pull_requests_created.assert_called_once_with(
+            cache_payload=cache_payload,
+            run_id=MOCK_RUN_ID,
+            pull_requests=[
+                {
+                    "repo_name": "acme/web",
+                    "pr_number": 482,
+                    "pr_url": "https://gh/acme/web/pull/482",
+                }
+            ],
+        )
+
+    def test_skips_entrypoints_without_a_cached_run(self):
+        mock_entrypoint_cls = self._notify(cache_payload=None)
+        mock_entrypoint_cls.on_agent_pull_requests_created.assert_not_called()
+
+    def test_refuses_a_payload_cached_for_another_organization(self):
+        cache_payload = {"thread_id": "abc", "organization_id": self.organization.id + 1}
+        mock_entrypoint_cls = self._notify(cache_payload=cache_payload)
+        mock_entrypoint_cls.on_agent_pull_requests_created.assert_not_called()
+
+    def test_skips_pull_requests_missing_a_link(self):
+        cache_payload = {"thread_id": "abc", "organization_id": self.organization.id}
+        mock_entrypoint_cls = self._notify(
+            cache_payload=cache_payload,
+            payload=[{"repo_name": "acme/web", "pull_request": {"pr_number": 482}}],
+        )
+        mock_entrypoint_cls.on_agent_pull_requests_created.assert_not_called()

--- a/tests/sentry/seer/test_pull_requests.py
+++ b/tests/sentry/seer/test_pull_requests.py
@@ -329,6 +329,32 @@ class NotifySeerPrCreatedTest(TestCase):
         assert SeerRunPullRequest.objects.filter(pull_request=pull_request).exists()
         assert not PullRequestAttribution.objects.filter(pull_request=pull_request).exists()
 
+    @patch("sentry.seer.entrypoints.operator.notify_agent_entrypoints_of_pull_requests")
+    def test_groupless_run_notifies_agent_entrypoints(self, mock_notify: Mock) -> None:
+        """A run with no issue has no autofix thread to announce its PR on, so the chat
+        entrypoints are told directly."""
+        self._notify(self._payload(), group_id=None)
+
+        mock_notify.assert_called_once_with(
+            organization=self.organization, run_id=RUN_STATE_ID, pull_requests=self._payload()
+        )
+
+    @patch("sentry.seer.entrypoints.operator.notify_agent_entrypoints_of_pull_requests")
+    def test_issue_run_leaves_pr_announcement_to_autofix(self, mock_notify: Mock) -> None:
+        self._notify(self._payload(), group_id=self.group.id)
+
+        mock_notify.assert_not_called()
+
+    @patch(
+        "sentry.seer.entrypoints.operator.notify_agent_entrypoints_of_pull_requests",
+        side_effect=RuntimeError("slack down"),
+    )
+    def test_entrypoint_failure_does_not_fail_the_rpc(self, _mock_notify: Mock) -> None:
+        result = self._notify(self._payload(), group_id=None)
+
+        assert isinstance(result, NotifySeerPrCreatedSuccessResponse)
+        assert SeerRunPullRequest.objects.filter(pull_request=self._linked_pull_request()).exists()
+
     def test_returns_error_when_organization_missing(self) -> None:
         result = notify_seer_pr_created(
             organization_id=self.organization.id + 10_000,


### PR DESCRIPTION
Sentry half of the "ad-hoc PRs from Chat UI/Slack" PRD, paired with getsentry/seer#8123. That PR teaches the Seer agent to open a pull request from a conversation's own edits and to publish a `pullRequestRef` card while it does; this PR renders the card in the chat and carries the finished PR to Slack.

**Chat card.** `pullRequestRef` joins `agentWriteApproval` in `STRUCTURED_SEER_EMBED_SCHEMAS`, so it is not exported to the widget list the agent sees and the agent is never told it may write the tag — Seer publishes the card and the frontend fills it from `structuredContent`. The new `PullRequestRefEmbed` reads the run's `repo_pr_states` from a `SeerRepoPRStatesProvider` that the explorer now wraps around the transcript (it replaces the existing `Fragment`, so nothing re-indents). The explorer already polls the session every 500 ms while a push is in flight and stops when `pr_creation_status` settles, so the card follows *Opening a pull request in repo…* → a **View repo#N** link or the recorded error without a poller of its own. The body pins the PR only when the push updates one that already exists; that is what keeps a reopened conversation's card linked after polling has stopped, and a host without the provider falls back to it.

**Slack.** The agent's reply is posted by the completion hook when its turn ends, but the PR is opened by a separate Seer step that outlives the turn and reports back through the `pr_created` RPC. Issue-anchored runs already announce their PR through the autofix thread updates keyed by group; a run with no issue has no group to key on, so `notify_seer_pr_created` now fans out to the agent entrypoints that hold a cached payload for the run (`notify_agent_entrypoints_of_pull_requests`, mirroring the completion hook's loop and org check), and the Slack entrypoint posts a new `SeerAgentPullRequests` message. It renders as mrkdwn links rather than link buttons: a button posts a block action back to Sentry, which would need a routed action id to acknowledge, and there is nothing for Sentry to do with the click. The fan-out is best-effort and never fails the RPC that reported the PR.

**Run flags.** Chat runs with coding enabled also get `enable_pr_context_tools`, so the agent can read a PR's status, reviews, and failed CI to iterate on what it opened.

Feature gating is unchanged and lives on the existing coding switches: the org option `sentry:enable_seer_coding` and `organizations:seer-explorer-chat-coding` decide whether the agent may edit code and therefore open PRs; `organizations:seer-explorer-code-mode-tools` selects the Code Mode surface the new helpers live on.

Not in this PR: live CI/merge status inside the card (it would need a Sentry endpoint proxying the SCM; today the agent reads status through Seer's `get_pull_request_status` and says it in prose), and screenshots — the card only appears in a live explorer session with the seer branch deployed, which I could not stand up here. The jest spec covers the creating, pushing, completed, error, body-fallback, and waiting states.

https://claude.ai/code/session_01CCbNR4yCgKpn3yewPcPPHX
