### PR TITLE
feat(ai-monitoring): add conversation project links

### DIFF
--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
@@ -10,6 +10,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 
 from sentry.ai_monitoring.conversation_titles import fetch_conversation_title
+from sentry.ai_monitoring.utils import (
+    ConversationProject,
+    get_conversation_url,
+    serialize_conversation_project,
+)
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
@@ -120,6 +125,8 @@ class AIConversationDetailsResponse(TypedDict):
 
     conversationId: str
     title: str | None
+    projects: list[ConversationProject]
+    webUrl: str
     spans: list[dict[str, Any]]
 
 
@@ -200,9 +207,19 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
             def on_results(spans: list[SpanRow]) -> AIConversationDetailsResponse:
                 self._repair_parent_links(spans, resolved_params, conversation_id)
                 self._annotate_issues(spans, resolved_params, organization)
+                # Treat conversations as single-project for now. Multi-project conversations are
+                # an edge case, so this response exposes only one of their projects.
+                project_id = next(
+                    (value for span in spans if isinstance(value := span.get("project.id"), int)),
+                    None,
+                )
+                projects_by_id = {project.id: project for project in resolved_params.projects}
+                project = projects_by_id.get(project_id)
                 return {
                     "conversationId": conversation_id,
                     "title": self._resolve_title(conversation_id, spans, organization),
+                    "projects": [serialize_conversation_project(project)] if project else [],
+                    "webUrl": get_conversation_url(organization, conversation_id, project_id),
                     "spans": spans,
                 }
 

--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
@@ -15,10 +15,13 @@ from sentry.ai_monitoring.conversation_query import compile_conversation_query
 from sentry.ai_monitoring.conversation_titles import fetch_conversation_titles
 from sentry.ai_monitoring.serializers import OrganizationAIConversationsSerializer
 from sentry.ai_monitoring.utils import (
+    ConversationProject,
     get_aggregated_first_input,
     get_aggregated_last_output,
+    get_conversation_url,
     get_first_input_message,
     get_last_output,
+    serialize_conversation_project,
     timestamp_to_float,
 )
 from sentry.api.api_owners import ApiOwner
@@ -61,7 +64,7 @@ class UserResponse(TypedDict):
     ip_address: str | None
 
 
-class AIConversationResponse(TypedDict):
+class AIConversationData(TypedDict):
     conversationId: str
     title: str | None
     projectId: int | None
@@ -83,6 +86,11 @@ class AIConversationResponse(TypedDict):
     user: UserResponse | None
     toolNames: list[str]
     toolErrors: int
+
+
+class AIConversationResponse(AIConversationData):
+    projects: list[ConversationProject]
+    webUrl: str
 
 
 # Matches a query that is exactly a single gen_ai.conversation.id filter, e.g.
@@ -168,7 +176,7 @@ def _build_conversation_response(
     title: str | None = None,
     generation_duration: float = 0,
     project_id: int | None = None,
-) -> AIConversationResponse:
+) -> AIConversationData:
     return {
         "conversationId": conv_id,
         "title": title,
@@ -318,9 +326,31 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         if not conversation_ids:
             return []
 
-        if use_single_query:
-            return self._get_conversations_data_single_query(snuba_params, conversation_ids)
-        return self._get_conversations_data(snuba_params, conversation_ids)
+        conversations = (
+            self._get_conversations_data_single_query(snuba_params, conversation_ids)
+            if use_single_query
+            else self._get_conversations_data(snuba_params, conversation_ids)
+        )
+
+        organization = snuba_params.organization
+        assert organization is not None
+        projects_by_id = {project.id: project for project in snuba_params.projects}
+        # Treat conversations as single-project for now. Multi-project conversations are
+        # an edge case, so this response exposes only one of their projects.
+        response: list[AIConversationResponse] = []
+        for conversation in conversations:
+            project_id = conversation["projectId"]
+            project = projects_by_id.get(project_id)
+            response.append(
+                {
+                    **conversation,
+                    "projects": [serialize_conversation_project(project)] if project else [],
+                    "webUrl": get_conversation_url(
+                        organization, conversation["conversationId"], project_id
+                    ),
+                }
+            )
+        return response
 
     @trace
     def _fetch_conversation_ids(
@@ -366,7 +396,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     @trace
     def _get_conversations_data(
         self, snuba_params: SnubaParams, conversation_ids: list[str]
-    ) -> list[AIConversationResponse]:
+    ) -> list[AIConversationData]:
         config = SearchResolverConfig(auto_fields=True, disable_aggregate_extrapolation=True)
         resolver = Spans.get_resolver(snuba_params, config)
 
@@ -475,12 +505,12 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
 
     def _build_conversations_from_aggregations(
         self, aggregations: EAPResponse
-    ) -> dict[str, AIConversationResponse]:
+    ) -> dict[str, AIConversationData]:
         with start_span(
             op="ai_conversations.build_from_aggregations",
             name="Build conversations from aggregations",
         ):
