### PR TITLE
build(rspack): Run React Compiler through oxc-transform-react

### DIFF
--- a/build-utils/react-compiler-loader.ts
+++ b/build-utils/react-compiler-loader.ts
@@ -1,0 +1,59 @@
+import type {LoaderDefinitionFunction} from '@rspack/core';
+import {type ReactCompilerOptions, transformSync} from 'oxc-transform-react';
+
+type ReactCompilerLoaderOptions = ReactCompilerOptions;
+
+/**
+ * `.ts` is parsed as TypeScript rather than TSX because the two grammars
+ * disagree on `<T>value`: TSX reads it as an element, TypeScript as a cast.
+ * Plain `.js` goes through the JSX grammar so the untyped files that still
+ * contain elements keep parsing.
+ */
+function getLang(resourcePath: string) {
+  if (resourcePath.endsWith('.tsx')) {
+    return 'tsx' as const;
+  }
+  // Declarations reach the loader because they also match `.ts`, and only the
+  // ambient grammar accepts their uninitialized `const`s.
+  if (resourcePath.endsWith('.d.ts')) {
+    return 'dts' as const;
+  }
+  if (resourcePath.endsWith('.ts')) {
+    return 'ts' as const;
+  }
+  return 'jsx' as const;
+}
+
+const reactCompilerLoader: LoaderDefinitionFunction<ReactCompilerLoaderOptions> =
+  function (source) {
+    const result = transformSync(this.resourcePath, source, {
+      lang: getLang(this.resourcePath),
+      sourceType: 'module',
+      sourcemap: this.sourceMap,
+      // JSX is left intact so swc-loader still owns the emotion pragma,
+      // component annotation and fast refresh transforms downstream.
+      jsx: 'preserve',
+      reactCompiler: this.getOptions(),
+    });
+
+    // The compiler bails out silently on anything it cannot memoize, so a fatal
+    // result is a parse or semantic failure rather than a component that opted
+    // out, and it should stop the build instead of shipping unread source.
+    if (result.fatal) {
+      this.callback(new Error(result.errors.map(error => error.message).join('\n')));
+      return;
+    }
+
+    for (const error of result.errors) {
+      this.emitWarning(new Error(error.message));
+    }
+
+    // oxc leaves `file` unset, which the loader source map type requires.
+    this.callback(
+      null,
+      result.code,
+      result.map && {...result.map, file: result.map.file ?? this.resourcePath}
+    );
+  };
+
+export default reactCompilerLoader;

--- a/package.json
+++ b/package.json
@@ -259,6 +259,7 @@
     "jest-fail-on-console": "3.3.4",
     "knip": "6.32.1",
     "odiff-bin": "4.3.8",
+    "oxc-transform-react": "0.149.0",
     "oxfmt": "^0.63.0",
     "oxlint": "1.81.0",
     "oxlint-plugin-eslint": "1.81.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,6 +636,9 @@ importers:
       odiff-bin:
         specifier: 4.3.8
         version: 4.3.8
+      oxc-transform-react:
+        specifier: 0.149.0
+        version: 0.149.0
       oxfmt:
         specifier: ^0.63.0
         version: 0.63.0
