### PR TITLE
docs(breadcrumbList): Stop documenting a preservePageFilters prop

### DIFF
--- a/static/app/components/core/breadcrumbList/breadcrumbList.mdx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.mdx
@@ -101,9 +101,13 @@ leading graphics, trailing actions, or an editable control.
 
 ### `'link'` — parent page
 
-A clickable, muted-weight crumb that navigates to a parent page. Set
-`preservePageFilters` to carry project, environment, and date filters across the
-navigation.
+A clickable, muted-weight crumb that navigates to a parent page. It takes a
+string `label`, a `to` destination, and an optional `leadingGraphic`.
+
+Page filters are not carried automatically. To keep the project, environment, and
+date selection across the navigation, build the query into `to` yourself with
+`extractSelectionParameters` from `sentry/components/pageFilters/parse`,
+overriding any parameter the destination needs different.
 
 <Storybook.Demo>
   <BreadcrumbListDemo
@@ -117,7 +121,6 @@ navigation.
         type: 'link',
         label: 'Issues',
         to: '/organizations/org-slug/issues/',
-        preservePageFilters: true,
       },
     ]}
   />
@@ -127,7 +130,11 @@ navigation.
   <BreadcrumbList
     items={[
       {type: 'link', label: 'Projects', to: '/organizations/org-slug/projects/'},
-      {type: 'link', label: 'Issues', to: '/issues/', preservePageFilters: true},
+      {
+        type: 'link',
+        label: 'Issues',
+        to: {pathname: '/issues/', query: extractSelectionParameters(location.query)},
+      },
     ]}
   />
 </TopBar.Slot>


### PR DESCRIPTION
The `'link'` section of the BreadcrumbList story described a `preservePageFilters` prop and demoed it twice. `BreadcrumbItemLinkProps` has never accepted it — the prop is silently dropped, so a developer following the docs ships a crumb that loses the project, environment, and date selection on click. It fails quietly: no type error through a spread, no failing test.

The story now documents what the item actually takes (`label`, `to`, `leadingGraphic`) and shows the query built into `to` with `extractSelectionParameters`, which is how the already-migrated call sites carry filters today.

Story copy only — no component or runtime change.

I audited every other prop the story names against the real types while I was in here; `preservePageFilters` was the only drift.

This does not settle *how* filters should be preserved — six call sites still pass the legacy prop on the old component, and whether the answer is a call-site convention or a destination-side mechanism is open (see #123903). This just stops the docs asserting something untrue in the meantime.
