### PR TITLE
feat(explore): use new starring utils for saved queries

### DIFF
--- a/src/sentry/discover/models.py
+++ b/src/sentry/discover/models.py
@@ -278,7 +278,7 @@ class DiscoverSavedQueryStarredManager(BaseManager["DiscoverSavedQueryStarred"])
         Returns:
             True if the query was unstarred, False if the query was already unstarred
         """
-        from sentry.explore.utils import shift_starred_positions_by_one
+        from sentry.explore.utils import shift_starred_positions
 
         with transaction.atomic(using=router.db_for_write(DiscoverSavedQueryStarred)):
             if not (starred_query := self.get_starred_query(organization, user_id, query)):
@@ -290,8 +290,8 @@ class DiscoverSavedQueryStarredManager(BaseManager["DiscoverSavedQueryStarred"])
             # A row unstarred via ``updated_starred_query`` holds no position and so left no
             # gap to close. Filtering on ``position__gt=None`` would raise, not match nothing.
             if deleted_position is not None:
-                shift_starred_positions_by_one(
-                    organization, user_id, from_position=deleted_position
+                shift_starred_positions(
+                    organization, user_id, from_position=deleted_position, delta=-1
                 )
             return True
 

--- a/src/sentry/explore/endpoints/explore_saved_queries.py
+++ b/src/sentry/explore/endpoints/explore_saved_queries.py
@@ -268,7 +268,7 @@ def sync_prebuilt_queries(organization):
             ).delete()
 
 
-def sync_prebuilt_queries_starred(organization, user_id):
+def sync_prebuilt_queries_starred(organization, user):
     """
     Queries the database to check if prebuilt queries have an ExploreSavedQueryStarred record for the user_id, and creates them if they don't.
     This ensures that prebuilt queries are starred by default for all users.
@@ -277,7 +277,7 @@ def sync_prebuilt_queries_starred(organization, user_id):
         prebuilt_starred = list(
             ExploreSavedQueryStarred.objects.filter(
                 organization=organization,
-                user_id=user_id,
+                user_id=user.id,
                 starred=True,
                 explore_saved_query__prebuilt_id__isnull=False,
             )
@@ -297,7 +297,7 @@ def sync_prebuilt_queries_starred(organization, user_id):
             .exclude(
                 id__in=ExploreSavedQueryStarred.objects.filter(
                     organization=organization,
-                    user_id=user_id,
+                    user_id=user.id,
                 ).values_list("explore_saved_query_id", flat=True)
             )
             .order_by("name")
@@ -305,10 +305,10 @@ def sync_prebuilt_queries_starred(organization, user_id):
         for query in missing_queries:
             if is_default_order:
                 ExploreSavedQueryStarred.objects.insert_starred_query_alphabetically(
-                    organization, user_id, query
+                    organization, user, query
                 )
             else:
-                ExploreSavedQueryStarred.objects.insert_starred_query(organization, user_id, query)
+                ExploreSavedQueryStarred.objects.insert_starred_query(organization, user, query)
 
 
 @extend_schema(tags=["Discover"])
@@ -371,7 +371,7 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
                 # Deletes old prebuilt queries from the database if they should no longer exist.
                 # Stars prebuilt queries for the user if it is the first time they are being fetched by the user.
                 sync_prebuilt_queries(organization)
-                sync_prebuilt_queries_starred(organization, request.user.id)
+                sync_prebuilt_queries_starred(organization, request.user)
         except UnableToAcquireLock:
             # Another process is already syncing the prebuilt queries. We can skip syncing this time.
             pass
@@ -572,7 +572,7 @@ class ExploreSavedQueriesEndpoint(OrganizationEndpoint):
         try:
             if "starred" in request.data and request.data["starred"]:
                 ExploreSavedQueryStarred.objects.insert_starred_query(
-                    organization, request.user.id, model, starred=True
+                    organization, request.user, model, starred=True
                 )
         except Exception as err:
             sentry_sdk.capture_exception(err)

--- a/src/sentry/explore/endpoints/explore_saved_query_starred.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_starred.py
@@ -67,7 +67,7 @@ class ExploreSavedQueryStarredEndpoint(OrganizationEndpoint):
         # prevent the initial lazy-starring from happening again.
         if query.prebuilt_id is not None:
             if ExploreSavedQueryStarred.objects.updated_starred_query(
-                organization, request.user.id, query, bool(is_starred)
+                organization, request.user, query, bool(is_starred)
             ):
                 return Response(status=status.HTTP_200_OK)
             else:
@@ -75,12 +75,12 @@ class ExploreSavedQueryStarredEndpoint(OrganizationEndpoint):
 
         if is_starred:
             if ExploreSavedQueryStarred.objects.insert_starred_query(
-                organization, request.user.id, query
+                organization, request.user, query
             ):
                 return Response(status=status.HTTP_200_OK)
         else:
             if ExploreSavedQueryStarred.objects.delete_starred_query(
-                organization, request.user.id, query
+                organization, request.user, query
             ):
                 return Response(status=status.HTTP_200_OK)
 

--- a/src/sentry/explore/endpoints/explore_saved_query_starred_order.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_starred_order.py
@@ -10,6 +10,8 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.explore.models import ExploreSavedQueryStarred
+from sentry.explore.types import SavedQueryRef, SavedQueryType
+from sentry.explore.utils import reorder_starred_queries
 from sentry.models.organization import Organization
 
 
@@ -40,6 +42,11 @@ class ExploreSavedQueryStarredOrderEndpoint(OrganizationEndpoint):
             "organizations:visibility-explore-view", organization, actor=request.user
         )
 
