### PR TITLE
ref(dynamic-sampling): Disable the switch into Advanced Mode

### DIFF
--- a/static/app/views/settings/dynamicSampling/samplingModeSwitch.spec.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitch.spec.tsx
@@ -17,14 +17,22 @@ describe('SamplingModeSwitch', () => {
     MockApiClient.clearMockResponses();
   });
 
-  it('renders correctly in organization mode', () => {
+  it('cannot enter advanced mode from organization mode', async () => {
     render(<SamplingModeSwitch />, {
       organization,
     });
 
-    expect(screen.getByRole('checkbox')).toBeEnabled();
     expect(screen.getByText('Advanced Mode')).toBeInTheDocument();
     expect(screen.getByRole('checkbox')).not.toBeChecked();
+    expect(screen.getByRole('checkbox')).toBeDisabled();
+
+    await userEvent.hover(screen.getByRole('checkbox'));
+    expect(
+      await screen.findByText(
+        'Advanced Mode is no longer available. Sample rates are configured for the whole organization.'
+      )
+    ).toBeInTheDocument();
+    expect(openSamplingModeSwitchModal).not.toHaveBeenCalled();
   });
 
   it('renders correctly in project mode', () => {
@@ -33,25 +41,26 @@ describe('SamplingModeSwitch', () => {
     });
 
     expect(screen.getByRole('checkbox')).toBeChecked();
+    expect(screen.getByRole('checkbox')).toBeEnabled();
   });
 
-  it('opens modal when switch is clicked', async () => {
+  it('opens the modal to leave advanced mode when the switch is clicked', async () => {
     render(<SamplingModeSwitch initialTargetRate={0.3} />, {
-      organization,
+      organization: {...organization, samplingMode: 'project'},
     });
 
     await userEvent.click(screen.getByRole('checkbox'));
 
     expect(openSamplingModeSwitchModal).toHaveBeenCalledWith({
-      samplingMode: 'project',
+      samplingMode: 'organization',
       initialTargetRate: 0.3,
     });
   });
 
-  it('disables switch when user lacks permission', () => {
+  it('disables switch when user lacks permission', async () => {
     const orgWithoutAccess = OrganizationFixture({
       access: [], // No project:write access
-      samplingMode: 'organization',
+      samplingMode: 'project',
     });
 
     render(<SamplingModeSwitch />, {
@@ -59,5 +68,10 @@ describe('SamplingModeSwitch', () => {
     });
 
     expect(screen.getByRole('checkbox')).toBeDisabled();
+
+    await userEvent.hover(screen.getByRole('checkbox'));
+    expect(
+      await screen.findByText('You do not have permission to change this setting.')
+    ).toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/dynamicSampling/samplingModeSwitch.tsx
+++ b/static/app/views/settings/dynamicSampling/samplingModeSwitch.tsx
@@ -19,13 +19,21 @@ interface Props {
 export function SamplingModeSwitch({initialTargetRate}: Props) {
   const {samplingMode} = useOrganization();
   const hasAccess = useHasDynamicSamplingWriteAccess();
+  // Advanced Mode can no longer be entered. An organization already in it can still leave it.
+  const isInAdvancedMode = samplingMode === 'project';
 
   const handleSwitchMode = () => {
     openSamplingModeSwitchModal({
-      samplingMode: samplingMode === 'organization' ? 'project' : 'organization',
+      samplingMode: 'organization',
       initialTargetRate,
     });
   };
+
+  const disabledReason = isInAdvancedMode
+    ? t('You do not have permission to change this setting.')
+    : t(
+        'Advanced Mode is no longer available. Sample rates are configured for the whole organization.'
+      );
 
   return (
     <Flex as="label" align="center" gap="md" marginBottom="0">
@@ -42,15 +50,12 @@ export function SamplingModeSwitch({initialTargetRate}: Props) {
       >
         {t('Advanced Mode')}
       </InfoText>
-      <Tooltip
-        disabled={hasAccess}
-        title={t('You do not have permission to change this setting.')}
-      >
+      <Tooltip disabled={hasAccess && isInAdvancedMode} title={disabledReason}>
         <Switch
           size="lg"
           onChange={handleSwitchMode}
-          disabled={!hasAccess}
-          checked={samplingMode === 'project'}
+          disabled={!hasAccess || !isInAdvancedMode}
+          checked={isInAdvancedMode}
         />
       </Tooltip>
     </Flex>


### PR DESCRIPTION
- Advanced Mode (per-project sample rates) is closed to new organizations. The API rejects a switch into it in #124006.
- Disable the switch in Automatic Mode and explain why in its tooltip. An organization already in Advanced Mode keeps an enabled switch to leave it.

Contributes to TET-2900
