### PR TITLE
fix(similar-issues): stop truncating the score column headers

### DIFF
--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
@@ -16,11 +16,14 @@ import type {Project} from 'sentry/types/project';
 import {SimilarStackTraceItem, SimilarStackTraceItemSkeleton} from './item';
 import type {SimilarItem} from './types';
 
+// The count and score columns are sized by content rather than by a pixel width:
+// their cells are narrower than their own headers, so any width wide enough for
+// the English labels is still too narrow for the longer translations.
 const SIMILAR_ISSUE_COLUMNS: TableColumnConfig[] = [
   {key: 'merge', width: 'minmax(0, 1fr)'},
-  {key: 'events', width: '70px'},
-  {key: 'exception', width: '90px'},
-  {key: 'message', width: '90px'},
+  {key: 'events', width: 'max-content'},
+  {key: 'exception', width: 'max-content'},
+  {key: 'message', width: 'max-content'},
   {key: 'actions', width: '80px'},
 ];
 

--- a/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
+++ b/static/app/views/issueDetails/groupSimilarIssues/similarStackTrace/list.tsx
@@ -16,9 +16,6 @@ import type {Project} from 'sentry/types/project';
 import {SimilarStackTraceItem, SimilarStackTraceItemSkeleton} from './item';
 import type {SimilarItem} from './types';
 
-// The count and score columns are sized by content rather than by a pixel width:
-// their cells are narrower than their own headers, so any width wide enough for
-// the English labels is still too narrow for the longer translations.
 const SIMILAR_ISSUE_COLUMNS: TableColumnConfig[] = [
   {key: 'merge', width: 'minmax(0, 1fr)'},
   {key: 'events', width: 'max-content'},


### PR DESCRIPTION
In the Similar Issues drawer, the `Events` and `Exception` headers render as "Eve…" and "Except…" — at the drawer's widest, not just when it is squeezed. `Message` (shown when similarity embeddings are off) has the same problem.

`SIMILAR_ISSUE_COLUMNS` pinned those tracks to 70px and 90px. A header cell carries 16px of padding on each side, so a 70px track leaves 38px for a label that needs 47px, and a 90px track leaves 58px for one that needs 68px. The counts and score bars beneath are narrower still, so the columns looked roomy while the labels they were named for were the only thing that did not fit.

Sizing those tracks by content fits each header exactly (79px / 100px / 91px measured in the browser) and keeps fitting it for translations longer than the English labels, which any pixel width picked today would not.

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody><tr>
<td><img width="927" height="409" alt="Headers truncated to Eve… and Except…" src="https://github.com/user-attachments/assets/03b5fe9f-3c26-4343-b37a-05651f5a10d5" /></td>
<td><img width="927" height="409" alt="Headers reading Events and Exception in full" src="https://github.com/user-attachments/assets/e1d54fe2-888c-48e9-bfa7-5bdf40d7d86d" /></td>
</tr></tbody>
</table>

Both shots are the drawer at its default width, with the similarity response stubbed to synthetic issues.

Pre-existing on `master`; flagged by @priscilawebdev in https://github.com/getsentry/sentry/pull/123177#discussion_r3978642279.

Fixes DE-1596
