### PR TITLE
feat(seer): Render the pull request card the Seer agent publishes from chat

### DIFF
--- a/static/app/components/seer/markdown/embeds/components/pullRequestRef.spec.tsx
+++ b/static/app/components/seer/markdown/embeds/components/pullRequestRef.spec.tsx
@@ -1,0 +1,121 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import {SeerMarkdown} from 'sentry/components/seer/markdown';
+import {SeerRepoPRStatesProvider} from 'sentry/components/seer/markdown/embeds/components/pullRequestRef';
+import type {RepoPRState} from 'sentry/views/seerExplorer/types';
+
+const REPO = 'acme/web';
+const PR_URL = 'https://github.com/acme/web/pull/482';
+
+function makeState(overrides: Partial<RepoPRState> = {}): RepoPRState {
+  return {
+    repo_name: REPO,
+    branch_name: 'seer/add-cart-logging',
+    commit_sha: 'abc123',
+    pr_creation_error: null,
+    pr_creation_status: 'completed',
+    pr_id: 999,
+    pr_number: 482,
+    pr_url: PR_URL,
+    title: 'Add cart total logging',
+    ...overrides,
+  };
+}
+
+function renderCard({
+  states,
+  body = {repoName: REPO, runId: 42},
+}: {
+  states: Record<string, RepoPRState> | null;
+  body?: Record<string, unknown>;
+}) {
+  return render(
+    <SeerRepoPRStatesProvider repoPRStates={states}>
+      <SeerMarkdown
+        raw="{% pullRequestRef /%}"
+        structuredContent={{pullRequestRef: body}}
+      />
+    </SeerRepoPRStatesProvider>
+  );
+}
+
+describe('pullRequestRef embed', () => {
+  it('shows progress while the pull request is being opened', () => {
+    renderCard({
+      states: {
+        [REPO]: makeState({
+          pr_creation_status: 'creating',
+          pr_number: null,
+          pr_url: null,
+        }),
+      },
+    });
+
+    expect(screen.getByText(REPO)).toBeInTheDocument();
+    expect(screen.getByText('Opening a pull request in acme/web…')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('shows progress against the existing pull request when pushing to one', () => {
+    renderCard({
+      states: {[REPO]: makeState({pr_creation_status: 'creating'})},
+    });
+
+    expect(screen.getByText('Pushing changes to acme/web#482…')).toBeInTheDocument();
+  });
+
+  it('links the pull request once the push completes', () => {
+    renderCard({states: {[REPO]: makeState()}});
+
+    const link = screen.getByRole('button', {name: 'View acme/web#482'});
+    expect(link).toHaveAttribute('href', PR_URL);
+    expect(screen.getByText('Add cart total logging')).toBeInTheDocument();
+  });
+
+  it('reports a failed push with the error Seer recorded', () => {
+    renderCard({
+      states: {
+        [REPO]: makeState({
+          pr_creation_status: 'error',
+          pr_number: null,
+          pr_url: null,
+          pr_creation_error: 'No write access to repository',
+        }),
+      },
+    });
+
+    expect(screen.getByText('Seer could not push to acme/web.')).toBeInTheDocument();
+    expect(screen.getByText('No write access to repository')).toBeInTheDocument();
+  });
+
+  it('falls back to the pull request pinned in the body when the host has no run state', () => {
+    renderCard({
+      states: null,
+      body: {
+        repoName: REPO,
+        prNumber: 482,
+        prUrl: PR_URL,
+        title: 'Add cart total logging',
+      },
+    });
+
+    expect(screen.getByRole('button', {name: 'View acme/web#482'})).toHaveAttribute(
+      'href',
+      PR_URL
+    );
+  });
+
+  it('waits when neither the host nor the body knows the pull request yet', () => {
+    renderCard({states: {}});
+
+    expect(
+      screen.getByText('Waiting for the pull request in acme/web…')
+    ).toBeInTheDocument();
+  });
+
+  it('renders nothing for a body without a repository', () => {
+    renderCard({states: {}, body: {runId: 42}});
+
+    expect(screen.queryByTestId('pull-request-ref-embed')).not.toBeInTheDocument();
+  });
+});

--- a/static/app/components/seer/markdown/embeds/components/pullRequestRef.tsx
+++ b/static/app/components/seer/markdown/embeds/components/pullRequestRef.tsx
@@ -1,0 +1,148 @@
+import {createContext, useContext, type ReactNode} from 'react';
+
+import {LinkButton} from '@sentry/scraps/button';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
+
+import {getRepoPullRequestLink} from 'sentry/components/events/autofix/pullRequests';
+import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {
+  defineSeerEmbed,
+  type EmbedOutput,
+} from 'sentry/components/seer/markdown/embeds/utils';
+import {IconOpen} from 'sentry/icons/iconOpen';
+import {IconPullRequest} from 'sentry/icons/iconPullRequest';
+import {t} from 'sentry/locale';
+import type {RepoPRState} from 'sentry/views/seerExplorer/types';
+
+/**
+ * The run's per-repository PR state, supplied by the host that already polls the run.
+ * The card reads it from here instead of fetching on its own: the explorer polls the
+ * session every 500ms while a push is in flight, so a second poller per card would only
+ * add load and could disagree with the header widget.
+ */
+const SeerRepoPRStatesContext = createContext<Record<string, RepoPRState> | null>(null);
+
+export function SeerRepoPRStatesProvider({
+  children,
+  repoPRStates,
+}: {
+  children: ReactNode;
+  repoPRStates: Record<string, RepoPRState> | null | undefined;
+}) {
+  return (
+    <SeerRepoPRStatesContext.Provider value={repoPRStates ?? null}>
+      {children}
+    </SeerRepoPRStatesContext.Provider>
+  );
+}
+
+export const PullRequestRefEmbed = defineSeerEmbed({
+  name: 'pullRequestRef',
+  render(props) {
+    return <PullRequestRefContent {...props} />;
+  },
+});
+
+interface PullRequestLink {
+  label: string;
+  url: string;
+}
+
+/**
+ * Seer emits the card before the PR exists, so the body carries the PR only when the
+ * push updates one that is already open. The live state wins whenever the host has it;
+ * the body is what keeps an old conversation's card linked once the host stops polling.
+ */
+function resolveLink(
+  state: RepoPRState | undefined,
+  {repoName, prNumber, prUrl}: EmbedOutput<'pullRequestRef'>
+): PullRequestLink | null {
+  const live = state ? getRepoPullRequestLink(state) : null;
+  if (live) {
+    return live;
+  }
+  if (prUrl && prNumber) {
+    return {label: t('View %s#%s', repoName, prNumber), url: prUrl};
+  }
+  return null;
+}
+
+function PullRequestRefContent(props: EmbedOutput<'pullRequestRef'>) {
+  const {repoName, prNumber, title} = props;
+  const repoPRStates = useContext(SeerRepoPRStatesContext);
+  const state = repoPRStates?.[repoName];
+  const link = resolveLink(state, props);
+  const displayTitle = state?.title ?? title;
+  const targetNumber = state?.pr_number ?? prNumber;
+
+  let body: ReactNode;
+  if (state?.pr_creation_status === 'creating') {
+    body = (
+      <Flex gap="md" align="center">
+        <LoadingIndicator size={16} style={{margin: 0}} />
+        <Text variant="muted" size="sm">
+          {targetNumber
+            ? t('Pushing changes to %s#%s…', repoName, targetNumber)
+            : t('Opening a pull request in %s…', repoName)}
+        </Text>
+      </Flex>
+    );
+  } else if (state?.pr_creation_status === 'error') {
+    body = (
+      <Stack gap="2xs">
+        <Text variant="danger" size="sm">
+          {t('Seer could not push to %s.', repoName)}
+        </Text>
+        {state.pr_creation_error && (
+          <Text variant="muted" size="sm">
+            {state.pr_creation_error}
+          </Text>
+        )}
+      </Stack>
+    );
+  } else if (link) {
+    body = (
+      <Flex>
+        <LinkButton size="sm" icon={<IconOpen />} href={link.url} external>
+          {link.label}
+        </LinkButton>
+      </Flex>
+    );
+  } else {
+    body = (
+      <Text variant="muted" size="sm">
+        {t('Waiting for the pull request in %s…', repoName)}
+      </Text>
+    );
+  }
+
+  return (
+    <Container
+      data-test-id="pull-request-ref-embed"
+      width="fit-content"
+      maxWidth="100%"
+      padding="md"
+      border="primary"
+      radius="md"
+      background="secondary"
+    >
+      <Flex gap="md" align="start">
+        <IconPullRequest size="sm" />
+        <Stack gap="sm">
+          <Stack gap="2xs">
+            <Text bold size="sm">
+              {repoName}
+            </Text>
+            {displayTitle && (
+              <Text variant="muted" size="sm">
+                {displayTitle}
+              </Text>
+            )}
+          </Stack>
+          {body}
+        </Stack>
+      </Flex>
+    </Container>
+  );
+}

--- a/static/app/components/seer/markdown/embeds/index.ts
+++ b/static/app/components/seer/markdown/embeds/index.ts
@@ -16,6 +16,7 @@ import {LogsQuery} from './components/logsQuery';
 import {MetricsQuery} from './components/metricsQuery';
 import {Monitor} from './components/monitor/monitor';
 import {Profile} from './components/profile/profile';
+import {PullRequestRefEmbed} from './components/pullRequestRef';
 import {Release} from './components/release';
 import {Replay} from './components/replay';
 import {ReplaysQuery} from './components/replaysQuery';
@@ -47,6 +48,7 @@ const embeds = [
   MetricsQuery,
   Monitor,
   Profile,
+  PullRequestRefEmbed,
   Release,
   Replay,
   ReplaysQuery,

--- a/static/app/components/seer/markdown/embeds/schemas.ts
+++ b/static/app/components/seer/markdown/embeds/schemas.ts
@@ -1079,6 +1079,25 @@ export const STRUCTURED_SEER_EMBED_SCHEMAS = {
       status: z.enum(['pending', 'approved', 'rejected']),
     }),
   },
+  /**
+   * Published by Seer's pull request lib when the agent opens or updates a PR from
+   * the run's own edits. Structured-only so the agent is never told to write the
+   * tag itself: the card follows the run's `repo_pr_states`, which the host that
+   * polls the run supplies, and the body only pins the PR the push targets when
+   * one already exists.
+   */
+  pullRequestRef: {
+    description:
+      'Follow the pull request Seer is opening or updating for a repository from the run state.',
+    level: ['block'],
+    schema: z.object({
+      repoName: z.string().min(1),
+      runId: z.union([z.string(), z.number()]).optional(),
+      prNumber: z.number().optional(),
+      prUrl: z.string().optional(),
+      title: z.string().optional(),
+    }),
+  },
 } as const satisfies Record<string, SeerEmbedSchema>;
 
 export const ALL_SEER_EMBED_SCHEMAS = {

--- a/static/app/views/seerExplorer/components/seerExplorerContent.tsx
+++ b/static/app/views/seerExplorer/components/seerExplorerContent.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useEffect, useMemo, useRef, type ReactNode} from 'react';
+import {useCallback, useEffect, useMemo, useRef, type ReactNode} from 'react';
 import styled from '@emotion/styled';
 import {skipToken, useQuery} from '@tanstack/react-query';
 
@@ -13,6 +13,7 @@ import {
   AutofixChatProvider,
   type SendMessageOptions,
 } from 'sentry/components/seer/autofixChatContext';
+import {SeerRepoPRStatesProvider} from 'sentry/components/seer/markdown/embeds/components/pullRequestRef';
 import {SEER_AGENTS_PROJECT_ID} from 'sentry/constants';
 import {IconClose, IconRefresh} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -624,7 +625,7 @@ export function SeerExplorerContent({
               onSuggestionClick={readOnly ? undefined : sendMessage}
             />
           ) : (
-            <Fragment>
+            <SeerRepoPRStatesProvider repoPRStates={repoPRStates}>
               {groupTranscript(blocks).map(segment => {
                 const interactionPending =
                   isFileApprovalPending ||
@@ -701,7 +702,7 @@ export function SeerExplorerContent({
                   }
                 />
               )}
-            </Fragment>
+            </SeerRepoPRStatesProvider>
           )}
         </BlocksContainer>
         {isTimedOut && (


### PR DESCRIPTION
Frontend half of the "ad-hoc PRs from Chat UI/Slack" PRD on the Sentry side. getsentry/seer#8123 teaches the Seer agent to open a pull request from a conversation's own edits and to publish a `pullRequestRef` card while it does; this PR renders that card in the chat. The Slack announcement is a separate backend PR (link below), and neither depends on the other.

`pullRequestRef` joins `agentWriteApproval` in `STRUCTURED_SEER_EMBED_SCHEMAS`, so it is not exported to the widget list the agent sees and the agent is never told it may write the tag — Seer publishes the card and the frontend fills it from `structuredContent`. The new `PullRequestRefEmbed` reads the run's `repo_pr_states` from a `SeerRepoPRStatesProvider` that the explorer now wraps around the transcript (it replaces the existing `Fragment`, so nothing re-indents). The explorer already polls the session every 500 ms while a push is in flight and stops when `pr_creation_status` settles, so the card follows *Opening a pull request in repo…* → a **View repo#N** link or the recorded error without a poller of its own.

The body pins the PR only when the push updates one that already exists; that is what keeps a reopened conversation's card linked after polling has stopped, and a host without the provider falls back to it. `pnpm gen:embed-widgets` produces no diff, as expected for a structured-only schema.

Gating is unchanged: whether the agent can open a PR at all is decided on the Seer side by the coding switches (`sentry:enable_seer_coding` org option, `organizations:seer-explorer-chat-coding`, and `organizations:seer-explorer-code-mode-tools` for the Code Mode surface). The card renders wherever a conversation already carries one.

Not in this PR: live CI/merge status inside the card (it would need a Sentry endpoint proxying the SCM; today the agent reads status through Seer's `get_pull_request_status` and says it in prose), and screenshots — the card only appears in a live explorer session with the seer branch deployed. The jest spec covers the creating, pushing, completed, error, body-fallback, and waiting states.

Related: backend Slack announcement PR — https://github.com/getsentry/sentry/pull/124064

https://claude.ai/code/session_01CCbNR4yCgKpn3yewPcPPHX
