### PR TITLE
fix(scm-messaging): Persist and Busy Confirm and continue during project creation 

### DIFF
--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -83,10 +83,12 @@ function mockChannelValidate(valid: boolean, integrationId: string) {
 function renderPicker({
   eligibleIntegrations = [slackIntegration],
   existingSetup,
+  isContinuing,
   providerKey = 'slack',
 }: {
   eligibleIntegrations?: OrganizationIntegration[];
   existingSetup?: ScmMessagingSetup;
+  isContinuing?: boolean;
   providerKey?: ScmMessagingProviderKey;
 } = {}) {
   const onConfigured = jest.fn();
@@ -97,6 +99,7 @@ function renderPicker({
       providerKey={providerKey}
       onConfigured={onConfigured}
       existingSetup={existingSetup}
+      isContinuing={isContinuing}
     />,
     {organization}
   );
@@ -175,6 +178,16 @@ describe('ScmMessagingChannelPicker', () => {
       renderPicker({eligibleIntegrations: [slackIntegration]});
 
       expect(screen.getByRole('button', {name: 'Confirm and continue'})).toBeDisabled();
+    });
+
+    it('busies Confirm and continue while isContinuing', () => {
+      mockChannels('10', [slackChannel]);
+      renderPicker({eligibleIntegrations: [slackIntegration], isContinuing: true});
+
+      expect(screen.getByRole('button', {name: 'Confirm and continue'})).toHaveAttribute(
+        'aria-busy',
+        'true'
+      );
     });
   });
 

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.spec.tsx
@@ -83,7 +83,7 @@ function mockChannelValidate(valid: boolean, integrationId: string) {
 function renderPicker({
   eligibleIntegrations = [slackIntegration],
   existingSetup,
-  isContinuing,
+  isContinuing = false,
   providerKey = 'slack',
 }: {
   eligibleIntegrations?: OrganizationIntegration[];
@@ -180,7 +180,7 @@ describe('ScmMessagingChannelPicker', () => {
       expect(screen.getByRole('button', {name: 'Confirm and continue'})).toBeDisabled();
     });
 
-    it('busies Confirm and continue while isContinuing', () => {
+    it('busies the submit button while isContinuing', () => {
       mockChannels('10', [slackChannel]);
       renderPicker({eligibleIntegrations: [slackIntegration], isContinuing: true});
 
@@ -373,6 +373,7 @@ describe('ScmMessagingChannelPicker', () => {
           eligibleIntegrations={[slackIntegration, slackIntegration2]}
           providerKey="slack"
           onConfigured={onConfigured}
+          isContinuing={false}
         />,
         {organization}
       );
@@ -387,6 +388,7 @@ describe('ScmMessagingChannelPicker', () => {
           eligibleIntegrations={[slackIntegration]}
           providerKey="slack"
           onConfigured={onConfigured}
+          isContinuing={false}
         />
       );
 
@@ -419,6 +421,7 @@ describe('ScmMessagingChannelPicker', () => {
           providerKey="slack"
           onConfigured={onConfigured}
           existingSetup={selectedSlackSetup}
+          isContinuing={false}
         />,
         {organization}
       );
@@ -437,6 +440,7 @@ describe('ScmMessagingChannelPicker', () => {
           providerKey="slack"
           onConfigured={onConfigured}
           existingSetup={selectedSlackSetup}
+          isContinuing={false}
         />
       );
 
@@ -479,6 +483,7 @@ describe('ScmMessagingChannelPicker', () => {
             providerKey="slack"
             onConfigured={jest.fn()}
             existingSetup={selectedSlackSetup}
+            isContinuing={false}
           />
         </QueryClientProvider>,
         {organization}
@@ -517,6 +522,7 @@ describe('ScmMessagingChannelPicker', () => {
             eligibleIntegrations={[slackIntegration]}
             providerKey="slack"
             onConfigured={jest.fn()}
+            isContinuing={false}
           />
         </QueryClientProvider>,
         {organization}

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -28,12 +28,12 @@ export interface ScmMessagingChannelPickerProps {
    * can receive Issue Alert actions.
    */
   eligibleIntegrations: OrganizationIntegration[];
+  /** True while the parent is creating the project after a destination is saved. */
+  isContinuing: boolean;
   onConfigured: (setup: ScmMessagingSetup & {mode: 'selected'}) => void;
   providerKey: ScmMessagingProviderKey;
   /** Pre-seeds the channel selector when editing an existing destination. */
   existingSetup?: ScmMessagingSetup;
-  /** True while the parent is creating the project after Confirm and continue. */
-  isContinuing?: boolean;
   /** When provided a Cancel button is shown (e.g. in Edit mode). */
   onCancel?: () => void;
 }
@@ -44,7 +44,7 @@ export function ScmMessagingChannelPicker({
   onConfigured,
   existingSetup,
   providerKey,
-  isContinuing = false,
+  isContinuing,
 }: ScmMessagingChannelPickerProps) {
   const theme = useTheme();
   const {channelSelectedBy} = providerDetails[providerKey];

--- a/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingChannelPicker.tsx
@@ -32,6 +32,8 @@ export interface ScmMessagingChannelPickerProps {
   providerKey: ScmMessagingProviderKey;
   /** Pre-seeds the channel selector when editing an existing destination. */
   existingSetup?: ScmMessagingSetup;
+  /** True while the parent is creating the project after Confirm and continue. */
+  isContinuing?: boolean;
   /** When provided a Cancel button is shown (e.g. in Edit mode). */
   onCancel?: () => void;
 }
@@ -42,6 +44,7 @@ export function ScmMessagingChannelPicker({
   onConfigured,
   existingSetup,
   providerKey,
+  isContinuing = false,
 }: ScmMessagingChannelPickerProps) {
   const theme = useTheme();
   const {channelSelectedBy} = providerDetails[providerKey];
@@ -143,6 +146,9 @@ export function ScmMessagingChannelPicker({
     });
   };
 
+  const isConfirmDisabled =
+    !channel || !!channelError || isChannelLoading || isContinuing;
+
   return (
     <Container>
       <Stack gap="lg" padding="xl">
@@ -199,14 +205,15 @@ export function ScmMessagingChannelPicker({
         style={{borderRadius: `0 0 ${theme.radius.lg} ${theme.radius.lg}`}}
       >
         {onCancel && (
-          <Button size="sm" variant="link" onClick={onCancel}>
+          <Button size="sm" variant="link" disabled={isContinuing} onClick={onCancel}>
             {t('Cancel')}
           </Button>
         )}
         <Button
           size="sm"
           variant="primary"
-          disabled={!channel || !!channelError || isChannelLoading}
+          busy={isContinuing}
+          disabled={isConfirmDisabled}
           analyticsEventKey="onboarding.scm_messaging_confirm_and_continue_clicked"
           analyticsEventName="Onboarding: SCM Messaging Confirm And Continue Clicked"
           analyticsParams={{provider: providerKey}}

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow/index.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow/index.spec.tsx
@@ -154,6 +154,7 @@ function ControlledRow({
       onMessagingSetupChange={onMessagingSetupChange}
       renderChannelPicker={renderChannelPicker}
       isRefetchingIntegrations={isRefetchingIntegrations}
+      isContinuing={false}
     />
   );
 }
@@ -377,6 +378,7 @@ describe('ScmMessagingProviderRow', () => {
           onContinue={jest.fn()}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
+          isContinuing={false}
         />,
         {organization}
       );
@@ -399,6 +401,7 @@ describe('ScmMessagingProviderRow', () => {
           onContinue={jest.fn()}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
+          isContinuing={false}
         />
       );
 
@@ -434,6 +437,7 @@ describe('ScmMessagingProviderRow', () => {
           onContinue={jest.fn()}
           onInstallComplete={onInstallComplete}
           onMessagingSetupChange={jest.fn()}
+          isContinuing={false}
         />
       );
 
@@ -452,6 +456,7 @@ describe('ScmMessagingProviderRow', () => {
           onContinue={jest.fn()}
           onInstallComplete={onInstallComplete}
           onMessagingSetupChange={jest.fn()}
+          isContinuing={false}
           isRefetchingIntegrations
         />
       );
@@ -481,6 +486,7 @@ describe('ScmMessagingProviderRow', () => {
           onContinue={jest.fn()}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
+          isContinuing={false}
         />,
         {organization}
       );
@@ -498,6 +504,7 @@ describe('ScmMessagingProviderRow', () => {
           onContinue={jest.fn()}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
+          isContinuing={false}
           isRefetchingIntegrations
         />
       );
@@ -514,6 +521,7 @@ describe('ScmMessagingProviderRow', () => {
           onContinue={jest.fn()}
           onInstallComplete={jest.fn()}
           onMessagingSetupChange={jest.fn()}
+          isContinuing={false}
         />
       );
 

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow/index.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow/index.spec.tsx
@@ -663,8 +663,9 @@ describe('ScmMessagingProviderRow', () => {
       ).toBeInTheDocument();
     });
 
-    it('saves the setup and transitions to configured when onConfigured is called', async () => {
+    it('saves the setup and calls onContinue without closing the picker', async () => {
       const onMessagingSetupChange = jest.fn();
+      const onContinue = jest.fn();
       let capturedOnConfigured:
         | ((setup: ScmMessagingSetup & {mode: 'selected'}) => void)
         | undefined;
@@ -676,8 +677,9 @@ describe('ScmMessagingProviderRow', () => {
         }
       );
 
-      const {rerender} = renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+      renderRow(connectedSlack, UNCONFIGURED_SCM_MESSAGING_SETUP, {
         onMessagingSetupChange,
+        onContinue,
         renderChannelPicker,
       });
 
@@ -685,24 +687,9 @@ describe('ScmMessagingProviderRow', () => {
 
       act(() => capturedOnConfigured?.(selectedSlackSetup));
       expect(onMessagingSetupChange).toHaveBeenCalledWith(selectedSlackSetup);
-
-      // Simulate the parent updating the messagingSetup prop after the save.
-      rerender(
-        <ScmMessagingProviderRow
-          resolvedProvider={connectedSlack}
-          messagingSetup={selectedSlackSetup}
-          activeRow={null}
-          onActiveRowChange={jest.fn()}
-          onContinue={jest.fn()}
-          onInstallComplete={jest.fn()}
-          onMessagingSetupChange={onMessagingSetupChange}
-          renderChannelPicker={renderChannelPicker}
-        />
-      );
-
-      await waitFor(() =>
-        expect(screen.queryByText('channel-picker')).not.toBeInTheDocument()
-      );
+      expect(onContinue).toHaveBeenCalledTimes(1);
+      // Picker stays open — activeRow is not cleared so the step can unmount cleanly.
+      expect(screen.getByText('channel-picker')).toBeInTheDocument();
     });
   });
 

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow/index.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow/index.tsx
@@ -233,10 +233,9 @@ export function ScmMessagingProviderRow({
   const handleConfigured = useCallback(
     (setup: ScmMessagingSetup & {mode: 'selected'}) => {
       onMessagingSetupChange(setup);
-      onActiveRowChange(null);
       onContinue();
     },
-    [onMessagingSetupChange, onActiveRowChange, onContinue]
+    [onMessagingSetupChange, onContinue]
   );
 
   const errorMessage = getInstallErrorMessage(installState);

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow/index.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow/index.tsx
@@ -125,8 +125,8 @@ function getInstallErrorMessage(
 export interface ScmMessagingProviderRowProps {
   activeRow: ScmMessagingActiveRow;
   /**
-   * True while Confirm and continue is waiting on revalidation or project
-   * create. Required alongside `onContinue` so Confirm cannot stay idle.
+   * True while continue is waiting on revalidation or project create.
+   * Required alongside `onContinue` so the picker cannot stay idle.
    */
   isContinuing: boolean;
   messagingSetup: ScmMessagingSetup;

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow/index.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow/index.tsx
@@ -124,6 +124,11 @@ function getInstallErrorMessage(
 
 export interface ScmMessagingProviderRowProps {
   activeRow: ScmMessagingActiveRow;
+  /**
+   * True while Confirm and continue is waiting on revalidation or project
+   * create. Required alongside `onContinue` so Confirm cannot stay idle.
+   */
+  isContinuing: boolean;
   messagingSetup: ScmMessagingSetup;
   onActiveRowChange: (row: ScmMessagingActiveRow) => void;
   onContinue: () => void;
@@ -162,6 +167,7 @@ export function ScmMessagingProviderRow({
   onActiveRowChange,
   renderChannelPicker,
   isRefetchingIntegrations = false,
+  isContinuing,
   onContinue,
 }: ScmMessagingProviderRowProps) {
   const organization = useOrganization();
@@ -330,6 +336,7 @@ export function ScmMessagingProviderRow({
                   onCancel={handleCancelConfiguring}
                   onConfigured={handleConfigured}
                   existingSetup={isConfigured ? messagingSetup : undefined}
+                  isContinuing={isContinuing}
                 />
               )}
             </Container>

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -1100,7 +1100,7 @@ describe('ScmMessaging', () => {
       );
     });
 
-    it('Confirm and continue keeps siblings hidden and restores the footer when creation fails', async () => {
+    it('Confirm and continue keeps siblings and the footer hidden when creation fails', async () => {
       mockExclusiveSlackProviders();
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/slack-1/channels/',
@@ -1132,16 +1132,15 @@ describe('ScmMessaging', () => {
       await selectEvent.select(screen.getByLabelText('channel'), '#alerts');
       await userEvent.click(screen.getByRole('button', {name: 'Confirm and continue'}));
 
-      // activeRow clears after save; selected setup keeps siblings hidden and
-      // brings the footer back. The requested continue fails, so the step
-      // stays with the destination staged and Continue enabled for a retry.
+      // Picker stays open (activeRow is not cleared), so siblings remain hidden
+      // and the footer stays hidden. The requested continue fails, so the step
+      // stays with the destination staged for a retry from the picker.
       expect(screen.queryByText('discord')).not.toBeInTheDocument();
       expect(screen.queryByText('msteams')).not.toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Set up later'})).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Set up later'})
+      ).not.toBeInTheDocument();
       await waitFor(() => expect(createProjectRequest).toHaveBeenCalledTimes(1));
-      await waitFor(() =>
-        expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled()
-      );
       expect(onComplete).not.toHaveBeenCalled();
     });
 

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -125,8 +125,8 @@ export function ScmMessaging({
   );
 
   const isSubmitting = isCreating || submissionMode !== undefined;
-  // Confirm and continue stays on the picker through revalidation and create,
-  // so it must spin from the click — not only after submissionMode is set.
+  // The picker stays open through revalidation and create, so it must spin
+  // from the click — not only after submissionMode is set.
   const isContinuing = continueRequested || submissionMode === 'continue';
 
   // Continue creates the project and alert rules, so it must wait for a

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -125,6 +125,9 @@ export function ScmMessaging({
   );
 
   const isSubmitting = isCreating || submissionMode !== undefined;
+  // Confirm and continue stays on the picker through revalidation and create,
+  // so it must spin from the click — not only after submissionMode is set.
+  const isContinuing = continueRequested || submissionMode === 'continue';
 
   // Continue creates the project and alert rules, so it must wait for a
   // conclusively revalidated destination — not merely the absence of a
@@ -347,6 +350,7 @@ export function ScmMessaging({
                     activeRow={validatedActiveRow}
                     onActiveRowChange={setActiveRow}
                     isRefetchingIntegrations={isRefetchingIntegrations}
+                    isContinuing={isContinuing}
                     onContinue={requestContinue}
                   />
                 ))}


### PR DESCRIPTION
Confirm and continue no longer collapses into the Edit/Remove row before the next step; the picker stays open until the step unmounts (Edit/Remove only after Back). While the destination is revalidated and the project is created, Confirm stays busy/disabled like Continue, and isContinuing is required so that busy state cannot be dropped by accident.

<img width="827" height="464" alt="Screenshot 2026-09-10 at 10 00 37 AM" src="https://github.com/user-attachments/assets/595d74b4-382c-457e-b22d-1e3e83d9db01" />
