### PR TITLE
ref(logs): Remove useBox latest-ref helper from LogsInfiniteTable

### DIFF
--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -369,12 +369,14 @@ export function LogsInfiniteTable({
 
   useEffect(() => {
     if (
-      pseudoRowIndex !== -1 &&
-      tableBodyRef?.current &&
-      !additionalData?.scrollToDisabled
+      pseudoRowIndex === -1 ||
+      !tableBodyRef?.current ||
+      additionalData?.scrollToDisabled
     ) {
-      setTimeout(() => scrollToPseudoRow(), 100);
+      return;
     }
+    const timeoutId = setTimeout(() => scrollToPseudoRow(), 100);
+    return () => clearTimeout(timeoutId);
   }, [pseudoRowIndex, virtualizer, tableBodyRef, additionalData?.scrollToDisabled]);
 
   const hasReplay = !!embeddedOptions?.replay;

--- a/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
+++ b/static/app/views/explore/logs/tables/logsInfiniteTable.tsx
@@ -2,10 +2,10 @@ import {
   Fragment,
   useCallback,
   useEffect,
+  useEffectEvent,
   useMemo,
   useRef,
   useState,
-  type RefObject,
 } from 'react';
 import styled from '@emotion/styled';
 import * as Sentry from '@sentry/react';
@@ -173,7 +173,6 @@ export function LogsInfiniteTable({
   );
 
   const baseData = localOnlyItemFilters?.filteredItems ?? originalData;
-  const baseDataLength = useBox(baseData.length);
 
   const sortBys = useQueryParamsSortBys();
   const hasInjectedErrorRows =
@@ -214,8 +213,7 @@ export function LogsInfiniteTable({
       withEvent = baseData || [];
     } else {
       withEvent = [...baseData];
-      const newSelectedIndex =
-        pseudoRowIndex === -2 ? baseDataLength.current : pseudoRowIndex;
+      const newSelectedIndex = pseudoRowIndex === -2 ? baseData.length : pseudoRowIndex;
       withEvent.splice(
         newSelectedIndex,
         0,
@@ -237,7 +235,6 @@ export function LogsInfiniteTable({
     isPending,
     isError,
     pseudoRowIndex,
-    baseDataLength,
     hasInjectedErrorRows,
     injectedErrorRows,
   ]);
@@ -359,28 +356,26 @@ export function LogsInfiniteTable({
     [virtualizer]
   );
 
+  // The -2 sentinel means the pseudo row sits after every loaded row. Reading the
+  // row count from an effect event keeps it out of the effect deps, so scrolling
+  // does not repeat each time the infinite table loads another page.
+  const scrollToPseudoRow = useEffectEvent(() => {
+    const scrollToIndex = pseudoRowIndex === -2 ? baseData.length : pseudoRowIndex;
+    virtualizer.scrollToIndex(scrollToIndex, {
+      behavior: 'smooth',
+      align: 'center',
+    });
+  });
+
   useEffect(() => {
     if (
       pseudoRowIndex !== -1 &&
       tableBodyRef?.current &&
       !additionalData?.scrollToDisabled
     ) {
-      setTimeout(() => {
-        const scrollToIndex =
-          pseudoRowIndex === -2 ? baseDataLength.current : pseudoRowIndex;
-        virtualizer.scrollToIndex(scrollToIndex, {
-          behavior: 'smooth',
-          align: 'center',
-        });
-      }, 100);
+      setTimeout(() => scrollToPseudoRow(), 100);
     }
-  }, [
-    pseudoRowIndex,
-    virtualizer,
-    tableBodyRef,
-    baseDataLength,
-    additionalData?.scrollToDisabled,
-  ]);
+  }, [pseudoRowIndex, virtualizer, tableBodyRef, additionalData?.scrollToDisabled]);
 
   const hasReplay = !!embeddedOptions?.replay;
 
@@ -953,10 +948,4 @@ function BackToTopButton({
       <IconArrow size="md" />
     </Button>
   );
-}
-
-function useBox<T>(value: T): RefObject<T> {
-  const box = useRef(value);
-  box.current = value;
-  return box;
 }


### PR DESCRIPTION
Removes the local `useBox` latest-ref helper from `LogsInfiniteTable`. It existed so that two places could read the current row count without listing it as a dependency. Each place now gets the count a different way.

The `data` memo already depends on `baseData`, so `baseData.length` is always current inside it. The box added nothing there and is replaced with a direct read.

The scroll-to-pseudo-row effect is the interesting one. It fires on `pseudoRowIndex`, and the `-2` sentinel means "after every loaded row". Adding `baseData.length` to the effect deps would re-scroll the user each time the infinite table loads another page, which is the behavior the box was avoiding. The deferred scroll now runs through `useEffectEvent`, which reads the latest row count at call time while keeping the effect's trigger set unchanged. This matches how `useEffectEvent` is already used elsewhere in the explore views.

While here, the effect now clears its pending timeout on cleanup. Before, the deferred scroll could still fire after the drawer closed or after the row position changed. Now only the most recent pending scroll runs.

There is no feature flag and no visual change, so no screenshot.

https://claude.ai/code/session_01Y8ST15L2khX1QSLVvm5vBS