+    def has_migrate_feature(self, organization, request):
+        return features.has(
+            "organizations:discover-queries-in-all-queries", organization, actor=request.user
+        )
+
     def put(self, request: Request, organization: Organization) -> Response:
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -58,11 +65,18 @@ class ExploreSavedQueryStarredOrderEndpoint(OrganizationEndpoint):
 
         try:
             with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
-                ExploreSavedQueryStarred.objects.reorder_starred_queries(
-                    organization=organization,
-                    user_id=request.user.id,
-                    new_query_positions=query_ids,
-                )
+                # This is for transitioning from this endpoint to the new SavedQueryStarredEndpoint
+                if self.has_migrate_feature(organization, request):
+                    refs = [
+                        SavedQueryRef(SavedQueryType.EXPLORE, query_id) for query_id in query_ids
+                    ]
+                    reorder_starred_queries(organization, request.user.id, refs)
+                else:
+                    ExploreSavedQueryStarred.objects.reorder_starred_queries(
+                        organization=organization,
+                        user_id=request.user.id,
+                        new_query_positions=query_ids,
+                    )
         except (IntegrityError, ValueError):
             raise ParseError("Mismatch between existing and provided starred queries.")
 

--- a/src/sentry/explore/endpoints/explore_saved_query_starred_order.py
+++ b/src/sentry/explore/endpoints/explore_saved_query_starred_order.py
@@ -10,8 +10,6 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases.organization import OrganizationEndpoint, OrganizationPermission
 from sentry.explore.models import ExploreSavedQueryStarred
-from sentry.explore.types import SavedQueryRef, SavedQueryType
-from sentry.explore.utils import reorder_starred_queries
 from sentry.models.organization import Organization
 
 
@@ -42,11 +40,6 @@ class ExploreSavedQueryStarredOrderEndpoint(OrganizationEndpoint):
             "organizations:visibility-explore-view", organization, actor=request.user
         )
 
-    def has_migrate_feature(self, organization, request):
-        return features.has(
-            "organizations:discover-queries-in-all-queries", organization, actor=request.user
-        )
-
     def put(self, request: Request, organization: Organization) -> Response:
         if not request.user.is_authenticated:
             return Response(status=status.HTTP_400_BAD_REQUEST)
@@ -65,18 +58,11 @@ class ExploreSavedQueryStarredOrderEndpoint(OrganizationEndpoint):
 
         try:
             with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
-                # This is for transitioning from this endpoint to the new SavedQueryStarredEndpoint
-                if self.has_migrate_feature(organization, request):
-                    refs = [
-                        SavedQueryRef(SavedQueryType.EXPLORE, query_id) for query_id in query_ids
-                    ]
-                    reorder_starred_queries(organization, request.user.id, refs)
-                else:
-                    ExploreSavedQueryStarred.objects.reorder_starred_queries(
-                        organization=organization,
-                        user_id=request.user.id,
-                        new_query_positions=query_ids,
-                    )
+                ExploreSavedQueryStarred.objects.reorder_starred_queries(
+                    organization=organization,
+                    user_id=request.user.id,
+                    new_query_positions=query_ids,
+                )
         except (IntegrityError, ValueError):
             raise ParseError("Mismatch between existing and provided starred queries.")
 

