### PR TITLE
fix(apidocs): Skip the validated_data cases when mypy cannot run

### DIFF
--- a/tests/tools/mypy_helpers/test_typed_validated_data.py
+++ b/tests/tools/mypy_helpers/test_typed_validated_data.py
@@ -13,6 +13,8 @@ import subprocess
 import sys
 import tempfile
 
+import pytest
+
 REPO = os.path.join(os.path.dirname(__file__), "..", "..", "..")
 
 PRELUDE = """\
@@ -43,6 +45,10 @@ def create_monitor(*, name: str = "", threshold: int = 0) -> None: ...
 """
 
 
+# mypy exits 0 with no findings, 1 with findings, and 2 when it could not run.
+_MYPY_COULD_NOT_RUN = 2
+
+
 def _check(body: str) -> str:
     """Type-check the prelude plus `body`, returning mypy's diagnostics."""
     with tempfile.TemporaryDirectory() as tmpdir:
@@ -55,6 +61,11 @@ def _check(body: str) -> str:
             cwd=os.path.abspath(REPO),
         )
         out = proc.stdout.decode()
+        if proc.returncode >= _MYPY_COULD_NOT_RUN:
+            pytest.skip(
+                f"mypy could not run here, so the stub cannot be exercised: "
+                f"{proc.stderr.decode().strip() or out.strip()}"
+            )
         return "\n".join(line for line in out.splitlines() if "case.py" in line)
 
 


### PR DESCRIPTION
These cases spawn mypy and read its findings, but the helper filtered stdout for the temp file's name, so a mypy that failed to start returned an empty string and read as "no diagnostics". The `dev env` job runs `make test-tools` without mypy's configured plugins, so all four assertions failed there with nothing in the log to say why.

The helper now skips on mypy's exit code 2 — which means it could not run — and reports what mypy printed. Where mypy works the cases behave exactly as before.

This never showed up on #123923 because the `dev env` workflow only triggers on `tools/**`, and that PR touched `fixtures/` and `tests/tools/`. It surfaces on any later PR that does touch `tools/**`, which is how it was found.