### PR TITLE
chore(metrics): Remove New badges from navigation and Explore

### DIFF
--- a/static/app/views/explore/metrics/content.tsx
+++ b/static/app/views/explore/metrics/content.tsx
@@ -1,6 +1,5 @@
 import {Fragment} from 'react';
 
-import {FeatureBadge} from '@sentry/scraps/badge';
 import {Stack} from '@sentry/scraps/layout';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
@@ -121,7 +120,6 @@ function MetricsHeader() {
         ) : (
           title || METRICS_TITLE
         )}
-        <FeatureBadge type="new" />
         {titleTooltip}
       </TopBar.Slot>
       <TopBar.Slot name="feedback">

--- a/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
+++ b/static/app/views/navigation/secondary/sections/explore/exploreSecondaryNavigation.tsx
@@ -44,7 +44,7 @@ function ExploreSecondaryNavigationImpl() {
     navItems.push({label: 'Logs', to: `${baseUrl}/logs/`});
   }
   if (organization.features.includes('tracemetrics-enabled')) {
-    navItems.push({label: 'Metrics', badge: 'new', to: `${baseUrl}/metrics/`});
+    navItems.push({label: 'Metrics', to: `${baseUrl}/metrics/`});
   }
   if (organization.features.includes('explore-errors')) {
     navItems.push({label: 'Errors', badge: 'alpha', to: `${baseUrl}/errors-v2/`});
@@ -125,7 +125,6 @@ function ExploreSecondaryNavigationImpl() {
                 <SecondaryNavigation.Link
                   to={`${baseUrl}/metrics/`}
                   analyticsItemName="explore_metrics"
-                  trailingItems={<FeatureBadge type="new" />}
                 >
                   {t('Metrics')}
                 </SecondaryNavigation.Link>


### PR DESCRIPTION
Remove the “New” badge from Metrics in the Explore side navigation and from the Application Metrics page header. Update the navigation metadata to match the displayed label.
