### PR TITLE
chore(deps): Bump @sentry/conventions to 0.22.0

### DIFF
--- a/build-utils/ts-extract-gettext.ts
+++ b/build-utils/ts-extract-gettext.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs/promises';
 import path, {resolve} from 'node:path'; // Added for module check
 import {fileURLToPath} from 'node:url';
 
-import {ATTRIBUTE_SEARCH_METADATA} from '@sentry/conventions';
+import {ATTRIBUTE_SEARCH_METADATA} from '@sentry/conventions/attributes/search';
 import {po} from 'gettext-parser';
 import type {GetTextTranslation, GetTextTranslations} from 'gettext-parser';
 import {glob} from 'tinyglobby';
@@ -225,7 +225,7 @@ function extractBriefsFromAttributeMetadata(
       msgid: brief,
       msgstr: [''],
       comments: {
-        extracted: `Attribute \`${attributeName}\` metadata description from @sentry/conventions`,
+        extracted: `Attribute \`${attributeName}\` metadata description from @sentry/conventions/attributes/search`,
       },
     };
 

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "@sentry-internal/rrweb-player": "2.41.0",
     "@sentry-internal/rrweb-snapshot": "2.41.0",
     "@sentry/browser": "11.0.0-beta.2",
-    "@sentry/conventions": "^0.21.0",
+    "@sentry/conventions": "^0.22.0",
     "@sentry/core": "11.0.0-beta.2",
     "@sentry/node": "11.0.0-beta.2",
     "@sentry/react": "11.0.0-beta.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,8 +195,8 @@ importers:
         specifier: 11.0.0-beta.2
         version: 11.0.0-beta.2
       '@sentry/conventions':
-        specifier: ^0.21.0
-        version: 0.21.0
+        specifier: ^0.22.0
+        version: 0.22.0
       '@sentry/core':
         specifier: 11.0.0-beta.2
         version: 11.0.0-beta.2
@@ -3204,8 +3204,8 @@ packages:
     resolution: {integrity: sha512-nAL3tL+xgom6Dbuxq0NCEZZfBNIrUspjDJRcMMRl3WLiBCSeZzNCa7an48IpnrZoVMpAi2NQ2v9rFU+EQziKuQ==}
     engines: {node: '>=14'}
 
