### PR TITLE
fix(github): Refresh stale permission snapshots before commenting on a PR

### DIFF
--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -18,7 +18,10 @@ from sentry.integrations.services.integration import (
     integration_service,
 )
 from sentry.integrations.types import IntegrationIssueConfigField
-from sentry.integrations.utils.github_permissions import get_missing_github_app_permissions
+from sentry.integrations.utils.github_permissions import (
+    get_missing_github_app_permissions,
+    is_permissions_snapshot_stale,
+)
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -95,6 +98,18 @@ class IntegrationSerializer(Serializer):
         match provider.key:
             case "github":
                 out_of_date = bool(get_missing_github_app_permissions(obj.metadata))
+                if out_of_date and is_permissions_snapshot_stale(obj.metadata):
+                    # The banner still shows, but this answer is a guess: the
+                    # snapshot predates the app's permissions change, so it was
+                    # read against the old required set and may be naming
+                    # permissions this install was never asked for. Logged
+                    # rather than resolved because serializing a page is the
+                    # wrong place to mint a GitHub token, once per integration
+                    # on the list, to find out.
+                    logger.warning(
+                        "github_permissions.stale_snapshot",
+                        extra={"integration_id": obj.id},
+                    )
             case "slack":
                 out_of_date = SlackScope.APP_MENTIONS_READ not in (obj.metadata.get("scopes") or [])
 

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -324,7 +324,16 @@ class GithubProxyClient(IntegrationProxyClient):
         return get_jwt()
 
     @control_silo_function
-    def _refresh_access_token(self) -> AccessTokenData | None:
+    def refresh_access_token(self) -> AccessTokenData | None:
+        """Mint a new installation token and store what GitHub says it grants.
+
+        Public because re-reading an installation's permissions has no other
+        entrypoint: they arrive with the token and nowhere else. Callers outside
+        control silo go through ``integration_service.refresh_github_permissions``.
+
+        Unconditional -- ``get_access_token`` is the one that decides whether a
+        refresh is due.
+        """
         integration = Integration.objects.filter(id=self.integration.id).first()
         if not integration:
             return None
@@ -439,7 +448,7 @@ class GithubProxyClient(IntegrationProxyClient):
         should_refresh = not access_token or not expires_at or close_to_expiry
 
         if should_refresh:
-            return self._refresh_access_token()
+            return self.refresh_access_token()
 
         if access_token:
             return {

--- a/src/sentry/integrations/github/client.py
+++ b/src/sentry/integrations/github/client.py
@@ -343,11 +343,18 @@ class GithubProxyClient(IntegrationProxyClient):
         access_token = data["token"]
         expires_at = datetime.strptime(data["expires_at"], "%Y-%m-%dT%H:%M:%SZ").isoformat()
         permissions = data.get("permissions")
+        # GitHub only reports permissions when it mints a token, so this is the
+        # only moment we learn them. Stamping when that happened alongside them
+        # is what lets a reader tell a current answer from a months-old one --
+        # debug_data has carried the same stamp for a while, but nothing outside
+        # control silo can see that field.
+        last_refresh_at = deprecated_utcnow().isoformat()
         integration.metadata.update(
             {
                 "access_token": access_token,
                 "expires_at": expires_at,
                 "permissions": permissions,
+                "last_refresh_at": last_refresh_at,
             }
         )
 
@@ -358,7 +365,7 @@ class GithubProxyClient(IntegrationProxyClient):
             {
                 "permissions": permissions,
                 "expires_at": expires_at,
-                "last_refresh_at": deprecated_utcnow().isoformat(),
+                "last_refresh_at": last_refresh_at,
             }
         )
 

--- a/src/sentry/integrations/services/integration/impl.py
+++ b/src/sentry/integrations/services/integration/impl.py
@@ -46,6 +46,7 @@ from sentry.integrations.services.integration.serial import (
     serialize_integration_external_project,
     serialize_organization_integration,
 )