@@ -2324,6 +2327,128 @@ packages:
 
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
     resolution: {integrity: sha512-UqGPmo56KDfLlfXFAFIrNflHT8tFxWGEivWg3Zeyp4Uy2NlKN1FGPr6/BxcLGG3+kZ6Wp14g5Uj+n71boqZfiw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-transform-react/binding-android-arm-eabi@0.149.0':
+    resolution: {integrity: sha512-j9tB2Ug9rZMxBxE57nJJvB0QMXqrAYdPB5653DtAFCbp5WmuOPot2iz9Ctm64oMQchdutYwVoHKfZPC23ZpN+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform-react/binding-android-arm64@0.149.0':
+    resolution: {integrity: sha512-GE5jGUca23DbM6jsMccmrkBe7LlbKvO03JznFXMupKN3os2MrwNnT9bm3CxgC5ih0KKnpwdOhP6+gayaf/RsRQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform-react/binding-darwin-arm64@0.149.0':
+    resolution: {integrity: sha512-3XWdu3umUjOyDWamugshtYYglZJR/TnP7gjnvGc3vI1ozqRrtS+QLjs73XOKU7KTkfuoBSh0lf0cF+Y8u8aqng==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-darwin-x64@0.149.0':
+    resolution: {integrity: sha512-qUcf+jK5c5uvSCH392AOSZKj6fwdYxMC9zwpshIzf0Kpj73RGZciN3E7OG77epVQvh+B/REurBTV+dmywmZwRQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform-react/binding-freebsd-x64@0.149.0':
+    resolution: {integrity: sha512-curcmpjfcjNJd+OcvnBAZGWbY5oWNmOduYMrIpRAt+2Vr85BOk6t++bjn1vIJ+0CIOSd86EPNh5H2uEGfrjUpg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.149.0':
+    resolution: {integrity: sha512-6PsFpEwOLCMLTCH7K9/UaUY9JXimAf3PaVrUKFEKZenBAVByV8Rpk5hK8xFk9+xWA4+a3EckqzgT7VHnTV8POQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.149.0':
+    resolution: {integrity: sha512-Jqnar7VWfwZovsfhJu0cXXOtypQYaEPSrhScNVtAPrWkb8bpuvF2JJ3BebxyvGcXi2MMRMaD9LyyVrBlGfeCFw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.149.0':
+    resolution: {integrity: sha512-c+pZ8PPe9KpaTvkASe1QK//YxghFVoPTvg/oOQqldBUje04kemIR7ThfvLDfMe36UQ/wm/KYSNmISDJis1DXZQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.149.0':
+    resolution: {integrity: sha512-EUxJd2xsFvNvfMGZIgssLXH7AcsRTCo/2BXUZZOUgyPB59KsnxhQ+KRwi9NeX7YhgLMx6fv+ZuYpCyPs6PIw4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.149.0':
+    resolution: {integrity: sha512-+DtOzO4MgQvubmmZRQPpUO6aWffXkrjv3XnenkC9Jf0UMW644o0TRADCfP0Qye+evLv9pEHpiLbI9aH5w6WzpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.149.0':
+    resolution: {integrity: sha512-8s2RVzHkUjDvGM1k9BdVxUvoJUcMQ2yUFH+vJWhb+T/Pwsr0EasHih5YN+zv+Wx/YviiH0gDkqxx2vpInAhQyA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.149.0':
+    resolution: {integrity: sha512-S/GBmspvYLfxbT6muuyaguA/9msJvZAaZ1fHrAt+moW6msZyokEnJ/3CvOX15gcXbj93+LSSsusReQpbovHZhQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.149.0':
+    resolution: {integrity: sha512-8U+ZC2sqpXxDptpvqQRtompH1ivacHiEUgtsMva8IugCvxcNmd+A7sDtxlOYfNrKPO8ToUPEuWA9qEzJtm6YAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.149.0':
+    resolution: {integrity: sha512-RLMKO7f7c/lM5Q3Uw8SFyI7eJ7tPqPjo/3C2EgANvtY3/ySiRSoaxC5OozX/1ATvqO5X75r6TjjPx+lPKsJ11A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.149.0':
+    resolution: {integrity: sha512-F3iGtmHwRZa9OCQ43ccod3tQpfWaPiUGRSCjMV7EJK7qWsGqp8fgMxIUIRip/iEXBodIQ9iq4bA4vszhwohRkA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.149.0':
+    resolution: {integrity: sha512-+DYaxAGwHkKVIf1+zRS3is8ay2ZADfreYRhLLJ7CbvJqmpE4tjJoIIqjcWmZnRIhZK2+u9GDOfV17byr0nitbw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.149.0':
+    resolution: {integrity: sha512-F0x4PSnABQzrqjUBQgh5NOCj0uJnRkgeQoULsVADpS0DdKCO4qNIF8PABjAzmx1hl/6Mg/Cs07s5bvTfiRFOUw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.149.0':
+    resolution: {integrity: sha512-z5Idox/U/jAR5I+uCBgcEK49I0fXsA2+BaQ58xeKl//BDG4tFYnFSBBg24z/PaouDqXJHAi8koimLReFDwoG+A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.149.0':
+    resolution: {integrity: sha512-g3v1prVeSrseqsRRU44lL8V64yWBkRxcdrY5j80b5OxUjFv643qXv80n1JcS4iH3RbqQylfJFldginKo8XOsIQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
@@ -7296,6 +7421,10 @@ packages:
   oxc-resolver@11.24.2:
     resolution: {integrity: sha512-FY91FiDBj7ls5MsFS9jN3tjz2o0/zsdSsymlakySaBwVJZorHhkWyICLZMKxlu1R9vYo+sd3z1jwb4J8x7bNDw==}
 
+  oxc-transform-react@0.149.0:
+    resolution: {integrity: sha512-ab3dxcPtkDSfIR9tNdxHUtmpdL0lhHndsBD9IUAU5BxtJtwGG/85NnRzs2f2KwouNkHl7caSswMLQeUvw3FERw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   oxfmt@0.63.0:
     resolution: {integrity: sha512-kgdDwv35wvVf6554U2Ab8Jnd0zTM+TsEQWwaB70RAjK3gICFAFGO+2Hd3Be27GMoXj3XRL9IKSNRVl7KBQL6iw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -10542,6 +10671,63 @@ snapshots:
     optional: true
 
   '@oxc-resolver/binding-win32-x64-msvc@11.24.2':
+    optional: true
+
+  '@oxc-transform-react/binding-android-arm-eabi@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-android-arm64@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-arm64@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-darwin-x64@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-freebsd-x64@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-gnueabihf@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm-musleabihf@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-gnu@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-arm64-musl@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-ppc64-gnu@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-gnu@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-riscv64-musl@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-s390x-gnu@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-gnu@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-linux-x64-musl@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-openharmony-arm64@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-arm64-msvc@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-ia32-msvc@0.149.0':
+    optional: true
+
+  '@oxc-transform-react/binding-win32-x64-msvc@0.149.0':
     optional: true
 
   '@oxfmt/binding-android-arm-eabi@0.63.0':
@@ -16445,6 +16631,28 @@ snapshots:
       '@oxc-resolver/binding-wasm32-wasi': 11.24.2
       '@oxc-resolver/binding-win32-arm64-msvc': 11.24.2
       '@oxc-resolver/binding-win32-x64-msvc': 11.24.2
+
+  oxc-transform-react@0.149.0:
+    optionalDependencies:
+      '@oxc-transform-react/binding-android-arm-eabi': 0.149.0
+      '@oxc-transform-react/binding-android-arm64': 0.149.0
+      '@oxc-transform-react/binding-darwin-arm64': 0.149.0
+      '@oxc-transform-react/binding-darwin-x64': 0.149.0
+      '@oxc-transform-react/binding-freebsd-x64': 0.149.0
+      '@oxc-transform-react/binding-linux-arm-gnueabihf': 0.149.0
+      '@oxc-transform-react/binding-linux-arm-musleabihf': 0.149.0
+      '@oxc-transform-react/binding-linux-arm64-gnu': 0.149.0
+      '@oxc-transform-react/binding-linux-arm64-musl': 0.149.0
+      '@oxc-transform-react/binding-linux-ppc64-gnu': 0.149.0
+      '@oxc-transform-react/binding-linux-riscv64-gnu': 0.149.0
+      '@oxc-transform-react/binding-linux-riscv64-musl': 0.149.0
+      '@oxc-transform-react/binding-linux-s390x-gnu': 0.149.0
+      '@oxc-transform-react/binding-linux-x64-gnu': 0.149.0
+      '@oxc-transform-react/binding-linux-x64-musl': 0.149.0
+      '@oxc-transform-react/binding-openharmony-arm64': 0.149.0
+      '@oxc-transform-react/binding-win32-arm64-msvc': 0.149.0
+      '@oxc-transform-react/binding-win32-ia32-msvc': 0.149.0
+      '@oxc-transform-react/binding-win32-x64-msvc': 0.149.0
 
   oxfmt@0.63.0:
     dependencies:

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -15,6 +15,7 @@ import {ReactRefreshRspackPlugin} from '@rspack/plugin-react-refresh';
 import {sentryWebpackPlugin} from '@sentry/webpack-plugin/webpack5';
 import CompressionPlugin from 'compression-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
+import type {ReactCompilerOptions} from 'oxc-transform-react';
 import {TsCheckerRspackPlugin} from 'ts-checker-rspack-plugin';
 
 import LastBuiltPlugin from './build-utils/last-built-plugin.ts';
@@ -45,6 +46,9 @@ const IS_DEPLOY_PREVIEW = !!env.NOW_GITHUB_DEPLOYMENT;
 
 const IS_UI_DEV_ONLY = !!env.SENTRY_UI_DEV_ONLY;
 const IS_ADMIN_UI_DEV = !!env.SENTRY_ADMIN_UI_DEV;
+
+// TODO: Enable in production
+const USE_REACT_COMPILER = IS_DEPLOY_PREVIEW || IS_ACCEPTANCE_TEST || IS_UI_DEV_ONLY;
 
 const DEV_MODE = !(IS_PRODUCTION || IS_CI);
 const WEBPACK_MODE: Configuration['mode'] = IS_PRODUCTION ? 'production' : 'development';
@@ -198,7 +202,7 @@ const DEFINED_ENV_VARS = {
   'process.env.ENABLE_SENTRY_TOOLBAR': JSON.stringify(ENABLE_SENTRY_TOOLBAR),
 };
 
-const swcReactLoaderConfig = (options: {reactCompiler: boolean}): SwcLoaderOptions => ({
+const swcReactLoaderConfig = (): SwcLoaderOptions => ({
   env: {
     mode: 'usage',
     // https://rspack.rs/guide/features/builtin-swc-loader#polyfill-injection
@@ -243,10 +247,6 @@ const swcReactLoaderConfig = (options: {reactCompiler: boolean}): SwcLoaderOptio
       tsx: true,
     },
     transform: {
-      // TODO: Enable in production
-      reactCompiler:
-        options.reactCompiler &&
-        (IS_DEPLOY_PREVIEW || IS_ACCEPTANCE_TEST || IS_UI_DEV_ONLY),
       react: {
         runtime: 'automatic',
         development: DEV_MODE,
@@ -257,6 +257,16 @@ const swcReactLoaderConfig = (options: {reactCompiler: boolean}): SwcLoaderOptio
   },
   isModule: 'unknown',
 });
+
+/**
+ * Memoizes components ahead of swc-loader. The compiler needs the pristine
+ * source, so it cannot share swc's pass, and running it here keeps the JSX,
+ * emotion and fast refresh transforms in one place downstream.
+ */
+const reactCompilerLoader = {
+  loader: path.resolve(import.meta.dirname, './build-utils/react-compiler-loader.ts'),
+  options: {target: '19'} satisfies ReactCompilerOptions,
+};
 
 /**
  * Main Webpack config for Sentry React SPA.
@@ -333,13 +343,15 @@ const appConfig: Configuration = {
             // "illegal escape sequence" warnings in dev mode.
             exclude: /node_modules[\\/](core-js|react-select)/,
             loader: 'builtin:swc-loader',
-            options: swcReactLoaderConfig({reactCompiler: false}),
+            options: swcReactLoaderConfig(),
           },
           {
             // Application code only.
             exclude: /node_modules/,
-            loader: 'builtin:swc-loader',
-            options: swcReactLoaderConfig({reactCompiler: true}),
+            use: [
+              {loader: 'builtin:swc-loader', options: swcReactLoaderConfig()},
+              ...(USE_REACT_COMPILER ? [reactCompilerLoader] : []),
+            ],
           },
         ],
       },
@@ -348,7 +360,7 @@ const appConfig: Configuration = {
         use: [
           {
             loader: 'builtin:swc-loader',
-            options: swcReactLoaderConfig({reactCompiler: false}),
+            options: swcReactLoaderConfig(),
           },
           {
             loader: '@mdx-js/loader',


### PR DESCRIPTION
> **Blocked on an upstream miscompile — do not merge.** `oxc-transform-react@0.149.0` drops optional-chaining guards, which crashes the issue page. Details at the bottom. The build wiring below is what I would land once oxc has a fix.

The React Compiler runs through [`oxc-transform-react`](https://oxc.rs/blog/2026-08-18-react-compiler-support) as an rspack loader instead of swc's `jsc.transform.reactCompiler`. When it runs does not change — same gate, same environments — so this swaps the engine rather than rolling anything out.

The reason to swap is that we already lint with oxc's React Compiler. `oxlint.config.ts` runs `react/invariant`, `react/immutability`, `react/set-state-in-render`, `react/use-memo` and friends at `error`, with another dozen parked at `off` behind TODOs. Right now the compiler that tells us a component is unsafe to memoize and the compiler that actually memoizes it are two different implementations, so a bailout in one does not imply a bailout in the other. Sharing one engine means promoting a parked rule tells us something real about what the build does.

The two compilers otherwise produce near-identical bundles: 11,377 memo-cache sentinels on master vs 11,430 here, and 25,803 vs 25,985 `data-sentry-component` attributes. This really is an engine swap.

### Why a loader

`builtin:swc-loader` is native and owns the emotion pragma, `swc-plugin-component-annotate` and fast refresh. Handing the whole file to oxc would give all of that up. Instead the loader uses oxc's `jsx: 'preserve'`, so the compiler memoizes against the pristine AST and hands JSX back untouched for swc to finish:

```jsx
// in
<Wrapper css={{color: 'red'}}>{items.map(i => <Row key={i} />)}</Wrapper>

// out — memoized, still JSX, emotion's css prop intact
let t3;
if ($[6] === Symbol.for("react.memo_cache_sentinel")) { t3 = {color: "red"}; $[6] = t3; }
t1 = <Wrapper css={t3}>{items.map(t6)}</Wrapper>;
```

Running both compilers is not an option, since the second re-compiles the first's output, and `@vitejs/plugin-react({compiler: true})` from the announcement does not apply because we build with rspack.

### The blocker

`Acceptance` fails on `test_cocoa_event_frame_line_hover`, which times out waiting for `.traceback li:nth-child(2)` — the stack trace never renders. It failed all five reruns, and master is green on the same workflow, so it is this branch.

oxc drops the optional-chaining guard when a TypeScript `!` assertion appears later in the same chain, but only inside a function the compiler actually compiles:

```tsx
// source
const frames = data?.exceptions[idx]!.frames.map(f => g(f));

// oxc, inside a compiled component — `?.` is gone, and `data.exceptions`
// is also read unguarded in the dependency comparison on every render
if ($[0] !== data.exceptions || $[1] !== idx) {
  t1 = data.exceptions[idx].frames.map(_temp);
```

Remove the `!` and oxc keeps the guard. At module scope, oxc keeps the guard even with the `!`. swc lowers the same expression to a correct ternary in every case.

`static/app/components/events/interfaces/crashContent/exception/content.tsx:168` uses exactly that shape, so rendering an exception throws `TypeError: Cannot read properties of undefined (reading 'exceptions')` and takes the traceback down with it. The existing unit tests pin it down without needing acceptance — same suite, three transforms:

| transform | `crashContent/exception/content.spec.tsx` |
|---|---|
| none (today's jest) | 9 passed |
| swc `reactCompiler` (master's build) | 9 passed |
| oxc `reactCompiler` (this branch) | 9 failed |

61 files contain 107 of these `?.` + `!` chains. Only this one is covered by a test, so the rest are latent. Rewriting them to dodge a miscompile would be the wrong fix, and 0.149.0 is still the newest release, so this waits on oxc.

### Testing this once it is unblocked

There is no FlagPole flag. The gate is `USE_REACT_COMPILER` in `rspack.config.ts`, unchanged from the condition that was inline in the swc options, and still carrying its `TODO: Enable in production`:

```
NOW_GITHUB_DEPLOYMENT  (deploy previews)
IS_ACCEPTANCE_TEST     (acceptance tests)
SENTRY_UI_DEV_ONLY     (pnpm run dev-ui)
```

`IS_ACCEPTANCE_TEST=1 pnpm run build` is the quickest way to see it on. When the gate is off the loader is left out of the chain entirely, so ordinary dev and production builds keep the single native loader and pay nothing.

### Where to look

The `oneOf` order in `module.rules` carries an `XXX` warning about breaking getsentry. The app-code branch changes from `loader`/`options` shorthand to a `use` array, but its `include`/`exclude` conditions are untouched — that is the line worth a second pair of eyes.

`.d.ts` files match the `.tsx?` test and reach the loader, and only oxc's `dts` grammar accepts their uninitialized `const`s, so `getLang` special-cases them. Running the transform over all 9,053 files in `static/` memoizes 4,305 with no parse failures and no diagnostics, which is why the loader fails the build on a `fatal` result rather than passing the original source through.

https://claude.ai/code/session_01FfCv9ouirbDG72xWsMT82z