-  '@sentry/conventions@0.21.0':
-    resolution: {integrity: sha512-JS+FGO/WsCzbtJWXGCpqCDon51aQMIcYlPe0XIzfP51vzILZMJr/QgvbuKmKG8sNVR3+i6GrGAN3GFXQCTZhHQ==}
+  '@sentry/conventions@0.22.0':
+    resolution: {integrity: sha512-5YerRXch4//zimh04JTJwk8G4754DRXk0U88h4uKGh6aNlAcltUthmlt27jNu1QgXwgtbuH/DhFiIdrgoF6ipw==}
     engines: {node: '>=14'}
 
   '@sentry/core@11.0.0-beta.2':
@@ -11415,7 +11415,7 @@ snapshots:
 
   '@sentry/conventions@0.20.0': {}
 
-  '@sentry/conventions@0.21.0': {}
+  '@sentry/conventions@0.22.0': {}
 
   '@sentry/core@11.0.0-beta.2':
     dependencies:

--- a/static/app/components/seer/markdown/embeds/renderTracking.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/renderTracking.spec.tsx
@@ -1,4 +1,4 @@
-import {GEN_AI_CONVERSATION_ID} from '@sentry/conventions/attributes';
+import {SEARCH_GEN_AI__CONVERSATION__ID} from '@sentry/conventions/attributes/search';
 import * as Sentry from '@sentry/react';
 
 import {render} from 'sentry-test/reactTestingLibrary';
@@ -51,7 +51,7 @@ describe('seer embed render tracking', () => {
         'seer_embed.level': 'inline',
         'seer_embed.index': 0,
         'seer_embed.surface': 'seer_explorer',
-        [GEN_AI_CONVERSATION_ID]: current.conversationId,
+        [SEARCH_GEN_AI__CONVERSATION__ID]: current.conversationId,
         'seer_embed.conversation_id': current.conversationId,
         'seer_embed.message_id': 'block-1',
         'seer_embed.message_key': `${current.conversationId}:block-1`,

--- a/static/app/components/seer/markdown/embeds/renderTracking.tsx
+++ b/static/app/components/seer/markdown/embeds/renderTracking.tsx
@@ -1,5 +1,5 @@
 import {createContext, useContext, useEffect} from 'react';
-import {GEN_AI_CONVERSATION_ID} from '@sentry/conventions/attributes';
+import {SEARCH_GEN_AI__CONVERSATION__ID} from '@sentry/conventions/attributes/search';
 import * as Sentry from '@sentry/react';
 
 /**
@@ -94,7 +94,7 @@ export function useTrackEmbedRendered({
       // The message has no such pair: `gen_ai.response.id` means the
       // provider's completion id, not a Seer block id, so writing a block id
       // there would put two meanings behind one key.
-      [GEN_AI_CONVERSATION_ID]: scope.conversationId,
+      [SEARCH_GEN_AI__CONVERSATION__ID]: scope.conversationId,
       'seer_embed.conversation_id': scope.conversationId,
       'seer_embed.message_id': scope.messageId,
       // Pre-composed because the query layer cannot concatenate attributes:

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -403,7 +403,7 @@ function gettextComponentTemplate(
 
 /**
  * Translates a string without formatting support. Used for translating
- * pre-extracted strings like attribute descriptions from @sentry/conventions.
+ * pre-extracted strings like attribute descriptions from @sentry/conventions/attributes/search.
  * This function is intentionally not included in the gettext extraction script.
  */
 function gettextDescription(string: string): string {

--- a/static/app/utils/fields/getAttributeValue.ts
+++ b/static/app/utils/fields/getAttributeValue.ts
@@ -1,4 +1,5 @@
-import {ATTRIBUTE_SEARCH_METADATA, type AttributeValue} from '@sentry/conventions';
+import type {AttributeValue} from '@sentry/conventions/attributes';
+import {ATTRIBUTE_SEARCH_METADATA} from '@sentry/conventions/attributes/search';
 
 const TYPED_TAG_KEY_RE = /tags\[(\S*),(\S*)\]/;
 const ATTRIBUTE_DEPRECATION_CHAIN_BY_KEY = new Map<

--- a/static/app/utils/fields/index.ts
+++ b/static/app/utils/fields/index.ts
@@ -1,4 +1,4 @@
-import {ATTRIBUTE_SEARCH_METADATA} from '@sentry/conventions';
+import {ATTRIBUTE_SEARCH_METADATA} from '@sentry/conventions/attributes/search';
 
 import {t, td} from 'sentry/locale';
 import {

--- a/static/oxlint/eslintPluginSentry/noStaticTranslations.ts
+++ b/static/oxlint/eslintPluginSentry/noStaticTranslations.ts
@@ -11,7 +11,7 @@ export const noStaticTranslations = ESLintUtils.RuleCreator.withoutDocs({
     schema: [],
     messages: {
       forbidden:
-        'td() must use ATTRIBUTE_SEARCH_METADATA[key].brief from @sentry/conventions',
+        'td() must use ATTRIBUTE_SEARCH_METADATA[key].brief from @sentry/conventions/attributes/search',
     },
   },
 


### PR DESCRIPTION
`@sentry/conventions` 0.22.0 no longer re-exports `ATTRIBUTE_SEARCH_METADATA` from the package root. Search metadata, gettext extraction, and the `td()` lint now import from `@sentry/conventions/attributes/search`, and Seer embed render tracking uses the search conversation-id name. Attribute value types still come from `/attributes`.
