### PR TITLE
ref(autofix): Pass proxy headers to rca-in-seer

### DIFF
--- a/src/sentry/seer/agent/client.py
+++ b/src/sentry/seer/agent/client.py
@@ -544,6 +544,7 @@ class SeerAgentClient:
         on_run_created: Callable[[SeerRun], None] | None = None,
         agent_run_options: AgentRunOptions | None = None,
         user_org_context: UserOrgContext | None = None,
+        proxy_headers: dict[str, str] | None = None,
     ) -> SeerRun:
         """Dispatch a run to a registered Seer feature by feature_id via the
         SEER_RUN_CREATE outbox. The feature builds its own agent run from
@@ -594,6 +595,8 @@ class SeerAgentClient:
         )
         if user_org_context is not None:
             body["user_org_context"] = user_org_context
+        if proxy_headers is not None:
+            body["proxy_headers"] = proxy_headers
 
         return enqueue_seer_run(
             organization=self.organization,

--- a/src/sentry/seer/agent/client_utils.py
+++ b/src/sentry/seer/agent/client_utils.py
@@ -147,6 +147,7 @@ class SeerFeatureRunRequest(TypedDict):
     payload: dict[str, Any]
     agent_run_options: NotRequired[AgentRunOptions]
     user_org_context: NotRequired[UserOrgContext]
+    proxy_headers: NotRequired[dict[str, str] | None]
     referrer: str
 
 

--- a/src/sentry/seer/autofix/feature/dispatch.py
+++ b/src/sentry/seer/autofix/feature/dispatch.py
@@ -9,7 +9,11 @@ from sentry import quotas
 from sentry.constants import DataCategory
 from sentry.models.group import Group
 from sentry.seer.agent.client import SeerAgentClient
-from sentry.seer.agent.client_utils import AgentRunOptions, collect_user_org_context
+from sentry.seer.agent.client_utils import (
+    AgentRunOptions,
+    collect_user_org_context,
+    get_proxy_headers,
+)
 from sentry.seer.agent.on_completion_hook import extract_hook_definition
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -112,6 +116,7 @@ def trigger_autofix_feature(
         extras=extras,
         referrer=referrer.value,
         user_org_context=collect_user_org_context(user, group.organization),
+        proxy_headers=get_proxy_headers(),
         agent_run_options=AgentRunOptions(
             is_context_engine_enabled=False,
             enable_frontend_code_search=False,

--- a/tests/sentry/seer/agent/test_agent_client.py
+++ b/tests/sentry/seer/agent/test_agent_client.py
@@ -1470,6 +1470,25 @@ class TestStartFeatureRun(TestCase):
 
     @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
     @patch("sentry.receivers.outbox.cell.make_feature_run_request")
+    def test_feature_run_enqueues_proxy_headers(self, mock_request, _mock_access) -> None:
+        proxy_headers = {"X-Viewer-Context": "signed-viewer-context"}
+        client = SeerAgentClient(self.organization, self.user)
+        run = client.start_feature_run(
+            feature_id="autofix",
+            payload={},
+            title="Autofix RCA",
+            flush=False,
+            referrer="autofix",
+            proxy_headers=proxy_headers,
+        )
+
+        mock_request.assert_not_called()
+        outbox = self._outbox_for(run)
+        assert outbox is not None and outbox.payload is not None
+        assert outbox.payload["body"]["proxy_headers"] == proxy_headers
+
+    @patch("sentry.seer.agent.client.has_seer_access_with_detail", return_value=(True, None))
+    @patch("sentry.receivers.outbox.cell.make_feature_run_request")
     def test_creates_agent_run_mirror(self, mock_request, _mock_access) -> None:
         client = SeerAgentClient(self.organization, self.user)
         run = client.start_feature_run(

--- a/tests/sentry/seer/autofix/feature/test_dispatch.py
+++ b/tests/sentry/seer/autofix/feature/test_dispatch.py
@@ -27,6 +27,10 @@ class TestTriggerAutofixFeature(TestCase):
                 "sentry.seer.autofix.feature.dispatch.collect_user_org_context",
                 return_value=expected_context,
             ) as mock_collect_context,
+            patch(
+                "sentry.seer.autofix.feature.dispatch.get_proxy_headers",
+                return_value={"X-Viewer-Context": "signed-viewer-context"},
+            ) as mock_get_proxy_headers,
             patch("sentry.seer.autofix.feature.dispatch.quotas") as mock_quotas,
         ):
             mock_quotas.backend.check_seer_quota.return_value = True
@@ -73,7 +77,9 @@ class TestTriggerAutofixFeature(TestCase):
         }
         assert run_kwargs["referrer"] == AutofixReferrer.NIGHT_SHIFT.value
         assert run_kwargs["user_org_context"] == expected_context
+        assert run_kwargs["proxy_headers"] == {"X-Viewer-Context": "signed-viewer-context"}
         mock_collect_context.assert_called_once_with(None, self.group.organization)
+        mock_get_proxy_headers.assert_called_once_with()
 
         # A new run consumes Seer autofix budget.
         mock_quotas.backend.record_seer_run.assert_called_once()


### PR DESCRIPTION
These are only used for codemode (not yet enabled for autofix). Going ahead and piping them to rca-in-seer so we can use them in the future when we enable code mode.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>