### PR TITLE
feat(preprod): Make single-image snapshot cards zoomable in list view

### DIFF
--- a/static/app/views/preprod/snapshots/main/imageDisplay/zoomControls.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/zoomControls.tsx
@@ -15,7 +15,13 @@ interface ZoomControlsProps {
 
 export function ZoomControls({onZoomIn, onZoomOut, onReset}: ZoomControlsProps) {
   return (
-    <Container position="absolute" bottom="8px" right="8px" style={{zIndex: 1}}>
+    <Container
+      position="absolute"
+      bottom="8px"
+      right="8px"
+      style={{zIndex: 1}}
+      onClick={e => e.stopPropagation()}
+    >
       <ButtonBar>
         <Button size="xs" icon={<IconAdd />} aria-label="Zoom in" onClick={onZoomIn} />
         <Button

--- a/static/app/views/preprod/snapshots/main/snapshotCards.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.spec.tsx
@@ -64,3 +64,17 @@ describe('ImageCard canvas theme', () => {
     expectLightCanvas();
   });
 });
+
+describe('ImageCard zoom', () => {
+  it('renders zoom controls wired to the image zoom', async () => {
+    renderImageCard(null);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Zoom in'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Zoom out'}));
+    await userEvent.click(screen.getByRole('button', {name: 'Reset zoom'}));
+
+    expect(mockZoom.zoomIn).toHaveBeenCalledTimes(1);
+    expect(mockZoom.zoomOut).toHaveBeenCalledTimes(1);
+    expect(mockZoom.resetZoom).toHaveBeenCalledTimes(1);
+  });
+});

--- a/static/app/views/preprod/snapshots/main/snapshotCards.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.spec.tsx
@@ -21,7 +21,10 @@ jest.mock('sentry/utils/useCopyToClipboard', () => ({
   useCopyToClipboard: () => ({copy: jest.fn()}),
 }));
 
