### PR TITLE
ref(groupresolution): order releases by date_released when it is set

### DIFF
--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -19,6 +19,18 @@ from sentry.models.releases.constants import DB_VERSION_LENGTH
 from sentry.utils import metrics
 
 
+def release_order_date(date_added, date_released=None):
+    """The date a release is ordered by.
+
+    Mirrors `COALESCE(date_released, date_added)`, the ordering the releases
+    endpoints and `most_recent_release` already use. `date_added` alone is when
+    Sentry first saw the release, which is not when it shipped: a release row
+    created by an incoming event from an old build carries a recent
+    `date_added` and so outranks the release that actually fixed the issue.
+    """
+    return date_released or date_added
+
+
 @cell_silo_model
 class GroupResolution(Model):
     """
@@ -81,14 +93,17 @@ class GroupResolution(Model):
             Helper function that compares release versions based on date for
             `GroupResolution.Type.in_next_release`
             """
-            return res_release == release.id or res_release_datetime > release.date_added
+            return res_release == release.id or res_release_datetime > release_order_date(
+                release.date_added, release.date_released
+            )
 
         try:
             (
                 res_type,
                 res_release,
                 res_release_version,
-                res_release_datetime,
+                res_release_date_added,
+                res_release_date_released,
                 current_release_version,
             ) = (
                 cls.objects.filter(group=group)
@@ -98,11 +113,16 @@ class GroupResolution(Model):
                     "release__id",
                     "release__version",
                     "release__date_added",
+                    "release__date_released",
                     "current_release_version",
                 )[0]
             )
         except IndexError:
             return False
+
+        res_release_datetime = release_order_date(
+            res_release_date_added, res_release_date_released
+        )
 
         # if no release is present, we assume we've gone from "no release" to "some release"
         # in application configuration, and thus this must be older
@@ -155,7 +175,10 @@ class GroupResolution(Model):
 
                     return compare_release_dates_for_in_next_release(
                         res_release=current_release_obj.id,
-                        res_release_datetime=current_release_obj.date_added,
+                        res_release_datetime=release_order_date(
+                            current_release_obj.date_added,
+                            current_release_obj.date_released,
+                        ),
                         release=release,
                     )
                 except Release.DoesNotExist:
@@ -194,6 +217,8 @@ class GroupResolution(Model):
                     ...
 
             # Fallback to older model if semver comparison fails due to whatever reason
-            return res_release_datetime >= release.date_added
+            return res_release_datetime >= release_order_date(
+                release.date_added, release.date_released
+            )
         else:
             raise NotImplementedError

--- a/src/sentry/models/groupresolution.py
+++ b/src/sentry/models/groupresolution.py
@@ -120,9 +120,7 @@ class GroupResolution(Model):
         except IndexError:
             return False
 
-        res_release_datetime = release_order_date(
-            res_release_date_added, res_release_date_released
-        )
+        res_release_datetime = release_order_date(res_release_date_added, res_release_date_released)
 
         # if no release is present, we assume we've gone from "no release" to "some release"
         # in application configuration, and thus this must be older

--- a/tests/sentry/models/test_groupresolution.py
+++ b/tests/sentry/models/test_groupresolution.py
@@ -16,6 +16,13 @@ class GroupResolutionTest(TestCase):
         self.group = self.create_group()
         self.old_semver_release = self.create_release(version="foo_package@1.0")
         self.new_semver_release = self.create_release(version="foo_package@2.0")
+        # Added after new_release, but finalized with an earlier ship date --
+        # the shape a straggler event from an old build produces.
+        self.late_registered_old_release = self.create_release(
+            version="c",
+            date_added=timezone.now(),
+            date_released=timezone.now() - timedelta(minutes=60),
+        )
 
     def test_in_next_release_with_new_release(self) -> None:
         GroupResolution.objects.create(
@@ -171,6 +178,30 @@ class GroupResolutionTest(TestCase):
             release=self.new_release, group=self.group, type=GroupResolution.Type.in_release
         )
         assert GroupResolution.has_resolution(self.group, self.old_release)
+
+    def test_in_release_with_late_registered_old_release(self) -> None:
+        """A release finalized as older must not clear a newer resolution."""
+        GroupResolution.objects.create(
+            release=self.new_release, group=self.group, type=GroupResolution.Type.in_release
+        )
+        assert GroupResolution.has_resolution(self.group, self.late_registered_old_release)
+
+    def test_in_next_release_with_late_registered_old_release(self) -> None:
+        GroupResolution.objects.create(
+            release=self.new_release,
+            group=self.group,
+            type=GroupResolution.Type.in_next_release,
+        )
+        assert GroupResolution.has_resolution(self.group, self.late_registered_old_release)
+
+    def test_in_release_resolved_in_a_late_registered_release(self) -> None:
+        """The resolution's own release is ordered by its ship date too."""
+        GroupResolution.objects.create(
+            release=self.late_registered_old_release,
+            group=self.group,
+            type=GroupResolution.Type.in_release,
+        )
+        assert not GroupResolution.has_resolution(self.group, self.new_release)
 
     def test_for_semver_in_release_with_new_release(self) -> None:
         GroupResolution.objects.create(


### PR DESCRIPTION
This is a behaviour change rather than a pure bug fix, and I'd like direction on how you'd want it gated before it's worth polishing. Opening it mainly so #47218 has something concrete attached.

Fixes the inconsistency in #47218 (open since 2023; #9771 reported the same in 2018): the releases endpoints order by `COALESCE(date_released, date_added)`, but `GroupResolution.has_resolution` compares `date_added` alone. Both are called "release order" in the UI, and they disagree.

## The problem

`date_added` is when Sentry first saw a release, not when it shipped. A release row created by an incoming event from an old build carries a recent `date_added`, so it outranks the release that actually fixed the issue, and the issue reopens.

From our org today:

```
regressor  2.102.0-stable.5+ci7642794   date_added 2026-09-02   date_released 2025-12-01
fix        2.132.0-stable.3+ci8156657   date_added 2026-06-18   date_released 2026-06-18
```

The regressing build shipped nine months before the fix and its `dateReleased` says so, but the row was only created on 2026-09-02 when an old client first sent an event. The activity feed calls the reopening "based on release order".

Finalizing does not help, because the resolution path never reads the field. There is no workaround either: `date_added` is not settable through the API — the release serializer ignores `dateCreated`/`dateAdded` while accepting `dateReleased` in the same request.

## The change

One helper, `release_order_date(date_added, date_released)`, used at the four places `has_resolution` compares dates. It mirrors the `COALESCE` the releases endpoints and `most_recent_release` already use, so both meanings of "release order" agree.

Three tests cover a release added late but finalized with an earlier ship date, for `in_release` and `in_next_release`, and for a resolution whose own release was late-registered.

## What I need direction on

- **Gating.** This changes which issues reopen for any org that has finalized releases with dates differing from `date_added`. Should it sit behind a feature flag or an org option rather than shipping unconditionally?
- **Scope.** I left `most_recent_release` and the semver paths alone. `get_current_release_version_of_group` may deserve the same treatment.
- **Testing.** I have not run your suite — it needs the devservices stack. The tests mirror the existing ones in that file and `create_release` accepts `date_released`, but they are unverified. Happy to iterate if CI disagrees.

Context: we hit this after backfilling `dateReleased` onto 3,301 historical releases from our CI's build manifest. It corrected the Releases list ordering and changed nothing about regressions.
