### PR TITLE
ref(sdk): Add option-backed per-transaction trace sample rates

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1062,6 +1062,14 @@ register("store.allow-s4s-ddm-sample-rate", default=0.0, flags=FLAG_AUTOMATOR_MO
 # Sample rate for transaction/span data sent to S4S upstream (1.0 = keep all, 0.05 = keep 5%)
 register("store.s4s-transaction-sample-rate", default=1.0, flags=FLAG_AUTOMATOR_MODIFIABLE)
 
+# Client-side trace sample rates for the internal SDK, keyed by transaction name:
+# a task name (`sentry.tasks.store.process_event`) or a parameterized route
+# (`/api/0/organizations/{organization_id_or_slug}/events/`), as shown in the
+# `transaction` field of the spans dataset. Entries override `SAMPLED_TASKS` in
+# `sentry.utils.sdk`; unlisted transactions keep their settings-based rate.
+# Example: {"sentry.tasks.post_process.post_process_group": 0.000003}
+register("sdk.transaction-sample-rates", default={}, flags=FLAG_AUTOMATOR_MODIFIABLE)
+
 
 # Killswitch to stop storing any reprocessing payloads.
 register("store.reprocessing-force-disable", default=False, flags=FLAG_AUTOMATOR_MODIFIABLE)

--- a/src/sentry/utils/sdk.py
+++ b/src/sentry/utils/sdk.py
@@ -34,9 +34,11 @@ from sentry_sdk.utils import logger as sdk_error_logger
 
 from sentry import options
 from sentry.conf.types.sdk_config import SdkConfig
+from sentry.constants import HEALTH_CHECK_GLOBS
 from sentry.options.rollout import in_random_rollout
 from sentry.utils import json, metrics
 from sentry.utils.db import DjangoAtomicIntegration
+from sentry.utils.glob import glob_match
 from sentry.utils.rust import RustInfoIntegration
 from sentry.utils.tracing import get_current_span, start_span
 from sentry.viewer_context import set_viewer_context_organization
@@ -59,6 +61,7 @@ UNSAFE_FILES = (
 
 # Tasks not included here are sampled with `SENTRY_BACKEND_APM_SAMPLING`.
 # If a parent task schedules other tasks, rates propagate to the children.
+# The `sdk.transaction-sample-rates` option overrides entries here at runtime.
 SAMPLED_TASKS = {
     "sentry.tasks.auto_source_code_config.derive_code_mappings": settings.SAMPLED_DEFAULT_RATE,
     "sentry.tasks.send_ping": settings.SAMPLED_DEFAULT_RATE,
@@ -107,6 +110,9 @@ SAMPLED_ROUTES = {
 AI_CONVERSATION_ROUTE = re.compile(
     r"/api/0/organizations/[^/]+/(?:ai-conversations|agents/conversations)(?:/[^/]+)?/"
 )
+
+# Same reduction dynamic sampling applies to health checks (`IGNORE_HEALTH_CHECKS_FACTOR_TRACES`).
+HEALTH_CHECK_SAMPLE_RATE_DIVISOR = 3
 
 if settings.ADDITIONAL_SAMPLED_TASKS:
     SAMPLED_TASKS.update(settings.ADDITIONAL_SAMPLED_TASKS)
@@ -198,6 +204,29 @@ def get_project_key():
     return key
 
 
+def _transaction_name(sampling_context, wsgi_path: str | None) -> str | None:
+    """
+    The name the transaction will carry once it is stored: the task name for
+    tasks, the parameterized route (e.g. `/api/0/organizations/{organization_id_or_slug}/events/`)
+    for requests. This matches the `transaction` field in the spans dataset, so
+    rates measured there can be copied into `sdk.transaction-sample-rates` as-is.
+    """
+    if "taskworker" in sampling_context:
+        return sampling_context["taskworker"].get("task")
+
+    if wsgi_path:
+        try:
+            return LEGACY_RESOLVER.resolve(wsgi_path)
+        except Exception:
+            return None
+
+    return None
+
+
+def _is_health_check(transaction_name: str) -> bool:
+    return any(glob_match(transaction_name, pattern) for pattern in HEALTH_CHECK_GLOBS)
+
+
 def traces_sampler(sampling_context):
     wsgi_path = sampling_context.get("wsgi_environ", {}).get("PATH_INFO")
     if wsgi_path:
@@ -205,6 +234,16 @@ def traces_sampler(sampling_context):
             return SAMPLED_ROUTES[wsgi_path]
         if AI_CONVERSATION_ROUTE.fullmatch(wsgi_path):
             return 1.0
+
+    transaction_name = _transaction_name(sampling_context, wsgi_path)
+
+    # The option table holds the rate for the root of a trace, the same way
+    # dynamic sampling keyed its rules on the root transaction. Children keep
+    # inheriting the parent's decision below.
+    if transaction_name is not None and sampling_context["parent_sampled"] is None:
+        configured_rate = options.get("sdk.transaction-sample-rates").get(transaction_name)
+        if configured_rate is not None:
+            return float(configured_rate)
 
     # Apply sample_rate from custom_sampling_context
     custom_sample_rate = sampling_context.get("sample_rate")
@@ -215,14 +254,14 @@ def traces_sampler(sampling_context):
     if sampling_context["parent_sampled"] is not None:
         return sampling_context["parent_sampled"]
 
-    if "taskworker" in sampling_context:
-        task_name = sampling_context["taskworker"].get("task")
+    if transaction_name in SAMPLED_TASKS:
+        return SAMPLED_TASKS[transaction_name]
 
-        if task_name in SAMPLED_TASKS:
-            return SAMPLED_TASKS[task_name]
+    default_rate = float(settings.SENTRY_BACKEND_APM_SAMPLING or 0)
+    if transaction_name is not None and _is_health_check(transaction_name):
+        return default_rate / HEALTH_CHECK_SAMPLE_RATE_DIVISOR
 
-    # Default to the sampling rate in settings
-    return float(settings.SENTRY_BACKEND_APM_SAMPLING or 0)
+    return default_rate
 
 
 def profiles_sampler(sampling_context):

--- a/tests/sentry/utils/test_sdk.py
+++ b/tests/sentry/utils/test_sdk.py
@@ -13,6 +13,7 @@ from sentry_sdk import Scope
 
 from sentry.models.organization import Organization
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.utils import sdk
 from sentry.utils.sdk import (
     bind_ambiguous_org_context,
@@ -57,6 +58,94 @@ def test_ai_conversation_routes_are_fully_sampled(path: str) -> None:
         )
         == 1.0
     )
+
+
+class TracesSamplerTest(TestCase):
+    def test_task_rate_from_option_overrides_sampled_tasks(self) -> None:
+        task = "sentry.tasks.store.process_event"
+        assert task in sdk.SAMPLED_TASKS
+        with override_options({"sdk.transaction-sample-rates": {task: 0.25}}):
+            assert (
+                sdk.traces_sampler({"taskworker": {"task": task}, "parent_sampled": None}) == 0.25
+            )
+
+    def test_task_falls_back_to_sampled_tasks(self) -> None:
+        task = "sentry.monitors.tasks.clock_pulse"
+        with override_options({"sdk.transaction-sample-rates": {}}):
+            assert (
+                sdk.traces_sampler({"taskworker": {"task": task}, "parent_sampled": None})
+                == sdk.SAMPLED_TASKS[task]
+            )
+
+    def test_route_rate_matches_parameterized_transaction_name(self) -> None:
+        rates = {"/api/0/organizations/{organization_id_or_slug}/events/": 0.125}
+        with override_options({"sdk.transaction-sample-rates": rates}):
+            assert (
+                sdk.traces_sampler(
+                    {
+                        "wsgi_environ": {"PATH_INFO": "/api/0/organizations/org-slug/events/"},
+                        "parent_sampled": None,
+                    }
+                )
+                == 0.125
+            )
+
+    def test_unlisted_route_uses_settings_default(self) -> None:
+        with (
+            override_options({"sdk.transaction-sample-rates": {}}),
+            self.settings(SENTRY_BACKEND_APM_SAMPLING=0.5),
+        ):
+            assert (
+                sdk.traces_sampler(
+                    {
+                        "wsgi_environ": {"PATH_INFO": "/api/0/organizations/org-slug/events/"},
+                        "parent_sampled": None,
+                    }
+                )
+                == 0.5
+            )
+
+    def test_parent_decision_wins_over_configured_rate(self) -> None:
+        rates = {"/api/0/organizations/{organization_id_or_slug}/events/": 0.125}
+        with override_options({"sdk.transaction-sample-rates": rates}):
+            assert (
+                sdk.traces_sampler(
+                    {
+                        "wsgi_environ": {"PATH_INFO": "/api/0/organizations/org-slug/events/"},
+                        "parent_sampled": True,
+                    }
+                )
+                is True
+            )
+
+    def test_configured_rate_wins_over_call_site_rate(self) -> None:
+        task = "sentry.replays.tasks.process_replay_recording"
+        with override_options({"sdk.transaction-sample-rates": {task: 0.000004}}):
+            assert (
+                sdk.traces_sampler(
+                    {"taskworker": {"task": task}, "sample_rate": 0.002, "parent_sampled": None}
+                )
+                == 0.000004
+            )
+
+    def test_call_site_rate_still_applies_without_configured_rate(self) -> None:
+        task = "sentry.replays.tasks.process_replay_recording"
+        with override_options({"sdk.transaction-sample-rates": {}}):
+            assert (
+                sdk.traces_sampler(
+                    {"taskworker": {"task": task}, "sample_rate": 0.002, "parent_sampled": None}
+                )
+                == 0.002
+            )
+
+    def test_health_checks_get_a_third_of_the_default_rate(self) -> None:
+        with (
+            override_options({"sdk.transaction-sample-rates": {}}),
+            self.settings(SENTRY_BACKEND_APM_SAMPLING=0.3),
+        ):
+            assert sdk.traces_sampler(
+                {"taskworker": {"task": "sentry.tasks.heartbeat"}, "parent_sampled": None}
+            ) == pytest.approx(0.1)
 
 
 class SDKUtilsTest(TestCase):


### PR DESCRIPTION
- Add `sdk.transaction-sample-rates`, a dict option mapping a transaction name (task name or parameterized route) to a client sample rate
- Resolve request paths in `traces_sampler` with the SDK's route resolver so keys match the `transaction` field in the spans dataset
- Option entries win over `SAMPLED_TASKS` and call-site `custom_sampling_context` rates at trace roots; children keep the parent decision
- Health-check transactions get a third of the default rate, matching the dynamic sampling bias
- First step of moving the internal orgs off Dynamic Sampling; rates are populated in a follow-up options-automator change

Contributes to TET-2974