### PR TITLE
perf(integrations): Share full organization data across integration configs

### DIFF
--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.constants import ObjectStatus
+from sentry.hybridcloud.rpc.service import RpcException
 from sentry.integrations.base import IntegrationProvider
 from sentry.integrations.constants import SlackScope
 from sentry.integrations.models.integration import Integration
@@ -19,6 +20,7 @@ from sentry.integrations.services.integration import (
 )
 from sentry.integrations.types import IntegrationIssueConfigField
 from sentry.integrations.utils.github_permissions import get_missing_github_app_permissions
+from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
@@ -129,6 +131,7 @@ class IntegrationConfigSerializer(IntegrationSerializer):
         attrs: Mapping[str, Any],
         user: User | RpcUser | AnonymousUser,
         include_config: bool = True,
+        organization: RpcOrganization | None = None,
         **kwargs: Any,
     ) -> IntegrationConfigSerializerResponse:
         base = super().serialize(obj, attrs, user)
@@ -145,6 +148,9 @@ class IntegrationConfigSerializer(IntegrationSerializer):
             # The integration may not implement a Installed Integration object
             # representation.
             return {**base, "configOrganization": []}
+
+        if organization is not None:
+            installation.organization = organization
 
         # TicketRuleModal only needs the ticket-creation form for this request.
         if self.params.get("action") == "create":
@@ -171,14 +177,28 @@ class OrganizationIntegrationSerializer(Serializer):
         self,
         item_list: Sequence[RpcOrganizationIntegration],
         user: User | RpcUser | AnonymousUser,
+        include_config: bool = True,
         **kwargs: Any,
     ) -> MutableMapping[RpcOrganizationIntegration, MutableMapping[str, Any]]:
         integrations = integration_service.get_integrations(
             integration_ids=[item.integration_id for item in item_list]
         )
         integrations_by_id: dict[int, RpcIntegration] = {i.id: i for i in integrations}
+        organizations: dict[int, RpcOrganization | None] = {}
+        if include_config:
+            for organization_id in {item.organization_id for item in item_list}:
+                try:
+                    organizations[organization_id] = organization_service.get(id=organization_id)
+                except RpcException:
+                    # Fall back to per-installation lookups and their existing error handling.
+                    # A failed prefetch must not prevent unrelated integrations from rendering.
+                    continue
         return {
-            item: {"integration": integrations_by_id[item.integration_id]} for item in item_list
+            item: {
+                "integration": integrations_by_id[item.integration_id],
+                "organization": organizations.get(item.organization_id),
+            }
+            for item in item_list
         }
 
     def serialize(
@@ -194,11 +214,13 @@ class OrganizationIntegrationSerializer(Serializer):
         # integration installation config object which very well may be making
         # API request for config options.
         integration: RpcIntegration = attrs.get("integration")  # type: ignore[assignment]
+        organization: RpcOrganization | None = attrs.get("organization")
         integration_config = serialize(
             objects=integration,
             user=user,
             serializer=IntegrationConfigSerializer(obj.organization_id, params=self.params),
             include_config=include_config,
+            organization=organization,
         )
         serialized_integration: MutableMapping[str, Any] = {**integration_config}
 
@@ -222,6 +244,8 @@ class OrganizationIntegrationSerializer(Serializer):
             config_data = obj.config if include_config else None
         else:
             try:
+                if organization is not None:
+                    installation.organization = organization
                 installation.org_integration = obj
                 config_data = installation.get_config_data() if include_config else None  # type: ignore[assignment]
                 dynamic_display_information = installation.get_dynamic_display_information()

--- a/tests/sentry/integrations/api/endpoints/test_organization_integrations.py
+++ b/tests/sentry/integrations/api/endpoints/test_organization_integrations.py
@@ -1,6 +1,11 @@
+from unittest.mock import patch
+
+from sentry.constants import ObjectStatus
+from sentry.hybridcloud.rpc.service import RpcRemoteException
 from sentry.integrations.api.endpoints.organization_integrations_index import (
     OrganizationIntegrationsEndpoint,
 )
+from sentry.organizations.services.organization import organization_service
 from sentry.testutils.cases import APITestCase
 from sentry.testutils.silo import control_silo_test
 
@@ -45,9 +50,109 @@ class OrganizationIntegrationsListTest(APITestCase):
         assert "configOrganization" in response.data[0]
 
     def test_no_config(self) -> None:
-        response = self.get_success_response(self.organization.slug, qs_params={"includeConfig": 0})
+        with patch.object(organization_service, "get", wraps=organization_service.get) as get_org:
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"includeConfig": 0}
+            )
 
         assert "configOrganization" not in response.data[0]