-            conversations_map: dict[str, AIConversationResponse] = {}
+            conversations_map: dict[str, AIConversationData] = {}
 
             for row in aggregations.get("data", []):
                 conv_id = row.get("gen_ai.conversation.id", "")
@@ -531,7 +561,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
 
     def _apply_enrichment(
         self,
-        conversations_map: dict[str, AIConversationResponse],
+        conversations_map: dict[str, AIConversationData],
         enrichment_data: EAPResponse,
     ) -> dict[str, set[int]]:
         """Apply enrichment data, returning the project ids each conversation spans."""
@@ -605,7 +635,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
 
     def _apply_first_last_io(
         self,
-        conversations_map: dict[str, AIConversationResponse],
+        conversations_map: dict[str, AIConversationData],
         first_last_io_data: EAPResponse,
     ) -> None:
         with start_span(
@@ -645,7 +675,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     @trace
     def _get_conversations_data_single_query(
         self, snuba_params: SnubaParams, conversation_ids: list[str]
-    ) -> list[AIConversationResponse]:
+    ) -> list[AIConversationData]:
         operation_filter = "has:gen_ai.operation.type"
         ai_client_filter = "gen_ai.operation.type:ai_client"
         results = Spans.run_table_query(
@@ -693,7 +723,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
             sampling_mode="HIGHEST_ACCURACY",
         )
 
-        conversations_map: dict[str, AIConversationResponse] = {}
+        conversations_map: dict[str, AIConversationData] = {}
         project_ids_by_conversation: dict[str, set[int]] = {}
         for row in results.get("data", []):
             conversation_id = str(row.get("gen_ai.conversation.id") or "")
