### PR TITLE
perf(ai-monitoring): Reduce conversation parent repair latency

### DIFF
--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from collections.abc import Collection, Mapping, Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta
@@ -376,10 +377,14 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
             return {}
 
         requested_keys = set(parent_keys)
+        parent_ids_by_trace: defaultdict[str, list[str]] = defaultdict(list)
+        for trace_id, span_id in sorted(requested_keys):
+            parent_ids_by_trace[trace_id].append(span_id)
+
         query_string = " OR ".join(
             f"({build_escaped_term_filter('trace', [trace_id])} "
-            f"{build_escaped_term_filter('span_id', [span_id])})"
-            for trace_id, span_id in sorted(requested_keys)
+            f"{build_escaped_term_filter('span_id', span_ids)})"
+            for trace_id, span_ids in parent_ids_by_trace.items()
         )
         result = Spans.run_table_query(
             params=snuba_params,
@@ -389,7 +394,7 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
             offset=0,
             limit=len(requested_keys),
             referrer=Referrer.API_AI_CONVERSATION_DETAILS.value,
-            config=SearchResolverConfig(auto_fields=True),
+            config=SearchResolverConfig(auto_fields=False),
             sampling_mode="HIGHEST_ACCURACY",
         )
 
@@ -425,13 +430,15 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
             ):
                 pending[child_key] = (span, parent_key, {child_key})
 
-        cache: dict[SpanKey, SpanRow] = {}
+        cache = {key: span for span in spans if (key := self._span_key(span)) is not None}
         fetched_keys: set[SpanKey] = set()
         for depth in range(1, MAX_PARENT_REPAIR_DEPTH + 1):
             if not pending:
                 break
 
-            missing_keys = {parent_key for _, parent_key, _ in pending.values()} - fetched_keys
+            missing_keys = (
+                {parent_key for _, parent_key, _ in pending.values()} - cache.keys() - fetched_keys
+            )
             fetched_keys.update(missing_keys)
             try:
                 cache.update(self._fetch_parent_spans(snuba_params, missing_keys))

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -22,6 +22,64 @@ from sentry.utils.snuba_rpc import SnubaRPCTimeout
 from .test_organization_ai_conversations_base import BaseAIConversationsTestCase
 
 
+def test_parent_fetch_groups_span_ids_by_trace() -> None:
+    endpoint = OrganizationAIConversationDetailsEndpoint()
+    snuba_params = MagicMock()
+    parent_keys = {
+        ("trace-a", "parent-2"),
+        ("trace-b", "parent-3"),
+        ("trace-a", "parent-1"),
+    }
+    parent = {"trace": "trace-a", "span_id": "parent-1"}
+
+    with patch.object(Spans, "run_table_query", return_value={"data": [parent]}) as run_query:
+        result = endpoint._fetch_parent_spans(snuba_params, parent_keys)
+
+    assert result == {("trace-a", "parent-1"): parent}
+    assert run_query.call_args.kwargs["query_string"] == (
+        '(trace:"trace-a" span_id:["parent-1", "parent-2"]) OR (trace:"trace-b" span_id:"parent-3")'
+    )
+    assert run_query.call_args.kwargs["limit"] == 3
+    assert run_query.call_args.kwargs["config"].auto_fields is False
+
+
+def test_parent_repair_uses_spans_from_page() -> None:
+    endpoint = OrganizationAIConversationDetailsEndpoint()
+    conversation_id = uuid4().hex
+    trace_id = uuid4().hex
+    root = {
+        "trace": trace_id,
+        "span_id": "root",
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "invoke_agent",
+    }
+    bridge = {
+        "trace": trace_id,
+        "span_id": "bridge",
+        "parent_span": "root",
+        "gen_ai.conversation.id": conversation_id,
+        "span.op": "http.client",
+    }
+    child = {
+        "trace": trace_id,
+        "span_id": "child",
+        "parent_span": "bridge",
+        "gen_ai.conversation.id": conversation_id,
+        "gen_ai.operation.type": "ai_client",
+    }
+
+    with (
+        patch.object(Spans, "run_table_query") as run_query,
+        patch(
+            "sentry.ai_monitoring.endpoints.organization_ai_conversation_details.metrics.distribution"
+        ),
+    ):
+        endpoint._repair_parent_links([root, bridge, child], MagicMock(), conversation_id)
+
+    assert child["parent_span"] == "root"
+    run_query.assert_not_called()
+
+
 def test_parent_repair_stops_after_five_hops() -> None:
     endpoint = OrganizationAIConversationDetailsEndpoint()
     conversation_id = uuid4().hex


### PR DESCRIPTION
Conversation detail requests now reuse spans already loaded for current page and group missing parent IDs by trace before querying Snuba. This reduces repeated search terms and avoids parent lookups when page data already contains required links.

Parent queries request only explicit repair attributes. Existing five-hop traversal, failure handling, and returned span hierarchy remain unchanged.
