### PR TITLE
test(breadcrumbList): Drop the stale containerType warning tolerance

### DIFF
--- a/static/app/components/core/breadcrumbList/breadcrumbList.spec.tsx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.spec.tsx
@@ -26,16 +26,9 @@ describe('BreadcrumbList container-query collapse', () => {
   let consoleError: jest.SpyInstance;
 
   beforeEach(() => {
-    // Known pre-existing issue: the `containerType` prop leaks a `containertype`
-    // attribute onto the DOM node, which React warns about. That's a bug in the
-    // core Container primitive, unrelated to the collapse behavior under test —
-    // tolerate exactly that warning and re-throw anything else.
+    // These tests assert on rendered DOM and emitted styles, where a React
+    // warning usually means a prop leaked onto a host element. Fail on any.
     consoleError = jest.spyOn(console, 'error').mockImplementation((...args) => {
-      // React formats warnings with %s placeholders, so the offending prop name
-      // ("containerType") lands in a later arg — check them all.
-      if (args.some(arg => typeof arg === 'string' && arg.includes('containerType'))) {
-        return;
-      }
       throw new Error(`Unexpected console.error: ${args.map(String).join(' ')}`);
     });
   });


### PR DESCRIPTION
`breadcrumbList.spec.tsx` wraps its tests in a `console.error` guard that fails on any React warning, with one exception: a `containertype` attribute said to leak onto the DOM from the `containerType` prop.

That exception is dead code. `Container` destructures `containerType` out before spreading to the host element, so nothing lands on the DOM and no warning is emitted. Removing the exception leaves all 11 tests green; a deliberately injected `console.error` still fails the suite, so the guard itself is unaffected.

Removing it means a real prop leak in this component would now fail the suite instead of being swallowed by a `.includes('containerType')` substring match.

No component or runtime change.
