### PR TITLE
feat(github): Record when an installation's permissions were last read

### DIFF
--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -343,11 +343,18 @@ class GithubProxyClient(IntegrationProxyClient):
         access_token = data["token"]
         expires_at = datetime.strptime(data["expires_at"], "%Y-%m-%dT%H:%M:%SZ").isoformat()
         permissions = data.get("permissions")
+        # GitHub only reports permissions when it mints a token, so this is the
+        # only moment we learn them. Stamping when that happened alongside them
+        # is what lets a reader tell a current answer from a months-old one --
+        # debug_data has carried the same stamp for a while, but nothing outside
+        # control silo can see that field.
+        last_refresh_at = deprecated_utcnow().isoformat()
         integration.metadata.update(
             {
                 "access_token": access_token,
                 "expires_at": expires_at,
                 "permissions": permissions,
+                "last_refresh_at": last_refresh_at,
             }
         )
 
@@ -358,7 +365,7 @@ class GithubProxyClient(IntegrationProxyClient):
             {
                 "permissions": permissions,
                 "expires_at": expires_at,
-                "last_refresh_at": deprecated_utcnow().isoformat(),
+                "last_refresh_at": last_refresh_at,
             }
         )
 

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1448,6 +1448,12 @@ class GithubProxyClientTest(TestCase):
         assert mock_jwt.called
 
         self.integration.refresh_from_db()
+        # Stamped so a reader can tell whether the permissions beside it are
+        # current, and written from the same value debug_data records.
+        assert (
+            self.integration.metadata.pop("last_refresh_at")
+            == self.integration.debug_data["last_refresh_at"]
+        )
         assert self.integration.metadata == {
             "access_token": self.access_token,
             "expires_at": self.expires_at.rstrip("Z"),


### PR DESCRIPTION
GitHub only reports an installation's permissions when it mints an access
token, so metadata["permissions"] is a snapshot from whenever that last
happened. On a dormant install that can be months ago, and nothing stored
alongside it says so.

debug_data has carried a last_refresh_at stamp for a while, but that field
is not on RpcIntegration, so no caller outside control silo can see it.
Write the same value into metadata, which every silo already reads.

Nothing consumes it yet.

