### PR TITLE
feat(conversations): Add conversation aliases

### DIFF
--- a/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.spec.tsx
@@ -141,6 +141,29 @@ describe('ConversationsChart', () => {
     });
   });
 
+  it('disables the chart for conversation alias filters', () => {
+    render(<ConversationsChart />, {
+      organization,
+      initialRouterConfig: {
+        location: {
+          pathname: '/',
+          query: {
+            chartCollapsed: 'true',
+            query: 'conversation.totalCost:>10 conversation.errors:>0',
+          },
+        },
+      },
+    });
+
+    expect(
+      screen.getByText(
+        'Remove these conversation-level filters to view chart data: conversation.totalCost, conversation.errors'
+      )
+    ).toBeInTheDocument();
+    expect(timeseriesRequest).not.toHaveBeenCalled();
+    expect(screen.queryByRole('button', {name: 'Chart actions'})).not.toBeInTheDocument();
+  });
+
   it('shows an empty state when there is no data', async () => {
     MockApiClient.clearMockResponses();
     MockApiClient.addMockResponse({

--- a/static/app/views/explore/conversations/components/conversationsChart.tsx
+++ b/static/app/views/explore/conversations/components/conversationsChart.tsx
@@ -12,6 +12,8 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 import Feature from 'sentry/components/acl/feature';
 import {DropdownMenu, type MenuItemProps} from 'sentry/components/dropdownMenu';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {parseSearch, Token} from 'sentry/components/searchSyntax/parser';
+import {getKeyName} from 'sentry/components/searchSyntax/utils';
 import {IconClock, IconContract, IconEllipsis, IconExpand, IconGraph} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {NewQuery} from 'sentry/types/organization';
@@ -42,6 +44,7 @@ import {Line} from 'sentry/views/dashboards/widgets/timeSeriesWidget/plottables/
 import {TimeSeriesWidgetVisualization} from 'sentry/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization';
 import {Widget} from 'sentry/views/dashboards/widgets/widget/widget';
 import {handleAddQueryToDashboard} from 'sentry/views/discover/utils';
+import {CONVERSATION_FIELDS} from 'sentry/views/explore/conversations/hooks/useConversations';
 import {Referrer} from 'sentry/views/explore/conversations/utils/referrers';
 import {getAlertsUrl} from 'sentry/views/insights/common/utils/getAlertsUrl';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
@@ -50,6 +53,23 @@ import {SpanFields} from 'sentry/views/insights/types';
 
 const CONVERSATION_SPANS_FILTER = `has:${SpanFields.GEN_AI_CONVERSATION_ID}`;
 const AI_CLIENT_FILTER = `${SpanFields.GEN_AI_OPERATION_TYPE}:ai_client`;
+const CONVERSATION_ALIAS_KEYS = new Set<string>(
+  Object.values(CONVERSATION_FIELDS).map(field => field.key)
+);
+
+function getConversationAliasFilters(query: string): string[] {
+  const aliases = new Set<string>();
+  for (const token of parseSearch(query, {flattenParenGroups: true}) ?? []) {
+    if (token.type !== Token.FILTER) {
+      continue;
+    }
+    const key = getKeyName(token.key);
+    if (CONVERSATION_ALIAS_KEYS.has(key)) {
+      aliases.add(key);
+    }
+  }
+  return [...aliases];
+}
 
 const CHART_VISUALIZATIONS = {
   chats: {
@@ -114,12 +134,15 @@ export function ConversationsChart() {
 
   const {label, yAxis, filter} = CHART_VISUALIZATIONS[visualization];
   const query = useCombinedQuery(filter);
+  const conversationAliasFilters = getConversationAliasFilters(query);
+  const chartDisabled = conversationAliasFilters.length > 0;
 
   const {data, isPending, error} = useFetchSpanTimeSeries(
     {
       yAxis: [yAxis],
       query,
       interval,
+      enabled: chartDisabled ? false : undefined,
     },
     Referrer.CHART
   );
@@ -143,6 +166,26 @@ export function ConversationsChart() {
     CHART_TYPE_OPTIONS.find(option => option.value === chartType)?.label ?? '';
   const intervalLabel =
     intervalOptions.find(option => option.value === interval)?.label ?? interval;
+
+  if (chartDisabled) {
+    return (
+      <Widget
+        Title={<Widget.WidgetTitle title={label} />}
+        Visualization={
+          <Container position="absolute" inset={0}>
+            <Widget.WidgetError
+              error={t(
+                'Remove these conversation-level filters to view chart data: %s',
+                conversationAliasFilters.join(', ')
+              )}
+            />
+          </Container>
+        }
+        height={195}
+        revealActions="always"
+      />
+    );
+  }
 
   const visualizationSelect = (
     <CompactSelect

--- a/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.spec.tsx
@@ -256,7 +256,7 @@ describe('ConversationsTable', () => {
       expect(request).toHaveBeenCalledWith(
         `/organizations/${sortingOrganization.slug}/agents/conversations/`,
         expect.objectContaining({
-          query: expect.objectContaining({sort: ['-totalCost']}),
+          query: expect.objectContaining({sort: ['-conversation.totalCost']}),
         })
       )
     );

--- a/static/app/views/explore/conversations/components/conversationsTable.tsx
+++ b/static/app/views/explore/conversations/components/conversationsTable.tsx
@@ -36,6 +36,7 @@ import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjectFromId} from 'sentry/utils/useProjectFromId';
 import {useConversationDirectHitRedirect} from 'sentry/views/explore/conversations/hooks/useConversationDirectHitRedirect';
 import {
+  CONVERSATION_FIELDS,
   useConversations,
   type Conversation,
   type ConversationSortField,
@@ -94,11 +95,11 @@ const COLUMN_DEFAULTS: Record<ColumnKey, {name: string; width: number}> = {
 const RIGHT_ALIGNED_COLUMNS = new Set<ColumnKey>(['age']);
 
 const SORT_FIELD_BY_COLUMN: Partial<Record<ColumnKey, ConversationSortField>> = {
-  duration: 'generationDuration',
-  messages: 'llmCalls',
-  errors: 'errors',
-  cost: 'totalCost',
-  age: 'age',
+  duration: CONVERSATION_FIELDS.generationDuration.key,
+  messages: CONVERSATION_FIELDS.messages.key,
+  errors: CONVERSATION_FIELDS.errors.key,
+  cost: CONVERSATION_FIELDS.totalCost.key,
+  age: CONVERSATION_FIELDS.age.key,
 };
 
 // Persisted per-column widths. Only the widths are stored, keyed by column:

--- a/static/app/views/explore/conversations/hooks/useConversations.tsx
+++ b/static/app/views/explore/conversations/hooks/useConversations.tsx
@@ -4,7 +4,9 @@ import {parseAsStringLiteral, useQueryState} from 'nuqs';
 
 import {normalizeDateTimeParams} from 'sentry/components/pageFilters/parse';
 import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {t} from 'sentry/locale';
 import {apiOptions, selectJsonWithHeaders} from 'sentry/utils/api/apiOptions';
+import {FieldValueType} from 'sentry/utils/fields';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useCombinedQuery} from 'sentry/views/insights/pages/agents/hooks/useCombinedQuery';
 import {useTableCursor} from 'sentry/views/insights/pages/agents/hooks/useTableCursor';
@@ -55,15 +57,76 @@ interface ConversationApiResponse extends Omit<
 
 const CONVERSATION_LIST_PER_PAGE = 50;
 
-const CONVERSATION_SORT_FIELDS = [
-  'age',
-  'generationDuration',
-  'llmCalls',
-  'errors',
-  'totalCost',
-] as const;
+export const CONVERSATION_FIELDS = {
+  age: {
+    key: 'conversation.age',
+    valueType: FieldValueType.DATE,
+    description: t("Time of the conversation's latest span."),
+    sortable: true,
+  },
+  duration: {
+    key: 'conversation.duration',
+    valueType: FieldValueType.DURATION,
+    description: t('Combined duration of all AI spans.'),
+  },
+  generationDuration: {
+    key: 'conversation.generationDuration',
+    valueType: FieldValueType.DURATION,
+    description: t('Combined duration of all LLM calls.'),
+    sortable: true,
+  },
+  errors: {
+    key: 'conversation.errors',
+    valueType: FieldValueType.INTEGER,
+    description: t('Number of failed spans.'),
+    sortable: true,
+  },
+  messages: {
+    key: 'conversation.messages',
+    valueType: FieldValueType.INTEGER,
+    description: t('Number of LLM calls.'),
+    sortable: true,
+  },
+  toolCalls: {
+    key: 'conversation.toolCalls',
+    valueType: FieldValueType.INTEGER,
+    description: t('Number of tool calls.'),
+  },
+  totalTokens: {
+    key: 'conversation.totalTokens',
+    valueType: FieldValueType.INTEGER,
+    description: t('Total tokens used by LLM calls.'),
+  },
+  inputTokens: {
+    key: 'conversation.inputTokens',
+    valueType: FieldValueType.INTEGER,
+    description: t('Input tokens used by LLM calls.'),
+  },
+  outputTokens: {
+    key: 'conversation.outputTokens',
+    valueType: FieldValueType.INTEGER,
+    description: t('Output tokens used by LLM calls.'),
+  },
+  totalCost: {
+    key: 'conversation.totalCost',
+    valueType: FieldValueType.CURRENCY,
+    description: t('Total cost of LLM calls.'),
+    sortable: true,
+  },
+  toolErrors: {
+    key: 'conversation.toolErrors',
+    valueType: FieldValueType.INTEGER,
+    description: t('Number of failed tool calls.'),
+  },
+} as const;
 
-export type ConversationSortField = (typeof CONVERSATION_SORT_FIELDS)[number];
+type ConversationField = (typeof CONVERSATION_FIELDS)[keyof typeof CONVERSATION_FIELDS];
+type SortableConversationField = Extract<ConversationField, {sortable: true}>;
+export type ConversationSortField = SortableConversationField['key'];
+
+const CONVERSATION_SORT_FIELDS = Object.values(CONVERSATION_FIELDS)
+  .filter((field): field is SortableConversationField => 'sortable' in field)
+  .map(field => field.key);
 
 const CONVERSATION_SORTS = CONVERSATION_SORT_FIELDS.flatMap(field => [
   field,
@@ -88,7 +151,9 @@ export function useConversations() {
   );
   const [sort, setSort] = useQueryState(
     'sort',
-    parseAsStringLiteral(CONVERSATION_SORTS).withDefault('-age')
+    parseAsStringLiteral(CONVERSATION_SORTS).withDefault(
+      `-${CONVERSATION_FIELDS.age.key}`
+    )
   );
 
   const {

--- a/static/app/views/explore/conversations/overview.spec.tsx
+++ b/static/app/views/explore/conversations/overview.spec.tsx
@@ -1,0 +1,109 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {TimeSeriesFixture} from 'sentry-fixture/timeSeries';
+
+import {render, screen, userEvent} from 'sentry-test/reactTestingLibrary';
+
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
+
+import ConversationsOverviewPage from './overview';
+
+const organization = OrganizationFixture({
+  features: ['gen-ai-conversations', 'gen-ai-conversations-querying-enhancements'],
+});
+
+describe('ConversationsOverviewPage', () => {
+  beforeEach(() => {
+    PageFiltersStore.init();
+    localStorage.setItem(
+      `conversations:projects-with-data:${organization.slug}`,
+      JSON.stringify([-1])
+    );
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events/`,
+      body: {data: []},
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/events-timeseries/`,
+      body: {
+        timeSeries: [
+          TimeSeriesFixture({
+            yAxis: 'count_unique(gen_ai.conversation.id)',
+            meta: {valueType: 'number', valueUnit: null, interval: 1_800_000},
+          }),
+        ],
+      },
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/agents/conversations/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/trace-items/attributes/`,
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      body: [],
+    });
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    MockApiClient.clearMockResponses();
+  });
+
+  it('prefers recent filters when available', async () => {
+    MockApiClient.addMockResponse({
+      url: `/organizations/${organization.slug}/recent-searches/`,
+      body: [{query: 'span.op:http'}],
+    });
+    render(<ConversationsOverviewPage />, {organization});
+
+    await userEvent.click(
+      await screen.findByRole('combobox', {name: 'Add a search term'})
+    );
+
+    expect(await screen.findByTestId('recent-filter-key')).toHaveTextContent('span.op');
+  });
+
+  it('offers conversation aggregate aliases as filters', async () => {
+    render(<ConversationsOverviewPage />, {organization});
+
+    await userEvent.click(
+      await screen.findByRole('combobox', {name: 'Add a search term'})
+    );
+
+    const aliases = [
+      'conversation.age',
+      'conversation.duration',
+      'conversation.generationDuration',
+      'conversation.errors',
+      'conversation.messages',
+      'conversation.toolCalls',
+      'conversation.totalTokens',
+      'conversation.inputTokens',
+      'conversation.outputTokens',
+      'conversation.totalCost',
+      'conversation.toolErrors',
+    ];
+    const options = await screen.findAllByRole('option');
+
+    aliases.forEach((alias, index) => {
+      expect(options[index]).toHaveAccessibleName(alias);
+    });
+
+    await userEvent.keyboard('{ArrowDown}');
+    expect(
+      await screen.findByText("Time of the conversation's latest span.")
+    ).toBeInTheDocument();
+
+    await userEvent.click(
+      screen.getByRole('option', {name: 'conversation.generationDuration'})
+    );
+    expect(
+      await screen.findByRole('row', {
+        name: 'conversation.generationDuration:>10ms',
+      })
+    ).toBeInTheDocument();
+  });
+});

--- a/static/app/views/explore/conversations/overview.tsx
+++ b/static/app/views/explore/conversations/overview.tsx
@@ -16,7 +16,9 @@ import {
 import type {GetTagValues} from 'sentry/components/searchQueryBuilder';
 import {SearchQueryBuilderProvider} from 'sentry/components/searchQueryBuilder/context';
 import {t} from 'sentry/locale';
+import type {TagCollection} from 'sentry/types/group';
 import {trackAnalytics} from 'sentry/utils/analytics';
+import {FieldKind, type FieldDefinition} from 'sentry/utils/fields';
 import {useDatePageFilterProps} from 'sentry/utils/useDatePageFilterProps';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {
@@ -28,7 +30,10 @@ import {ConversationMissingMessagesAlert} from 'sentry/views/explore/conversatio
 import {ConversationsChart} from 'sentry/views/explore/conversations/components/conversationsChart';
 import {ConversationsTable} from 'sentry/views/explore/conversations/components/conversationsTable';
 import {SaveConversationQueryButton} from 'sentry/views/explore/conversations/components/saveConversationQueryButton';
-import {useConversations} from 'sentry/views/explore/conversations/hooks/useConversations';
+import {
+  CONVERSATION_FIELDS,
+  useConversations,
+} from 'sentry/views/explore/conversations/hooks/useConversations';
 import {useShowConversationOnboarding} from 'sentry/views/explore/conversations/hooks/useShowConversationOnboarding';
 import {ConversationOnboarding} from 'sentry/views/explore/conversations/onboarding';
 import {MAX_PICKABLE_DAYS} from 'sentry/views/explore/conversations/settings';
@@ -40,8 +45,34 @@ import {
   TableUrlParams,
 } from 'sentry/views/insights/pages/agents/utils/urlParams';
 
+const CONVERSATION_FIELD_DEFINITIONS: Record<string, FieldDefinition> =
+  Object.fromEntries(
+    Object.values(CONVERSATION_FIELDS).map(({key, valueType, description}) => [
+      key,
+      {
+        kind: FieldKind.FIELD,
+        valueType,
+        desc: description,
+      },
+    ])
+  );
+
+const CONVERSATION_FILTER_KEYS: TagCollection = Object.fromEntries(
+  Object.values(CONVERSATION_FIELDS).map(({key}) => [
+    key,
+    {
+      key,
+      name: key,
+      kind: FieldKind.MEASUREMENT,
+    },
+  ])
+);
+
 function ConversationsOverviewPage() {
   const organization = useOrganization();
+  const queryingEnhancementsEnabled = organization.features.includes(
+    'gen-ai-conversations-querying-enhancements'
+  );
   const datePageFilterProps = useDatePageFilterProps({
     maxPickableDays: MAX_PICKABLE_DAYS,
     maxUpgradableDays: MAX_PICKABLE_DAYS,
@@ -130,11 +161,34 @@ function ConversationsOverviewPage() {
       );
     };
 
+    if (!queryingEnhancementsEnabled) {
+      return {
+        ...spanSearchQueryBuilderProviderProps,
+        getTagValues: getTagValuesWithoutCounts,
+      };
+    }
+
+    const fieldDefinitionGetter =
+      spanSearchQueryBuilderProviderProps.fieldDefinitionGetter;
     return {
       ...spanSearchQueryBuilderProviderProps,
+      filterKeys: {
+        ...spanSearchQueryBuilderProviderProps.filterKeys,
+        ...CONVERSATION_FILTER_KEYS,
+      },
+      filterKeySections: [
+        {
+          value: 'conversation',
+          label: t('Conversation'),
+          children: Object.keys(CONVERSATION_FILTER_KEYS),
+        },
+        ...spanSearchQueryBuilderProviderProps.filterKeySections,
+      ],
+      fieldDefinitionGetter: (key: string, options?: {kind?: FieldKind}) =>
+        CONVERSATION_FIELD_DEFINITIONS[key] ?? fieldDefinitionGetter(key, options),
       getTagValues: getTagValuesWithoutCounts,
     };
-  }, [spanSearchQueryBuilderProviderProps]);
+  }, [queryingEnhancementsEnabled, spanSearchQueryBuilderProviderProps]);
 
   return (
     <SearchQueryBuilderProvider {...searchQueryBuilderProviderProps}>


### PR DESCRIPTION
Conversation search now offers conversation-scoped fields such as `conversation.messages`, `conversation.totalCost`, and `conversation.totalTokens`, with descriptions and matching value types. Table sorting uses the same field names as search.

Charts stop fetching when these conversation-level filters are active and list the filters to remove. The timeseries endpoint evaluates spans rather than grouped conversations, so chart results would otherwise use different semantics from the conversation list.

Backend support for the conversation aliases landed in #124013. Compatibility support for `conversation.messages` landed in #124152.
