### PR TITLE
feat(preprod): Add keyboard shortcuts help to the snapshot toolbar

### DIFF
--- a/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/preprodBuildAnalyticsEvents.tsx
@@ -110,6 +110,9 @@ export type PreprodBuildEventParameters = {
     diff_status: string | null;
     organization: Organization;
   };
+  'preprod.snapshots.details.keyboard_shortcuts_opened': {
+    organization: Organization;
+  };
   'preprod.snapshots.details.view_mode_changed': {
     organization: Organization;
     view_mode: string;
@@ -169,6 +172,8 @@ export const preprodBuildEventMap: Record<PreprodBuildAnalyticsKey, string | nul
   'preprod.snapshots.details.image_link_copied': 'Preprod Snapshots: Image Link Copied',
   'preprod.snapshots.details.image_metadata_copied':
     'Preprod Snapshots: Image Metadata Copied',
+  'preprod.snapshots.details.keyboard_shortcuts_opened':
+    'Preprod Snapshots: Keyboard Shortcuts Opened',
   'preprod.snapshots.details.view_mode_changed': 'Preprod Snapshots: View Mode Changed',
   'preprod.snapshots.details.diff_mode_changed': 'Preprod Snapshots: Diff Mode Changed',
   'preprod.settings.status_check_rule_created':

--- a/static/app/views/preprod/snapshots/main/imageDisplay/zoomControls.tsx
+++ b/static/app/views/preprod/snapshots/main/imageDisplay/zoomControls.tsx
@@ -2,15 +2,27 @@ import styled from '@emotion/styled';
 import type {ZoomTransform} from 'd3-zoom';
 
 import {Button, ButtonBar} from '@sentry/scraps/button';
+import {Hotkey, Kbd} from '@sentry/scraps/hotkey';
 import {Image} from '@sentry/scraps/image';
-import {Container} from '@sentry/scraps/layout';
+import {Container, Flex} from '@sentry/scraps/layout';
 
 import {IconAdd, IconRefresh, IconSubtract} from 'sentry/icons';
+import {t} from 'sentry/locale';
 
 interface ZoomControlsProps {
   onReset: () => void;
   onZoomIn: () => void;
   onZoomOut: () => void;
+}
+
+function ScrollHint({label}: {label: string}) {
+  return (
+    <Flex align="center" gap="xs">
+      {label}
+      <Hotkey value="command" />
+      <Kbd>{t('Scroll')}</Kbd>
+    </Flex>
+  );
 }
 
 export function ZoomControls({onZoomIn, onZoomOut, onReset}: ZoomControlsProps) {
@@ -23,11 +35,18 @@ export function ZoomControls({onZoomIn, onZoomOut, onReset}: ZoomControlsProps) 
       onClick={e => e.stopPropagation()}
     >
       <ButtonBar>
-        <Button size="xs" icon={<IconAdd />} aria-label="Zoom in" onClick={onZoomIn} />
+        <Button
+          size="xs"
+          icon={<IconAdd />}
+          aria-label={t('Zoom in')}
+          tooltipProps={{title: <ScrollHint label={t('Zoom in')} />}}
+          onClick={onZoomIn}
+        />
         <Button
           size="xs"
           icon={<IconSubtract />}
-          aria-label="Zoom out"
+          aria-label={t('Zoom out')}
+          tooltipProps={{title: <ScrollHint label={t('Zoom out')} />}}
           onClick={onZoomOut}
         />
         <Button
@@ -41,10 +60,10 @@ export function ZoomControls({onZoomIn, onZoomOut, onReset}: ZoomControlsProps) 
   );
 }
 
