### PR TITLE
feat(discover): add starring to saved query response

### DIFF
--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -215,7 +215,9 @@ class DiscoverSavedQueryModelSerializer(Serializer[DiscoverSavedQueryResponse]):
 
         if "starred" in attrs:
             data["starred"] = attrs["starred"]
-            data["position"] = attrs.get("position")
+
+        if "position" in attrs:
+            data["position"] = attrs["position"]
 
         for key in query_keys:
             if obj.query.get(key) is not None:

--- a/src/sentry/api/serializers/models/discoversavedquery.py
+++ b/src/sentry/api/serializers/models/discoversavedquery.py
@@ -9,6 +9,7 @@ from sentry.discover.models import (
     DatasetSourcesTypes,
     DiscoverSavedQuery,
     DiscoverSavedQueryLastVisited,
+    DiscoverSavedQueryStarred,
     DiscoverSavedQueryTypes,
 )
 from sentry.explore.models import ExploreSavedQuery, ExploreSavedQueryDataset
@@ -37,6 +38,8 @@ class DiscoverSavedQueryResponseOptional(TypedDict, total=False):
     interval: str
     exploreQuery: dict
     lastVisited: str
+    starred: bool
+    position: int | None
 
 
 class DiscoverSavedQueryResponse(DiscoverSavedQueryResponseOptional):
@@ -108,6 +111,14 @@ class DiscoverSavedQueryModelSerializer(Serializer[DiscoverSavedQueryResponse]):
 
         user_last_visited: dict[int, datetime] = {}
         if has_migrate_feature:
+            starred_queries = dict(
+                DiscoverSavedQueryStarred.objects.filter(
+                    discover_saved_query__in=item_list,
+                    user_id=user.id,
+                    organization=item_list[0].organization if item_list else None,
+                    starred=True,
+                ).values_list("discover_saved_query_id", "position")
+            )
             user_last_visited = dict(
                 DiscoverSavedQueryLastVisited.objects.filter(
                     discover_saved_query__in=item_list,
@@ -154,6 +165,14 @@ class DiscoverSavedQueryModelSerializer(Serializer[DiscoverSavedQueryResponse]):
                     discover_saved_query.explore_query_id
                 )
             if has_migrate_feature:
+                if discover_saved_query.id in starred_queries:
+                    result[discover_saved_query]["starred"] = True
+                    result[discover_saved_query]["position"] = starred_queries[
+                        discover_saved_query.id
+                    ]
+                else:
+                    result[discover_saved_query]["starred"] = False
+                    result[discover_saved_query]["position"] = None
                 result[discover_saved_query]["user_last_visited"] = user_last_visited.get(
                     discover_saved_query.id
                 )
@@ -193,6 +212,10 @@ class DiscoverSavedQueryModelSerializer(Serializer[DiscoverSavedQueryResponse]):
 
         if "user_last_visited" in attrs:
             data["lastVisited"] = attrs["user_last_visited"]
+
+        if "starred" in attrs:
+            data["starred"] = attrs["starred"]
+            data["position"] = attrs.get("position")
 
         for key in query_keys:
             if obj.query.get(key) is not None:

--- a/tests/snuba/api/endpoints/test_discover_saved_queries.py
+++ b/tests/snuba/api/endpoints/test_discover_saved_queries.py
@@ -3,6 +3,7 @@ from django.urls import reverse
 from sentry.discover.models import (
     DiscoverSavedQuery,
     DiscoverSavedQueryLastVisited,
+    DiscoverSavedQueryStarred,
     DiscoverSavedQueryTypes,
 )
 from sentry.explore.models import ExploreSavedQuery, ExploreSavedQueryDataset
@@ -332,6 +333,49 @@ class DiscoverSavedQueriesTest(DiscoverSavedQueryBase):
 
         assert response.status_code == 200
         assert response.data[0]["lastVisited"] is None
+
+    def test_get_starred_query_serializes_starred_and_position(self) -> None:
+        test_query = DiscoverSavedQuery.objects.get(organization=self.org, name="Test query")
+
+        DiscoverSavedQueryStarred.objects.create(
+            organization=self.org,
+            user_id=self.user.id,
+            discover_saved_query=test_query,
+            position=3,
+            starred=True,
+        )
+
+        with self.feature([self.feature_name, self.migrate_feature_name]):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert response.data[0]["starred"] is True
+        assert response.data[0]["position"] == 3
+
+    def test_get_unstarred_query_serializes_false_and_null_position(self) -> None:
+        with self.feature([self.feature_name, self.migrate_feature_name]):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert response.data[0]["starred"] is False
+        assert response.data[0]["position"] is None
+        other_org = self.create_organization(owner=self.user)
+        test_query = DiscoverSavedQuery.objects.get(organization=self.org, name="Test query")
+
+        DiscoverSavedQueryStarred.objects.create(
+            organization=other_org,
+            user_id=self.user.id,
+            discover_saved_query=test_query,
+            position=1,
+            starred=True,
+        )
+
+        with self.feature([self.feature_name, self.migrate_feature_name]):
+            response = self.client.get(self.url)
+
+        assert response.status_code == 200
+        assert response.data[0]["starred"] is False
+        assert response.data[0]["position"] is None
 
     def test_get_sortby_myqueries(self) -> None:
         uhoh_user = self.create_user(username="uhoh")


### PR DESCRIPTION
## Changes

This is part of [EXP-1132](https://linear.app/getsentry/issue/EXP-1132/port-saved-queries-into-explore-saved-queries-view) in effort to port discover saved queries to explore all queries. This PR just adds the starred and position field to the DiscoverSavedQueryResponse, hidden behind a feature flag.