+from sentry.integrations.types import IntegrationProviderSlug
 from sentry.sentry_apps.api.serializers.app_platform_event import AppPlatformEvent
 from sentry.sentry_apps.event_types import SentryAppEventType
 from sentry.sentry_apps.metrics import (
@@ -656,4 +657,37 @@ class DatabaseBackedIntegrationService(IntegrationService):
         )
         integration.refresh_from_db()
 
+        return serialize_integration(integration)
+
+    def refresh_github_permissions(
+        self, *, integration_id: int, organization_id: int
+    ) -> RpcIntegration | None:
+        try:
+            integration = Integration.objects.get(
+                id=integration_id,
+                provider__in=[
+                    IntegrationProviderSlug.GITHUB.value,
+                    IntegrationProviderSlug.GITHUB_ENTERPRISE.value,
+                ],
+                status=ObjectStatus.ACTIVE,
+            )
+        except Integration.DoesNotExist:
+            return None
+
+        installation = integration.get_installation(organization_id=organization_id)
+        # get_installation doesn't actually check if the integration is
+        # associated with the organization, so this validates that it does,
+        # and caches the org_integration preemptively.
+        try:
+            installation.org_integration
+        except OrganizationIntegrationNotFound:
+            return None
+
+        # Unconditional, unlike refresh_github_access_token: a token that is
+        # still valid was minted before the app's permissions changed, so
+        # letting it stand is exactly the stale answer we are here to replace.
+        if installation.get_client().refresh_access_token() is None:
+            return None
+
+        integration.refresh_from_db()
         return serialize_integration(integration)

--- a/src/sentry/integrations/services/integration/service.py
+++ b/src/sentry/integrations/services/integration/service.py
@@ -322,6 +322,27 @@ class IntegrationService(RpcService):
 
     @rpc_method
     @abstractmethod