-export function zoomTransformStyle(t: ZoomTransform): React.CSSProperties {
+export function zoomTransformStyle(transform: ZoomTransform): React.CSSProperties {
   return {
     transformOrigin: '0 0',
-    transform: `translate(${t.x}px, ${t.y}px) scale(${t.k})`,
+    transform: `translate(${transform.x}px, ${transform.y}px) scale(${transform.k})`,
   };
 }
 

--- a/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.spec.tsx
@@ -5,6 +5,7 @@ import {
   renderGlobalModal,
   screen,
   userEvent,
+  within,
 } from 'sentry-test/reactTestingLibrary';
 
 import {trackAnalytics} from 'sentry/utils/analytics';
@@ -36,6 +37,11 @@ describe('KeyboardShortcutsButton', () => {
     expect(screen.getByRole('heading', {name: 'Keyboard shortcuts'})).toBeInTheDocument();
     expect(dialog).toHaveTextContent('Next image');
     expect(dialog).toHaveTextContent('Zoom in list and split views');
+    expect(
+      within(dialog)
+        .getAllByText(/^(List view|Single image view|Navigation|Zoom)$/)
+        .map(el => el.textContent)
+    ).toEqual(['List view', 'Single image view', 'Navigation', 'Zoom']);
     expect(trackAnalytics).toHaveBeenCalledWith(
       'preprod.snapshots.details.keyboard_shortcuts_opened',
       {organization}

--- a/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.spec.tsx
@@ -1,0 +1,44 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+
+import {
+  render,
+  renderGlobalModal,
+  screen,
+  userEvent,
+} from 'sentry-test/reactTestingLibrary';
+
+import {trackAnalytics} from 'sentry/utils/analytics';
+
+import {KeyboardShortcutsButton} from './keyboardShortcutsButton';
+
+jest.mock('sentry/utils/analytics');
+
+describe('KeyboardShortcutsButton', () => {
+  const organization = OrganizationFixture();
+
+  it('shows the shortcuts in a tooltip on hover', async () => {
+    render(<KeyboardShortcutsButton />, {organization});
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Keyboard shortcuts'}));
+
+    expect(await screen.findByText('List view')).toBeInTheDocument();
+    expect(screen.getByText('Open selected snapshot')).toBeInTheDocument();
+    expect(screen.getByText('Pan a zoomed image')).toBeInTheDocument();
+  });
+
+  it('opens a modal with the shortcuts on click', async () => {
+    render(<KeyboardShortcutsButton />, {organization});
+    renderGlobalModal();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Keyboard shortcuts'}));
+
+    const dialog = await screen.findByRole('dialog');
+    expect(screen.getByRole('heading', {name: 'Keyboard shortcuts'})).toBeInTheDocument();
+    expect(dialog).toHaveTextContent('Next image');
+    expect(dialog).toHaveTextContent('Zoom in list and split views');
+    expect(trackAnalytics).toHaveBeenCalledWith(
+      'preprod.snapshots.details.keyboard_shortcuts_opened',
+      {organization}
+    );
+  });
+});

--- a/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.tsx
+++ b/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.tsx
@@ -1,0 +1,176 @@
+import {Fragment, type ReactNode} from 'react';
+import {css} from '@emotion/react';
+
+import {Button} from '@sentry/scraps/button';
+import {Hotkey, Kbd} from '@sentry/scraps/hotkey';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Heading, Text} from '@sentry/scraps/text';
+import {Tooltip} from '@sentry/scraps/tooltip';
+
+import {openModal} from 'sentry/actionCreators/modal';
+import {IconCommand} from 'sentry/icons';
+import {t} from 'sentry/locale';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
+
+interface Shortcut {
+  description: string;
+  keys: ReactNode;
+}
+
+interface ShortcutGroup {
+  shortcuts: Shortcut[];
+  title: string;
+}
+
+function Keys({children}: {children: ReactNode}) {
+  return (
+    <Flex align="center" gap="xs">
+      {children}
+    </Flex>
+  );
+}
+
+function getShortcutGroups(): ShortcutGroup[] {
+  return [
+    {
+      title: t('Navigation'),
+      shortcuts: [
+        {keys: <Hotkey value="left" />, description: t('Switch to list view')},
+        {keys: <Hotkey value="right" />, description: t('Switch to single image view')},
+      ],
+    },
+    {
+      title: t('List view'),
+      shortcuts: [
+        {
+          keys: (
+            <Keys>
+              <Hotkey value="up" />
+              <Hotkey value="down" />
+            </Keys>
+          ),
+          description: t('Move selection up / down'),
+        },
+        {
+          keys: (
+            <Keys>
+              <Hotkey value="command+up" />
+              <Hotkey value="command+down" />
+            </Keys>
+          ),
+          description: t('Select first / last snapshot'),
+        },
+        {keys: <Hotkey value="enter" />, description: t('Open selected snapshot')},
+        {
+          keys: <Hotkey value="space" />,
+          description: t('Scroll selected snapshot into view'),
+        },
+      ],
+    },
+    {
+      title: t('Single image view'),
+      shortcuts: [
+        {keys: <Hotkey value="up" />, description: t('Previous image')},
+        {keys: <Hotkey value="down" />, description: t('Next image')},
+        {
+          keys: (
+            <Keys>
+              <Hotkey value="command+up" />
+              <Hotkey value="command+down" />
+            </Keys>
+          ),
+          description: t('First / last image'),
+        },
+      ],
+    },
+    {
+      title: t('Zoom'),
+      shortcuts: [
+        {
+          keys: (
+            <Keys>
+              <Hotkey value="command" />
+              <Kbd>{t('Scroll')}</Kbd>
+            </Keys>
+          ),
+          description: t('Zoom in list and split views'),
+        },
+        {keys: <Kbd>{t('Scroll')}</Kbd>, description: t('Zoom in single image view')},
+        {keys: <Kbd>{t('Drag')}</Kbd>, description: t('Pan a zoomed image')},
+      ],
+    },
+  ];
+}
+
+function KeyboardShortcutsList({
+  columns,
+}: {
+  columns: React.ComponentProps<typeof Grid>['columns'];
+}) {
+  return (
+    <Grid columns={columns} gap="xl">
+      {getShortcutGroups().map(group => (
+        <Stack key={group.title} gap="sm">
+          <Text size="sm" bold>
+            {group.title}
+          </Text>
+          {group.shortcuts.map(shortcut => (
+            <Flex key={shortcut.description} justify="between" align="center" gap="lg">
+              <Text size="sm">{shortcut.description}</Text>
+              {shortcut.keys}
+            </Flex>
+          ))}
+        </Stack>
+      ))}
+    </Grid>
+  );
+}
+
+const modalCss = css`
+  width: calc(100vw - 80px);
+  max-width: calc(100vw - 80px);
+  height: calc(100vh - 80px);
+  max-height: calc(100vh - 80px);
+
+  [role='document'] {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+`;
+
+function openKeyboardShortcutsModal() {
+  openModal(
+    ({Header, Body}) => (
+      <Fragment>
+        <Header closeButton>
+          <Heading as="h3">{t('Keyboard shortcuts')}</Heading>
+        </Header>
+        <Body>
+          <KeyboardShortcutsList columns={{zero: '1fr', sm: '1fr 1fr'}} />
+        </Body>
+      </Fragment>
+    ),
+    {modalCss}
+  );
+}
+
+export function KeyboardShortcutsButton() {
+  const organization = useOrganization();
+  return (
+    <Tooltip title={<KeyboardShortcutsList columns="1fr" />} maxWidth={360}>
+      <Button
+        size="xs"
+        icon={<IconCommand />}
+        aria-label={t('Keyboard shortcuts')}
+        onClick={() => {
+          trackAnalytics('preprod.snapshots.details.keyboard_shortcuts_opened', {
+            organization,
+          });
+          openKeyboardShortcutsModal();
+        }}
+      />
+    </Tooltip>
+  );
+}

--- a/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.tsx
+++ b/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.tsx
@@ -128,16 +128,8 @@ function KeyboardShortcutsList({
 }
 
 const modalCss = css`
-  width: calc(100vw - 80px);
+  width: max-content;
   max-width: calc(100vw - 80px);
-  height: calc(100vh - 80px);
-  max-height: calc(100vh - 80px);
-
-  [role='document'] {
-    height: 100%;
-    display: flex;
-    flex-direction: column;
-  }
 `;
 
 function openKeyboardShortcutsModal() {

--- a/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.tsx
+++ b/static/app/views/preprod/snapshots/main/keyboardShortcutsButton.tsx
@@ -34,13 +34,6 @@ function Keys({children}: {children: ReactNode}) {
 function getShortcutGroups(): ShortcutGroup[] {
   return [
     {
-      title: t('Navigation'),
-      shortcuts: [
-        {keys: <Hotkey value="left" />, description: t('Switch to list view')},
-        {keys: <Hotkey value="right" />, description: t('Switch to single image view')},
-      ],
-    },
-    {
       title: t('List view'),
       shortcuts: [
         {
@@ -82,6 +75,13 @@ function getShortcutGroups(): ShortcutGroup[] {
           ),
           description: t('First / last image'),
         },
+      ],
+    },
+    {
+      title: t('Navigation'),
+      shortcuts: [
+        {keys: <Hotkey value="left" />, description: t('Switch to list view')},
+        {keys: <Hotkey value="right" />, description: t('Switch to single image view')},
       ],
     },
     {

--- a/static/app/views/preprod/snapshots/main/snapshotCards.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotCards.spec.tsx
@@ -82,6 +82,14 @@ describe('ImageCard zoom', () => {
     expect(mockZoom.resetZoom).toHaveBeenCalledTimes(1);
   });
 
+  it('hints at modifier scroll zoom on the zoom buttons', async () => {
+    renderImageCard(null);
+
+    await userEvent.hover(screen.getByRole('button', {name: 'Zoom in'}));
+
+    expect(await screen.findByText('Scroll')).toBeInTheDocument();
+  });
+
   it('does not toggle card selection when using zoom controls', async () => {
     const onSelectSnapshot = jest.fn();
     renderImageCard(null, onSelectSnapshot);

--- a/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.spec.tsx
@@ -1,5 +1,6 @@
 import {fireEvent, render, screen, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import {closeModal, openModal} from 'sentry/actionCreators/modal';
 import {mockElementSize} from 'sentry/utils/fixtures/virtualization';
 import type {
   SidebarItem,
@@ -179,5 +180,41 @@ describe('SnapshotListView', () => {
 
     fireEvent.keyDown(document.body, {key: 'ArrowDown'});
     expect(onSelectSnapshot).toHaveBeenCalledWith('s1.png');
+  });
+
+  it('leaves Enter and Space to a focused button instead of opening the snapshot', () => {
+    const onOpenSnapshot = jest.fn();
+    render(
+      <SnapshotListView
+        items={[changedGroup(1)]}
+        imageBaseUrl="/api/0/projects/org-slug/project-slug/files/images/"
+        selectedSnapshotKey="s0.png"
+        onOpenSnapshot={onOpenSnapshot}
+      />
+    );
+
+    const button = screen.getAllByRole('button', {name: 'Zoom in'})[0]!;
+    fireEvent.keyDown(button, {key: 'Enter'});
+    fireEvent.keyDown(button, {key: ' '});
+
+    expect(onOpenSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('ignores shortcuts while a modal is open', () => {
+    const onSelectSnapshot = jest.fn();
+    render(
+      <SnapshotListView
+        items={[changedGroup(3)]}
+        imageBaseUrl="/api/0/projects/org-slug/project-slug/files/images/"
+        selectedSnapshotKey="s0.png"
+        onSelectSnapshot={onSelectSnapshot}
+      />
+    );
+
+    openModal(() => null);
+    fireEvent.keyDown(document.body, {key: 'ArrowDown'});
+    closeModal();
+
+    expect(onSelectSnapshot).not.toHaveBeenCalled();
   });
 });

--- a/static/app/views/preprod/snapshots/main/snapshotListView.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotListView.tsx
@@ -16,6 +16,7 @@ import {Container, Flex} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {t} from 'sentry/locale';
+import {ModalStore} from 'sentry/stores/modalStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {DiffStatus, isPairSidebarItem} from 'sentry/views/preprod/types/snapshotTypes';
@@ -492,8 +493,14 @@ export const SnapshotListView = memo(function SnapshotListViewImpl({
       ) {
         return;
       }
+      if (typeof ModalStore.getState().renderer === 'function') {
+        return;
+      }
       const tag = (e.target as HTMLElement)?.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') {
+        return;
+      }
+      if (tag === 'BUTTON' && (e.key === 'Enter' || e.key === ' ')) {
         return;
       }
       const {

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -148,6 +148,12 @@ describe('SnapshotMainContent', () => {
     jest.restoreAllMocks();
   });
 
+  it('renders the keyboard shortcuts button in the toolbar', () => {
+    renderSnapshotMainContent();
+
+    expect(screen.getByRole('button', {name: 'Keyboard shortcuts'})).toBeInTheDocument();
+  });
+
   it('keeps the diff/head toggle visible when viewing the head-only comparison', async () => {
     const onToggleSoloView = jest.fn();
 

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -148,12 +148,6 @@ describe('SnapshotMainContent', () => {
     jest.restoreAllMocks();
   });
 
-  it('renders the keyboard shortcuts button in the toolbar', () => {
-    renderSnapshotMainContent();
-
-    expect(screen.getByRole('button', {name: 'Keyboard shortcuts'})).toBeInTheDocument();
-  });
-
   it('keeps the diff/head toggle visible when viewing the head-only comparison', async () => {
     const onToggleSoloView = jest.fn();
 

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.snapshots.tsx
@@ -1,16 +1,20 @@
 import {Fragment} from 'react';
 import {ThemeProvider} from '@emotion/react';
+import {OrganizationFixture} from 'sentry-fixture/organization';
 
 import {CompactSelect as mockCompactSelect} from 'sentry-test/snapshots/mocks/compactSelect';
 
 import {Tag} from '@sentry/scraps/badge';
 
 import {t} from 'sentry/locale';
+import {OrganizationContext} from 'sentry/utils/organizationContext';
 import {darkTheme, lightTheme} from 'sentry/utils/theme/theme';
 
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
 
-jest.mock('@sentry/scraps/compactSelect', () => ({CompactSelect: mockCompactSelect}));
+jest.mock('@sentry/scraps/compactSelect', () => ({
+  CompactSelect: mockCompactSelect,
+}));
 
 import {Container} from '@sentry/scraps/layout';
 
@@ -76,49 +80,52 @@ function SnapshotsToolbarWithControls({
   }
 
   return (
-    <Container containerType="inline-size">
-      <ToolbarContainer
-        toggle={
-          <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
-        }
-        sortDropdown={
-          sort ? <SortDropdown value={sort.value} onChange={sort.onChange} /> : null
-        }
-        progressIndicator={
-          progress ? (
-            <ProgressPill>
-              <ToolbarProgressBar value={progress.percent} />
-              <ProgressCounter size="xs" variant="muted">
-                {progress.current}/{progress.total}
-              </ProgressCounter>
-            </ProgressPill>
-          ) : null
-        }
-        diffControls={
-          diff ? (
-            <Fragment>
-              {diff.mode === 'split' && (
-                <ColorPickerButton
-                  color={diff.overlayColor}
-                  onChange={diff.onOverlayColorChange}
-                  opacity={diff.overlayOpacity}
-                  onOpacityChange={diff.onOverlayOpacityChange}
+    <OrganizationContext value={organization}>
+      <Container containerType="inline-size">
+        <ToolbarContainer
+          toggle={
+            <ViewModeToggle viewMode={viewMode} onViewModeChange={onViewModeChange} />
+          }
+          sortDropdown={
+            sort ? <SortDropdown value={sort.value} onChange={sort.onChange} /> : null
+          }
+          progressIndicator={
+            progress ? (
+              <ProgressPill>
+                <ToolbarProgressBar value={progress.percent} />
+                <ProgressCounter size="xs" variant="muted">
+                  {progress.current}/{progress.total}
+                </ProgressCounter>
+              </ProgressPill>
+            ) : null
+          }
+          diffControls={
+            diff ? (
+              <Fragment>
+                {diff.mode === 'split' && (
+                  <ColorPickerButton
+                    color={diff.overlayColor}
+                    onChange={diff.onOverlayColorChange}
+                    opacity={diff.overlayOpacity}
+                    onOpacityChange={diff.onOverlayOpacityChange}
+                  />
+                )}
+                <DiffModeToggle
+                  diffMode={diff.mode}
+                  onDiffModeChange={diff.onModeChange}
+                  showSplit={diff.showSplit ?? true}
                 />
-              )}
-              <DiffModeToggle
-                diffMode={diff.mode}
-                onDiffModeChange={diff.onModeChange}
-                showSplit={diff.showSplit ?? true}
-              />
-            </Fragment>
-          ) : null
-        }
-        soloDiffToggle={soloDiffToggle}
-      />
-    </Container>
+              </Fragment>
+            ) : null
+          }
+          soloDiffToggle={soloDiffToggle}
+        />
+      </Container>
+    </OrganizationContext>
   );
 }
 
+const organization = OrganizationFixture();
 const themes = {light: lightTheme, dark: darkTheme};
 
 const noop = () => {};

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -16,6 +16,7 @@ import {IconExpand, IconInput, IconList, IconPause, IconStack} from 'sentry/icon
 import {t} from 'sentry/locale';
 
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
+import {KeyboardShortcutsButton} from './keyboardShortcutsButton';
 
 const TRANSPARENT_COLOR = 'transparent';
 
@@ -72,6 +73,7 @@ export function ToolbarContainer({
             </Flex>
           )}
           <Flex display={{zero: 'none', xl: 'flex'}}>{soloDiffToggle}</Flex>
+          <KeyboardShortcutsButton />
         </Flex>
       </Flex>
       <Separator orientation="horizontal" />

--- a/static/app/views/preprod/snapshots/snapshots.tsx
+++ b/static/app/views/preprod/snapshots/snapshots.tsx
@@ -17,6 +17,7 @@ import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {SentryDocumentTitle} from 'sentry/components/sentryDocumentTitle';
 import {IconGrabbable} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {ModalStore} from 'sentry/stores/modalStore';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
@@ -667,6 +668,9 @@ export default function SnapshotsPage() {
         e.key !== 'ArrowLeft' &&
         e.key !== 'ArrowRight'
       ) {
+        return;
+      }
+      if (typeof ModalStore.getState().renderer === 'function') {
         return;
       }
       const tag = (e.target as HTMLElement)?.tagName;


### PR DESCRIPTION
Follows #124062, which made single-image cards zoomable.

The snapshot comparison page has a fair number of keyboard shortcuts (arrow keys to switch between list and single view, up/down and cmd+up/down to move through snapshots, enter and space in the list, modifier+wheel zoom) but nothing on the page tells users they exist. This adds a small ⌘ button on the right of the snapshot toolbar. Hovering it shows every shortcut in a tooltip, and clicking it opens a modal sized to its content with the same list in two columns. Opening the modal fires a `preprod.snapshots.details.keyboard_shortcuts_opened` analytics event. The zoom in and zoom out buttons on each image also get a tooltip with the cmd/ctrl + scroll gesture; reset zoom has no keyboard equivalent so it stays as-is.

The shortcut list lives in one place, `getShortcutGroups`, and both the tooltip and the modal render from it, so they cannot drift from each other. Key caps use the core `Hotkey` component so cmd renders as ⌘ on Mac and Ctrl elsewhere; the mouse gestures (Scroll, Drag) in the Zoom group use a plain `Kbd` cap since the glyph resolver only knows keyboard keys. The list is a hand-maintained mirror of the keydown handlers in `snapshots.tsx` and `snapshotListView.tsx`, so a future change to those handlers needs a matching edit here.

Adding the help surfaced two gaps in those handlers, fixed here. Both document-level keydown handlers now bail while a modal is open, so trying a shortcut while reading about it no longer changes the page behind the modal. The list handler also leaves Enter and Space to a focused button, since it previously called `preventDefault` on them and blocked native button activation, which meant the help button could not be opened from the keyboard.

Covered by tests for the tooltip contents on hover, the modal contents and analytics call on click, the button being present in the toolbar, the zoom button hint, and both handler guards.