### PR TITLE
feat(conversations): Add scoped aggregate filters

### DIFF
--- a/static/app/views/explore/conversations/overview.spec.tsx
+++ b/static/app/views/explore/conversations/overview.spec.tsx
@@ -1,0 +1,89 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+
+import ConversationsOverviewPage from './overview';
+
+const organization = OrganizationFixture({
+  features: ['gen-ai-conversations', 'gen-ai-conversations-querying-enhancements'],
+});
+
+describe('ConversationsOverviewPage', () => {
+  beforeEach(() => {
+    PageFiltersStore.init();
+    localStorage.setItem(
+      `conversations:projects-with-data:${organization.slug}`,
+      JSON.stringify([-1])
+    );
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {data: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      body: {
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'count_unique(gen_ai.conversation.id)',
+            meta: {valueType: 'number', valueUnit: null, interval: 1_800_000},
+          }),
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/agents/conversations/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      body: [],
+    });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('offers conversation aggregate aliases as filters', async () => {
+    render(<ConversationsOverviewPage />, {organization});
+
+    await userEvent.click(
+      await screen.findByRole('combobox', {name: 'Add a search term'})
+    );
+
+    for (const alias of [
+      'conversationId',
+      'duration',
+      'generationDuration',
+      'errors',
+      'llmCalls',
+      'toolCalls',
+      'totalTokens',
+      'inputTokens',
+      'outputTokens',
+      'totalCost',
+      'toolErrors',
+    ]) {
+      expect(
+        await screen.findByRole('option', {name: `conversation.${alias}`})
+      ).toBeInTheDocument();
+    }
+
+    await userEvent.click(
+      screen.getByRole('option', {name: 'conversation.generationDuration'})
+    );
+    expect(
+      await screen.findByRole('row', {
+        name: 'conversation.generationDuration:>10ms',
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -16,7 +16,9 @@ import {
 import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {FieldKind, FieldValueType, type FieldDefinition} from 'sentry/utils/fields';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
@@ -40,8 +42,48 @@ import {
   TableUrlParams,
 } from 'sentry/views/insights/pages/agents/utils/urlParams';
 
+const CONVERSATION_FIELD_TYPES = {
+  conversationId: FieldValueType.STRING,
+  duration: FieldValueType.DURATION,
+  generationDuration: FieldValueType.DURATION,
+  errors: FieldValueType.INTEGER,
+  llmCalls: FieldValueType.INTEGER,
+  toolCalls: FieldValueType.INTEGER,
+  totalTokens: FieldValueType.INTEGER,
+  inputTokens: FieldValueType.INTEGER,
+  outputTokens: FieldValueType.INTEGER,
+  totalCost: FieldValueType.CURRENCY,
+  toolErrors: FieldValueType.INTEGER,
+};
+
+const CONVERSATION_FIELD_DEFINITIONS: Record<string, FieldDefinition> =
+  Object.fromEntries(
+    Object.entries(CONVERSATION_FIELD_TYPES).map(([key, valueType]) => [
+      `conversation.${key}`,
+      {
+        kind: FieldKind.FIELD,
+        valueType,
+        allowWildcard: valueType === FieldValueType.STRING ? false : undefined,
+      },
+    ])
+  );
+
+const CONVERSATION_FILTER_KEYS: TagCollection = Object.fromEntries(
+  Object.entries(CONVERSATION_FIELD_DEFINITIONS).map(([key, {valueType}]) => [
+    key,
+    {
+      key,
+      name: key,
+      kind: valueType === FieldValueType.STRING ? FieldKind.TAG : FieldKind.MEASUREMENT,
+    },
+  ])
+);
+
 function ConversationsOverviewPage() {
   const organization = useOrganization();
+  const queryingEnhancementsEnabled = organization.features.includes(
+    'gen-ai-conversations-querying-enhancements'
+  );
   const datePageFilterProps = useDatePageFilterProps({
     maxPickableDays: MAX_PICKABLE_DAYS,
     maxUpgradableDays: MAX_PICKABLE_DAYS,
@@ -130,11 +172,26 @@ function ConversationsOverviewPage() {
       );
     };
 
+    if (!queryingEnhancementsEnabled) {
+      return {
+        ...spanSearchQueryBuilderProviderProps,
+        getTagValues: getTagValuesWithoutCounts,
+      };
+    }
+
+    const fieldDefinitionGetter =
+      spanSearchQueryBuilderProviderProps.fieldDefinitionGetter;
     return {
       ...spanSearchQueryBuilderProviderProps,
+      filterKeys: {
+        ...spanSearchQueryBuilderProviderProps.filterKeys,
+        ...CONVERSATION_FILTER_KEYS,
+      },
+      fieldDefinitionGetter: (key: string, options?: {kind?: FieldKind}) =>
+        CONVERSATION_FIELD_DEFINITIONS[key] ?? fieldDefinitionGetter(key, options),
       getTagValues: getTagValuesWithoutCounts,
     };
-  }, [spanSearchQueryBuilderProviderProps]);
+  }, [queryingEnhancementsEnabled, spanSearchQueryBuilderProviderProps]);
 
   return (
     <SearchQueryBuilderProvider {...searchQueryBuilderProviderProps}>


### PR DESCRIPTION
Conversation search now offers scoped fields such as `conversation.totalCost`, `conversation.totalTokens`, and related conversation aggregates. Each field uses its matching value type, so duration, count, and currency filters get correct operators and defaults.

Land #124010 first so every prefixed query is accepted before this UI deploys.
