### PR TITLE
ref(seer): Split the trace waterfall into its own embed

### DIFF
--- a/src/sentry/seer/agent/embed_widgets.generated.json
+++ b/src/sentry/seer/agent/embed_widgets.generated.json
@@ -713,8 +713,43 @@
   },
   {
     "name": "trace",
-    "description": "The ONLY way to reference a Sentry trace (the trace waterfall view). Use the 32-character trace ID. Provide `timestamp` when known so the waterfall opens on the right time range, and `spanId` to focus a span. Inline: renders a compact link. Block: renders the live trace waterfall. Do not duplicate the waterfall spans or duration details as text. Never use a markdown link for trace references.",
-    "level": ["inline", "block"],
+    "description": "The ONLY way to reference a Sentry trace. Renders a compact link. Use the 32-character trace ID. Provide `timestamp` when known so the link opens on the right time range, and `spanId` to focus a span. This never renders the waterfall itself — when the user wants to see the trace, emit the separate `traceWaterfall` embed. Never use a markdown link for trace references.",
+    "level": ["inline"],
+    "body": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "type": "object",
+      "properties": {
+        "traceId": {
+          "type": "string",
+          "minLength": 1
+        },
+        "timestamp": {
+          "type": "string",
+          "format": "date-time",
+          "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$"
+        },
+        "spanId": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": ["traceId"],
+      "additionalProperties": false
+    },
+    "examples": [
+      {
+        "label": "Trace",
+        "data": {
+          "traceId": "a1b2c3d4e5f678901234567890abcdef",
+          "timestamp": "2026-08-25T16:37:12Z"
+        }
+      }
+    ]
+  },
+  {
+    "name": "traceWaterfall",
+    "description": "Render the live, interactive trace waterfall for one trace. This is a large, data-heavy widget that loads the whole span tree, so only emit it when the user actually wants to look at the trace — they asked to see it, or the answer is about the shape or timing of the spans. Merely citing a trace is the `trace` embed, which does NOT expand into a waterfall. Use the 32-character trace ID. Provide `timestamp` when known so the waterfall opens on the right time range, and `spanId` to focus a span. Do not duplicate the waterfall spans or duration details as text. Emit at most one per response.",
+    "level": ["block"],
     "body": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "type": "object",

--- a/static/app/components/seer/markdown/__stories__/traceEmbedStory.tsx
+++ b/static/app/components/seer/markdown/__stories__/traceEmbedStory.tsx
@@ -7,7 +7,15 @@ import {useTracesApiOptions} from 'sentry/views/explore/hooks/useTraces';
 
 import {EmbedStory, EmbedVariant} from './embedStory';
 
-export function TraceEmbedStory() {
+/**
+ * `trace` and `traceWaterfall` take the same data and both need a real trace to
+ * demo against, so they share one story component rather than one fetch each.
+ */
+interface TraceEmbedStoryProps {
+  name?: 'trace' | 'traceWaterfall';
+}
+
+export function TraceEmbedStory({name = 'trace'}: TraceEmbedStoryProps) {
   const {data, isError, isPending} = useQuery(
     useTracesApiOptions({
       datetime: {period: '7d', start: null, end: null, utc: null},
@@ -18,15 +26,15 @@ export function TraceEmbedStory() {
   const trace = data?.data.find(candidate => candidate.numSpans > 0);
 
   return (
-    <EmbedStory name="trace">
+    <EmbedStory name={name}>
       {isPending ? (
         <LoadingIndicator />
       ) : isError ? (
         <Text variant="muted">Unable to load a trace example.</Text>
       ) : trace ? (
         <EmbedVariant
-          name="trace"
-          label="Trace"
+          name={name}
+          label={name === 'traceWaterfall' ? 'Trace waterfall' : 'Trace'}
           data={{traceId: trace.trace, timestamp: new Date(trace.end).toISOString()}}
         />
       ) : (

--- a/static/app/components/seer/markdown/embeds/components/trace.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/trace.spec.tsx
@@ -1,37 +1,10 @@
-import {screen, waitFor} from 'sentry-test/reactTestingLibrary';
+import {screen} from 'sentry-test/reactTestingLibrary';
 
 import {getEmbedLinkHref, renderEmbed} from './resourceEmbedTestUtils';
 
 describe('trace embed', () => {
   const traceId = 'a1b2c3d4e5f678901234567890abcdef';
   const timestamp = '2026-08-25T16:37:12Z';
-
-  const originalSearch = window.location.search;
-
-  afterEach(() => {
-    window.history.replaceState({}, '', `/${originalSearch}`);
-  });
-
-  function mockTraceRequests() {
-    const traceRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/events-trace/${traceId}/`,
-      body: {transactions: [], orphan_errors: []},
-    });
-    const metaRequest = MockApiClient.addMockResponse({
-      url: `/organizations/org-slug/events-trace-meta/${traceId}/`,
-      body: {
-        errors: 0,
-        performance_issues: 0,
-        projects: 0,
-        transactions: 0,
-        transaction_child_count_map: [],
-        span_count: 0,
-        span_count_map: {},
-      },
-    });
-
-    return {traceRequest, metaRequest};
-  }
 
   it('converts the ISO timestamp to unix seconds for the waterfall', () => {
     const href = getEmbedLinkHref('trace', 'Trace a1b2c3d4', {
@@ -55,101 +28,18 @@ describe('trace embed', () => {
     );
   });
 
-  it('renders the trace waterfall at block level', async () => {
-    const {traceRequest, metaRequest} = mockTraceRequests();
+  it('stays a link at block level instead of loading the waterfall', () => {
+    // The waterfall is its own embed now, so a trace reference on its own line must not
+    // expand into one — nor fetch the trace to try.
+    const traceRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events-trace/${traceId}/`,
+      body: {transactions: [], orphan_errors: []},
+    });
 
     renderEmbed({name: 'trace', data: {traceId, timestamp}});
 
-    expect(
-      await screen.findByText(
-        /We were unable to find any spans for this trace/,
-        {},
-        {timeout: 10_000}
-      )
-    ).toBeInTheDocument();
-    expect(screen.getByRole('link', {name: 'Trace a1b2c3d4'})).toHaveAttribute(
-      'href',
-      expect.stringContaining(`/explore/traces/trace/${traceId}/`)
-    );
-    await waitFor(() => {
-      expect(traceRequest).toHaveBeenCalledWith(
-        expect.anything(),
-        expect.objectContaining({
-          query: expect.objectContaining({
-            referrer: 'api.seer.trace-waterfall-embed',
-            timestamp: String(Date.parse(timestamp) / 1000),
-          }),
-        })
-      );
-      expect(metaRequest).toHaveBeenCalled();
-    });
-  });
-
-  it('does not let the host page query string steer the trace fetch', async () => {
-    // `useTrace`/`useTraceMeta` parse `location.search` themselves, so opting the waterfall out of
-    // URL sync is not enough — the fetches need their own opt-out or the host page's event and
-    // window params ride along.
-    window.history.replaceState(
-      {},
-      '',
-      '/?eventId=hosteventid&node=span-hostspan&limit=5&statsPeriod=90d'
-    );
-    const {traceRequest} = mockTraceRequests();
-
-    renderEmbed({name: 'trace', data: {traceId}});
-
-    await waitFor(() => {
-      expect(traceRequest).toHaveBeenCalled();
-    });
-
-    expect(traceRequest).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: expect.not.objectContaining({targetId: 'hosteventid'}),
-      })
-    );
-    expect(traceRequest).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: expect.not.objectContaining({limit: 5}),
-      })
-    );
-    expect(traceRequest).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: expect.not.objectContaining({statsPeriod: '90d'}),
-      })
-    );
-  });
-
-  it('ignores a host page timestamp when the embed carries none', async () => {
-    window.history.replaceState({}, '', '/?timestamp=1111111111');
-    const {traceRequest} = mockTraceRequests();
-
-    renderEmbed({name: 'trace', data: {traceId}});
-
-    await waitFor(() => {
-      expect(traceRequest).toHaveBeenCalled();
-    });
-
-    expect(traceRequest).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        query: expect.not.objectContaining({timestamp: '1111111111'}),
-      })
-    );
-  });
-
-  it('does not seed the embed search box from the host page query string', async () => {
-    // The embed is rendered inside another page (a Seer response), so the surrounding page's
-    // `?search=`/`?node=` must not steer it.
-    window.history.replaceState({}, '', '/?search=http.client&node=span-hostspan');
-    mockTraceRequests();
-
-    renderEmbed({name: 'trace', data: {traceId, timestamp}});
-
-    expect(
-      await screen.findByPlaceholderText('Search in trace', {}, {timeout: 10_000})
-    ).toHaveValue('');
+    expect(screen.getByRole('link', {name: 'Trace a1b2c3d4'})).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText('Search in trace')).not.toBeInTheDocument();
+    expect(traceRequest).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/seer/markdown/embeds/components/trace.tsx
+++ b/static/app/components/seer/markdown/embeds/components/trace.tsx
@@ -1,18 +1,10 @@
-import {lazy} from 'react';
-
-import {LazyLoad} from 'sentry/components/lazyLoad';
 import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
 
 import {TraceLink} from './traceLink';
 
-const LazyTraceBlock = lazy(() => import('./traceBlock'));
-
 export const Trace = defineSeerEmbed({
   name: 'trace',
-  render(props, level) {
-    if (level === 'block') {
-      return <LazyLoad LazyComponent={LazyTraceBlock} {...props} />;
-    }
+  render(props) {
     return <TraceLink {...props} />;
   },
 });

--- a/static/app/components/seer/markdown/embeds/components/traceWaterfall.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/traceWaterfall.spec.tsx
@@ -1,0 +1,133 @@
+import {screen, waitFor} from 'sentry-test/reactTestingLibrary';
+
+import {renderEmbed} from './resourceEmbedTestUtils';
+
+describe('traceWaterfall embed', () => {
+  const traceId = 'a1b2c3d4e5f678901234567890abcdef';
+  const timestamp = '2026-08-25T16:37:12Z';
+
+  const originalSearch = window.location.search;
+
+  afterEach(() => {
+    window.history.replaceState({}, '', `/${originalSearch}`);
+  });
+
+  function mockTraceRequests() {
+    const traceRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events-trace/${traceId}/`,
+      body: {transactions: [], orphan_errors: []},
+    });
+    const metaRequest = MockApiClient.addMockResponse({
+      url: `/organizations/org-slug/events-trace-meta/${traceId}/`,
+      body: {
+        errors: 0,
+        performance_issues: 0,
+        projects: 0,
+        transactions: 0,
+        transaction_child_count_map: [],
+        span_count: 0,
+        span_count_map: {},
+      },
+    });
+
+    return {traceRequest, metaRequest};
+  }
+
+  it('renders the trace waterfall', async () => {
+    const {traceRequest, metaRequest} = mockTraceRequests();
+
+    renderEmbed({name: 'traceWaterfall', data: {traceId, timestamp}});
+
+    expect(
+      await screen.findByText(
+        /We were unable to find any spans for this trace/,
+        {},
+        {timeout: 10_000}
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', {name: 'Trace a1b2c3d4'})).toHaveAttribute(
+      'href',
+      expect.stringContaining(`/explore/traces/trace/${traceId}/`)
+    );
+    await waitFor(() => {
+      expect(traceRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          query: expect.objectContaining({
+            referrer: 'api.seer.trace-waterfall-embed',
+            timestamp: String(Date.parse(timestamp) / 1000),
+          }),
+        })
+      );
+      expect(metaRequest).toHaveBeenCalled();
+    });
+  });
+
+  it('does not let the host page query string steer the trace fetch', async () => {
+    // `useTrace`/`useTraceMeta` parse `location.search` themselves, so opting the waterfall out of
+    // URL sync is not enough — the fetches need their own opt-out or the host page's event and
+    // window params ride along.
+    window.history.replaceState(
+      {},
+      '',
+      '/?eventId=hosteventid&node=span-hostspan&limit=5&statsPeriod=90d'
+    );
+    const {traceRequest} = mockTraceRequests();
+
+    renderEmbed({name: 'traceWaterfall', data: {traceId}});
+
+    await waitFor(() => {
+      expect(traceRequest).toHaveBeenCalled();
+    });
+
+    expect(traceRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.not.objectContaining({targetId: 'hosteventid'}),
+      })
+    );
+    expect(traceRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.not.objectContaining({limit: 5}),
+      })
+    );
+    expect(traceRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.not.objectContaining({statsPeriod: '90d'}),
+      })
+    );
+  });
+
+  it('ignores a host page timestamp when the embed carries none', async () => {
+    window.history.replaceState({}, '', '/?timestamp=1111111111');
+    const {traceRequest} = mockTraceRequests();
+
+    renderEmbed({name: 'traceWaterfall', data: {traceId}});
+
+    await waitFor(() => {
+      expect(traceRequest).toHaveBeenCalled();
+    });
+
+    expect(traceRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        query: expect.not.objectContaining({timestamp: '1111111111'}),
+      })
+    );
+  });
+
+  it('does not seed the embed search box from the host page query string', async () => {
+    // The embed is rendered inside another page (a Seer response), so the surrounding page's
+    // `?search=`/`?node=` must not steer it.
+    window.history.replaceState({}, '', '/?search=http.client&node=span-hostspan');
+    mockTraceRequests();
+
+    renderEmbed({name: 'traceWaterfall', data: {traceId, timestamp}});
+
+    expect(
+      await screen.findByPlaceholderText('Search in trace', {}, {timeout: 10_000})
+    ).toHaveValue('');
+  });
+});

--- a/static/app/components/seer/markdown/embeds/components/traceWaterfall.tsx
+++ b/static/app/components/seer/markdown/embeds/components/traceWaterfall.tsx
@@ -1,0 +1,18 @@
+import {lazy} from 'react';
+
+import {LazyLoad} from 'sentry/components/lazyLoad';
+import {defineSeerEmbed} from 'sentry/components/seer/markdown/embeds/utils';
+
+const LazyTraceWaterfallBlock = lazy(() => import('./traceWaterfallBlock'));
+
+/**
+ * Split out of the `trace` embed so a trace reference never implies the
+ * waterfall. This loads the trace's whole span tree, so Seer has to ask for it
+ * by name rather than getting it for free by mentioning a trace at block level.
+ */
+export const TraceWaterfall = defineSeerEmbed({
+  name: 'traceWaterfall',
+  render(props) {
+    return <LazyLoad LazyComponent={LazyTraceWaterfallBlock} {...props} />;
+  },
+});

--- a/static/app/components/seer/markdown/embeds/components/traceWaterfallBlock.tsx
+++ b/static/app/components/seer/markdown/embeds/components/traceWaterfallBlock.tsx
@@ -40,7 +40,11 @@ const TRACE_ADDITIONAL_ATTRIBUTES = [
   'span.status',
 ];
 
-function TraceWaterfallEmbed({traceId, timestamp, spanId}: EmbedOutput<'trace'>) {
+function TraceWaterfallEmbed({
+  traceId,
+  timestamp,
+  spanId,
+}: EmbedOutput<'traceWaterfall'>) {
   const organization = useOrganization();
   const timestampSeconds = getTimeStampFromTableDateField(timestamp);
 
@@ -115,7 +119,7 @@ function TraceWaterfallEmbed({traceId, timestamp, spanId}: EmbedOutput<'trace'>)
   );
 }
 
-export default function TraceBlock(props: EmbedOutput<'trace'>) {
+export default function TraceWaterfallBlock(props: EmbedOutput<'traceWaterfall'>) {
   return (
     <Container
       background="primary"

--- a/static/app/components/seer/markdown/embeds/index.ts
+++ b/static/app/components/seer/markdown/embeds/index.ts
@@ -24,6 +24,7 @@ import {SavedQuery} from './components/savedQuery';
 import {SpansQuery} from './components/spansQuery';
 import {Timestamp} from './components/timestamp';
 import {Trace} from './components/trace';
+import {TraceWaterfall} from './components/traceWaterfall';
 import {User} from './components/user';
 import {SeerEmbedRegistry} from './registry';
 
@@ -56,6 +57,7 @@ const embeds = [
   SpansQuery,
   Timestamp,
   Trace,
+  TraceWaterfall,
   User,
 ];
 for (const embed of embeds) {

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -523,13 +523,40 @@ export const SEER_EMBED_SCHEMAS = {
   },
   trace: {
     description:
-      'The ONLY way to reference a Sentry trace (the trace waterfall view). ' +
+      'The ONLY way to reference a Sentry trace. Renders a compact link. ' +
+      'Use the 32-character trace ID. Provide `timestamp` when known so the ' +
+      'link opens on the right time range, and `spanId` to focus a span. ' +
+      'This never renders the waterfall itself — when the user wants to see the ' +
+      'trace, emit the separate `traceWaterfall` embed. ' +
+      'Never use a markdown link for trace references.',
+    level: ['inline'],
+    schema: z.object({
+      traceId: z.string().min(1),
+      timestamp: isoTimestampSchema.optional(),
+      spanId: z.string().min(1).optional(),
+    }),
+    examples: [
+      {
+        label: 'Trace',
+        data: {
+          traceId: 'a1b2c3d4e5f678901234567890abcdef',
+          timestamp: '2026-08-25T16:37:12Z',
+        },
+      },
+    ],
+  },
+  traceWaterfall: {
+    description:
+      'Render the live, interactive trace waterfall for one trace. ' +
+      'This is a large, data-heavy widget that loads the whole span tree, so only ' +
+      'emit it when the user actually wants to look at the trace — they asked to ' +
+      'see it, or the answer is about the shape or timing of the spans. Merely ' +
+      'citing a trace is the `trace` embed, which does NOT expand into a waterfall. ' +
       'Use the 32-character trace ID. Provide `timestamp` when known so the ' +
       'waterfall opens on the right time range, and `spanId` to focus a span. ' +
-      'Inline: renders a compact link. Block: renders the live trace waterfall. ' +
       'Do not duplicate the waterfall spans or duration details as text. ' +
-      'Never use a markdown link for trace references.',
-    level: ['inline', 'block'],
+      'Emit at most one per response.',
+    level: ['block'],
     schema: z.object({
       traceId: z.string().min(1),
       timestamp: isoTimestampSchema.optional(),
@@ -538,7 +565,6 @@ export const SEER_EMBED_SCHEMAS = {
     examples: [
       {
         label: 'Trace waterfall',
-        level: 'block',
         data: {
           traceId: 'a1b2c3d4e5f678901234567890abcdef',
           timestamp: '2026-08-25T16:37:12Z',

--- a/static/app/components/seer/markdown/seerMarkdown.mdx
+++ b/static/app/components/seer/markdown/seerMarkdown.mdx
@@ -117,6 +117,10 @@ Tag syntax: `{% name %}{"key":"value"}{% /name %}`. The JSON body is validated a
 
 <TraceEmbedStory />
 
+### traceWaterfall
+
+<TraceEmbedStory name="traceWaterfall" />
+
 ### profile
 
 <ProfileEmbedStory />


### PR DESCRIPTION
### Why?

The `trace` embed rendered a compact link inline and the full trace waterfall at block level. That meant Seer got the waterfall for free just by mentioning a trace on its own line — the waterfall loads the trace's entire span tree, which is a lot of widget, and a lot of data, for what is often a passing reference.

The waterfall should be something the agent asks for on purpose, not something it falls into.

### How?

`trace` drops to `level: ['inline']` and is now a link, always. A new `traceWaterfall` embed carries the same fields and owns the block rendering, with a schema description that tells the agent it is large and data-heavy and to emit it only when the user actually wants to look at the trace. `traceBlock.tsx` moves to `traceWaterfallBlock.tsx` otherwise unchanged, so its existing URL-isolation carries over verbatim.

https://claude.ai/code/session_01Ghv8oF4JfC62u7ZtcSgWFG