### PR TITLE
fix(explore): Ignore empty cross-event query filters

### DIFF
--- a/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.spec.tsx
@@ -94,6 +94,34 @@ describe('useCrossEventQueries', () => {
     });
   });
 
+  it.each(['', '   '])('ignores blank logs and spans queries (%j)', query => {
+    const {result} = renderHookWithProviders(useCrossEventQueries, {
+      additionalWrapper: wrapper([
+        {type: 'logs', query},
+        {type: 'spans', query},
+      ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
+    });
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('preserves populated queries alongside blank queries', () => {
+    const {result} = renderHookWithProviders(useCrossEventQueries, {
+      additionalWrapper: wrapper([
+        {type: 'logs', query: '   '},
+        {type: 'spans', query: 'test:a'},
+      ]),
+      initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
+    });
+
+    expect(result.current).toStrictEqual({
+      logQuery: [],
+      spanQuery: ['test:a'],
+      metricQuery: [],
+    });
+  });
+
   it('appends queries with the same types', () => {
     const {result} = renderHookWithProviders(useCrossEventQueries, {
       additionalWrapper: wrapper([
@@ -258,10 +286,6 @@ describe('useCrossEventQueries', () => {
       initialProps: ALL_CROSS_EVENT_DATASETS_AVAILABLE,
     });
 
-    expect(result.current).toStrictEqual({
-      logQuery: [],
-      spanQuery: [],
-      metricQuery: [],
-    });
+    expect(result.current).toBeUndefined();
   });
 });

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -63,8 +63,10 @@ export function useCrossEventQueries(
       }
     }
 
-    if (spanQuery.length || logQuery.length || metricQuery.length) {
-      return {spanQuery, logQuery, metricQuery};
+    if (!spanQuery.length && !logQuery.length && !metricQuery.length) {
+      return;
     }
+
+    return {spanQuery, logQuery, metricQuery};
   }, [availability, crossEvents]);
 }

--- a/static/app/views/explore/hooks/useCrossEventQueries.tsx
+++ b/static/app/views/explore/hooks/useCrossEventQueries.tsx
@@ -40,6 +40,10 @@ export function useCrossEventQueries(
     const metricQuery: string[] = [];
 
     for (const crossEvent of slicedCrossEvents) {
+      if (crossEvent.type !== 'metrics' && crossEvent.query.trim() === '') {
+        continue;
+      }
+
       switch (crossEvent.type) {
         case 'spans':
           spanQuery.push(crossEvent.query);
@@ -59,6 +63,8 @@ export function useCrossEventQueries(
       }
     }
 
-    return {spanQuery, logQuery, metricQuery};
+    if (spanQuery.length || logQuery.length || metricQuery.length) {
+      return {spanQuery, logQuery, metricQuery};
+    }
   }, [availability, crossEvents]);
 }

--- a/static/app/views/explore/spans/spansTab.spec.tsx
+++ b/static/app/views/explore/spans/spansTab.spec.tsx
@@ -829,14 +829,28 @@ describe('SpansTabContent', () => {
       ).toBeDisabled();
     });
 
-    it('adds a cross event search bar when cross event added', async () => {
+    it('adds and removes an empty cross event search bar without refetching results', async () => {
       const logsProject = makeProject({id: '3', slug: 'logs-project', hasLogs: true});
       setProjects([logsProject]);
+
+      const tableRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events/`,
+        body: {},
+      });
+      const timeseriesRequest = MockApiClient.addMockResponse({
+        url: `/organizations/${organization.slug}/events-timeseries/`,
+        body: {timeSeries: []},
+      });
 
       render(<SpansTabContent datePageFilterProps={datePageFilterProps} />, {
         organization,
         additionalWrapper: Wrapper,
       });
+
+      await screen.findByText(/No spans found/);
+      await waitFor(() => expect(timeseriesRequest).toHaveBeenCalled());
+      const tableRequestCount = tableRequest.mock.calls.length;
+      const timeseriesRequestCount = timeseriesRequest.mock.calls.length;
 
       await userEvent.click(
         screen.getByRole('button', {name: 'Add a cross event query'})
@@ -848,6 +862,17 @@ describe('SpansTabContent', () => {
       expect(
         screen.getByPlaceholderText('Search for logs, users, tags, and more')
       ).toBeInTheDocument();
+
+      expect(tableRequest).toHaveBeenCalledTimes(tableRequestCount);
+      expect(timeseriesRequest).toHaveBeenCalledTimes(timeseriesRequestCount);
+
+      await userEvent.click(screen.getByLabelText('Remove cross event search for logs'));
+
+      expect(
+        screen.queryByPlaceholderText('Search for logs, users, tags, and more')
+      ).not.toBeInTheDocument();
+      expect(tableRequest).toHaveBeenCalledTimes(tableRequestCount);
+      expect(timeseriesRequest).toHaveBeenCalledTimes(timeseriesRequestCount);
     });
 
     it('can remove a cross event query', async () => {


### PR DESCRIPTION
Adding or removing a blank logs or spans cross-event row now leaves the effective table and chart requests unchanged, avoiding redundant fetches. Empty and whitespace-only filters are omitted alongside populated filters; selected metrics still contribute their identity filter even with empty search text. Existing cross-event tab and date-range restrictions remain in place.

Regression coverage verifies that adding and removing an empty logs row does not refetch table or chart results.
