### PR TITLE
tests(explore): Avoid mocking router hooks in useSortByFields.spec.tsx

### DIFF
--- a/static/app/views/explore/hooks/useSortByFields.spec.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.spec.tsx
@@ -1,4 +1,3 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
@@ -42,10 +41,7 @@ describe('useSortByFields', () => {
           yAxes: ['avg(span.duration)'],
           mode: Mode.SAMPLES,
         }),
-      {
-        organization,
-        initialRouterConfig: {location: LocationFixture()},
-      }
+      {organization}
     );
 
     expect(result.current.map(field => field.value)).toEqual([
@@ -68,10 +64,7 @@ describe('useSortByFields', () => {
           yAxes: ['avg(span.duration)'],
           mode: Mode.AGGREGATE,
         }),
-      {
-        organization,
-        initialRouterConfig: {location: LocationFixture()},
-      }
+      {organization}
     );
 
     expect(result.current.map(field => field.value)).toEqual([

--- a/static/app/views/explore/hooks/useSortByFields.spec.tsx
+++ b/static/app/views/explore/hooks/useSortByFields.spec.tsx
@@ -3,14 +3,11 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
-import {useLocation} from 'sentry/utils/useLocation';
 import {Mode} from 'sentry/views/explore/contexts/pageParamsContext/mode';
 import {useSortByFields} from 'sentry/views/explore/hooks/useSortByFields';
 import type {TraceItemAttributeConfig} from 'sentry/views/explore/hooks/useTraceItemAttributes';
 import {TraceItemDataset} from 'sentry/views/explore/types';
 
-jest.mock('sentry/utils/useLocation');
-const mockedUsedLocation = jest.mocked(useLocation);
 const spansConfig: TraceItemAttributeConfig = {
   traceItemType: TraceItemDataset.SPANS,
   enabled: true,
@@ -26,8 +23,6 @@ describe('useSortByFields', () => {
       url: '/organizations/org-slug/trace-items/attributes/',
       body: [],
     });
-
-    mockedUsedLocation.mockReturnValue(LocationFixture());
   });
 
   it('returns a valid list of field options in samples mode', () => {
@@ -47,7 +42,10 @@ describe('useSortByFields', () => {
           yAxes: ['avg(span.duration)'],
           mode: Mode.SAMPLES,
         }),
-      {organization}
+      {
+        organization,
+        initialRouterConfig: {location: LocationFixture()},
+      }
     );
 
     expect(result.current.map(field => field.value)).toEqual([
@@ -70,7 +68,10 @@ describe('useSortByFields', () => {
           yAxes: ['avg(span.duration)'],
           mode: Mode.AGGREGATE,
         }),
-      {organization}
+      {
+        organization,
+        initialRouterConfig: {location: LocationFixture()},
+      }
     );
 
     expect(result.current.map(field => field.value)).toEqual([


### PR DESCRIPTION
I am attempting to add a lint rule to disallow these kind of module mocks - this is one change of many to ensure those lint rules pass when added.