+    def refresh_github_permissions(
+        self, *, integration_id: int, organization_id: int
+    ) -> RpcIntegration | None:
+        """Re-read what a GitHub App installation grants, from any silo.
+
+        Mints a fresh installation token, because that response is the only
+        place GitHub reports permissions, and returns the integration with the
+        new ``metadata["permissions"]`` and ``metadata["last_refresh_at"]``.
+
+        Org-scoped like ``refresh_github_access_token``: the caller has to name
+        an organization the install is actually linked to. The mint itself is
+        authed with the app's own JWT and would work without one, but reaching
+        an installation through an integration id alone is not a door we want
+        open.
+
+        None when the integration is missing, not GitHub, not active, or not
+        installed on that organization.
+        """
+
+    @rpc_method
+    @abstractmethod
     def get_gcp_service_account_email(
         self,
         *,

--- a/src/sentry/integrations/utils/github_permissions.py
+++ b/src/sentry/integrations/utils/github_permissions.py
@@ -13,6 +13,7 @@ where the warnings are implemented since this API returns the list of missing sc
 
 import logging
 from collections.abc import Mapping
+from datetime import UTC, datetime
 from typing import Any, TypedDict
 
 from sentry import options
@@ -20,6 +21,39 @@ from sentry import options
 logger = logging.getLogger(__name__)
 
 GITHUB_APP_REQUIRED_PERMISSIONS_OPTION = "github-app.required-permissions"
+
+# Approximately when the Sentry GitHub App's requested permissions last changed. A snapshot
+# recorded before this was read against the old required set, so it says nothing
+# about whether an install is missing anything from the current one, and treating
+# it as authoritative nags people over permissions we never asked them for.
+GITHUB_APP_PERMISSIONS_UPDATED_AT = datetime(2026, 7, 11, tzinfo=UTC)
+
+
+def _parse_last_refresh_at(metadata: Mapping[str, Any] | None) -> datetime | None:
+    """When the permissions in `metadata` were read off a fresh installation token.
+
+    Written by the token refresh as a naive UTC isoformat string, so a value
+    without an offset is read back as UTC rather than rejected.
+    """
+    raw = (metadata or {}).get("last_refresh_at")
+    if not isinstance(raw, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    return parsed.replace(tzinfo=UTC) if parsed.tzinfo is None else parsed.astimezone(UTC)
+
+
+def is_permissions_snapshot_stale(metadata: Mapping[str, Any] | None) -> bool:
+    """True when metadata["permissions"] is too old to judge an install against.
+
+    An absent or unparseable stamp counts as stale: metadata only started
+    carrying one when the app's permissions were already changing, so a missing
+    one means the snapshot is older than any date we would set here.
+    """
+    last_refresh_at = _parse_last_refresh_at(metadata)
+    return last_refresh_at is None or last_refresh_at < GITHUB_APP_PERMISSIONS_UPDATED_AT
 
 
 class GitHubAppPermission(TypedDict):

--- a/src/sentry/seer/autofix/github_perms.py
+++ b/src/sentry/seer/autofix/github_perms.py
@@ -10,6 +10,7 @@ from sentry.integrations.services.integration import RpcIntegration, integration
 from sentry.integrations.utils.github_permissions import (
     get_github_permissions_update_url,
     get_missing_github_app_permissions,
+    is_permissions_snapshot_stale,
 )
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
@@ -155,6 +156,10 @@ def get_missing_permissions_by_repo(
             )
             continue
 
+        integration = _with_fresh_permissions(organization, integration, repository_id)
+        if integration is None:
+            continue
+
         missing = get_missing_github_app_permissions(integration.metadata)
         missing_scopes = [permission["expected"]["scope"] for permission in (missing or [])]
         if missing_scopes:
@@ -166,6 +171,57 @@ def get_missing_permissions_by_repo(
         _warn_unresolved(organization, "no_repository_row", scm_repo_full_name=repo_name)
 
     return missing_by_repo
+
+
+def _with_fresh_permissions(
+    organization: Organization, integration: RpcIntegration, repository_id: int
+) -> RpcIntegration | None:
+    """`integration` with a permissions snapshot recent enough to judge, or None.
+
+    A snapshot older than the app's permissions change was read against the old
+    required set, so it cannot say whether this install is missing anything now.
+    Mint a fresh installation token and re-read instead of commenting off it.
+
+    This is self-limiting rather than a per-call cost: the refresh rewrites
+    ``last_refresh_at``, so an integration takes this path once and every later
+    call short-circuits on the first line.
+
+    None when the refresh fails or the snapshot is still stale afterwards. The
+    caller reads that as "nothing missing", which is deliberate -- staying quiet
+    beats telling someone to accept permissions we cannot confirm they lack.
+    """
+    if not is_permissions_snapshot_stale(integration.metadata):
+        return integration
+
+    try:
+        refreshed = integration_service.refresh_github_permissions(
+            integration_id=integration.id, organization_id=organization.id
+        )
+    except Exception:
+        # Minting the token talks to GitHub, so this fails for reasons that have
+        # nothing to do with permissions. Treat it as "cannot tell" rather than
+        # letting a GitHub blip fail the task that called us.
+        refreshed = None
+
+    if refreshed is None or is_permissions_snapshot_stale(refreshed.metadata):
+        _warn_unresolved(
+            organization,
+            "stale_permissions_snapshot",
+            repository_id=repository_id,
+            integration_id=integration.id,
+            refreshed=refreshed is not None,
+        )
+        return None
+
+    logger.info(
+        "autofix.github_perms.permissions_refreshed",
+        extra={
+            "organization_id": organization.id,
+            "integration_id": integration.id,
+            "repository_id": repository_id,
+        },
+    )
+    return refreshed
 
 
 def _warn_unresolved(organization: Organization, reason: str, **fields: object) -> None:

--- a/tests/integration/test_service.py
+++ b/tests/integration/test_service.py
@@ -211,3 +211,86 @@ class IntegrationServiceTest(TestCase):
         )
 
         assert rpc_integration is None
+
+    @responses.activate
+    @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
+    def test_refresh_permissions_mints_even_when_the_token_is_still_good(self, mock_jwt):
+        """The point of this call is the permissions, not the token.
+
+        A live token would satisfy refresh_github_access_token and leave a
+        months-old permissions snapshot in place, which is exactly the case
+        callers use this to get out of.
+        """
+        integration = self.generate_integration(
+            metadata={
+                "access_token": "token_valid",
+                "expires_at": "2025-01-01T05:32:01Z",
+                "permissions": {"contents": "read"},
+            }
+        )
+
+        responses.add(
+            responses.POST,
+            "https://api.github.com/app/installations/github:1/access_tokens",
+            json={
+                "token": "token_new",
+                "expires_at": "2025-01-01T06:22:00Z",
+                "permissions": {"contents": "write"},
+            },
+            status=200,
+            content_type="application/json",
+        )
+
+        rpc_integration = integration_service.refresh_github_permissions(
+            integration_id=integration.id,
+            organization_id=self.organization.id,
+        )
+
+        assert rpc_integration is not None
+        assert rpc_integration.metadata["permissions"] == {"contents": "write"}
+        assert rpc_integration.metadata["last_refresh_at"] == "2025-01-01T05:22:00"
+
+    def test_refresh_permissions_for_an_install_on_another_organization(self):
+        """An integration id alone is not enough to reach an installation.
+
+        The org has to actually have it installed, or a caller anywhere in the
+        codebase could mint tokens against someone else's install.
+        """
+        integration = self.create_integration(
+            organization=self.create_organization(owner=self.create_user()),
+            provider="github",
+            external_id="github:1",
+        )
+
+        assert (
+            integration_service.refresh_github_permissions(
+                integration_id=integration.id,
+                organization_id=self.organization.id,
+            )
+            is None
+        )
+
+    def test_refresh_permissions_for_an_unknown_integration(self):
+        integration = self.generate_integration()
+
+        assert (
+            integration_service.refresh_github_permissions(
+                integration_id=integration.id + 1000,
+                organization_id=self.organization.id,
+            )
+            is None
+        )
+
+    def test_refresh_permissions_for_a_disabled_integration(self):
+        integration = self.generate_integration()
+        with assume_test_silo_mode_of(Integration):
+            integration.status = ObjectStatus.DISABLED
+            integration.save()
+
+        assert (
+            integration_service.refresh_github_permissions(
+                integration_id=integration.id,
+                organization_id=self.organization.id,
+            )
+            is None
+        )

--- a/tests/sentry/integrations/api/serializers/models/test_integration.py
+++ b/tests/sentry/integrations/api/serializers/models/test_integration.py
@@ -1,7 +1,13 @@
+from unittest import mock
+
 from sentry.api.serializers import serialize
+from sentry.integrations.api.serializers.models import integration as integration_serializer
 from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS_OPTION
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
+
+FRESH_REFRESH_AT = "2026-08-01T00:00:00"
+STALE_REFRESH_AT = "2026-07-01T00:00:00"
 
 
 class IntegrationSerializerTest(TestCase):
@@ -28,7 +34,10 @@ class IntegrationSerializerTest(TestCase):
             provider="github",
             external_id="1",
             name="octocat",
-            metadata={"permissions": {"contents": "read"}},
+            metadata={
+                "permissions": {"contents": "read"},
+                "last_refresh_at": FRESH_REFRESH_AT,
+            },
         )
 
         result = serialize(integration, self.user)
@@ -41,9 +50,70 @@ class IntegrationSerializerTest(TestCase):
             provider="github",
             external_id="2",
             name="octocat",
-            metadata={"permissions": {"contents": "write"}},
+            metadata={
+                "permissions": {"contents": "write"},
+                "last_refresh_at": FRESH_REFRESH_AT,
+            },
         )
 
         result = serialize(integration, self.user)
 
         assert result["outOfDate"] is False
