### PR TITLE
fix(eap): reject wildcards on virtual columns for timeseries requests

### DIFF
--- a/src/sentry/search/eap/resolver.py
+++ b/src/sentry/search/eap/resolver.py
@@ -566,6 +566,9 @@ class SearchResolver:
         resolved_column, context_definition = self.resolve_column(term.key.name)
         self._raise_if_hidden_api_attribute(term.key.name, resolved_column)
 
+        if context_definition is not None and term.value.is_wildcard():
+            raise InvalidSearchQuery(f"Cannot use wildcards with {term.key.name}")
+
         value = term.value.value
         if self.params.is_timeseries_request and context_definition is not None:
             resolved_column, value = self.map_search_term_context_to_original_column(
@@ -576,11 +579,6 @@ class SearchResolver:
 
         if not isinstance(resolved_column.proto_definition, AttributeKey):
             raise ValueError(f"{term.key.name} is not valid search term")
-
-        if context_definition:
-            if term.value.is_wildcard():
-                # Avoiding this for now, but we could theoretically do a wildcard search on the resolved contexts
-                raise InvalidSearchQuery(f"Cannot use wildcards with {term.key.name}")
 
         if term.value.is_wildcard():
             is_list = False

--- a/tests/sentry/search/eap/test_ourlogs.py
+++ b/tests/sentry/search/eap/test_ourlogs.py
@@ -17,6 +17,7 @@ from sentry_protos.snuba.v1.trace_item_filter_pb2 import (
     TraceItemFilter,
 )
 
+from sentry.exceptions import InvalidSearchQuery
 from sentry.search.eap.ourlogs.definitions import OURLOG_DEFINITIONS
 from sentry.search.eap.resolver import SearchResolver
 from sentry.search.eap.types import SearchResolverConfig
@@ -318,6 +319,20 @@ class SearchResolverQueryTest(TestCase):
             )
         )
         assert having is None
+
+    def test_wildcard_on_virtual_column_rejected(self) -> None:
+        with pytest.raises(InvalidSearchQuery, match="Cannot use wildcards with project"):
+            self.resolver.resolve_query("project:*sen*")
+
+    def test_wildcard_on_virtual_column_rejected_for_timeseries_request(self) -> None:
+        resolver = SearchResolver(
+            params=SnubaParams(granularity_secs=60),
+            config=SearchResolverConfig(),
+            definitions=OURLOG_DEFINITIONS,
+        )
+
+        with pytest.raises(InvalidSearchQuery, match="Cannot use wildcards with project"):
+            resolver.resolve_query("project:*sen*")
 
 
 def test_count_default_argument() -> None:

--- a/tests/sentry/search/eap/test_spans.py
+++ b/tests/sentry/search/eap/test_spans.py
@@ -564,6 +564,37 @@ class SearchResolverQueryTest(TestCase):
         with pytest.raises(InvalidSearchQuery, match="Could not parse"):
             resolver.resolve_query(f"count_unique({hidden_attribute}):>0")
 
+    def test_wildcard_on_virtual_column_rejected(self) -> None:
+        with pytest.raises(InvalidSearchQuery, match="Cannot use wildcards with device.class"):
+            self.resolver.resolve_query("device.class:*high*")
+
+    def test_wildcard_on_virtual_column_rejected_for_timeseries_request(self) -> None:
+        resolver = SearchResolver(
+            params=SnubaParams(granularity_secs=60),
+            config=SearchResolverConfig(),
+            definitions=SPAN_DEFINITIONS,
+        )
+
+        with pytest.raises(InvalidSearchQuery, match="Cannot use wildcards with device.class"):
+            resolver.resolve_query("device.class:*high*")
+
+    def test_virtual_column_remaps_value_for_timeseries_request(self) -> None:
+        resolver = SearchResolver(
+            params=SnubaParams(granularity_secs=60),
+            config=SearchResolverConfig(),
+            definitions=SPAN_DEFINITIONS,
+        )
+
+        where, having, _ = resolver.resolve_query("device.class:high")
+        assert where == TraceItemFilter(
+            comparison_filter=ComparisonFilter(
+                key=AttributeKey(name="sentry.device.class", type=AttributeKey.Type.TYPE_STRING),
+                op=ComparisonFilter.OP_EQUALS,
+                value=AttributeValue(val_str="3"),
+            )
+        )
+        assert having is None
+
     def test_query_hides_internal_api_attributes_in_if_subquery(self) -> None:
         resolver = SearchResolver(
             params=SnubaParams(),


### PR DESCRIPTION
`SearchResolver._resolve_term` rejects wildcards on virtual columns, but the guard sat *below* the timeseries remap - which sets `context_definition = None` before the guard is reached. So the guard never ran for timeseries requests (`granularity_secs` set).

This hoists the guard next to `resolve_column`, so table and timeseries requests reject the wildcard with the same error.

I'd found this in LOGS-958 -> #123788 as an existing issue.

Closes LOGS-966. 