--- a/src/sentry/explore/models.py
+++ b/src/sentry/explore/models.py
@@ -17,6 +17,7 @@ from sentry.db.models.manager.base import BaseManager
 from sentry.models.dashboard_widget import TypesClass
 from sentry.models.organization import Organization
 from sentry.search.eap.types import SupportedTraceItemType
+from sentry.users.models.user import User
 
 
 class ExploreSavedQueryDataset(TypesClass):
@@ -131,14 +132,13 @@ class ExploreSavedQuery(DefaultFieldsModel):
 
 
 class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
-    def has_migrate_feature(
-        self,
-        organization: Organization,
-    ) -> bool:
+    def has_migrate_feature(self, organization: Organization, actor: User) -> bool:
         """
-        Returns True if the user has any starred queries in the organization.
+        Whether to combine Discover queries with Explore queries
         """
-        return features.has("organizations:discover-queries-in-all-queries", organization)
+        return features.has(
+            "organizations:discover-queries-in-all-queries", organization, actor=actor
+        )
 
     def get_last_position(self, organization: Organization, user_id: int) -> int:
         """
@@ -206,7 +206,7 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
     def insert_starred_query(
         self,
         organization: Organization,
-        user_id: int,
+        user: User,
         query: ExploreSavedQuery,
         starred: bool = True,
     ) -> bool:
@@ -215,7 +215,7 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
 
         Args:
             organization: The organization the queries belong to
-            user_id: The ID of the user whose starred queries are being updated
+            user: The user whose starred queries are being updated
             explore_saved_query: The query to insert
 
         Returns:
@@ -224,17 +224,17 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
         from sentry.explore.utils import next_starred_position
 
         with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
-            if self.get_starred_query(organization, user_id, query):
+            if self.get_starred_query(organization, user.id, query):
                 return False
 
             position: int
-            if self.has_migrate_feature(organization):
-                position = next_starred_position(organization, user_id)
+            if self.has_migrate_feature(organization, user):
+                position = next_starred_position(organization, user.id)
             else:
-                position = self.get_last_position(organization, user_id) + 1
+                position = self.get_last_position(organization, user.id) + 1
             self.create(
                 organization=organization,
-                user_id=user_id,
+                user_id=user.id,
                 explore_saved_query=query,
                 position=position,
                 starred=starred,
@@ -244,7 +244,7 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
     def insert_starred_query_alphabetically(
         self,
         organization: Organization,
-        user_id: int,
+        user: User,
         query: ExploreSavedQuery,
     ) -> bool:
         """
@@ -255,13 +255,13 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
         from sentry.explore.utils import next_starred_position, shift_starred_positions
 
         with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
