### PR TITLE
docs(issues): Document preprod and configuration issue categories

### DIFF
--- a/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
+++ b/src/sentry/workflow_engine/endpoints/validators/api_docs_help_text.py
@@ -143,6 +143,8 @@ ACTION_FILTERS_HELP_TEXT = """The filters to run before the action will fire and
             - `13`: HTTP Client issues
             - `14`: Front end issues
             - `15`: Mobile issues
+            - `17`: Preprod issues
+            - `19`: Configuration issues
         ```json
             {
                 "type": "issue_category",


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry/pull/123649.

Adds `preprod` (17) and `configuration` (19) to the Issue Category API help text so that the documented options match the automation UI.