### PR TITLE
fix(ui): Disable the project badge link in the breadcrumb title

### DIFF
--- a/static/app/views/performance/transactionSummary/transactionBreadcrumbs.tsx
+++ b/static/app/views/performance/transactionSummary/transactionBreadcrumbs.tsx
@@ -191,6 +191,7 @@ function TransactionBreadcrumbsContent({
             label: transactionName,
             leadingGraphic: project ? (
               <IdBadge
+                disableLink
                 project={project}
                 avatarSize={16}
                 hideName


### PR DESCRIPTION
`BreadcrumbLeadingSlot` renders its children inside `aria-hidden="true"` — the graphic is decorative and the label carries the meaning. This `IdBadge` was missing `disableLink`, so `ProjectBadge` wrapped it in a link to the project overview, putting a focusable element with the accessible name "View Project Details" inside a hidden subtree. That is an `aria-hidden-focus` violation: a keyboard user can tab to it, and assistive tech cannot see what they landed on.

The three other pages that render a badge in this slot already pass `disableLink`, so this brings the fourth in line. The dropped destination was `ProjectBadge`'s auto-generated default rather than one this page chose, so nothing intentional is lost — no call site in the codebase passes an explicit `to` or `onClick` to a leading graphic.

Worth noting the underlying shape: `leadingGraphic` is typed `React.ReactNode`, so the slot's decorative-only contract is not enforceable at the type level and this is easy to get wrong again. That is a separate design question.