@@ -743,7 +773,7 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     @trace
     def _apply_titles(
         self,
-        conversations_map: dict[str, AIConversationResponse],
+        conversations_map: dict[str, AIConversationData],
         project_ids_by_conversation: Mapping[str, set[int]],
     ) -> None:
         """Set each conversation's `title` from storage when present.

--- a/src/sentry/ai_monitoring/utils.py
+++ b/src/sentry/ai_monitoring/utils.py
@@ -1,6 +1,7 @@
 from collections.abc import Mapping
 from datetime import datetime
-from typing import Any
+from typing import Any, TypedDict
+from urllib.parse import quote, urlencode
 
 from sentry.ai_monitoring.message_normalizer import (
     FILTERED,
@@ -8,6 +9,31 @@ from sentry.ai_monitoring.message_normalizer import (
     normalize_to_messages,
     stringify_message_content,
 )
+from sentry.models.organization import Organization
+from sentry.models.project import Project
+
+
+class ConversationProject(TypedDict):
+    id: int
+    name: str
+    slug: str
+
+
+def serialize_conversation_project(project: Project) -> ConversationProject:
+    return {"id": project.id, "name": project.name, "slug": project.slug}
+
+
+def get_conversation_url(
+    organization: Organization,
+    conversation_id: str,
+    project_id: int | None = None,
+) -> str:
+    query = urlencode({"project": project_id}) if project_id is not None else None
+    return organization.absolute_url(
+        f"/organizations/{organization.slug}/explore/agents/conversations/"
+        f"{quote(conversation_id, safe='')}/",
+        query=query,
+    )
 
 
 def timestamp_to_float(value: Any) -> float:

--- a/src/sentry/apidocs/examples/ai_conversation_examples.py
+++ b/src/sentry/apidocs/examples/ai_conversation_examples.py
@@ -8,6 +8,8 @@ class AIConversationExamples:
             value={
                 "conversationId": "01JQZ4W8X7J2Q9B4R5M6N7P8T9",
                 "title": "Check San Francisco weather",
+                "projects": [{"id": 1, "name": "Weather Assistant", "slug": "weather-assistant"}],
+                "webUrl": "https://sentry.io/organizations/org-slug/explore/agents/conversations/01JQZ4W8X7J2Q9B4R5M6N7P8T9/?project=1",
                 "spans": [
                     {
                         "span_id": "a1b2c3d4e5f67890",
@@ -51,6 +53,10 @@ class AIConversationExamples:
                     "conversationId": "01JQZ4W8X7J2Q9B4R5M6N7P8T9",
                     "title": "Check San Francisco weather",
                     "projectId": 1,
+                    "projects": [
+                        {"id": 1, "name": "Weather Assistant", "slug": "weather-assistant"}
+                    ],
+                    "webUrl": "https://sentry.io/organizations/org-slug/explore/agents/conversations/01JQZ4W8X7J2Q9B4R5M6N7P8T9/?project=1",
                     "flow": ["Weather Assistant"],
                     "errors": 0,
                     "llmCalls": 2,

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -350,6 +350,11 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.status_code == 200
         assert response.data["conversationId"] == conversation_id
         assert response.data["title"] is None
+        assert response.data["projects"] == []
+        assert response.data["webUrl"].endswith(
+            f"/organizations/{self.organization.slug}/explore/agents/conversations/"
+            f"{conversation_id}/"
+        )
         assert response.data["spans"] == []
 
     def test_single_trace_conversation(self) -> None:
@@ -1115,8 +1120,17 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         response = self.do_request(conversation_id, query)
 
         assert response.status_code == 200
-        assert set(response.data) == {"conversationId", "title", "spans"}
+        assert set(response.data) == {
+            "conversationId",
+            "title",
+            "projects",
+            "webUrl",
+            "spans",
+        }
         assert response.data["conversationId"] == conversation_id
+        assert response.data["projects"] == [
+            {"id": self.project.id, "name": self.project.name, "slug": self.project.slug}
+        ]
         assert len(response.data["spans"]) == 1
 
     def test_returns_stored_title(self) -> None:
@@ -1237,6 +1251,10 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         assert response.status_code == 200
         assert len(response.data["spans"]) == 2
         assert response.data["title"] == "Started here"
+        assert response.data["projects"] == [
+            {"id": self.project.id, "name": self.project.name, "slug": self.project.slug}
+        ]
+        assert response.data["webUrl"].endswith(f"/{conversation_id}/?project={self.project.id}")
 
     def test_empty_conversation_returns_envelope(self) -> None:
         now = before_now(days=5).replace(microsecond=0)

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -831,6 +831,13 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["outputTokens"] == LLM_OUTPUT_TOKENS * 2
         assert conversation["totalCost"] == LLM_COST * 2
         assert conversation["projectId"] == self.project.id
+        assert conversation["projects"] == [
+            {"id": self.project.id, "name": self.project.name, "slug": self.project.slug}
+        ]
+        assert conversation["webUrl"].endswith(
+            f"/organizations/{self.organization.slug}/explore/agents/conversations/"
+            f"{conversation_id}/?project={self.project.id}"
+        )
         assert conversation["generationDuration"] > 0
         assert conversation["traceCount"] == 1
         assert conversation["startTimestamp"] > 0
@@ -2151,6 +2158,12 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert response.status_code == 200, response.data
         assert len(response.data) == 1
         assert response.data[0]["title"] == "Lower project id title"
+        assert response.data[0]["projects"] == [
+            {"id": lower_project.id, "name": lower_project.name, "slug": lower_project.slug}
+        ]
+        assert response.data[0]["webUrl"].endswith(
+            f"/{conversation_id}/?project={lower_project.id}"
+        )
 
     def test_title_earliest_source_timestamp_wins_across_projects(self) -> None:
         """Across projects, earliest title_source_timestamp wins (not lowest project id)."""


### PR DESCRIPTION
AI conversation list and detail responses now include a canonical `webUrl` and project metadata so API consumers can show project context and link directly to each conversation in Sentry.

For now, the API treats each conversation as single-project and returns at most one `{id, name, slug}` entry. Multi-project conversations remain an edge case and may expose only one contributing project until follow-up work expands this contract.

Closes TET-2965