+        get_org.assert_not_called()
+
+    def test_organization_prefetch_failure_preserves_unaffected_integrations(self) -> None:
+        expected = self.get_success_response(self.organization.slug).data
+        self.create_integration(
+            organization=self.organization,
+            provider="github",
+            name="GitHub",
+            external_id="github:1",
+        )
+
+        with patch.object(
+            organization_service,
+            "get",
+            side_effect=RpcRemoteException("organization", "get_organization_by_id", "Unavailable"),
+        ):
+            response = self.get_success_response(self.organization.slug)
+
+        assert response.data == expected
+
+    def test_config_shares_full_organization_for_github(self) -> None:
+        for number in range(30):
+            self.create_integration(
+                organization=self.organization,
+                provider="github",
+                name=f"GitHub {number}",
+                external_id=f"github:{number}",
+            )
+
+        with patch.object(organization_service, "get", wraps=organization_service.get) as get_org:
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"provider_key": "github"}
+            )
+
+        assert len(response.data) == 30
+        assert all(item["configOrganization"] for item in response.data)
+        get_org.assert_called_once_with(id=self.organization.id)
+
+    def test_vercel_shares_full_organization_for_config_and_display(self) -> None:
+        last_project = self.create_project(organization=self.organization, slug="z-project")
+        first_project = self.create_project(organization=self.organization, slug="a-project")
+        self.create_project(
+            organization=self.organization, slug="disabled-project", status=ObjectStatus.DISABLED
+        )
+        for number in range(3):
+            self.create_integration(
+                organization=self.organization,
+                provider="vercel",
+                name=f"Vercel {number}",
+                external_id=f"vercel:{number}",
+                metadata={"installation_type": "user"},
+            )
+
+        with (
+            patch.object(organization_service, "get", wraps=organization_service.get) as get_org,
+            patch("sentry.integrations.vercel.integration.VercelIntegration.get_client") as client,
+        ):
+            client.return_value.get_user.return_value = {"username": "example"}
+            client.return_value.get_projects.return_value = []
+            response = self.get_success_response(
+                self.organization.slug,
+                qs_params={"provider_key": "vercel", "includeConfig": "1"},
+            )
+
+        assert len(response.data) == 3
+        for item in response.data:
+            projects = item["configOrganization"][0]["sentryProjects"]
+            assert [project["id"] for project in projects] == [first_project.id, last_project.id]
+            instructions = item["dynamicDisplayInformation"]["configure_integration"][
+                "instructions"
+            ]
+            assert f"/settings/{self.organization.slug}/integrations/" in instructions[0]
+        get_org.assert_called_once_with(id=self.organization.id)
+
+    def test_vercel_display_without_config(self) -> None:
+        self.create_integration(
+            organization=self.organization,
+            provider="vercel",
+            name="Vercel",
+            external_id="vercel:1",
+        )
+
+        with patch.object(organization_service, "get", wraps=organization_service.get) as get_org:
+            response = self.get_success_response(
+                self.organization.slug,
+                qs_params={"provider_key": "vercel", "includeConfig": "0"},
+            )
+
+        assert len(response.data) == 1
+        assert "configOrganization" not in response.data[0]
+        assert response.data[0]["configData"] is None
+        instructions = response.data[0]["dynamicDisplayInformation"]["configure_integration"][
+            "instructions"
+        ]
+        assert f"/settings/{self.organization.slug}/integrations/" in instructions[0]
+        # The display hook still lazily fetches its organization; there is no eager fetch.
+        get_org.assert_called_once_with(id=self.organization.id)
 
     def test_opts_out_of_organization_projects_and_teams(self) -> None:
         # This endpoint only needs the organization id, so it skips serializing every

--- a/tests/sentry/integrations/api/serializers/models/test_integration.py
+++ b/tests/sentry/integrations/api/serializers/models/test_integration.py
@@ -125,8 +125,8 @@ class IntegrationSerializerTest(TestCase):
         ):
             client.return_value.get_user.return_value = {"username": "example"}
             client.return_value.get_projects.return_value = []
