### PR TITLE
ref(sdk): Let pageloads decide their own trace sample rate

### DIFF
--- a/static/app/bootstrap/initializeSdk.spec.tsx
+++ b/static/app/bootstrap/initializeSdk.spec.tsx
@@ -67,6 +67,60 @@ describe('initializeSdk', () => {
       )
     ).toBe(true);
   });
+
+  describe('tracesSampler', () => {
+    function getTracesSampler(apmSampling: number) {
+      initializeSdk({
+        ...window.__initialData,
+        apmSampling,
+        sentryConfig: {
+          allowUrls: [],
+          dsn: '',
+          release: '',
+          tracePropagationTargets: [],
+        },
+      });
+      const tracesSampler = jest.mocked(Sentry.init).mock.lastCall?.[0]?.tracesSampler;
+      if (!tracesSampler) {
+        throw new Error('tracesSampler was not configured');
+      }
+      return tracesSampler;
+    }
+
+    function samplingContext(op: string, parentSampled: boolean | undefined) {
+      return {
+        name: '/issues/',
+        attributes: {[Sentry.SEMANTIC_ATTRIBUTE_SENTRY_OP]: op},
+        parentSampled,
+        parentSampleRate: undefined,
+        inheritOrSampleWith: jest.fn((fallback: number) => parentSampled ?? fallback),
+      };
+    }
+
+    it('lets a pageload decide with its own rate instead of the backend decision', () => {
+      const tracesSampler = getTracesSampler(0.4);
+      const context = samplingContext('pageload', false);
+
+      expect(tracesSampler(context)).toBe(0.4);
+      expect(context.inheritOrSampleWith).not.toHaveBeenCalled();
+    });
+
+    it('inherits the parent decision for navigations', () => {
+      const tracesSampler = getTracesSampler(0.4);
+      const context = samplingContext('navigation', true);
+
+      expect(tracesSampler(context)).toBe(true);
+      expect(context.inheritOrSampleWith).toHaveBeenCalledWith(0.4);
+    });
+
+    it('samples ui.action spans at a hundredth of the rate', () => {
+      const tracesSampler = getTracesSampler(0.4);
+      const context = samplingContext('ui.action.click', undefined);
+
+      expect(tracesSampler(context)).toBeCloseTo(0.004);
+      expect(context.inheritOrSampleWith).toHaveBeenCalledWith(0.004);
+    });
+  });
 });
 
 describe('isFilteredRequestErrorEvent', () => {

--- a/static/app/bootstrap/initializeSdk.tsx
+++ b/static/app/bootstrap/initializeSdk.tsx
@@ -118,6 +118,12 @@ export function initializeSdk(config: Config) {
       if (typeof op === 'string' && op.startsWith('ui.action')) {
         return context.inheritOrSampleWith(tracesSampleRate / 100);
       }
+      // The server-rendered page carries the backend request's `sentry-trace`
+      // meta tag. That decision is made with the backend's own rate, which is
+      // far below the frontend's, so a pageload must decide for itself.
+      if (op === 'pageload') {
+        return tracesSampleRate;
+      }
       return context.inheritOrSampleWith(tracesSampleRate);
     },
     ignoreSpans: IGNORED_SPAN_NAMES,


### PR DESCRIPTION
- The server-rendered page injects the backend request's `sentry-trace` meta tag, and `tracesSampler` inherited that decision for pageloads via `inheritOrSampleWith`
- Backend web routes will be sampled at their own, much lower rate once the internal orgs move off Dynamic Sampling; pageloads would then inherit "not sampled" almost every time
- Pageloads now sample with the frontend rate; navigations and `ui.action` spans keep inheriting the parent decision
- No behaviour change today: backend and frontend rates are both 1
- Tests for the three sampler branches