### PR TITLE
fix(derived): Properly classify promotion race

### DIFF
--- a/src/sentry/issues/derived/promote.py
+++ b/src/sentry/issues/derived/promote.py
@@ -81,13 +81,22 @@ class PromotionFailed(Exception):
         super().__init__(f"group {group_id}: {result.value} after {attempts} attempts")
 
 
-def _read_live_generated_at(group_id: int) -> datetime | None:
-    """Return the live row's ``generated_at``, or None if the row is absent."""
-    return (
+class _LiveState(NamedTuple):
+    generated_at: datetime
+    cursor_date: datetime
+    cursor_id: int
+
+
+def _read_live_state(group_id: int) -> _LiveState | None:
+    """Return the live row's CAS-relevant fields, or None if the row is absent."""
+    row = (
         GroupDerivedData.objects.filter(group_id=group_id)
-        .values_list("generated_at", flat=True)
+        .values_list("generated_at", "cursor_date", "cursor_id")
         .get_or_none()
     )
+    if row is None:
+        return None
+    return _LiveState(*row)
 
 
 def _classify_failed_create(group_id: int, generated_at: datetime) -> PromotionResult:
@@ -97,8 +106,8 @@ def _classify_failed_create(group_id: int, generated_at: datetime) -> PromotionR
     Group, so the error is either a concurrent writer winning the create
     race or the group having been deleted underneath us.
     """
-    live_generated_at = _read_live_generated_at(group_id)
-    if live_generated_at is None:
+    live = _read_live_state(group_id)
+    if live is None:
         # No visible winner. If the group is gone, that's the FK
         # violation. Otherwise we lost to some other race (e.g. a
         # concurrent GDD delete between our INSERT and this read);
@@ -107,7 +116,7 @@ def _classify_failed_create(group_id: int, generated_at: datetime) -> PromotionR
             return PromotionResult.GROUP_MISSING
         return PromotionResult.RACE_LOST
 
-    if live_generated_at > generated_at:
+    if live.generated_at > generated_at:
         return PromotionResult.SUPERSEDED
     # The winner is same-or-older generation, so its cursor position
     # tells us nothing about the log tail. Not CURSOR_BEHIND: that name
@@ -157,10 +166,9 @@ def promote_to_live(
     if updated:
         return PromotionResult.PROMOTED
 
-    # Check why we failed: row missing or newer generation?
-    live_generated_at = _read_live_generated_at(candidate.group_id)
+    live = _read_live_state(candidate.group_id)
 
-    if live_generated_at is None:
+    if live is None:
         # Row doesn't exist — try to create it. enforce_constraints so a
         # violation surfaces here instead of floating up to an
         # enclosing transaction's commit.
@@ -176,8 +184,13 @@ def promote_to_live(
             return _classify_failed_create(candidate.group_id, generated_at)
         return PromotionResult.PROMOTED
 
-    if live_generated_at > generated_at:
+    if live.generated_at > generated_at:
         return PromotionResult.SUPERSEDED
+    # The UPDATE guard would have matched this row had it been visible.
+    # We straddled a concurrent create; retry rather than give up as if
+    # the live cursor were genuinely ahead.
+    if (live.cursor_date, live.cursor_id) <= (candidate.cursor_date, candidate.cursor_id):
+        return PromotionResult.RACE_LOST
     return PromotionResult.CURSOR_BEHIND
 
 

--- a/tests/sentry/issues/derived/test_promote.py
+++ b/tests/sentry/issues/derived/test_promote.py
@@ -1,9 +1,10 @@
 from collections.abc import Generator
 from contextlib import contextmanager
-from datetime import datetime, timedelta
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from django.db.models.query import QuerySet
 from django.utils import timezone as django_timezone
 
 from sentry.issues.action_log.publish import publish_action
@@ -23,7 +24,8 @@ from sentry.issues.derived.promote import (
     PromotionFailed,
     PromotionResult,
     _generation_cache,
-    _read_live_generated_at,
+    _LiveState,
+    _read_live_state,
     build_and_promote_batch,
     build_and_promote_derived_data,
     promote_to_live,
@@ -58,12 +60,12 @@ def _hide_first_row_read() -> Generator[None]:
     """
     seen = iter([True])
 
-    def hide_once(group_id: int) -> datetime | None:
+    def hide_once(group_id: int) -> _LiveState | None:
         if next(seen, False):
             return None
-        return _read_live_generated_at(group_id)
+        return _read_live_state(group_id)
 
-    with patch("sentry.issues.derived.promote._read_live_generated_at", hide_once):
+    with patch("sentry.issues.derived.promote._read_live_state", hide_once):
         yield
 
 
@@ -263,6 +265,51 @@ class PromoteToLiveTest(TestCase):
 
         with _hide_first_row_read():
             assert promote_to_live(candidate) is PromotionResult.RACE_LOST
+
+    def test_promote_update_path_race_returns_race_lost_when_cursor_not_ahead(self) -> None:
+        """Straddling a concurrent create on the UPDATE path is RACE_LOST, not CURSOR_BEHIND.
+
+        The initial UPDATE can miss because the row isn't yet visible while
+        the follow-up SELECT sees the just-committed row with the same
+        cursor. That row would have satisfied the UPDATE guard, so retry.
+        """
+        group = self.create_group()
+        _publish(group=group, action=ViewAction(), actor=GroupActionActor.user(self.user.id))
+
+        gen_time = django_timezone.now()
+        candidate = GroupDerivedData(
+            group_id=group.id,
+            generated_at=gen_time,
+            cursor_date=EPOCH,
+            cursor_id=0,
+            data={},
+            pipeline_hash=PIPELINE.pipeline_hash,
+        )
+        processing._drain_log(candidate, PIPELINE, time_limit=timedelta(minutes=5), persist=False)
+
+        # Seed a row a same-cursor, older-generation writer would have
+        # produced. Forcing the first UPDATE to return 0 simulates the
+        # row being invisible when the UPDATE ran but visible to the
+        # follow-up SELECT.
+        GroupDerivedData.objects.filter(group_id=group.id).update(
+            generated_at=gen_time - timedelta(seconds=10),
+            cursor_date=candidate.cursor_date,
+            cursor_id=candidate.cursor_id,
+        )
+
+        real_update = QuerySet.update
+        blinded = 0
+
+        def blind_first_update(self: QuerySet, **kwargs: object) -> int:
+            nonlocal blinded
+            if self.model is GroupDerivedData and blinded == 0:
+                blinded += 1
+                return 0
+            return real_update(self, **kwargs)
+
+        with patch.object(QuerySet, "update", blind_first_update):
+            assert promote_to_live(candidate) is PromotionResult.RACE_LOST
+        assert blinded == 1
 
     def test_promote_returns_group_missing_when_group_deleted(self) -> None:
         candidate = GroupDerivedData(

--- a/tests/sentry/issues/derived/test_promote.py
+++ b/tests/sentry/issues/derived/test_promote.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
+from django.db.models import Model
 from django.db.models.query import QuerySet
 from django.utils import timezone as django_timezone
 
@@ -300,7 +301,7 @@ class PromoteToLiveTest(TestCase):
         real_update = QuerySet.update
         blinded = 0
 
-        def blind_first_update(self: QuerySet, **kwargs: object) -> int:
+        def blind_first_update(self: QuerySet[Model], **kwargs: object) -> int:
             nonlocal blinded
             if self.model is GroupDerivedData and blinded == 0:
                 blinded += 1


### PR DESCRIPTION
If an update fails, we check the row to see if it is missing and if not, why it would've failed.
That is by it's nature faulty; the row can change at every read.
This change corrects this by leaning more toward ignorance; if the row exists and should've
been updatable by us, we don't assume we're behind, we check, and if not, go with RACE_LOST.
RACE_LOST should be the default whenever we're unsure, and promotion failures (as opposed to
giving up) should usually only come after maxing out the retry budget.

Fixes SENTRY-5SFA.