### PR TITLE
ref(agents): Simplify explicit role check

### DIFF
--- a/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
+++ b/static/app/views/insights/pages/agents/utils/aiMessageNormalizer.ts
@@ -404,7 +404,7 @@ function bucketParts(parts: unknown[]): PartBuckets {
 }
 
 function selectAssistantMessages(rawMessages: RawMessage[]): RawMessage[] {
-  const hasRole = rawMessages.some(m => m.roleExplicit === true);
+  const hasRole = rawMessages.some(m => m.roleExplicit);
   if (hasRole) {
     return rawMessages.filter(m => m.role === 'assistant');
   }


### PR DESCRIPTION
The AI message normalizer compares an optional boolean to true when deciding whether any message declares a role, even though the condition only needs its truthiness.

Use the optional boolean directly in the predicate. This removes the redundant comparison while preserving the existing assistant-message selection behavior.