### PR TITLE
chore(sdk): Decrease `SAMPLED_DEFAULT_RATE` to 0.07

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2926,7 +2926,7 @@ SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT = 1000
 # Implemented in getsentry to run additional devserver workers.
 SENTRY_EXTRA_WORKERS: MutableSequence[str] = []
 
-SAMPLED_DEFAULT_RATE = 1.0
+SAMPLED_DEFAULT_RATE = 0.07
 
 # A set of extra URLs to sample
 ADDITIONAL_SAMPLED_URLS: dict[str, float] = {}


### PR DESCRIPTION
Adjust any constants used in the traces sampler passed to the SDK (these can be found in `SAMPLED_TASKS`).
The background is that we intend to turn off dynamic sampling for the monolith and are moving the average server sampling rate to the client.

https://github.com/getsentry/sentry/blob/e7f8b085e40070cbed73f5e948d5debbb68687ee/src/sentry/utils/sdk.py#L62

See corresponding `getsentry` PR: https://github.com/getsentry/getsentry/pull/21927