+
+    @override_options({GITHUB_APP_REQUIRED_PERMISSIONS_OPTION: {"contents": "write"}})
+    def test_github_warns_when_out_of_date_is_a_guess(self) -> None:
+        """A snapshot from before the app changed still shows the banner.
+
+        It was read against the old required set, so it may be naming a
+        permission this install was never asked for. The warning is how we find
+        out how often that happens before changing what users see.
+        """
+        integration = self.create_provider_integration(
+            provider="github",
+            external_id="3",
+            name="octocat",
+            metadata={
+                "permissions": {"contents": "read"},
+                "last_refresh_at": STALE_REFRESH_AT,
+            },
+        )
+
+        with mock.patch.object(integration_serializer.logger, "warning") as mock_warning:
+            result = serialize(integration, self.user)
+
+        assert result["outOfDate"] is True
+        assert mock_warning.call_args.args[0] == "github_permissions.stale_snapshot"
+
+    @override_options({GITHUB_APP_REQUIRED_PERMISSIONS_OPTION: {"contents": "write"}})
+    def test_github_warns_without_a_refresh_timestamp(self) -> None:
+        integration = self.create_provider_integration(
+            provider="github",
+            external_id="4",
+            name="octocat",
+            metadata={"permissions": {"contents": "read"}},
+        )
+
+        with mock.patch.object(integration_serializer.logger, "warning") as mock_warning:
+            result = serialize(integration, self.user)
+
+        assert result["outOfDate"] is True
+        assert mock_warning.call_args.args[0] == "github_permissions.stale_snapshot"
+
+    @override_options({GITHUB_APP_REQUIRED_PERMISSIONS_OPTION: {"contents": "write"}})
+    def test_github_does_not_warn_when_a_stale_snapshot_looks_complete(self) -> None:
+        """Nothing to guess about: we are not telling the user anything."""
+        integration = self.create_provider_integration(
+            provider="github",
+            external_id="5",
+            name="octocat",
+            metadata={
+                "permissions": {"contents": "write"},
+                "last_refresh_at": STALE_REFRESH_AT,
+            },
+        )
+
+        with mock.patch.object(integration_serializer.logger, "warning") as mock_warning:
+            result = serialize(integration, self.user)
+
+        assert result["outOfDate"] is False
+        assert not mock_warning.called

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1448,6 +1448,12 @@ class GithubProxyClientTest(TestCase):
         assert mock_jwt.called
 
         self.integration.refresh_from_db()
