### PR TITLE
docs(pageFilters): Document and test extractSelectionParameters

### DIFF
--- a/static/app/components/pageFilters/parse.spec.tsx
+++ b/static/app/components/pageFilters/parse.spec.tsx
@@ -1,4 +1,6 @@
+import {URL_PARAM} from 'sentry/components/pageFilters/constants';
 import {
+  extractSelectionParameters,
   normalizeDateTimeParams,
   parseStatsPeriod,
 } from 'sentry/components/pageFilters/parse';
@@ -240,5 +242,44 @@ describe('parseStatsPeriod', () => {
         {allowAbsoluteDatetime: false}
       )
     ).toEqual({statsPeriod: '14d'});
+  });
+});
+
+describe('extractSelectionParameters', () => {
+  const selection = {
+    project: ['1', '2'],
+    environment: 'production',
+    statsPeriod: '7d',
+    start: '2026-01-01T00:00:00',
+    end: '2026-01-08T00:00:00',
+    utc: 'true',
+  };
+
+  it('extracts every page filter key and nothing else', () => {
+    expect(
+      extractSelectionParameters({...selection, cursor: '0:0:1', query: 'is:unresolved'})
+    ).toEqual(selection);
+  });
+
+  it('covers exactly the keys in URL_PARAM', () => {
+    // Guards against a seventh page filter being added to URL_PARAM without
+    // callers of this helper learning to forward it.
+    expect(Object.keys(extractSelectionParameters(selection)).sort()).toEqual(
+      Object.values(URL_PARAM).sort()
+    );
+  });
+
+  it('drops empty values so they do not travel as blank params', () => {
+    expect(
+      extractSelectionParameters({
+        project: ['1'],
+        environment: '',
+        statsPeriod: undefined,
+      })
+    ).toEqual({project: ['1']});
+  });
+
+  it('returns an empty query when nothing is selected', () => {
+    expect(extractSelectionParameters({})).toEqual({});
   });
 });

--- a/static/app/components/pageFilters/parse.tsx
+++ b/static/app/components/pageFilters/parse.tsx
@@ -325,9 +325,34 @@ export function getStateFromQuery(
 }
 
 /**
- * Extract the page filter parameters from an object
- * Useful for extracting page filter properties from the current URL
- * when building another URL.
+ * Extract the page filter parameters — project, environment, and the datetime
+ * triple — from a location query, for building a link that should carry the
+ * current selection.
+ *
+ * Linking to a bare pathname does *not* keep the selection. `PageFiltersContainer`
+ * reconciles its store against the URL on navigation, and an absent `project`
+ * reads as an empty selection rather than "unchanged", so the filters clear.
+ * Spread this into the link's `query` to carry them across.
+ *
+ * Spread your own keys after it to override one. Setting a key to `undefined`
+ * clears it, which is how a relative period replaces an absolute range — send
+ * `statsPeriod` and clear `start`/`end`, or both travel and the destination
+ * picks one.
+ *
+ * @example
+ * to: {pathname: base, query: extractSelectionParameters(location.query)}
+ *
+ * @example
+ * // carry project and environment, but force the destination's default period
+ * to: {
+ *   pathname: base,
+ *   query: {
+ *     ...extractSelectionParameters(location.query),
+ *     statsPeriod: '24h',
+ *     start: undefined,
+ *     end: undefined,
+ *   },
+ * }
  */
 export function extractSelectionParameters(query: Location['query']) {
   return pickBy(pick(query, Object.values(URL_PARAM)), identity);


### PR DESCRIPTION
`extractSelectionParameters` is used at 23 call sites across 18 files. It had no tests, and a two-line comment that said what it returns but not why you would reach for it.

The part worth writing down is the bit nobody can guess: **linking to a bare pathname does not leave the page-filter selection alone.** `PageFiltersContainer` reconciles its store against the URL on navigation, and an absent `project` reads as an *empty selection* rather than "unchanged" — so the filters clear. Nothing about writing `to: somePathname` suggests that.

The docstring now covers that, plus how to override a single key, and why sending a relative period means also clearing `start`/`end` — otherwise both travel and the destination picks one.

Tests cover the six forwarded keys, that everything else is dropped, and that empty values don't travel as blank params. One asserts the returned keys match `Object.values(URL_PARAM)`, so adding a seventh page filter fails here rather than being silently unforwarded.

No behaviour change.

### What this replaced

An earlier revision of this PR added a `pageFilterQuery(query, overrides)` wrapper. Review pushed back that the diff at the converted call site looked functionally identical to the spread it replaced, and that was right — the only thing the wrapper really bought was type-checked override keys, which didn't justify a new export. The knowledge was the valuable part, and putting it on the existing helper reaches the 23 current call sites instead of only future ones.