### PR TITLE
fix(explore): Disable span details past the retention window

### DIFF
--- a/static/app/views/explore/tables/spansTable.spec.tsx
+++ b/static/app/views/explore/tables/spansTable.spec.tsx
@@ -12,6 +12,7 @@ import {
   waitFor,
   within,
 } from 'sentry-test/reactTestingLibrary';
+import {resetMockDate, setMockDate} from 'sentry-test/utils';
 
 import * as indicators from 'sentry/actionCreators/indicator';
 import {PageFiltersStore} from 'sentry/components/pageFilters/store';
@@ -135,6 +136,7 @@ describe('SpansTable', () => {
   const rows = [firstRow, secondRow];
 
   beforeEach(() => {
+    setMockDate(new Date('2026-09-10T12:00:00Z'));
     MockApiClient.clearMockResponses();
     jest.mocked(trackAnalytics).mockClear();
     ProjectsStore.loadInitialData([
@@ -151,11 +153,17 @@ describe('SpansTable', () => {
     });
   });
 
+  afterEach(() => {
+    resetMockDate();
+  });
+
   function renderTable({
+    fields,
     requestIdentityKey,
     tableResult,
     tableRows = rows,
   }: {
+    fields?: string[];
     requestIdentityKey?: string;
     tableResult?: SpansTableResult['result'];
     tableRows?: Array<Record<string, unknown>>;
@@ -177,6 +185,7 @@ describe('SpansTable', () => {
         initialRouterConfig: {
           location: {
             pathname: `/organizations/${organization.slug}/explore/traces/`,
+            query: fields ? {field: fields} : {},
           },
         },
       }
@@ -227,6 +236,44 @@ describe('SpansTable', () => {
       {pointerEventsCheck: 0}
     );
   }
+
+  it('disables old span details and links to similar spans', async () => {
+    const oldRow = {...firstRow, timestamp: '2026-08-10T12:00:00Z'};
+    const detailsMock = mockSpanDetails(oldRow, []);
+    const {router} = renderTable({tableRows: [oldRow]});
+    const toggle = screen.getByRole('button', {name: 'Show span details'});
+
+    expect(toggle).toBeDisabled();
+    await userEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(detailsMock).not.toHaveBeenCalled();
+    expect(trackAnalytics).not.toHaveBeenCalled();
+
+    await userEvent.hover(toggle);
+    expect(await screen.findByText(/Span is older than 30 days/)).toBeInTheDocument();
+    await userEvent.click(await screen.findByRole('link', {name: 'View similar spans'}));
+    expect(router.location.pathname).toBe(
+      `/organizations/${organization.slug}/explore/traces/`
+    );
+    expect(router.location.query).toEqual(
+      expect.objectContaining({
+        mode: 'samples',
+        project: project.id,
+        query: 'span.name:"span one" span.description:"GET /one"',
+        statsPeriod: '24h',
+      })
+    );
+    expect(detailsMock).not.toHaveBeenCalled();
+  });
+
+  it.each(['2026-08-11T12:00:00Z', '2026-08-10T12:00:01Z', undefined, null, ''])(
+    'allows span expansion for timestamp %s',
+    timestamp => {
+      renderTable({fields: ['id'], tableRows: [{...firstRow, timestamp}]});
+
+      expect(screen.getByRole('button', {name: 'Show span details'})).toBeEnabled();
+    }
+  );
 
   it('independently expands span details only after clicking the chevrons', async () => {
     const firstDetailsMock = mockSpanDetails(firstRow, [

--- a/static/app/views/explore/tables/spansTable.tsx
+++ b/static/app/views/explore/tables/spansTable.tsx
@@ -1,8 +1,9 @@
-import {Fragment, useEffect, useMemo, useRef, useState} from 'react';
+import {Fragment, useEffect, useMemo, useRef, useState, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {Link} from '@sentry/scraps/link';
 import {Pagination} from '@sentry/scraps/pagination';
 import {Text} from '@sentry/scraps/text';
 
@@ -10,18 +11,21 @@ import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
 import {Placeholder} from 'sentry/components/placeholder';
 import {DataTable} from 'sentry/components/tables/dataTable';
 import {getNextDirection} from 'sentry/components/tables/getNextSort';
 import {IconChevron} from 'sentry/icons/iconChevron';
 import {IconWarning} from 'sentry/icons/iconWarning';
-import {t} from 'sentry/locale';
+import {t, tct} from 'sentry/locale';
 import type {TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import type {EventData, MetaType} from 'sentry/utils/discover/eventView';
 import {fieldAlignment} from 'sentry/utils/discover/fields';
 import {FieldValueType, getFieldDefinition, prettifyTagKey} from 'sentry/utils/fields';
+import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useOrganization} from 'sentry/utils/useOrganization';
+import {useProjects} from 'sentry/utils/useProjects';
 import type {TableColumn} from 'sentry/views/discover/table/types';
 import type {SpansTableResult} from 'sentry/views/explore/hooks/useExploreSpansTable';
 import {usePaginationAnalytics} from 'sentry/views/explore/hooks/usePaginationAnalytics';
@@ -34,6 +38,7 @@ import {
   useSetQueryParamsSortBys,
 } from 'sentry/views/explore/queryParams/context';
 
+import {getSimilarEventsUrl, isPartialSpanOrTraceData} from './tracesTable/utils';
 import {FieldRenderer} from './fieldRenderer';
 import {SpanItemDetails} from './spanItemDetails';
 
@@ -292,6 +297,37 @@ function SpanSampleRow({
 }) {
   const organization = useOrganization();
   const [isExpanded, setIsExpanded] = useState(false);
+  const {selection} = usePageFilters();
+  const {projects} = useProjects();
+  const isPartialSpan = isPartialSpanOrTraceData(data.timestamp);
+  let disabledReason: ReactNode;
+
+  if (isPartialSpan) {
+    const project = projects.find(p => p.slug === data.project);
+    const queryString = new MutableSearch('');
+    for (const field of ['span.name', 'span.description']) {
+      if (data[field]) {
+        queryString.addFilterValue(field, data[field]);
+      }
+    }
+    disabledReason = tct(
+      'Span is older than 30 days. [similarSpans] in the past 24 hours.',
+      {
+        similarSpans: (
+          <Link
+            to={getSimilarEventsUrl({
+              queryString: queryString.formatString(),
+              organization,
+              projectIds: project ? [Number(project.id)] : selection.projects,
+              selection,
+            })}
+          >
+            {t('View similar spans')}
+          </Link>
+        ),
+      }
+    );
+  }
 
   return (
     <Fragment>
@@ -300,8 +336,10 @@ function SpanSampleRow({
           <Button
             aria-expanded={isExpanded}
             aria-label={isExpanded ? t('Hide span details') : t('Show span details')}
+            disabled={isPartialSpan}
             icon={<IconChevron size="xs" direction={isExpanded ? 'down' : 'right'} />}
             size="zero"
+            tooltipProps={{title: disabledReason}}
             variant="transparent"
             onClick={() => {
               setIsExpanded(e => !e);


### PR DESCRIPTION
Span sample rows now disable the details chevron when the span reaches 31 days old, matching the existing age check used by span links. The tooltip explains the restriction and offers “View similar spans,” searching the past 24 hours by span name, description, and project.

Missing or invalid timestamps leave the toggle enabled. Regression coverage checks the cutoff, prevents details requests from disabled toggles, and verifies navigation to similar spans.
