### PR TITLE
fix(proguard): left-align the mapping name under its header

### DIFF
--- a/static/app/views/settings/projectProguard/projectProguardRow.tsx
+++ b/static/app/views/settings/projectProguard/projectProguardRow.tsx
@@ -32,7 +32,7 @@ export function ProjectProguardRow({mapping, onDelete, downloadUrl, orgSlug}: Pr
 
   return (
     <SimpleTable.Row>
-      <SimpleTable.RowCell justify="center" align="start">
+      <SimpleTable.RowCell align="start">
         <Name>{debugId || uuid || `(${t('empty')})`}</Name>
         <TimeWrapper>
           <IconClock size="sm" />


### PR DESCRIPTION
The first cell of a ProGuard mapping row (Settings → [project] → ProGuard Mappings) is `justify="center"`, so the debug ID and its timestamp float in the middle of a very wide column while the "Mapping" header sits at the far left. Every row gets a large empty gutter and the header lines up with nothing underneath it.

Dropping `justify="center"` leaves the cell at its default `flex-start`, so the name starts where its header does.

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody><tr>
<td><img width="1629" height="342" alt="Mapping names centered under a left-aligned Mapping header" src="https://github.com/user-attachments/assets/cd81c416-2f8d-4613-9690-b300dcc39c41" /></td>
<td><img width="1640" height="342" alt="Mapping names left-aligned under the Mapping header" src="https://github.com/user-attachments/assets/22e3fb29-03ad-42ab-afbe-68ab542b51fe" /></td>
</tr></tbody>
</table>

Pre-existing on `master`; flagged by @priscilawebdev in https://github.com/getsentry/sentry/pull/123177#discussion_r3978642279.

Fixes DE-1594
