### PR TITLE
feat(preprod): Add one-click overlay visibility toggle to snapshot toolbar

### DIFF
--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -281,36 +281,7 @@ describe('SnapshotMainContent', () => {
     }
   });
 
-  it('hides the overlay from the toolbar eye button without opening the picker', async () => {
-    const onOverlayOpacityChange = jest.fn();
-    const changedItem = {
-      key: 'changed-buttons',
-      name: 'Buttons',
-      displayName: 'Buttons',
-      pairs: [changedPair],
-      type: 'changed' as const,
-    };
-
-    renderSnapshotMainContent({
-      comparisonType: 'diff',
-      diffMode: 'split',
-      isSoloView: false,
-      listItems: [changedItem],
-      selectedItem: changedItem,
-      onOverlayOpacityChange,
-      overlayOpacity: 50,
-      viewMode: 'single',
-    });
-
-    await userEvent.click(screen.getByRole('button', {name: 'Hide overlay'}));
-
-    expect(onOverlayOpacityChange).toHaveBeenCalledWith(0);
-    expect(
-      screen.queryByRole('button', {name: 'Overlay opacity 50%'})
-    ).not.toBeInTheDocument();
-  });
-
-  it('restores the previous opacity when showing the overlay again', async () => {
+  it('toggles the overlay off and restores the previous opacity', async () => {
     const onOverlayOpacityChange = jest.fn();
     const changedItem = {
       key: 'changed-buttons',

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -344,37 +344,6 @@ describe('SnapshotMainContent', () => {
     expect(onOverlayOpacityChange).toHaveBeenLastCalledWith(100);
   });
 
-  it('toggles the overlay by clicking the color circle and opens options from the chevron', async () => {
-    const onOverlayOpacityChange = jest.fn();
-    const changedItem = {
-      key: 'changed-buttons',
-      name: 'Buttons',
-      displayName: 'Buttons',
-      pairs: [changedPair],
-      type: 'changed' as const,
-    };
-
-    renderSnapshotMainContent({
-      comparisonType: 'diff',
-      diffMode: 'split',
-      isSoloView: false,
-      listItems: [changedItem],
-      selectedItem: changedItem,
-      onOverlayOpacityChange,
-      overlayOpacity: 50,
-      viewMode: 'single',
-    });
-
-    await userEvent.click(screen.getByRole('button', {name: 'Toggle overlay'}));
-    expect(onOverlayOpacityChange).toHaveBeenCalledWith(0);
-    expect(
-      screen.queryByRole('button', {name: 'Overlay opacity 50%'})
-    ).not.toBeInTheDocument();
-
-    await userEvent.click(screen.getByRole('button', {name: 'Overlay options'}));
-    expect(screen.getByRole('button', {name: 'Overlay opacity 50%'})).toBeInTheDocument();
-  });
-
   it('hides the color picker and opacity presets outside of split mode', () => {
     const changedItem = {
       key: 'changed-buttons',

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.spec.tsx
@@ -281,6 +281,100 @@ describe('SnapshotMainContent', () => {
     }
   });
 
+  it('hides the overlay from the toolbar eye button without opening the picker', async () => {
+    const onOverlayOpacityChange = jest.fn();
+    const changedItem = {
+      key: 'changed-buttons',
+      name: 'Buttons',
+      displayName: 'Buttons',
+      pairs: [changedPair],
+      type: 'changed' as const,
+    };
+
+    renderSnapshotMainContent({
+      comparisonType: 'diff',
+      diffMode: 'split',
+      isSoloView: false,
+      listItems: [changedItem],
+      selectedItem: changedItem,
+      onOverlayOpacityChange,
+      overlayOpacity: 50,
+      viewMode: 'single',
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Hide overlay'}));
+
+    expect(onOverlayOpacityChange).toHaveBeenCalledWith(0);
+    expect(
+      screen.queryByRole('button', {name: 'Overlay opacity 50%'})
+    ).not.toBeInTheDocument();
+  });
+
+  it('restores the previous opacity when showing the overlay again', async () => {
+    const onOverlayOpacityChange = jest.fn();
+    const changedItem = {
+      key: 'changed-buttons',
+      name: 'Buttons',
+      displayName: 'Buttons',
+      pairs: [changedPair],
+      type: 'changed' as const,
+    };
+    const props = {
+      comparisonType: 'diff' as const,
+      diffMode: 'split' as const,
+      isSoloView: false,
+      listItems: [changedItem],
+      selectedItem: changedItem,
+      onOverlayOpacityChange,
+      viewMode: 'single' as const,
+    };
+
+    const {rerender} = renderSnapshotMainContent({...props, overlayOpacity: 100});
+
+    await userEvent.click(screen.getByRole('button', {name: 'Hide overlay'}));
+    expect(onOverlayOpacityChange).toHaveBeenLastCalledWith(0);
+
+    rerender(
+      <Container containerType="inline-size">
+        <SnapshotMainContent {...buildProps({...props, overlayOpacity: 0})} />
+      </Container>
+    );
+
+    await userEvent.click(screen.getByRole('button', {name: 'Show overlay'}));
+    expect(onOverlayOpacityChange).toHaveBeenLastCalledWith(100);
+  });
+
+  it('toggles the overlay by clicking the color circle and opens options from the chevron', async () => {
+    const onOverlayOpacityChange = jest.fn();
+    const changedItem = {
+      key: 'changed-buttons',
+      name: 'Buttons',
+      displayName: 'Buttons',
+      pairs: [changedPair],
+      type: 'changed' as const,
+    };
+
+    renderSnapshotMainContent({
+      comparisonType: 'diff',
+      diffMode: 'split',
+      isSoloView: false,
+      listItems: [changedItem],
+      selectedItem: changedItem,
+      onOverlayOpacityChange,
+      overlayOpacity: 50,
+      viewMode: 'single',
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Toggle overlay'}));
+    expect(onOverlayOpacityChange).toHaveBeenCalledWith(0);
+    expect(
+      screen.queryByRole('button', {name: 'Overlay opacity 50%'})
+    ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', {name: 'Overlay options'}));
+    expect(screen.getByRole('button', {name: 'Overlay opacity 50%'})).toBeInTheDocument();
+  });
+
   it('hides the color picker and opacity presets outside of split mode', () => {
     const changedItem = {
       key: 'changed-buttons',

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -4,6 +4,7 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack, useResponsivePropValue} from '@sentry/scraps/layout';
+import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -211,12 +212,22 @@ export function SnapshotMainContent({
   const diffControls = hasChangedInList ? (
     <Fragment>
       {diffMode === 'split' && (
-        <ColorPickerButton
-          color={overlayColor}
-          onChange={onOverlayColorChange}
-          opacity={overlayOpacity}
-          onOpacityChange={onOverlayOpacityChange}
-        />
+        <Fragment>
+          <ColorPickerButton
+            color={overlayColor}
+            onChange={onOverlayColorChange}
+            opacity={overlayOpacity}
+            onOpacityChange={onOverlayOpacityChange}
+          />
+          <Separator orientation="vertical" />
+          <ColorPickerButton
+            color={overlayColor}
+            onChange={onOverlayColorChange}
+            opacity={overlayOpacity}
+            onOpacityChange={onOverlayOpacityChange}
+            toggleStyle="circle"
+          />
+        </Fragment>
       )}
       <DiffModeToggle
         diffMode={diffMode}

--- a/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotMainContent.tsx
@@ -4,7 +4,6 @@ import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Container, Flex, Stack, useResponsivePropValue} from '@sentry/scraps/layout';
-import {Separator} from '@sentry/scraps/separator';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
@@ -212,22 +211,12 @@ export function SnapshotMainContent({
   const diffControls = hasChangedInList ? (
     <Fragment>
       {diffMode === 'split' && (
-        <Fragment>
-          <ColorPickerButton
-            color={overlayColor}
-            onChange={onOverlayColorChange}
-            opacity={overlayOpacity}
-            onOpacityChange={onOverlayOpacityChange}
-          />
-          <Separator orientation="vertical" />
-          <ColorPickerButton
-            color={overlayColor}
-            onChange={onOverlayColorChange}
-            opacity={overlayOpacity}
-            onOpacityChange={onOverlayOpacityChange}
-            toggleStyle="circle"
-          />
-        </Fragment>
+        <ColorPickerButton
+          color={overlayColor}
+          onChange={onOverlayColorChange}
+          opacity={overlayOpacity}
+          onOpacityChange={onOverlayOpacityChange}
+        />
       )}
       <DiffModeToggle
         diffMode={diffMode}

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -4,6 +4,7 @@ import type {Theme} from '@emotion/react';
 import {css, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
+import {Button} from '@sentry/scraps/button';
 import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {Flex} from '@sentry/scraps/layout';
 import {SegmentedControl} from '@sentry/scraps/segmentedControl';
@@ -12,7 +13,16 @@ import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ProgressBar} from 'sentry/components/progressBar';
-import {IconExpand, IconInput, IconList, IconPause, IconStack} from 'sentry/icons';
+import {
+  IconChevron,
+  IconExpand,
+  IconHide,
+  IconInput,
+  IconList,
+  IconPause,
+  IconShow,
+  IconStack,
+} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 import type {DiffMode} from './imageDisplay/diffImageDisplay';
@@ -160,22 +170,44 @@ export function SortDropdown({
 }
 
 const OPACITY_PRESETS = [0, 50, 100];
+const DEFAULT_VISIBLE_OPACITY = 50;
+
+export type OverlayToggleStyle = 'eye' | 'circle';
+
+function useOverlayToggle(opacity: number, onOpacityChange: (opacity: number) => void) {
+  const lastVisibleOpacity = useRef(opacity || DEFAULT_VISIBLE_OPACITY);
+
+  useEffect(() => {
+    if (opacity > 0) {
+      lastVisibleOpacity.current = opacity;
+    }
+  }, [opacity]);
+
+  return () => onOpacityChange(opacity === 0 ? lastVisibleOpacity.current : 0);
+}
 
 export function ColorPickerButton({
   color,
   onChange,
   opacity,
   onOpacityChange,
+  toggleStyle = 'eye',
 }: {
   color: string;
   onChange: (color: string) => void;
   onOpacityChange: (opacity: number) => void;
   opacity: number;
+  toggleStyle?: OverlayToggleStyle;
 }) {
   const theme = useTheme();
   const [isOpen, setIsOpen] = useState(false);
   const pickerRef = useRef<HTMLDivElement>(null);
   const palette = theme.chart.getColorPalette(10);
+  const isHidden = opacity === 0;
+  const toggleOverlay = useOverlayToggle(opacity, onOpacityChange);
+  const toggleLabel = isHidden ? t('Show overlay') : t('Hide overlay');
+  // `transparent` supports legacy localStorage color values.
+  const showSlash = isHidden || color === TRANSPARENT_COLOR;
 
   useEffect(() => {
     if (!isOpen) {
@@ -192,15 +224,50 @@ export function ColorPickerButton({
 
   return (
     <ColorPickerWrapper ref={pickerRef}>
-      <Tooltip title={t('Overlay color')} skipWrapper>
-        <ColorTrigger
-          $color={color}
-          // `transparent` supports legacy localStorage color values.
-          $slash={opacity === 0 || color === TRANSPARENT_COLOR}
-          aria-label={t('Pick overlay color')}
-          onClick={() => setIsOpen(v => !v)}
-        />
-      </Tooltip>
+      {toggleStyle === 'eye' ? (
+        <Fragment>
+          <Tooltip title={toggleLabel} skipWrapper>
+            <Button
+              size="xs"
+              variant="transparent"
+              icon={isHidden ? <IconShow /> : <IconHide />}
+              aria-label={toggleLabel}
+              aria-pressed={!isHidden}
+              onClick={toggleOverlay}
+            />
+          </Tooltip>
+          <Tooltip title={t('Overlay color')} skipWrapper>
+            <ColorTrigger
+              $color={color}
+              $slash={showSlash}
+              aria-label={t('Pick overlay color')}
+              onClick={() => setIsOpen(v => !v)}
+            />
+          </Tooltip>
+        </Fragment>
+      ) : (
+        <Fragment>
+          <Tooltip title={toggleLabel} skipWrapper>
+            <ColorTrigger
+              $color={color}
+              $slash={showSlash}
+              aria-label={t('Toggle overlay')}
+              aria-pressed={!isHidden}
+              onClick={toggleOverlay}
+            />
+          </Tooltip>
+          <Tooltip title={t('Overlay options')} skipWrapper>
+            <Button
+              size="zero"
+              variant="transparent"
+              icon={<IconChevron direction="down" size="xs" />}
+              aria-label={t('Overlay options')}
+              aria-expanded={isOpen}
+              onClick={() => setIsOpen(v => !v)}
+            />
+          </Tooltip>
+        </Fragment>
+      )}
       {isOpen && (
         <ColorPickerDropdown>
           <Flex gap="xs" align="center">
@@ -288,6 +355,7 @@ const ColorPickerWrapper = styled('div')`
   position: relative;
   display: flex;
   align-items: center;
+  gap: ${p => p.theme.space['2xs']};
 `;
 
 const ColorPickerDropdown = styled('div')`

--- a/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
+++ b/static/app/views/preprod/snapshots/main/snapshotsToolbar.tsx
@@ -14,7 +14,6 @@ import {Tooltip} from '@sentry/scraps/tooltip';
 
 import {ProgressBar} from 'sentry/components/progressBar';
 import {
-  IconChevron,
   IconExpand,
   IconHide,
   IconInput,
@@ -172,8 +171,6 @@ export function SortDropdown({
 const OPACITY_PRESETS = [0, 50, 100];
 const DEFAULT_VISIBLE_OPACITY = 50;
 
-export type OverlayToggleStyle = 'eye' | 'circle';
-
 function useOverlayToggle(opacity: number, onOpacityChange: (opacity: number) => void) {
   const lastVisibleOpacity = useRef(opacity || DEFAULT_VISIBLE_OPACITY);
 
@@ -191,13 +188,11 @@ export function ColorPickerButton({
   onChange,
   opacity,
   onOpacityChange,
-  toggleStyle = 'eye',
 }: {
   color: string;
   onChange: (color: string) => void;
   onOpacityChange: (opacity: number) => void;
   opacity: number;
-  toggleStyle?: OverlayToggleStyle;
 }) {
   const theme = useTheme();
   const [isOpen, setIsOpen] = useState(false);
@@ -224,50 +219,24 @@ export function ColorPickerButton({
 
   return (
     <ColorPickerWrapper ref={pickerRef}>
-      {toggleStyle === 'eye' ? (
-        <Fragment>
-          <Tooltip title={toggleLabel} skipWrapper>
-            <Button
-              size="xs"
-              variant="transparent"
-              icon={isHidden ? <IconShow /> : <IconHide />}
-              aria-label={toggleLabel}
-              aria-pressed={!isHidden}
-              onClick={toggleOverlay}
-            />
-          </Tooltip>
-          <Tooltip title={t('Overlay color')} skipWrapper>
-            <ColorTrigger
-              $color={color}
-              $slash={showSlash}
-              aria-label={t('Pick overlay color')}
-              onClick={() => setIsOpen(v => !v)}
-            />
-          </Tooltip>
-        </Fragment>
-      ) : (
-        <Fragment>
-          <Tooltip title={toggleLabel} skipWrapper>
-            <ColorTrigger
-              $color={color}
-              $slash={showSlash}
-              aria-label={t('Toggle overlay')}
-              aria-pressed={!isHidden}
-              onClick={toggleOverlay}
-            />
-          </Tooltip>
-          <Tooltip title={t('Overlay options')} skipWrapper>
-            <Button
-              size="zero"
-              variant="transparent"
-              icon={<IconChevron direction="down" size="xs" />}
-              aria-label={t('Overlay options')}
-              aria-expanded={isOpen}
-              onClick={() => setIsOpen(v => !v)}
-            />
-          </Tooltip>
-        </Fragment>
-      )}
+      <Tooltip title={toggleLabel} skipWrapper>
+        <Button
+          size="xs"
+          variant="transparent"
+          icon={isHidden ? <IconShow /> : <IconHide />}
+          aria-label={toggleLabel}
+          aria-pressed={!isHidden}
+          onClick={toggleOverlay}
+        />
+      </Tooltip>
+      <Tooltip title={t('Overlay color')} skipWrapper>
+        <ColorTrigger
+          $color={color}
+          $slash={showSlash}
+          aria-label={t('Pick overlay color')}
+          onClick={() => setIsOpen(v => !v)}
+        />
+      </Tooltip>
       {isOpen && (
         <ColorPickerDropdown>
           <Flex gap="xs" align="center">


### PR DESCRIPTION
In split view, hiding and showing the diff overlay currently means opening the
color picker popover and clicking an opacity swatch every time. When comparing
snapshots side by side that gets tedious, so this adds an eye icon button next
to the color circle that flips the overlay off and back on in one click,
restoring whichever opacity was selected before it was hidden.

The toggle reuses the existing localStorage-backed opacity setter, so nothing
new is persisted. The last visible opacity is remembered in a ref inside the
picker and falls back to 50% if the page loads with the overlay already hidden.