-            result = serialize(
-                integration, self.user, IntegrationConfigSerializer(self.organization.id)
+            result = IntegrationConfigSerializer(self.organization.id).serialize(
+                integration, {}, self.user
             )
 
         get_org.assert_called_once_with(id=self.organization.id)

--- a/tests/sentry/integrations/api/serializers/models/test_integration.py
+++ b/tests/sentry/integrations/api/serializers/models/test_integration.py
@@ -1,9 +1,16 @@
+from unittest.mock import call, patch
+
 from sentry.api.serializers import serialize
+from sentry.integrations.api.serializers.models.integration import IntegrationConfigSerializer
 from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS_OPTION
+from sentry.organizations.services.organization import organization_service
+from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
 from sentry.testutils.helpers.options import override_options
+from sentry.testutils.silo import control_silo_test
 
 
+@control_silo_test
 class IntegrationSerializerTest(TestCase):
     def setUp(self) -> None:
         super().setUp()
@@ -47,3 +54,119 @@ class IntegrationSerializerTest(TestCase):
         result = serialize(integration, self.user)
 
         assert result["outOfDate"] is False
+
+    def test_full_organizations_are_scoped_to_each_batch(self) -> None:
+        other_organization = self.create_organization()
+        project = self.create_project(organization=self.organization)
+        other_project = self.create_project(organization=other_organization)
+        integration = self.create_provider_integration(
+            provider="vercel",
+            name="Vercel",
+            external_id="vercel:1",
+            metadata={"installation_type": "user"},
+        )
+        first = self.create_organization_integration(
+            organization_id=self.organization.id, integration_id=integration.id
+        )
+        second = self.create_organization_integration(
+            organization_id=other_organization.id, integration_id=integration.id
+        )
+
+        with (
+            patch.object(organization_service, "get", wraps=organization_service.get) as get_org,
+            patch("sentry.integrations.vercel.integration.VercelIntegration.get_client") as client,
+        ):
+            client.return_value.get_user.return_value = {"username": "example"}
+            client.return_value.get_projects.return_value = []
+            result = serialize([first, second], self.user)
+            get_org.assert_has_calls(
+                [call(id=self.organization.id), call(id=other_organization.id)], any_order=True
+            )
+            assert get_org.call_count == 2
+
+            # The registered serializer is reused, but organization data must not be.
+            get_org.reset_mock()
+            repeated = serialize([first, second], self.user)
+            assert repeated == result
+            assert get_org.call_count == 2
+
+        assert [item["organizationId"] for item in result] == [
+            self.organization.id,
+            other_organization.id,
+        ]
+        assert [item["id"] for item in result[0]["configOrganization"][0]["sentryProjects"]] == [
+            project.id
+        ]
+        assert [item["id"] for item in result[1]["configOrganization"][0]["sentryProjects"]] == [
+            other_project.id
+        ]
+        assert (
+            f"/settings/{self.organization.slug}/integrations/"
+            in result[0]["dynamicDisplayInformation"]["configure_integration"]["instructions"][0]
+        )
+        assert (
+            f"/settings/{other_organization.slug}/integrations/"
+            in result[1]["dynamicDisplayInformation"]["configure_integration"]["instructions"][0]
+        )
+
+    def test_config_serializer_without_preloaded_organization(self) -> None:
+        project = self.create_project(organization=self.organization)
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="vercel",
+            name="Vercel",
+            external_id="vercel:1",
+            metadata={"installation_type": "user"},
+        )
+
+        with (
+            patch.object(organization_service, "get", wraps=organization_service.get) as get_org,
+            patch("sentry.integrations.vercel.integration.VercelIntegration.get_client") as client,
+        ):
+            client.return_value.get_user.return_value = {"username": "example"}
+            client.return_value.get_projects.return_value = []
+            result = serialize(
+                integration, self.user, IntegrationConfigSerializer(self.organization.id)
+            )
+
+        get_org.assert_called_once_with(id=self.organization.id)
+        assert [item["id"] for item in result["configOrganization"][0]["sentryProjects"]] == [
+            project.id
+        ]
+
+    def test_config_data_error_disables_integration(self) -> None:
+        integration = self.create_provider_integration(
+            provider="example", name="Example", external_id="example:1"
+        )
+        org_integration = self.create_organization_integration(
+            organization_id=self.organization.id, integration_id=integration.id
+        )
+
+        with patch(
+            "sentry.integrations.example.integration.ExampleIntegration.get_config_data",
+            side_effect=ApiError("Unable to load configuration"),
+        ):
+            result = serialize(org_integration, self.user)
+
+        assert result["status"] == "disabled"
+        assert result["configData"] is None
+        assert result["organizationId"] == self.organization.id
+
+    def test_provider_without_installation(self) -> None:
+        integration = self.create_provider_integration(
+            provider="example", name="Example", external_id="example:1"
+        )
+        org_integration = self.create_organization_integration(
+            organization_id=self.organization.id,
+            integration_id=integration.id,
+            config={"setting": "value"},
+        )
+
+        with patch(
+            "sentry.integrations.example.integration.ExampleIntegrationProvider.integration_cls",
+            None,
+        ):
+            result = serialize(org_integration, self.user)
+
+        assert result["configOrganization"] == []
+        assert result["configData"] == {"setting": "value"}


### PR DESCRIPTION
Resolves https://linear.app/getsentry/issue/ISWF-3359/organization-integrations-endpoint-does-one-full-org-rpc-per.

Listing organization integrations with configuration enabled now fetches the full organization once per organization in the serialization batch and shares it across configuration and display installations. This removes repeated full-org RPCs while retaining the project data required by Vercel's configuration form.

The configuration-disabled path remains lazy. Failed prefetches fall back to existing per-installation lookups and error handling.