+        # Stamped so a reader can tell whether the permissions beside it are
+        # current, and written from the same value debug_data records.
+        assert (
+            self.integration.metadata.pop("last_refresh_at")
+            == self.integration.debug_data["last_refresh_at"]
+        )
         assert self.integration.metadata == {
             "access_token": self.access_token,
             "expires_at": self.expires_at.rstrip("Z"),

--- a/tests/sentry/integrations/github/test_client.py
+++ b/tests/sentry/integrations/github/test_client.py
@@ -1437,14 +1437,14 @@ class GithubProxyClientTest(TestCase):
 
     @responses.activate
     @mock.patch("sentry.integrations.github.client.get_jwt", return_value=jwt)
-    def test__refresh_access_token(self, mock_jwt) -> None:
+    def test_refresh_access_token(self, mock_jwt) -> None:
         assert self.integration.metadata == {
             "access_token": None,
             "expires_at": None,
             "permissions": None,
         }
 
-        self.gh_client._refresh_access_token()
+        self.gh_client.refresh_access_token()
         assert mock_jwt.called
 
         self.integration.refresh_from_db()
@@ -1477,8 +1477,8 @@ class GithubProxyClientTest(TestCase):
         ).prepare()
 
         with mock.patch(
-            "sentry.integrations.github.client.GithubProxyClient._refresh_access_token",
-            wraps=self.gh_client._refresh_access_token,
+            "sentry.integrations.github.client.GithubProxyClient.refresh_access_token",
+            wraps=self.gh_client.refresh_access_token,
         ) as mock_refresh_token:
             # Regular API requests should use access tokens
             token = self.gh_client._get_token(prepared_request=access_token_request)

