### PR TITLE
tests(explore): avoid mocking router hooks in useVisualizeFields.spec

### DIFF
--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -1,4 +1,3 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
@@ -36,7 +35,6 @@ describe('useVisualizeFields', () => {
   it('returns numeric fields', () => {
     const {result} = renderHookWithProviders(() => useWrapper('avg(score.ttfb)'), {
       organization,
-      initialRouterConfig: {location: LocationFixture()},
     });
 
     expect(result.current.map(field => field.value)).toEqual([
@@ -57,7 +55,6 @@ describe('useVisualizeFields', () => {
   it('returns numeric fields for count', () => {
     const {result} = renderHookWithProviders(() => useWrapper('count(span.duration)'), {
       organization,
-      initialRouterConfig: {location: LocationFixture()},
     });
 
     expect(result.current.map(field => field.value)).toEqual(['span.duration']);
@@ -66,7 +63,6 @@ describe('useVisualizeFields', () => {
   it('returns string fields for count_unique', () => {
     const {result} = renderHookWithProviders(() => useWrapper('count_unique(foobar)'), {
       organization,
-      initialRouterConfig: {location: LocationFixture()},
     });
 
     expect(result.current.map(field => field.value)).toEqual(

--- a/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
+++ b/static/app/views/explore/hooks/useVisualizeFields.spec.tsx
@@ -4,13 +4,9 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
 import {parseFunction} from 'sentry/utils/discover/fields';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useSpanItemAttributes} from 'sentry/views/explore/hooks/useTraceItemAttributes';
 import {useVisualizeFields} from 'sentry/views/explore/hooks/useVisualizeFields';
 import {TraceItemDataset} from 'sentry/views/explore/types';
-
-jest.mock('sentry/utils/useLocation');
-const mockedUsedLocation = jest.mocked(useLocation);
 
 function useWrapper(yAxis: string) {
   const {attributes: stringTags} = useSpanItemAttributes({}, 'string');
@@ -35,13 +31,12 @@ describe('useVisualizeFields', () => {
       url: '/organizations/org-slug/trace-items/attributes/',
       body: [],
     });
-
-    mockedUsedLocation.mockReturnValue(LocationFixture());
   });
 
   it('returns numeric fields', () => {
     const {result} = renderHookWithProviders(() => useWrapper('avg(score.ttfb)'), {
       organization,
+      initialRouterConfig: {location: LocationFixture()},
     });
 
     expect(result.current.map(field => field.value)).toEqual([
@@ -62,6 +57,7 @@ describe('useVisualizeFields', () => {
   it('returns numeric fields for count', () => {
     const {result} = renderHookWithProviders(() => useWrapper('count(span.duration)'), {
       organization,
+      initialRouterConfig: {location: LocationFixture()},
     });
 
     expect(result.current.map(field => field.value)).toEqual(['span.duration']);
@@ -70,6 +66,7 @@ describe('useVisualizeFields', () => {
   it('returns string fields for count_unique', () => {
     const {result} = renderHookWithProviders(() => useWrapper('count_unique(foobar)'), {
       organization,
+      initialRouterConfig: {location: LocationFixture()},
     });
 
     expect(result.current.map(field => field.value)).toEqual(


### PR DESCRIPTION
I am attempting to add a lint rule to disallow these kind of module mocks - this is one change of many to ensure those lint rules pass when added.