-function renderImageCard(canvasTheme: SnapshotImage['canvas_theme']) {
+function renderImageCard(
+  canvasTheme: SnapshotImage['canvas_theme'],
+  onSelectSnapshot?: (key: string | null) => void
+) {
   const image: SnapshotImage = {
     display_name: 'Button',
     height: 180,
@@ -39,6 +42,7 @@ function renderImageCard(canvasTheme: SnapshotImage['canvas_theme']) {
       isSelected={false}
       copyUrl="/copy/"
       snapshotKey={image.key}
+      onSelectSnapshot={onSelectSnapshot}
     />
   );
 }
@@ -76,5 +80,14 @@ describe('ImageCard zoom', () => {
     expect(mockZoom.zoomIn).toHaveBeenCalledTimes(1);
     expect(mockZoom.zoomOut).toHaveBeenCalledTimes(1);
     expect(mockZoom.resetZoom).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not toggle card selection when using zoom controls', async () => {
+    const onSelectSnapshot = jest.fn();
+    renderImageCard(null, onSelectSnapshot);
+
+    await userEvent.click(screen.getByRole('button', {name: 'Zoom in'}));
+
+    expect(onSelectSnapshot).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotDiffBodies.tsx
@@ -12,7 +12,7 @@ import {t} from 'sentry/locale';
 import type {SnapshotImage} from 'sentry/views/preprod/types/snapshotTypes';
 import {getImageName} from 'sentry/views/preprod/types/snapshotTypes';
 
-import {useSyncedD3Zoom} from './imageDisplay/useD3Zoom';
+import {useD3Zoom, useSyncedD3Zoom} from './imageDisplay/useD3Zoom';
 import {ZoomControls, zoomTransformStyle} from './imageDisplay/zoomControls';
 import {computeMaskSize} from './computeMaskSize';
 import {DiffOverlay} from './diffOverlay';
@@ -71,18 +71,14 @@ export const SplitPairBody = memo(function SplitPairBodyImpl({
               {t('Base')}
             </Text>
           </Container>
-          <ZoomViewport ref={zoom1.containerRef}>
-            <ImageSizer {...imageSizerProps(baseImage)}>
-              <ZoomTransformLayer style={zoomTransformStyle(zoom1.transform)}>
-                <LazyImage
-                  src={baseUrl}
-                  alt={`${altPrefix} (base)`}
-                  width={baseImage.width || undefined}
-                  height={baseImage.height || undefined}
-                />
-              </ZoomTransformLayer>
-            </ImageSizer>
-          </ZoomViewport>
+          <ZoomPane zoom={zoom1} image={baseImage}>
+            <LazyImage
+              src={baseUrl}
+              alt={`${altPrefix} (base)`}
+              width={baseImage.width || undefined}
+              height={baseImage.height || undefined}
+            />
+          </ZoomPane>
         </Stack>
         <Stack minWidth="0" borderLeft="secondary">
           <Container padding="sm xl">
@@ -90,27 +86,23 @@ export const SplitPairBody = memo(function SplitPairBodyImpl({
               {headLabel}
             </Text>
           </Container>
-          <ZoomViewport ref={zoom2.containerRef}>
-            <ImageSizer {...imageSizerProps(headImage)}>
-              <ZoomTransformLayer style={zoomTransformStyle(zoom2.transform)}>
-                <LazyImage
-                  src={headUrl}
-                  alt={`${altPrefix} (head)`}
-                  width={headImage.width || undefined}
-                  height={headImage.height || undefined}
-                >
-                  {diffMaskUrl && (
-                    <DiffOverlay
-                      $overlayColor={overlayColor!}
-                      $opacity={overlayOpacity}
-                      $maskUrl={diffMaskUrl}
-                      $maskSize={computeMaskSize(baseImage, headImage)}
-                    />
-                  )}
-                </LazyImage>
-              </ZoomTransformLayer>
-            </ImageSizer>
-          </ZoomViewport>
+          <ZoomPane zoom={zoom2} image={headImage}>
+            <LazyImage
+              src={headUrl}
+              alt={`${altPrefix} (head)`}
+              width={headImage.width || undefined}
+              height={headImage.height || undefined}
+            >
+              {diffMaskUrl && (
+                <DiffOverlay
+                  $overlayColor={overlayColor!}
+                  $opacity={overlayOpacity}
+                  $maskUrl={diffMaskUrl}
+                  $maskSize={computeMaskSize(baseImage, headImage)}
+                />
+              )}
+            </LazyImage>
+          </ZoomPane>
         </Stack>
       </Grid>
       <ZoomControls
@@ -131,19 +123,45 @@ export const ImageColumn = memo(function ImageColumnImpl({
   image: SnapshotImage;
   src: string;
 }) {
+  const zoom = useD3Zoom({wheelRequiresModifier: true});
   return (
-    <Stack minWidth="0">
-      <Flex justify="center">
+    <Container position="relative">
+      <ZoomPane zoom={zoom} image={image}>
         <LazyImage
           src={src}
           alt={alt}
           width={image.width || undefined}
           height={image.height || undefined}
         />
-      </Flex>
-    </Stack>
+      </ZoomPane>
+      <ZoomControls
+        onZoomIn={zoom.zoomIn}
+        onZoomOut={zoom.zoomOut}
+        onReset={zoom.resetZoom}
+      />
+    </Container>
   );
 });
+
+function ZoomPane({
+  zoom,
+  image,
+  children,
+}: {
+  children: ReactNode;
+  image: SnapshotImage;
+  zoom: ReturnType<typeof useD3Zoom>;
+}) {
+  return (
+    <ZoomViewport ref={zoom.containerRef}>
+      <ImageSizer {...imageSizerProps(image)}>
+        <ZoomTransformLayer style={zoomTransformStyle(zoom.transform)}>
+          {children}
+        </ZoomTransformLayer>
+      </ImageSizer>
+    </ZoomViewport>
+  );
+}
 
 const WIPE_MIN_HEIGHT = 160;
 


### PR DESCRIPTION
Single-image cards in the snapshot list (added, removed, renamed, unchanged, and solo snapshots) now support the same pan and zoom as pair cards: ctrl/cmd/shift + wheel zooms, drag pans, and the corner controls zoom in, zoom out, and reset. Plain wheel scrolling still moves the list. Previously these cards rendered a plain image while only split-mode pair cards had a D3 zoom container, so with Split selected every image on the page is now zoomable in both list and focus view.

The single-image column gets its own `useD3Zoom` instance with the same modifier-wheel gating as pair cards. The `ZoomViewport` / `ImageSizer` / `ZoomTransformLayer` nesting that `SplitPairBody` repeated per pane is extracted into a small `ZoomPane` helper shared by all three panes. Performance should be unaffected: per-card virtualization from #123500 bounds the mounted window to the visible rows plus overscan, and each pair card in that window already carries two zoom instances, so a single-image card adds at most half of what a pair card costs.

This also fixes a pre-existing bug surfaced while testing: the zoom control buttons sit inside the card frame whose click handler toggles selection, so clicking zoom in, zoom out, or reset also selected or deselected the card. `ZoomControls` now stops click propagation at its wrapper, which covers pair cards as well.

Covered by tests asserting the controls are wired on a solo card and that using them does not fire the card's select handler. I could not drive the devserver from this session, so a manual check that drag and modifier+wheel feel right on single cards would be worthwhile.