### PR TITLE
ref(attachments): Killswitch for txn pending check

### DIFF
--- a/src/sentry/event_manager.py
+++ b/src/sentry/event_manager.py
@@ -2895,18 +2895,19 @@ def save_transaction_events(
     _nodestore_save_many(jobs=jobs, app_feature="transactions")
     _eventstream_insert_many(jobs)
 
-    for job in jobs:
-        # NOTE: This puts a postgres query in the critical ingestion path for transactions.
-        # `save_pending_attachments` currently early-returns for most projects, but before graduation,
-        # we should make sure that the extra load on postgres is justifiable, given the facts that transactions
-        # are a legacy feature and transaction attachments are a niche use case.
-        safe_execute(
-            save_pending_attachments,
-            project=projects[job["project_id"]],
-            event_id=job["event"].event_id,
-            group_id=None,
-            source="save_transaction_events",
-        )
+    if options.get("store.transactions.check-pending-attachments"):
+        for job in jobs:
+            # NOTE: This puts a postgres query in the critical ingestion path for transactions.
+            # `save_pending_attachments` currently early-returns for most projects, but before graduation,
+            # we should make sure that the extra load on postgres is justifiable, given the facts that transactions
+            # are a legacy feature and transaction attachments are a niche use case.
+            safe_execute(
+                save_pending_attachments,
+                project=projects[job["project_id"]],
+                event_id=job["event"].event_id,
+                group_id=None,
+                source="save_transaction_events",
+            )
 
     for job in jobs:
         track_sampled_event(

--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1078,6 +1078,15 @@ register(
     default=False,
     flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Whether or not to query postgres for pending attachments in `save_transaction_events`.
+#
+# Change this value to `False` in case `save_event_transaction` becomes slow.
+register(
+    "store.transactions.check-pending-attachments",
+    type=Bool,
+    default=True,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 
 # Enable sending the flag to the microservice to tell it to purposefully take longer than our


### PR DESCRIPTION
Add a killswitch so we can quickly disable the check for pending attachments in `save_event_transaction`, independently of the `projects:defer-attachment-storage` feature flag.

ref: INGEST-1167