### PR TITLE
fix: Disable insights modules by default

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -374,7 +374,7 @@ def register_temporary_features(manager: FeatureManager) -> None:
     # Enable SAML2 Single-logout
     manager.add("organizations:sso-saml2-slo", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=False)
     # Enable visibility and access to insight modules
-    manager.add("organizations:insight-modules", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=True)
+    manager.add("organizations:insight-modules", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True, default=False)
     # Make insights modules restrict queries to 30 days
     manager.add("organizations:insights-query-date-range-limit", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Make Insights overview pages use EAP instead of transactions (because eap is not on AM1)


### PR DESCRIPTION
Disables `organizations:insights-modules` by default. With this feature enabled,
span waterfalls cannot load because they result in the following API error:

```
{
    "detail": "Generic metrics sets, gauges, and distributions are no longer supported"
}
```

Regressed with #122014.
Fixes https://github.com/getsentry/self-hosted/issues/4491