-            if self.get_starred_query(organization, user_id, query):
+            if self.get_starred_query(organization, user.id, query):
                 return False
 
             next_prebuilt = (
                 self.filter(
                     organization=organization,
-                    user_id=user_id,
+                    user_id=user.id,
                     starred=True,
                     position__isnull=False,
                     explore_saved_query__prebuilt_id__isnull=False,
@@ -273,26 +273,26 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
 
             position: int
             if next_prebuilt is None or next_prebuilt.position is None:
-                if self.has_migrate_feature(organization):
-                    position = next_starred_position(organization, user_id)
+                if self.has_migrate_feature(organization, user):
+                    position = next_starred_position(organization, user.id)
                 else:
-                    position = self.get_last_position(organization, user_id) + 1
+                    position = self.get_last_position(organization, user.id) + 1
             else:
                 position = next_prebuilt.position
-                if self.has_migrate_feature(organization):
+                if self.has_migrate_feature(organization, user):
                     shift_starred_positions(
-                        organization, user_id, from_position=position, delta=1, inclusive=True
+                        organization, user.id, from_position=position, delta=1, inclusive=True
                     )
                 else:
                     self.filter(
                         organization=organization,
-                        user_id=user_id,
+                        user_id=user.id,
                         position__gte=position,
                     ).update(position=models.F("position") + 1)
 
             self.create(
                 organization=organization,
-                user_id=user_id,
+                user_id=user.id,
                 explore_saved_query=query,
                 position=position,
                 starred=True,
@@ -300,7 +300,7 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
             return True
 
     def delete_starred_query(
-        self, organization: Organization, user_id: int, query: ExploreSavedQuery
+        self, organization: Organization, user: User, query: ExploreSavedQuery
     ) -> bool:
         """
         Deletes a starred query from the list.
@@ -308,7 +308,7 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
 
         Args:
             organization: The organization the queries belong to
-            user_id: The ID of the user whose starred queries are being updated
+            user: The user whose starred queries are being updated
             explore_saved_query: The query to delete
 
         Returns:
@@ -317,28 +317,28 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
         from sentry.explore.utils import shift_starred_positions
 
         with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
-            if not (starred_query := self.get_starred_query(organization, user_id, query)):
+            if not (starred_query := self.get_starred_query(organization, user.id, query)):
                 return False
 
             deleted_position = starred_query.position
             starred_query.delete()
 
-            if self.has_migrate_feature(organization):
+            if self.has_migrate_feature(organization, user):
                 if deleted_position is not None:
                     shift_starred_positions(
-                        organization, user_id, from_position=deleted_position, delta=-1
+                        organization, user.id, from_position=deleted_position, delta=-1
                     )
                 return True
 
             self.filter(
-                organization=organization, user_id=user_id, position__gt=deleted_position
+                organization=organization, user_id=user.id, position__gt=deleted_position
             ).update(position=models.F("position") - 1)
             return True
 
     def updated_starred_query(
         self,
         organization: Organization,
-        user_id: int,
+        user: User,
         query: ExploreSavedQuery,
         starred: bool,
     ) -> bool:
@@ -348,15 +348,15 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
         from sentry.explore.utils import next_starred_position
 
         with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
-            if not (starred_query := self.get_starred_query(organization, user_id, query)):
+            if not (starred_query := self.get_starred_query(organization, user.id, query)):
                 return False
 
             starred_query.starred = starred
             if starred:
-                if self.has_migrate_feature(organization):
-                    starred_query.position = next_starred_position(organization, user_id)
+                if self.has_migrate_feature(organization, user):
+                    starred_query.position = next_starred_position(organization, user.id)
                 else:
-                    starred_query.position = self.get_last_position(organization, user_id) + 1
+                    starred_query.position = self.get_last_position(organization, user.id) + 1
             else:
                 starred_query.position = None
 

--- a/src/sentry/explore/models.py
+++ b/src/sentry/explore/models.py
@@ -7,6 +7,7 @@ from django.db import models, router, transaction
 from django.db.models import Q, UniqueConstraint
 from django.utils import timezone
 
+from sentry import features
 from sentry.backup.scopes import RelocationScope
 from sentry.db.models import FlexibleForeignKey, Model, cell_silo_model, sane_repr
 from sentry.db.models.base import DefaultFieldsModel
@@ -130,6 +131,15 @@ class ExploreSavedQuery(DefaultFieldsModel):
 
 
 class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
+    def has_migrate_feature(
+        self,
+        organization: Organization,
+    ) -> bool:
+        """
+        Returns True if the user has any starred queries in the organization.
+        """
+        return features.has("organizations:discover-queries-in-all-queries", organization)
+
     def get_last_position(self, organization: Organization, user_id: int) -> int:
         """
         Returns the last position of a user's starred queries in an organization.
@@ -211,12 +221,17 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
         Returns:
             True if the query was starred, False if the query was already starred
         """
+        from sentry.explore.utils import next_starred_position
+
         with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
             if self.get_starred_query(organization, user_id, query):
                 return False
 
-            position = self.get_last_position(organization, user_id) + 1
-
+            position: int
+            if self.has_migrate_feature(organization):
+                position = next_starred_position(organization, user_id)
+            else:
+                position = self.get_last_position(organization, user_id) + 1
             self.create(
                 organization=organization,
                 user_id=user_id,
@@ -237,6 +252,8 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
         whose name sorts after this one, shifting later positions by 1. Falls back
         to appending at the end when nothing sorts later.
         """
+        from sentry.explore.utils import next_starred_position, shift_starred_positions
+
         with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
             if self.get_starred_query(organization, user_id, query):
                 return False
@@ -256,14 +273,22 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
 
             position: int
             if next_prebuilt is None or next_prebuilt.position is None:
-                position = self.get_last_position(organization, user_id) + 1
+                if self.has_migrate_feature(organization):
+                    position = next_starred_position(organization, user_id)
+                else:
+                    position = self.get_last_position(organization, user_id) + 1
             else:
                 position = next_prebuilt.position
-                self.filter(
-                    organization=organization,
-                    user_id=user_id,
-                    position__gte=position,
-                ).update(position=models.F("position") + 1)
+                if self.has_migrate_feature(organization):
+                    shift_starred_positions(
+                        organization, user_id, from_position=position, delta=1, inclusive=True
+                    )
+                else:
+                    self.filter(
+                        organization=organization,
+                        user_id=user_id,
+                        position__gte=position,
+                    ).update(position=models.F("position") + 1)
 
             self.create(
                 organization=organization,
@@ -289,12 +314,21 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
         Returns:
             True if the query was unstarred, False if the query was already unstarred
         """
+        from sentry.explore.utils import shift_starred_positions
+
         with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
             if not (starred_query := self.get_starred_query(organization, user_id, query)):
                 return False
 
             deleted_position = starred_query.position
             starred_query.delete()
+
+            if self.has_migrate_feature(organization):
+                if deleted_position is not None:
+                    shift_starred_positions(
+                        organization, user_id, from_position=deleted_position, delta=-1
+                    )
+                return True
 
             self.filter(
                 organization=organization, user_id=user_id, position__gt=deleted_position
@@ -311,13 +345,18 @@ class ExploreSavedQueryStarredManager(BaseManager["ExploreSavedQueryStarred"]):
         """
         Updates the starred status of a query.
         """
+        from sentry.explore.utils import next_starred_position
+
         with transaction.atomic(using=router.db_for_write(ExploreSavedQueryStarred)):
             if not (starred_query := self.get_starred_query(organization, user_id, query)):
                 return False
 
             starred_query.starred = starred
             if starred:
-                starred_query.position = self.get_last_position(organization, user_id) + 1
+                if self.has_migrate_feature(organization):
+                    starred_query.position = next_starred_position(organization, user_id)
+                else:
+                    starred_query.position = self.get_last_position(organization, user_id) + 1
             else:
                 starred_query.position = None
 

--- a/src/sentry/explore/utils.py
+++ b/src/sentry/explore/utils.py
@@ -60,23 +60,35 @@ def next_starred_position(organization: Organization, user_id: int) -> int:
     return max(positions, default=0) + 1
 
 
-def shift_starred_positions_by_one(
+def shift_starred_positions(
     organization: Organization,
     user_id: int,
     *,
     from_position: int,
+    delta: int,
+    inclusive: bool = False,
 ) -> None:
     """
-    Move every position above ``from_position`` by negative one, closing a gap in the shared list of starred queries.
+    Move every position above ``from_position`` by ``delta``, closing a gap in the shared list of starred queries.
+    If ``inclusive`` is True, ``from_position`` itself is included in the shift. By default it is not.
     """
 
-    ExploreSavedQueryStarred.objects.filter(
-        organization=organization, user_id=user_id, position__gt=from_position
-    ).update(position=models.F("position") - 1)
+    if inclusive:
+        ExploreSavedQueryStarred.objects.filter(
+            organization=organization, user_id=user_id, position__gte=from_position
+        ).update(position=models.F("position") + delta)
 
-    DiscoverSavedQueryStarred.objects.filter(
-        organization=organization, user_id=user_id, position__gt=from_position
-    ).update(position=models.F("position") - 1)
+        DiscoverSavedQueryStarred.objects.filter(
+            organization=organization, user_id=user_id, position__gte=from_position
+        ).update(position=models.F("position") + delta)
+    else:
+        ExploreSavedQueryStarred.objects.filter(
+            organization=organization, user_id=user_id, position__gt=from_position
+        ).update(position=models.F("position") + delta)
+
+        DiscoverSavedQueryStarred.objects.filter(
+            organization=organization, user_id=user_id, position__gt=from_position
+        ).update(position=models.F("position") + delta)
 
 
 def reorder_starred_queries(

--- a/tests/sentry/explore/endpoints/test_explore_saved_queries.py
+++ b/tests/sentry/explore/endpoints/test_explore_saved_queries.py
@@ -496,7 +496,7 @@ class ExploreSavedQueriesTest(APITestCase):
 
     def test_sync_prebuilt_starred_alphabetical_for_new_user(self) -> None:
         sync_prebuilt_queries(self.org)
-        sync_prebuilt_queries_starred(self.org, self.user.id)
+        sync_prebuilt_queries_starred(self.org, self.user)
 
         starred = list(
             ExploreSavedQueryStarred.objects.filter(
@@ -519,7 +519,7 @@ class ExploreSavedQueriesTest(APITestCase):
     ) -> None:
         # Seed all prebuilts as if the user had synced previously.
         sync_prebuilt_queries(self.org)
-        sync_prebuilt_queries_starred(self.org, self.user.id)
+        sync_prebuilt_queries_starred(self.org, self.user)
 
         # Simulate a "new prebuilt added later" by removing the starred record for
         # one prebuilt that lives alphabetically in the middle of the list, then
@@ -544,7 +544,7 @@ class ExploreSavedQueriesTest(APITestCase):
             row.position = idx
             row.save()
 
-        sync_prebuilt_queries_starred(self.org, self.user.id)
+        sync_prebuilt_queries_starred(self.org, self.user)
 
         starred = list(
             ExploreSavedQueryStarred.objects.filter(
@@ -562,7 +562,7 @@ class ExploreSavedQueriesTest(APITestCase):
 
     def test_sync_prebuilt_starred_preserves_user_custom_order(self) -> None:
         sync_prebuilt_queries(self.org)
-        sync_prebuilt_queries_starred(self.org, self.user.id)
+        sync_prebuilt_queries_starred(self.org, self.user)
 
         original_ids = list(
             ExploreSavedQueryStarred.objects.filter(organization=self.org, user_id=self.user.id)
@@ -574,7 +574,7 @@ class ExploreSavedQueriesTest(APITestCase):
             self.org, self.user.id, reversed_ids
         )
 
-        sync_prebuilt_queries_starred(self.org, self.user.id)
+        sync_prebuilt_queries_starred(self.org, self.user)
 
         after_ids = list(
             ExploreSavedQueryStarred.objects.filter(organization=self.org, user_id=self.user.id)

--- a/tests/sentry/explore/test_utils.py
+++ b/tests/sentry/explore/test_utils.py
@@ -113,7 +113,7 @@ class ShiftPositionsTest(StarredHelpersTestBase):
         above = self.explore_star(3)
         above2 = self.explore_star(4)
 
-        utils.shift_starred_positions_by_one(self.org, self.user.id, from_position=1)
+        utils.shift_starred_positions(self.org, self.user.id, from_position=1, delta=-1)
 
         below.refresh_from_db()
         above.refresh_from_db()
@@ -121,6 +121,22 @@ class ShiftPositionsTest(StarredHelpersTestBase):
         assert below.position == 1
         assert above.position == 2
         assert above2.position == 3
+
+    def test_inclusive_gap(self) -> None:
+        below = self.explore_star(1)
+        above = self.discover_star(2)
+        above2 = self.explore_star(3)
+
+        utils.shift_starred_positions(
+            self.org, self.user.id, from_position=2, delta=1, inclusive=True
+        )
+
+        below.refresh_from_db()
+        above.refresh_from_db()
+        above2.refresh_from_db()
+        assert below.position == 1
+        assert above.position == 3
+        assert above2.position == 4
 
 
 class ReorderTest(StarredHelpersTestBase):


### PR DESCRIPTION
## Changes

This is part of [EXP-1169](https://linear.app/getsentry/issue/EXP-1169/add-endpoint-to-consolidate-fetching-discover-and-explore-saved) in effort to port remaining discover queries to explore all queries.

This PR update's explore starred manager and endpoint to use the new starring utils, since there are no stars for discover saved queries yet, the behaviour should be the same as before. This is currently feature flagged for Data Browsing team.