--- a/tests/sentry/integrations/utils/test_github_permissions.py
+++ b/tests/sentry/integrations/utils/test_github_permissions.py
@@ -4,6 +4,7 @@ from sentry.integrations.utils.github_permissions import (
     GITHUB_APP_REQUIRED_PERMISSIONS_OPTION,
     get_github_permissions_update_url,
     get_missing_github_app_permissions,
+    is_permissions_snapshot_stale,
 )
 from sentry.testutils.helpers.options import override_options
 
@@ -93,3 +94,27 @@ def test_get_github_permissions_update_url(
     assert (
         get_github_permissions_update_url(installation_id, account_type, account_login) == expected
     )
+
+
+@pytest.mark.parametrize(
+    ("metadata", "expected"),
+    [
+        # Written by the token refresh as a naive UTC isoformat string.
+        ({"last_refresh_at": "2026-08-01T00:00:00"}, False),
+        ({"last_refresh_at": "2026-07-11T00:00:00"}, False),
+        ({"last_refresh_at": "2026-07-10T23:59:59"}, True),
+        ({"last_refresh_at": "2026-07-01T00:00:00"}, True),
+        # An offset-aware value is compared in UTC, not rejected.
+        ({"last_refresh_at": "2026-07-10T21:00:00-04:00"}, False),
+        ({"last_refresh_at": "2026-07-10T18:00:00-04:00"}, True),
+        # No usable timestamp at all: the snapshot predates metadata carrying
+        # one, which is older than any cutoff we would set.
+        (None, True),
+        ({}, True),
+        ({"last_refresh_at": None}, True),
+        ({"last_refresh_at": "not a timestamp"}, True),
+        ({"last_refresh_at": 1752192000}, True),
+    ],
+)
+def test_is_permissions_snapshot_stale(metadata, expected) -> None:
+    assert is_permissions_snapshot_stale(metadata) is expected

--- a/tests/sentry/seer/autofix/test_github_perms.py
+++ b/tests/sentry/seer/autofix/test_github_perms.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from unittest import mock
 
 from sentry.constants import ObjectStatus
-from sentry.integrations.services.integration import integration_service
+from sentry.integrations.models.integration import Integration
+from sentry.integrations.services.integration import RpcIntegration, integration_service
+from sentry.integrations.services.integration.serial import serialize_integration
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.seer.agent.client_models import (
@@ -23,10 +26,16 @@ from sentry.seer.autofix.github_perms import (
 )
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.silo import assume_test_silo_mode_of
 from sentry.utils import json
 
 REPO_NAME = "getsentry/sentry"
 LOGGER_NAME = "sentry.seer.autofix.github_perms"
+
+# Both sides of GITHUB_APP_PERMISSIONS_UPDATED_AT, in the naive-UTC isoformat the
+# token refresh writes.
+FRESH_REFRESH_AT = "2026-08-01T00:00:00"
+STALE_REFRESH_AT = "2026-07-01T00:00:00"
 
 
 def _block(
@@ -89,7 +98,10 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             organization=self.organization,
             provider="github",
             external_id="9999",
-            metadata={"permissions": {"contents": "read"}},
+            metadata={
+                "permissions": {"contents": "read"},
+                "last_refresh_at": FRESH_REFRESH_AT,
+            },
         )
         self.repo = self.create_repo(
             project=self.create_project(organization=self.organization),
@@ -144,7 +156,10 @@ class GetMissingPermissionsByRepoTest(TestCase):
             organization=self.organization,
             provider="github",
             external_id="9999",
-            metadata={"permissions": {"contents": "read"}},
+            metadata={
+                "permissions": {"contents": "read"},
+                "last_refresh_at": FRESH_REFRESH_AT,
+            },
         )
         self.repo = self.create_repo(
             project=self.create_project(organization=self.organization),
@@ -193,6 +208,90 @@ class GetMissingPermissionsByRepoTest(TestCase):
         Repository.objects.filter(id=self.repo.id).update(integration_id=self.integration.id + 1000)
 
         self._assert_warns(self.organization, REPO_NAME, "integration_not_found")
+
+    def _set_last_refresh_at(self, last_refresh_at: str) -> None:
+        with assume_test_silo_mode_of(Integration):
+            self.integration.update(
+                metadata={**self.integration.metadata, "last_refresh_at": last_refresh_at}
+            )
+
+    def _refresh_to(self, permissions: dict[str, str]):
+        """Stand in for the token mint, which rewrites both permissions and stamp.
+
+        A side_effect rather than a return_value: the row has to still be stale
+        when get_missing_permissions_by_repo reads it, or it would never call us.
+        """
+
+        def refresh(**kwargs: object) -> RpcIntegration:
+            with assume_test_silo_mode_of(Integration):
+                self.integration.update(
+                    metadata={
+                        "permissions": permissions,
+                        "last_refresh_at": FRESH_REFRESH_AT,
+                    }
+                )
+            return serialize_integration(self.integration)
+
+        return mock.patch.object(
+            integration_service, "refresh_github_permissions", side_effect=refresh
+        )
+
+    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    def test_refreshes_a_stale_snapshot_and_judges_the_new_one(self) -> None:
+        self._set_last_refresh_at(STALE_REFRESH_AT)
+
+        with self._refresh_to({"contents": "write"}) as refresh:
+            assert get_missing_permissions_by_repo(self.organization, [REPO_NAME]) == {}
+
+        assert refresh.call_count == 1
+
+    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    def test_reports_what_the_refreshed_snapshot_is_still_missing(self) -> None:
+        self._set_last_refresh_at(STALE_REFRESH_AT)
+
+        with self._refresh_to({"contents": "read"}):
+            missing = get_missing_permissions_by_repo(self.organization, [REPO_NAME])
+
+        assert missing[REPO_NAME].missing_scopes == ["contents"]
+
+    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    def test_does_not_refresh_a_snapshot_that_is_recent_enough(self) -> None:
+        with self._refresh_to({"contents": "write"}) as refresh:
+            missing = get_missing_permissions_by_repo(self.organization, [REPO_NAME])
+
+        assert refresh.call_count == 0
+        assert missing[REPO_NAME].missing_scopes == ["contents"]
+
+    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    def test_warns_and_stays_quiet_when_the_refresh_finds_no_integration(self) -> None:
+        self._set_last_refresh_at(STALE_REFRESH_AT)
+
+        with mock.patch.object(
+            integration_service, "refresh_github_permissions", return_value=None
+        ):
+            self._assert_warns(self.organization, REPO_NAME, "stale_permissions_snapshot")
+
+    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    def test_warns_and_stays_quiet_when_the_refresh_raises(self) -> None:
+        self._set_last_refresh_at(STALE_REFRESH_AT)
+
+        with mock.patch.object(
+            integration_service,
+            "refresh_github_permissions",
+            side_effect=Exception("github is having a day"),
+        ):
+            self._assert_warns(self.organization, REPO_NAME, "stale_permissions_snapshot")
+
+    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    def test_warns_and_stays_quiet_when_the_snapshot_is_still_stale_after_refreshing(self) -> None:
+        self._set_last_refresh_at(STALE_REFRESH_AT)
+
+        with mock.patch.object(
+            integration_service,
+            "refresh_github_permissions",
+            return_value=serialize_integration(self.integration),
+        ):
+            self._assert_warns(self.organization, REPO_NAME, "stale_permissions_snapshot")
 
     @override_options({"github-app.required-permissions": {"contents": "write"}})
     def test_quiet_when_every_repo_resolves(self) -> None:


### PR DESCRIPTION
DEPLOY ORDER: do not roll this out until #123983, which adds

goal of this change is to avoid commenting on users' PRs if the permissions snapshot we have is stale, we want to avoid being noisy