### PR TITLE
ref(seer): Show tags the same way in the log and event embeds

### DIFF
--- a/static/app/components/seer/markdown/embeds/components/embedSection.tsx
+++ b/static/app/components/seer/markdown/embeds/components/embedSection.tsx
@@ -1,0 +1,32 @@
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+interface EmbedSectionProps {
+  children: React.ReactNode;
+  title: React.ReactNode;
+  /**
+   * Trailing element in the header, usually a `ResourceLink` out to the page
+   * that shows the whole of what the section samples. Omitted where the block's
+   * own link already covers it.
+   */
+  action?: React.ReactNode;
+}
+
+/**
+ * A labelled section under a block embed's summary. Every view renders through
+ * here so the label, the gap beneath it, and the position of the link out are
+ * the same whichever resource the block is showing.
+ */
+export function EmbedSection({action, children, title}: EmbedSectionProps) {
+  return (
+    <Stack gap="md">
+      <Flex align="center" gap="md" justify="between" wrap="wrap">
+        <Text bold size="xs" uppercase variant="muted">
+          {title}
+        </Text>
+        {action}
+      </Flex>
+      {children}
+    </Stack>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/components/event/event.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/event/event.spec.tsx
@@ -89,8 +89,10 @@ describe('Seer event embed', () => {
 
     renderEventEmbed({view: 'tags'});
 
-    expect(await screen.findByText('Tags')).toBeInTheDocument();
-    expect(await screen.findByText('Chrome')).toBeInTheDocument();
+    expect(await screen.findByTestId('seer-event-tags')).toBeInTheDocument();
+    // Sorted by key, the same tree the log embed renders its attributes in.
+    expect(screen.getByTestId('tree-key-browser')).toHaveTextContent('browser');
+    expect(screen.getByTestId('tree-key-level')).toHaveTextContent('level');
     expect(screen.getByRole('link', {name: 'All tags for this issue'})).toHaveAttribute(
       'href',
       `/organizations/org-slug/issues/${ISSUE_ID}/distributions/`
@@ -102,15 +104,13 @@ describe('Seer event embed', () => {
 
     renderEventEmbed({view: 'tags'});
 
-    // Wait on the rows themselves -- the summary above renders the same tag values
-    // before the tree has loaded its project.
-    expect(await screen.findAllByTestId('tag-tree-row')).toHaveLength(2);
-    // The row menu writes project highlight tags and builds its links out of the
-    // host page's `location.query`, so the embed renders the rows without it.
-    expect(screen.queryAllByLabelText('Tag Actions Menu')).toHaveLength(0);
+    expect(await screen.findAllByTestId('attribute-tree-row')).toHaveLength(2);
+    // The row menu builds its links out of the host page's `location.query`, so
+    // the embed renders the rows without it.
+    expect(screen.queryAllByLabelText('Attribute Actions Menu')).toHaveLength(0);
   });
 
-  it('renders a plain tag list when the event has no project slug', async () => {
+  it('renders the tag tree even when the event has no project slug', async () => {
     mockEvent({
       projectSlug: undefined,
       contexts: {},
@@ -119,9 +119,20 @@ describe('Seer event embed', () => {
 
     renderEventEmbed({view: 'tags'});
 
-    expect(await screen.findByText('Tags')).toBeInTheDocument();
-    expect(await screen.findByText('server_name')).toBeInTheDocument();
+    // The tree renders off the tags alone, so a response without a project slug
+    // no longer falls back to a bare list.
+    expect(await screen.findByTestId('seer-event-tags')).toBeInTheDocument();
+    expect(screen.getByTestId('tree-key-server_name')).toHaveTextContent('server_name');
     expect(screen.getByText('web-01')).toBeInTheDocument();
+  });
+
+  it('tells the reader when the event has no tags', async () => {
+    mockEvent({contexts: {}, tags: []});
+
+    renderEventEmbed({view: 'tags'});
+
+    expect(await screen.findByText('This event has no tags.')).toBeInTheDocument();
+    expect(screen.queryByTestId('seer-event-tags')).not.toBeInTheDocument();
   });
 
   it('renders the distribution of a single tag for view "tag"', async () => {

--- a/static/app/components/seer/markdown/embeds/components/event/event.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/event/event.spec.tsx
@@ -2,7 +2,7 @@ import {EventFixture} from 'sentry-fixture/event';
 import {ProjectFixture} from 'sentry-fixture/project';
 import {TagsFixture} from 'sentry-fixture/tags';
 
-import {screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
 
 import {
   getEmbedLinkHref,
@@ -124,6 +124,51 @@ describe('Seer event embed', () => {
     expect(await screen.findByTestId('seer-event-tags')).toBeInTheDocument();
     expect(screen.getByTestId('tree-key-server_name')).toHaveTextContent('server_name');
     expect(screen.getByText('web-01')).toBeInTheDocument();
+  });
+
+  it('renders the tags that are worth more than their own text', async () => {
+    mockEvent({
+      contexts: {},
+      projectID: '2',
+      tags: [
+        {key: 'release', value: '1.2.3'},
+        {key: 'transaction', value: '/checkout'},
+      ],
+    });
+
+    renderEventEmbed({view: 'tags'});
+
+    expect(await screen.findByTestId('seer-event-tags')).toBeInTheDocument();
+    // The release links to the release, not to the bare string.
+    expect(screen.getByRole('link', {name: '1.2.3'})).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: '/checkout'})).toHaveAttribute(
+      'href',
+      expect.stringContaining('transaction=%2Fcheckout')
+    );
+  });
+
+  it('annotates a tag whose value was scrubbed', async () => {
+    mockEvent({
+      contexts: {},
+      tags: [
+        {key: 'level', value: 'error'},
+        {key: 'server_name', value: '[Filtered]'},
+      ],
+      // Served positionally: this annotates `tags[1]`, not a key called '1'.
+      _meta: {
+        tags: {
+          1: {value: {'': {len: 7, rem: [['project:0', 's', 0, 10]]}}},
+        },
+      },
+    });
+
+    renderEventEmbed({view: 'tags'});
+
+    expect(await screen.findByTestId('seer-event-tags')).toBeInTheDocument();
+    await userEvent.hover(screen.getByText('[Filtered]'));
+    expect(
+      await screen.findByText(/Replaced because of a data scrubbing rule/)
+    ).toBeInTheDocument();
   });
 
   it('tells the reader when the event has no tags', async () => {

--- a/static/app/components/seer/markdown/embeds/components/event/eventBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/event/eventBlock.tsx
@@ -75,13 +75,7 @@ function EventBlockView({
 }) {
   switch (view) {
     case 'tags':
-      return (
-        <EventTagsView
-          event={event}
-          projectSlug={event.projectSlug}
-          distributionsHref={distributionsHref}
-        />
-      );
+      return <EventTagsView event={event} distributionsHref={distributionsHref} />;
     case 'tag':
       // `tagKeys` is required for this view; the caller already fell back to the
       // summary when it is missing or empty, so this is unreachable in practice.

--- a/static/app/components/seer/markdown/embeds/components/event/eventViews/eventTagRenderers.tsx
+++ b/static/app/components/seer/markdown/embeds/components/event/eventViews/eventTagRenderers.tsx
@@ -1,0 +1,92 @@
+import * as qs from 'query-string';
+
+import {Link} from '@sentry/scraps/link';
+
+import {DeviceName} from 'sentry/components/deviceName';
+import {Version} from 'sentry/components/version';
+import {VersionHoverCard} from 'sentry/components/versionHoverCard';
+import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
+import type {AttributesFieldRendererProps} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import {getTransactionSummaryBaseUrl} from 'sentry/views/performance/transactionSummary/utils';
+
+const REFERRER = 'seer-event-embed';
+
+export interface EventTagRendererExtra extends RenderFunctionBaggage {
+  /** `event.projectID`, which the transaction link needs to scope itself. */
+  projectId?: string;
+}
+
+type EventTagRendererProps = AttributesFieldRendererProps<EventTagRendererExtra>;
+
+type EventTagRenderer = (props: EventTagRendererProps) => React.ReactNode;
+
+/**
+ * Called as a plain function by the tree rather than mounted as a component, so
+ * nothing in here may use a hook -- everything it needs arrives on `extra`.
+ */
+function ReleaseRenderer({basicRendered, extra, item}: EventTagRendererProps) {
+  const version = String(item.value ?? '');
+  if (!version) {
+    return basicRendered;
+  }
+
+  const rendered = <Version version={version} truncate shouldWrapText />;
+
+  // The hover card is the one place this reaches for the project, and only once
+  // someone hovers -- unlike the tree it replaced, which fetched the detailed
+  // project up front just to draw a row.
+  return extra.projectSlug ? (
+    <VersionHoverCard
+      organization={extra.organization}
+      projectSlug={extra.projectSlug}
+      releaseVersion={version}
+      showUnderline
+      underlineColor="muted"
+    >
+      {rendered}
+    </VersionHoverCard>
+  ) : (
+    rendered
+  );
+}
+
+function TransactionRenderer({basicRendered, extra, item}: EventTagRendererProps) {
+  const transaction = String(item.value ?? '');
+  if (!transaction) {
+    return basicRendered;
+  }
+
+  const query = qs.stringify({
+    project: extra.projectId,
+    transaction,
+    referrer: REFERRER,
+  });
+
+  return (
+    <Link to={`${getTransactionSummaryBaseUrl(extra.organization)}/?${query}`}>
+      {transaction}
+    </Link>
+  );
+}
+
+/**
+ * Turns an iOS model identifier such as `iPhone13,4` into the name people use
+ * for it. Falls through to the raw value for everything it does not recognise.
+ */
+function DeviceRenderer({basicRendered, item}: EventTagRendererProps) {
+  const value = String(item.value ?? '');
+  return value ? <DeviceName value={value} /> : basicRendered;
+}
+
+/**
+ * The tags worth more than their own text, keyed the way the tree looks them
+ * up. Everything absent from here still gets the tree's own treatment -- a URL
+ * becomes a link, JSON gets structured, and a scrubbed value gets its
+ * annotation -- so only add a key here when plain text really loses something.
+ */
+export const EventTagsRendererMap: Record<string, EventTagRenderer> = {
+  release: ReleaseRenderer,
+  transaction: TransactionRenderer,
+  device: DeviceRenderer,
+  'device.model': DeviceRenderer,
+};

--- a/static/app/components/seer/markdown/embeds/components/event/eventViews/tag.tsx
+++ b/static/app/components/seer/markdown/embeds/components/event/eventViews/tag.tsx
@@ -107,9 +107,17 @@ export function EventTagView({
         Bare keys are container queries, and the block sets `containerType`, so
         this pairs up on the embed's own width rather than the viewport's --
         the embed has no idea how wide the page around it is.
+
+        One key is deliberately not half of a two-column grid: the log embed
+        draws its single attribute across the full width, and a lone card that
+        stopped halfway would be the same panel at two different sizes.
       */}
       <Grid
-        columns={{zero: 'minmax(0, 1fr)', sm: 'repeat(2, minmax(0, 1fr))'}}
+        columns={
+          singleTagKey
+            ? 'minmax(0, 1fr)'
+            : {zero: 'minmax(0, 1fr)', sm: 'repeat(2, minmax(0, 1fr))'}
+        }
         gap="md"
         align="start"
       >

--- a/static/app/components/seer/markdown/embeds/components/event/eventViews/tag.tsx
+++ b/static/app/components/seer/markdown/embeds/components/event/eventViews/tag.tsx
@@ -1,10 +1,11 @@
 import {useQuery} from '@tanstack/react-query';
 
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {fetchIssueTagApiOptions} from 'sentry/actionCreators/group';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {EmbedSection} from 'sentry/components/seer/markdown/embeds/components/embedSection';
 import {makeIssueTagDistributionPathname} from 'sentry/components/seer/markdown/embeds/components/event/eventPathnames';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
 import {IconIssues} from 'sentry/icons';
@@ -82,11 +83,9 @@ export function EventTagView({
   const singleTagKey = visibleTagKeys.length === 1 ? visibleTagKeys[0] : undefined;
 
   return (
-    <Stack gap="md">
-      <Flex align="center" gap="md" justify="between" wrap="wrap">
-        <Text bold size="xs" uppercase variant="muted">
-          {t('Tag Distribution')}
-        </Text>
+    <EmbedSection
+      title={t('Tag Distribution')}
+      action={
         <ResourceLink
           icon={IconIssues}
           href={
@@ -102,7 +101,8 @@ export function EventTagView({
             singleTagKey ? t('All %s values', singleTagKey) : t('All tags for this issue')
           }
         />
-      </Flex>
+      }
+    >
       {/*
         Bare keys are container queries, and the block sets `containerType`, so
         this pairs up on the embed's own width rather than the viewport's --
@@ -122,6 +122,6 @@ export function EventTagView({
           />
         ))}
       </Grid>
-    </Stack>
+    </EmbedSection>
   );
 }

--- a/static/app/components/seer/markdown/embeds/components/event/eventViews/tags.tsx
+++ b/static/app/components/seer/markdown/embeds/components/event/eventViews/tags.tsx
@@ -1,83 +1,92 @@
-import {Fragment} from 'react';
+import {useMemo} from 'react';
+import {useTheme} from '@emotion/react';
 
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Container} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {EventTags} from 'sentry/components/events/eventTags';
+import {EmbedSection} from 'sentry/components/seer/markdown/embeds/components/embedSection';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
+import {
+  INERT_LOCATION,
+  INERT_NAVIGATE,
+} from 'sentry/components/seer/markdown/embeds/inertRouting';
 import {IconIssues} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
+import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
+import {useOrganization} from 'sentry/utils/useOrganization';
+import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
+import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
 
 /**
- * The tag row menu writes project highlight tags and builds its links from the host
- * page's `location.query`; an embed must reach neither. Hoisted so the reference stays
- * stable -- `EventTagsTree` memoizes its columns against it.
+ * Dropped from the tree the way issue details drops it: the replay is its own
+ * embed, and the bare id is not something to read.
  */
-const READ_ONLY_ROW_CONFIG = {disableActions: true} as const;
+const HIDDEN_TAG_KEYS = ['replayId'];
 
 interface EventTagsViewProps {
   /** Link to the issue's tag distributions page. Derived once by the block. */
   distributionsHref: string;
   event: Event;
-  /** From `event.projectSlug`; undefined when the events API omitted it. */
-  projectSlug: string | undefined;
 }
 
 /**
- * Fallback for events served without a project slug -- `EventTags` needs one to
- * load the detailed project it renders tag rows against, so show the raw pairs
- * rather than an empty section.
+ * Every tag on the event, as the same tree the log embed renders its attributes
+ * in. Deliberately not `EventTags`: that one picks its own column count off the
+ * container, fetches the detailed project to render a row, and reports mobile
+ * device classifications to analytics -- three things an embed of a single event
+ * should not be doing, and none of which the tree here needs.
  */
-function PlainTagList({event}: {event: Event}) {
-  const tags = event.tags ?? [];
+export function EventTagsView({event, distributionsHref}: EventTagsViewProps) {
+  const organization = useOrganization();
+  const theme = useTheme();
 
-  if (tags.length === 0) {
-    return <Text variant="muted">{t('This event has no tags.')}</Text>;
-  }
-
-  return (
-    <Grid columns={{zero: 'minmax(0, 1fr)', sm: 'max-content minmax(0, 1fr)'}} gap="xs">
-      {tags.map(tag => (
-        <Fragment key={tag.key}>
-          <Text bold ellipsis size="sm">
-            {tag.key}
-          </Text>
-          <Text ellipsis size="sm" variant="muted">
-            {tag.value ?? ''}
-          </Text>
-        </Fragment>
-      ))}
-    </Grid>
+  const attributes = useMemo<TraceItemResponseAttribute[]>(
+    () =>
+      (event.tags ?? [])
+        .filter(tag => !HIDDEN_TAG_KEYS.includes(tag.key))
+        .map(tag => ({name: tag.key, type: 'str' as const, value: tag.value ?? ''}))
+        .toSorted((a, b) => a.name.localeCompare(b.name)),
+    [event.tags]
   );
-}
 
-export function EventTagsView({
-  event,
-  projectSlug,
-  distributionsHref,
-}: EventTagsViewProps) {
+  const rendererExtra = useMemo<RenderFunctionBaggage>(
+    () => ({
+      location: INERT_LOCATION,
+      navigate: INERT_NAVIGATE,
+      organization,
+      projectSlug: event.projectSlug,
+      theme,
+    }),
+    [event.projectSlug, organization, theme]
+  );
+
   return (
-    <Stack gap="md">
-      <Flex align="center" gap="md" justify="between" wrap="wrap">
-        <Text bold size="xs" uppercase variant="muted">
-          {t('Tags')}
-        </Text>
+    <EmbedSection
+      title={t('Tags')}
+      action={
         <ResourceLink
           icon={IconIssues}
           href={distributionsHref}
           title={t('All tags for this issue')}
         />
-      </Flex>
-      {projectSlug ? (
-        <EventTags
-          event={event}
-          projectSlug={projectSlug}
-          config={READ_ONLY_ROW_CONFIG}
-        />
+      }
+    >
+      {attributes.length === 0 ? (
+        <Text variant="muted">{t('This event has no tags.')}</Text>
       ) : (
-        <PlainTagList event={event} />
+        <Container data-test-id="seer-event-tags" width="100%">
+          <AttributesTree
+            attributes={attributes}
+            // A single column keeps the tree readable at the width Seer renders in.
+            columnCount={1}
+            // The row actions filter the page the tree normally lives in, which
+            // an embed has no query params to write to.
+            config={{disableActions: true}}
+            rendererExtra={rendererExtra}
+          />
+        </Container>
       )}
-    </Stack>
+    </EmbedSection>
   );
 }

--- a/static/app/components/seer/markdown/embeds/components/event/eventViews/tags.tsx
+++ b/static/app/components/seer/markdown/embeds/components/event/eventViews/tags.tsx
@@ -5,6 +5,10 @@ import {Container} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {EmbedSection} from 'sentry/components/seer/markdown/embeds/components/embedSection';
+import {
+  EventTagsRendererMap,
+  type EventTagRendererExtra,
+} from 'sentry/components/seer/markdown/embeds/components/event/eventViews/eventTagRenderers';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
 import {
   INERT_LOCATION,
@@ -13,10 +17,13 @@ import {
 import {IconIssues} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import type {Event} from 'sentry/types/event';
-import type {RenderFunctionBaggage} from 'sentry/utils/discover/fieldRenderers';
+import type {Meta} from 'sentry/types/group';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
-import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
+import type {
+  TraceItemDetailsMeta,
+  TraceItemResponseAttribute,
+} from 'sentry/views/explore/hooks/useTraceItemDetails';
 
 /**
  * Dropped from the tree the way issue details drops it: the replay is its own
@@ -28,6 +35,28 @@ interface EventTagsViewProps {
   /** Link to the issue's tag distributions page. Derived once by the block. */
   distributionsHref: string;
   event: Event;
+}
+
+/**
+ * The event serves its tag meta positionally -- `_meta.tags[2]` annotates
+ * `tags[2]` -- while the tree looks meta up by key. Re-key it on the way in, so
+ * a scrubbed value carries the same annotation here as it does on a log.
+ */
+function toTraceItemMeta(event: Event): TraceItemDetailsMeta {
+  const tagsMeta = event._meta?.tags as
+    | Record<string, {value?: Record<string, Meta>} | undefined>
+    | undefined;
+
+  if (!tagsMeta) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    (event.tags ?? []).flatMap((tag, index) => {
+      const valueMeta = tagsMeta[index]?.value?.[''];
+      return valueMeta ? [[tag.key, {meta: {value: {'': valueMeta}}}]] : [];
+    })
+  );
 }
 
 /**
@@ -50,15 +79,17 @@ export function EventTagsView({event, distributionsHref}: EventTagsViewProps) {
     [event.tags]
   );
 
-  const rendererExtra = useMemo<RenderFunctionBaggage>(
+  const rendererExtra = useMemo<EventTagRendererExtra>(
     () => ({
       location: INERT_LOCATION,
       navigate: INERT_NAVIGATE,
       organization,
+      projectId: event.projectID,
       projectSlug: event.projectSlug,
       theme,
+      traceItemMeta: toTraceItemMeta(event),
     }),
-    [event.projectSlug, organization, theme]
+    [event, organization, theme]
   );
 
   return (
@@ -76,13 +107,14 @@ export function EventTagsView({event, distributionsHref}: EventTagsViewProps) {
         <Text variant="muted">{t('This event has no tags.')}</Text>
       ) : (
         <Container data-test-id="seer-event-tags" width="100%">
-          <AttributesTree
+          <AttributesTree<EventTagRendererExtra>
             attributes={attributes}
             // A single column keeps the tree readable at the width Seer renders in.
             columnCount={1}
             // The row actions filter the page the tree normally lives in, which
             // an embed has no query params to write to.
             config={{disableActions: true}}
+            renderers={EventTagsRendererMap}
             rendererExtra={rendererExtra}
           />
         </Container>

--- a/static/app/components/seer/markdown/embeds/components/log/log.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/log/log.spec.tsx
@@ -188,7 +188,7 @@ describe('Seer log embed', () => {
 
   it('measures the breakdown against every value, not just the drawn ones', async () => {
     mockLogDetails();
-    // Six values for five slots: the sixth is what the drawn shares are missing.
+    // Four values for three slots: the fourth is what the drawn shares are missing.
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/events/',
       body: {
@@ -196,9 +196,7 @@ describe('Seer log embed', () => {
           {region: 'a', 'count()': 10},
           {region: 'b', 'count()': 10},
           {region: 'c', 'count()': 10},
-          {region: 'd', 'count()': 10},
-          {region: 'e', 'count()': 10},
-          {region: 'f', 'count()': 50},
+          {region: 'd', 'count()': 70},
         ],
       },
     });
@@ -206,11 +204,11 @@ describe('Seer log embed', () => {
     renderLog({view: 'attribute', attribute: 'region'});
 
     expect(await screen.findByTestId('seer-log-attribute-breakdown')).toBeInTheDocument();
-    // 10 of 100, not 10 of the 50 that fit.
-    expect(await screen.findAllByText('10%')).toHaveLength(5);
-    expect(screen.queryByText('f')).not.toBeInTheDocument();
+    // 10 of 100, not 10 of the 30 that fit.
+    expect(await screen.findAllByText('10%')).toHaveLength(3);
+    expect(screen.queryByText('d')).not.toBeInTheDocument();
     expect(screen.getByText('Other')).toBeInTheDocument();
-    expect(screen.getByText('50%')).toBeInTheDocument();
+    expect(screen.getByText('70%')).toBeInTheDocument();
   });
 
   it('falls back to the summary when view "attribute" has no key', async () => {

--- a/static/app/components/seer/markdown/embeds/components/log/logAttributeView.tsx
+++ b/static/app/components/seer/markdown/embeds/components/log/logAttributeView.tsx
@@ -1,19 +1,19 @@
 import {useMemo} from 'react';
 import {useQuery} from '@tanstack/react-query';
 
-import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {EmbedSection} from 'sentry/components/seer/markdown/embeds/components/embedSection';
 import {ResourceLink} from 'sentry/components/seer/markdown/embeds/components/resourceLink';
 import {IconList} from 'sentry/icons';
-import {t} from 'sentry/locale';
-import {percent} from 'sentry/utils';
+import {t, tct} from 'sentry/locale';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {DiscoverDatasets} from 'sentry/utils/discover/types';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SAMPLING_MODE} from 'sentry/views/explore/hooks/useProgressiveQuery';
-import {TagBar} from 'sentry/views/issueDetails/groupTags/tagDistribution';
+import {TagDistributionPanel} from 'sentry/views/issueDetails/groupTags/tagDistribution';
 
 import {
   getLogAttributeUrl,
@@ -26,13 +26,11 @@ import {
 
 const COUNT = 'count()';
 
-/** How many groups the card draws. */
-const TOP_VALUE_COUNT = 5;
-
 /**
- * How many it asks for. The surplus rows never render -- they are what makes
- * each share a portion of everything nearby rather than a portion of whatever
- * happened to fit, and what gives the remainder below a real size.
+ * How many groups the query asks for. Far more than the panel draws -- the
+ * surplus rows never render, but they are what makes each share a portion of
+ * everything nearby rather than a portion of whatever happened to fit, and what
+ * gives the remainder the panel folds into "Other" a real size.
  *
  * Deliberately not a second, ungrouped `count()` query the way the issue tag
  * distribution gets its total: the two are sampled independently, so that total
@@ -40,10 +38,6 @@ const TOP_VALUE_COUNT = 5;
  * than their sum often enough to render a negative remainder.
  */
 const AGGREGATE_ROW_LIMIT = 50;
-
-function formatShare(share: number) {
-  return share < 1 ? t('<1%') : `${Math.round(share)}%`;
-}
 
 /**
  * The aggregates endpoint returns one row per group, keyed by the attribute
@@ -59,9 +53,11 @@ interface LogAttributeViewProps {
 }
 
 /**
- * Logs have no attribute-distribution endpoint of their own -- the trace item
- * stats endpoint only serves spans and occurrences -- so break the attribute
- * down with a plain aggregate logs query instead.
+ * How one attribute is distributed across the logs around this one. Logs have
+ * no attribute-distribution endpoint of their own -- the trace item stats
+ * endpoint only serves spans and occurrences -- so break the attribute down with
+ * a plain aggregate logs query instead, then render it through the same panel
+ * the event embed uses for a tag.
  */
 export function LogAttributeView({attribute, identity}: LogAttributeViewProps) {
   const organization = useOrganization();
@@ -92,73 +88,50 @@ export function LogAttributeView({attribute, identity}: LogAttributeViewProps) {
     retry: false,
   });
 
-  const allRows = data?.data ?? [];
-  const rows = allRows.slice(0, TOP_VALUE_COUNT);
-  const total = allRows.reduce((sum, row) => sum + Number(row[COUNT] ?? 0), 0);
-  const shown = rows.reduce((sum, row) => sum + Number(row[COUNT] ?? 0), 0);
-  const otherCount = total - shown;
+  const rows = data?.data ?? [];
+  const values = rows.map(row => {
+    const value = row[attribute];
+    return {
+      count: Number(row[COUNT] ?? 0),
+      value: value === null || value === undefined ? '' : String(value),
+    };
+  });
+  const totalValues = values.reduce((sum, value) => sum + value.count, 0);
 
   return (
-    <Stack data-test-id="seer-log-attribute-breakdown" gap="sm">
-      <Flex align="center" gap="md" justify="between" wrap="wrap">
-        <Text bold size="xs" uppercase variant="muted">
-          {attribute}
-        </Text>
+    <EmbedSection
+      title={t('Attribute Distribution')}
+      action={
         <ResourceLink
           icon={IconList}
           href={getLogAttributeUrl({organization, attribute, ...identity})}
           title={t('Break down in Explore')}
         />
-      </Flex>
+      }
+    >
       {isPending ? (
         <Flex justify="center" padding="md">
           <LoadingIndicator mini />
         </Flex>
       ) : isError ? (
-        <Text variant="danger">{t('Unable to load attribute breakdown')}</Text>
-      ) : rows.length === 0 ? (
+        <Text variant="muted">{t('Unable to load values for %s', attribute)}</Text>
+      ) : values.length === 0 ? (
         <Text variant="muted">{t('No logs with this attribute nearby')}</Text>
       ) : (
-        <Stack gap="xs">
-          {rows.map((row, index) => {
-            const value = row[attribute];
-            const count = Number(row[COUNT] ?? 0);
-            const share = percent(count, total);
-
-            return (
-              <Grid
-                key={`${String(value)}-${index}`}
-                align="center"
-                columns="minmax(0, 1fr) auto"
-                gap="md"
-              >
-                <Text ellipsis monospace size="sm">
-                  {value === null || value === '' ? t('(empty)') : String(value)}
-                </Text>
-                <Flex align="center" gap="sm" width="140px">
-                  <Text size="sm" tabular variant="muted">
-                    {formatShare(share)}
-                  </Text>
-                  <TagBar percentage={share} />
-                </Flex>
-              </Grid>
-            );
-          })}
-          {otherCount > 0 && (
-            <Grid align="center" columns="minmax(0, 1fr) auto" gap="md">
-              <Text ellipsis size="sm" variant="muted">
-                {t('Other')}
-              </Text>
-              <Flex align="center" gap="sm" width="140px">
-                <Text size="sm" tabular variant="muted">
-                  {formatShare(percent(otherCount, total))}
-                </Text>
-                <TagBar percentage={percent(otherCount, total)} />
-              </Flex>
-            </Grid>
-          )}
-        </Stack>
+        <Container data-test-id="seer-log-attribute-breakdown" width="100%">
+          <TagDistributionPanel
+            formatCount={(count, total) =>
+              tct('[count] of [total] nearby logs', {
+                count: count.toLocaleString(),
+                total: total.toLocaleString(),
+              })
+            }
+            title={attribute}
+            totalValues={totalValues}
+            values={values}
+          />
+        </Container>
       )}
-    </Stack>
+    </EmbedSection>
   );
 }

--- a/static/app/components/seer/markdown/embeds/components/log/logAttributesView.tsx
+++ b/static/app/components/seer/markdown/embeds/components/log/logAttributesView.tsx
@@ -1,11 +1,16 @@
 import {useMemo} from 'react';
 import {useTheme} from '@emotion/react';
-import type {Location} from 'history';
 
 import {Container} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
+import {EmbedSection} from 'sentry/components/seer/markdown/embeds/components/embedSection';
+import {
+  INERT_LOCATION,
+  INERT_NAVIGATE,
+} from 'sentry/components/seer/markdown/embeds/inertRouting';
+import {t} from 'sentry/locale';
 import type {PageFilterDatetime} from 'sentry/types/core';
-import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {AttributesTree} from 'sentry/views/explore/components/traceItemAttributes/attributesTree';
 import type {TraceItemResponseAttribute} from 'sentry/views/explore/hooks/useTraceItemDetails';
@@ -15,25 +20,6 @@ import {
   type RendererExtra,
 } from 'sentry/views/explore/logs/fieldRenderers';
 import {adjustAliases} from 'sentry/views/explore/logs/utils';
-
-/**
- * The attribute renderers take a router location and a navigate callback so the
- * logs table can round-trip its own query params. An embed must not read or
- * write the host page's URL, so they get an inert pair instead: the one
- * renderer that reads the location (the trace link) then builds a clean target
- * from the attributes alone, and nothing in the map ever navigates.
- */
-const INERT_LOCATION: Location = {
-  pathname: '',
-  search: '',
-  hash: '',
-  query: {},
-  state: null,
-  key: '',
-  action: 'POP',
-};
-
-const INERT_NAVIGATE: ReactRouter3Navigate = () => {};
 
 interface LogAttributesViewProps {
   attributeTypes: RendererExtra['attributeTypes'];
@@ -94,23 +80,25 @@ export function LogAttributesView({
     ]
   );
 
-  if (visibleAttributes.length === 0) {
-    return null;
-  }
-
   return (
-    <Container data-test-id="seer-log-attributes" width="100%">
-      <AttributesTree<RendererExtra>
-        attributes={visibleAttributes}
-        // A single column keeps the tree readable at the width Seer renders in.
-        columnCount={1}
-        // The row actions filter the logs table the tree normally lives in,
-        // which an embed has no query params to write to.
-        config={{disableActions: true}}
-        getAdjustedAttributeKey={adjustAliases}
-        renderers={LogAttributesRendererMap}
-        rendererExtra={rendererExtra}
-      />
-    </Container>
+    <EmbedSection title={t('Attributes')}>
+      {visibleAttributes.length === 0 ? (
+        <Text variant="muted">{t('This log has no attributes.')}</Text>
+      ) : (
+        <Container data-test-id="seer-log-attributes" width="100%">
+          <AttributesTree<RendererExtra>
+            attributes={visibleAttributes}
+            // A single column keeps the tree readable at the width Seer renders in.
+            columnCount={1}
+            // The row actions filter the logs table the tree normally lives in,
+            // which an embed has no query params to write to.
+            config={{disableActions: true}}
+            getAdjustedAttributeKey={adjustAliases}
+            renderers={LogAttributesRendererMap}
+            rendererExtra={rendererExtra}
+          />
+        </Container>
+      )}
+    </EmbedSection>
   );
 }

--- a/static/app/components/seer/markdown/embeds/inertRouting.ts
+++ b/static/app/components/seer/markdown/embeds/inertRouting.ts
@@ -1,0 +1,26 @@
+import type {Location} from 'history';
+
+import type {ReactRouter3Navigate} from 'sentry/utils/useNavigate';
+
+/**
+ * Plenty of the widgets embeds reuse take a router location and a navigate
+ * callback so that, on their own pages, they can round-trip their query params.
+ * An embed must read neither and write neither -- see this directory's README --
+ * so it hands them this pair instead: a location with nothing in it, and a
+ * navigate that goes nowhere.
+ *
+ * A widget given these still renders; it just cannot reach the host page. Where
+ * one builds a link out of the location, it falls back to building it from the
+ * data it was handed, which is what an embed wants anyway.
+ */
+export const INERT_LOCATION: Location = {
+  pathname: '',
+  search: '',
+  hash: '',
+  query: {},
+  state: null,
+  key: '',
+  action: 'POP',
+};
+
+export const INERT_NAVIGATE: ReactRouter3Navigate = () => {};

--- a/static/app/views/issueDetails/groupTags/tagDistribution.tsx
+++ b/static/app/views/issueDetails/groupTags/tagDistribution.tsx
@@ -11,16 +11,56 @@ import {t, tct} from 'sentry/locale';
 import {percent} from 'sentry/utils';
 import type {GroupTag} from 'sentry/views/issueDetails/groupTags/useGroupTags';
 
-export function TagDistribution({tag}: {tag: GroupTag}) {
-  const visibleTagValues = tag.topValues.slice(0, 3);
+/**
+ * How many values a panel draws before folding the rest into "Other". Not a
+ * prop: every breakdown -- issue tags, feature flags, Seer's event and log
+ * embeds -- should cut off at the same place.
+ */
+const MAX_VALUES = 3;
+
+interface TagDistributionValue {
+  count: number;
+  value: string;
+  /** Rendered in place of the raw value, e.g. a `Version` or a `DeviceName`. */
+  node?: React.ReactNode;
+}
+
+interface TagDistributionPanelProps {
+  /**
+   * The row tooltip, e.g. "12 of 40 tagged events". Built by the caller so each
+   * surface keeps its own copy as one whole sentence for translators.
+   */
+  formatCount: (count: number, total: number) => React.ReactNode;
+  title: string;
+  /**
+   * Everything the values were counted out of, including the ones the panel does
+   * not draw -- this is what gives the "Other" row a size.
+   */
+  totalValues: number;
+  /** Most common first; the panel draws the first few and folds away the rest. */
+  values: TagDistributionValue[];
+}
+
+/**
+ * How often each value of one key occurs, as a labelled bar per value. Purely
+ * presentational, and the one implementation of this shape: a tag on an issue
+ * and an attribute on a log come out looking the same because they render here.
+ */
+export function TagDistributionPanel({
+  formatCount,
+  title,
+  totalValues,
+  values,
+}: TagDistributionPanelProps) {
+  const visibleTagValues = values.slice(0, MAX_VALUES);
 
   const totalVisible = visibleTagValues.reduce((sum, value) => sum + value.count, 0);
-  const hasOther = totalVisible < tag.totalValues;
+  const hasOther = totalVisible < totalValues;
 
   const otherPercentage =
     100 -
     visibleTagValues.reduce(
-      (sum, value) => sum + Math.round(percent(value.count, tag.totalValues)),
+      (sum, value) => sum + Math.round(percent(value.count, totalValues)),
       0
     );
   const otherDisplayPercentage =
@@ -33,15 +73,15 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
   return (
     <TagPanel>
       <TagHeader data-underline-on-hover="true">
-        <Tooltip title={tag.key} showOnlyOnOverflow skipWrapper>
-          {tag.key}
+        <Tooltip title={title} showOnlyOnOverflow skipWrapper>
+          {title}
         </Tooltip>
       </TagHeader>
       <TagValueContent>
         {visibleTagValues.map((tagValue, tagValueIdx) => {
-          const percentage = Math.round(percent(tagValue.count, tag.totalValues));
+          const percentage = Math.round(percent(tagValue.count, totalValues));
           // Ensure no item shows 100% when there are multiple items
-          const hasMultipleItems = tag.topValues.length > 1 || hasOther;
+          const hasMultipleItems = values.length > 1 || hasOther;
           const cappedPercentage =
             hasMultipleItems && percentage >= 100 ? 99 : percentage;
           const displayPercentage =
@@ -51,29 +91,20 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
                 ? '>99%'
                 : `${cappedPercentage.toFixed(0)}%`;
 
-          let valueComponent: React.ReactNode = tagValue.value;
-          if (tagValue.value === '') {
-            valueComponent = <Text variant="muted">{t('(empty)')}</Text>;
-          } else {
-            if (tag.key === 'release') {
-              valueComponent = <Version version={tagValue.value} anchor={false} />;
-            } else if (tag.key === 'device') {
-              valueComponent = <DeviceName value={tagValue.value} />;
-            }
-          }
+          const valueComponent =
+            tagValue.node ??
+            (tagValue.value === '' ? (
+              <Text variant="muted">{t('(empty)')}</Text>
+            ) : (
+              tagValue.value
+            ));
 
           return (
             <TagValueRow key={tagValueIdx}>
               <Tooltip delay={300} title={valueComponent} skipWrapper>
                 <TagValue>{valueComponent}</TagValue>
               </Tooltip>
-              <Tooltip
-                title={tct('[count] of [total] tagged events', {
-                  count: tagValue.count.toLocaleString(),
-                  total: tag.totalValues.toLocaleString(),
-                })}
-                skipWrapper
-              >
+              <Tooltip title={formatCount(tagValue.count, totalValues)} skipWrapper>
                 <TooltipContainer>
                   <TagBarValue>{displayPercentage}</TagBarValue>
                   <TagBar percentage={percentage} />
@@ -86,10 +117,7 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
           <TagValueRow>
             <TagValue>{t('Other')}</TagValue>
             <Tooltip
-              title={tct('[count] of [total] tagged events', {
-                count: (tag.totalValues - totalVisible).toLocaleString(),
-                total: tag.totalValues.toLocaleString(),
-              })}
+              title={formatCount(totalValues - totalVisible, totalValues)}
               skipWrapper
             >
               <TooltipContainer>
@@ -101,6 +129,44 @@ export function TagDistribution({tag}: {tag: GroupTag}) {
         )}
       </TagValueContent>
     </TagPanel>
+  );
+}
+
+/**
+ * Renders `release` and `device` values the way the rest of the product does.
+ * Returns nothing for every other key, and for a missing value, so the panel
+ * falls back to the raw string and to its own "(empty)" marker.
+ */
+function renderTagValue(tagKey: string, value: string): React.ReactNode {
+  if (value === '') {
+    return undefined;
+  }
+  if (tagKey === 'release') {
+    return <Version version={value} anchor={false} />;
+  }
+  if (tagKey === 'device') {
+    return <DeviceName value={value} />;
+  }
+  return undefined;
+}
+
+export function TagDistribution({tag}: {tag: GroupTag}) {
+  return (
+    <TagDistributionPanel
+      formatCount={(count, total) =>
+        tct('[count] of [total] tagged events', {
+          count: count.toLocaleString(),
+          total: total.toLocaleString(),
+        })
+      }
+      title={tag.key}
+      totalValues={tag.totalValues}
+      values={tag.topValues.map(topValue => ({
+        count: topValue.count,
+        value: topValue.value,
+        node: renderTagValue(tag.key, topValue.value),
+      }))}
+    />
   );
 }
 


### PR DESCRIPTION
The log and event embeds had each grown a tag breakdown and a full tag list, and no two of the four looked alike. This takes the better half of each pair and makes it consistent between the two.

Fixes CW-2011.

### The breakdown: the event embed's panel wins

`TagDistribution` already drew the shape we want — a bordered panel, bars aligned in a subgrid, a percentage per row, counts in the tooltip, a remainder folded into "Other". It's extracted here as `TagDistributionPanel`, and `TagDistribution({tag})` becomes a thin adapter over it, so issue tags and feature flags render byte-for-byte as they did.

The log embed drops its own flat rows and renders its attribute through that panel instead. A value cut off at three and a share rounded to `<1%`/`>99%` now mean the same thing on both sides. Its row tooltip reads "N of M nearby logs" against the event embed's "N of M tagged events" — the panel takes a `formatCount` callback rather than a noun to interpolate, so each sentence stays whole for translators.

### The full list: the log embed's tree wins

`AttributesTree` takes its column count as a prop and renders off the attributes alone. `EventTagsTree` measures its own container, calls `useDetailedProject` to draw a row, and fires device-classification analytics — three things an embed of a single event has no business doing. The event embed moves to `AttributesTree`, one column, actions off, sorted by key. The project-slug fallback list goes away with it, since the tree renders off the tags alone.

### What the move would have cost, and doesn't

The second commit puts the value rendering back through the tree's own extension points rather than reintroducing the old component:

- **Rich values** via the `renderers` map, the same mechanism the log embed uses. `release` is a linked `Version` in a hover card — which only reaches for the project on hover, unlike the tree it replaced; `transaction` links to its summary; `device`/`device.model` resolve model identifiers to the names people use. Everything absent from the map keeps the tree's own treatment, so a URL becomes a link and JSON gets structured — more than the flat list ever had.
- **Scrub annotations** via `traceItemMeta`. Events serve tag meta positionally (`_meta.tags[2]` annotates `tags[2]`) while the tree looks meta up by key, so it's re-keyed on the way in. A redacted tag now carries the same tooltip here that it carries on a log.

Both are covered by tests that fail without the wiring — I checked by removing each and watching them go red.

### Two things worth a reviewer's eye

- Renderers are checked **before** meta in `AttributesTreeValue`, so a scrubbed `release`/`transaction`/`device` shows the rich value without the annotation tooltip. This matches what issue details already does (`EventTagsTreeValue`'s switch overrides its annotated default for exactly those keys), so it isn't a divergence — but it's a real gap in both.
- Deliberately not ported: `replayId`/`replay_id` links (that tag is filtered from the tree, as in issue details, since the replay is its own embed) and the preprod `head.artifact_id`/`base.artifact_id` links (niche, and `getSizeBuildPath` wants context the embed doesn't carry).

### Also folded in

Both embeds head their sections through one `EmbedSection`, and the inert `location`/`navigate` pair this directory's README asks for now lives in one place rather than in the log view alone.

### Visual QA

Captured on the local dev-ui server against the `SeerMarkdown` story, which mounts `EventEmbedStory` and `LogEmbedStory` — between them they render all four changed views against live data.

**The full list, on each side.** Same header, same single column, same row rhythm; `runtime` → `name` on the left nests the way `device`/`os`/`sdk` do on the right. The log's `ATTRIBUTES` header is new — that view previously carried no label at all.

| event — all tags | log — all attributes |
|---|---|
| ![event all tags](https://github.com/user-attachments/assets/012a15b4-d0d3-472a-870e-05ac21816733) | ![log all attributes](https://github.com/user-attachments/assets/1129c414-a691-4bbf-a2ad-8662f45bd0a9) |

**The breakdown, on each side.** One bordered panel, title, right-aligned percentage and bar.

| event — tag distribution | log — attribute distribution |
|---|---|
| ![event tag distribution](https://github.com/user-attachments/assets/3ca235de-d951-49dc-8a08-4f0da41f5ef3) | ![log attribute distribution](https://github.com/user-attachments/assets/d0c6b665-d558-4439-a0d4-1afa7ca711ec) |

QA is what caught the third commit: the event view lays breakdowns out in two columns so several tags pair up, which left a *single* tag stopping halfway across while the log drew its single attribute full width — the same panel at two sizes, in the view this branch set out to unify. One key now spans the row; two or more still pair up as before. The shots above are after that fix.

**Dark mode**, both sides:

| event | log |
|---|---|
| ![event distribution dark](https://github.com/user-attachments/assets/53f8b2cc-c0fa-4773-9add-3a6f8bac0019) | ![log distribution dark](https://github.com/user-attachments/assets/d73f88d2-e5b5-411c-b3b1-414ddd8e02f6) |

Not covered by these captures, and resting on the unit tests instead: the `release`/`transaction`/`device` renderers and the scrub annotation — the story's event carries none of those tags and nothing redacted. The 2-up layout for several tag keys is likewise untested visually, since that event had only one qualifying key.

### Testing

184 tests pass across `embeds/`, `groupTags/` and `groupFeatureFlags/` (2 new). `pnpm run typecheck` is clean apart from two pre-existing `rspack.config.ts` errors on a file this branch doesn't touch. oxlint, oxfmt and knip clean. Frontend only — no backend changes.

https://claude.ai/code/session_015wzcjcVRuTca9t2LY74QH2
