### PR TITLE
feat(seer-infra-telemetry): Preserve service-level GCP connection verification results

### DIFF
--- a/src/sentry/api/endpoints/organization_monitoring_provider_verify_connection.py
+++ b/src/sentry/api/endpoints/organization_monitoring_provider_verify_connection.py
@@ -25,7 +25,6 @@ from sentry.api.serializers.rest_framework.base import (
 )
 from sentry.constants import ObjectStatus
 from sentry.integrations.gcp.client import verify_gcp_connection
-from sentry.integrations.gcp.utils import resolve_project_error_detail
 from sentry.integrations.services.integration import integration_service
 from sentry.integrations.types import IntegrationProviderSlug
 from sentry.models.organization import Organization
@@ -44,14 +43,14 @@ class GcpVerifyConnectionSerializer(CamelSnakeSerializer["GcpVerifyConnectionSer
 class GcpVerifyConnectionServiceResultSerializer(Serializer[dict[str, object]]):
     service = CharField()
     status = CharField()
-    error_detail = CharField(required=False, allow_null=True)
+    error_detail = CharField(required=False, allow_null=True, default=None)
 
 
 class GcpVerifyConnectionProjectResultSerializer(Serializer[dict[str, object]]):
     gcp_project_id = CharField()
     connection_status = CharField()
     services = GcpVerifyConnectionServiceResultSerializer(many=True)
-    error_detail = CharField(required=False, allow_null=True)
+    error_detail = CharField(required=False, allow_null=True, default=None)
 
 
 class GcpVerifyConnectionResponseSerializer(Serializer[dict[str, object]]):
@@ -96,6 +95,7 @@ def _record_verification_result(
                 {
                     "gcp_project_id": project["gcp_project_id"],
                     "connection_status": project["connection_status"],
+                    "services": project["services"],
                     "error_detail": project.get("error_detail"),
                 }
                 for project in result["projects"]
@@ -149,9 +149,6 @@ class OrganizationMonitoringProviderVerifyConnectionEndpoint(OrganizationEndpoin
             )
 
         verified_result = response_serializer.validated_data
-        for project in verified_result["projects"]:
-            project["error_detail"] = resolve_project_error_detail(project)
-
         try:
             _record_verification_result(organization, data, verified_result)
         except Exception:

--- a/src/sentry/integrations/gcp/integration.py
+++ b/src/sentry/integrations/gcp/integration.py
@@ -94,15 +94,29 @@ class GcpVerification(TypedDict):
     projects: list[GcpProjectVerification]
 
 
+class GcpServiceVerification(TypedDict):
+    service: str
+    status: str
+    error_detail: str | None
+
+
 class GcpProjectVerification(TypedDict):
     gcp_project_id: str
     connection_status: str
+    services: list[GcpServiceVerification]
     error_detail: str | None
+
+
+class GcpServiceVerificationSerializer(Serializer[GcpServiceVerification]):
+    service = CharField(required=True)
+    status = CharField(required=True)
+    error_detail = CharField(required=False, allow_null=True, allow_blank=True, default=None)
 
 
 class GcpProjectVerificationSerializer(Serializer[GcpProjectVerification]):
     gcp_project_id = CharField(required=True, max_length=64)
     connection_status = CharField(required=True)
+    services = GcpServiceVerificationSerializer(many=True, required=True)
     error_detail = CharField(required=False, allow_null=True, allow_blank=True, default=None)
 
 
@@ -192,6 +206,7 @@ class GcpVerificationApiStep:
                 {
                     "gcp_project_id": project["gcp_project_id"],
                     "connection_status": project["connection_status"],
+                    "services": project["services"],
                     "error_detail": project.get("error_detail") or None,
                 }
                 for project in validated_data["projects"]
@@ -297,6 +312,7 @@ class GcpIntegration(IntegrationInstallation):
             {
                 "gcp_project_id": project_id,
                 "connection_status": GCP_STATUS_UNVERIFIED,
+                "services": [],
                 "error_detail": None,
             }
             for project_id in new_config["projects"]
@@ -384,6 +400,7 @@ class GcpIntegrationProvider(IntegrationProvider):
                     {
                         "gcp_project_id": project_id,
                         "connection_status": "error",
+                        "services": [],
                         "error_detail": "Verification failed to run during setup.",
                     }
                     for project_id in extra["projects"]

--- a/src/sentry/integrations/gcp/utils.py
+++ b/src/sentry/integrations/gcp/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Mapping
 from typing import Any
 
 from sentry.shared_integrations.exceptions import IntegrationConfigurationError
@@ -13,12 +12,6 @@ GCP_MCP_URLS: tuple[str, ...] = (
     "https://monitoring.googleapis.com/mcp",
     "https://cloudtrace.googleapis.com/mcp",
 )
-
-GCP_SERVICE_LABELS: Mapping[str, str] = {
-    "logging": "Cloud Logging",
-    "monitoring": "Cloud Monitoring",
-    "cloudtrace": "Cloud Trace",
-}
 
 # Connection statuses returned by Seer's GCP verification endpoint. Mirrors
 # ConnectionStatus in seer/automation/agent/mcp/gcp_verification.py.
@@ -66,23 +59,3 @@ def parse_customer_sa_email(value: Any) -> str:
             f"Service account email must be at most {MAX_CUSTOMER_SA_EMAIL_LENGTH} characters."
         )
     return email
-
-
-def resolve_project_error_detail(project: Mapping[str, Any]) -> str | None:
-    existing = project.get("error_detail")
-    if existing:
-        return str(existing)
-
-    failed = [
-        service for service in project.get("services", []) if service.get("status") != "connected"
-    ]
-    if not failed:
-        return None
-
-    return "; ".join(
-        "{label}: {detail}".format(
-            label=GCP_SERVICE_LABELS.get(service.get("service", ""), service.get("service", "")),
-            detail=service.get("error_detail") or "Unknown error",
-        )
-        for service in failed
-    )

--- a/tests/sentry/api/endpoints/test_organization_monitoring_provider_verify_connection.py
+++ b/tests/sentry/api/endpoints/test_organization_monitoring_provider_verify_connection.py
@@ -28,6 +28,11 @@ def _denied_result(project_id: str = "proj-a") -> dict[str, Any]:
                 "services": [
                     {"service": "logging", "status": "connected", "error_detail": None},
                     {
+                        "service": "monitoring",
+                        "status": "api_disabled",
+                        "error_detail": "Enable the Monitoring API.",
+                    },
+                    {
                         "service": "cloudtrace",
                         "status": "permission_denied",
                         "error_detail": "IAM roles not granted",
@@ -68,6 +73,7 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
                         {
                             "gcp_project_id": project_id,
                             "connection_status": "unverified",
+                            "services": [],
                             "error_detail": None,
                         }
                         for project_id in project_ids
@@ -187,12 +193,14 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
         _PATCH_VERIFY,
         return_value={
             "connection_status": "connected",
-            "projects": [{"gcp_project_id": "proj-a"}],
+            "projects": [{"gcp_project_id": "proj-a", "connection_status": "connected"}],
         },
     )
     def test_invalid_seer_response_returns_502(
         self, mock_verify: MagicMock, mock_sa_email: MagicMock
     ) -> None:
+        self._install()
+        original_config = self._config()
         with self.feature("organizations:seer-infra-telemetry"):
             response = self.get_response(
                 self.organization.slug,
@@ -202,6 +210,7 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
 
         assert response.status_code == 502
         assert response.data == {"detail": "Failed to verify GCP connection. Please try again."}
+        assert self._config() == original_config
 
     def test_missing_required_fields(self) -> None:
         with self.feature("organizations:seer-infra-telemetry"):
@@ -273,7 +282,24 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
                 gcp_project_ids=["proj-a"],
             )
 
-        assert response.data["projects"][0]["errorDetail"] == ("Cloud Trace: IAM roles not granted")
+        assert response.data["projects"][0] == {
+            "gcpProjectId": "proj-a",
+            "connectionStatus": "permission_denied",
+            "services": [
+                {"service": "logging", "status": "connected", "errorDetail": None},
+                {
+                    "service": "monitoring",
+                    "status": "api_disabled",
+                    "errorDetail": "Enable the Monitoring API.",
+                },
+                {
+                    "service": "cloudtrace",
+                    "status": "permission_denied",
+                    "errorDetail": "IAM roles not granted",
+                },
+            ],
+            "errorDetail": None,
+        }
 
         config = self._config()
         assert config["connection_status"] == "permission_denied"
@@ -281,7 +307,20 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
             {
                 "gcp_project_id": "proj-a",
                 "connection_status": "permission_denied",
-                "error_detail": "Cloud Trace: IAM roles not granted",
+                "services": [
+                    {"service": "logging", "status": "connected", "error_detail": None},
+                    {
+                        "service": "monitoring",
+                        "status": "api_disabled",
+                        "error_detail": "Enable the Monitoring API.",
+                    },
+                    {
+                        "service": "cloudtrace",
+                        "status": "permission_denied",
+                        "error_detail": "IAM roles not granted",
+                    },
+                ],
+                "error_detail": None,
             }
         ]
         assert config["last_verified_at"] is not None
@@ -329,10 +368,114 @@ class OrganizationMonitoringProviderVerifyConnectionTest(APITestCase):
             {
                 "gcp_project_id": "proj-a",
                 "connection_status": "connected",
+                "services": [
+                    {"service": "logging", "status": "connected", "error_detail": None},
+                    {"service": "monitoring", "status": "connected", "error_detail": None},
+                    {"service": "cloudtrace", "status": "connected", "error_detail": None},
+                ],
                 "error_detail": None,
             }
         ]
         assert config["last_verified_at"] is not None
+
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
+    @patch(_PATCH_VERIFY)
+    def test_preserves_project_details_and_separates_projects(
+        self, mock_verify: MagicMock, mock_sa_email: MagicMock
+    ) -> None:
+        self._install(projects=["proj-a", "proj-b"])
+        denied = _denied_result()["projects"][0]
+        denied["error_detail"] = "Check the configured service account."
+        connected = {
+            "gcp_project_id": "proj-b",
+            "connection_status": "connected",
+            "services": [
+                {"service": "logging", "status": "connected", "error_detail": None},
+            ],
+            "error_detail": None,
+        }
+        mock_verify.return_value = {
+            "connection_status": "permission_denied",
+            "projects": [denied, connected],
+        }
+
+        with self.feature("organizations:seer-infra-telemetry"):
+            response = self.get_success_response(
+                self.organization.slug,
+                customer_sa_email=_CUSTOMER_SA,
+                gcp_project_ids=["proj-a", "proj-b"],
+            )
+
+        assert response.data["projects"][0]["errorDetail"] == (
+            "Check the configured service account."
+        )
+        assert response.data["projects"][1]["errorDetail"] is None
+        assert self._config()["project_statuses"] == [denied, connected]
+
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
+    @patch(_PATCH_VERIFY)
+    def test_missing_details_are_stored_as_null(
+        self, mock_verify: MagicMock, mock_sa_email: MagicMock
+    ) -> None:
+        self._install()
+        mock_verify.return_value = {
+            "connection_status": "connected",
+            "projects": [
+                {
+                    "gcp_project_id": "proj-a",
+                    "connection_status": "connected",
+                    "services": [{"service": "logging", "status": "connected"}],
+                }
+            ],
+        }
+
+        with self.feature("organizations:seer-infra-telemetry"):
+            response = self.get_success_response(
+                self.organization.slug,
+                customer_sa_email=_CUSTOMER_SA,
+                gcp_project_ids=["proj-a"],
+            )
+
+        assert response.data["projects"][0]["errorDetail"] is None
+        assert response.data["projects"][0]["services"][0]["errorDetail"] is None
+        assert self._config()["project_statuses"] == [
+            {
+                "gcp_project_id": "proj-a",
+                "connection_status": "connected",
+                "services": [
+                    {"service": "logging", "status": "connected", "error_detail": None},
+                ],
+                "error_detail": None,
+            }
+        ]
+
+    @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
+    @patch(_PATCH_VERIFY)
+    def test_invalid_services_are_not_recorded(
+        self, mock_verify: MagicMock, mock_sa_email: MagicMock
+    ) -> None:
+        self._install()
+        original_config = self._config()
+        mock_verify.return_value = {
+            "connection_status": "connected",
+            "projects": [
+                {
+                    "gcp_project_id": "proj-a",
+                    "connection_status": "connected",
+                    "services": [{"service": "logging"}],
+                }
+            ],
+        }
+
+        with self.feature("organizations:seer-infra-telemetry"):
+            response = self.get_response(
+                self.organization.slug,
+                customer_sa_email=_CUSTOMER_SA,
+                gcp_project_ids=["proj-a"],
+            )
+
+        assert response.status_code == 502
+        assert self._config() == original_config
 
     @patch(_PATCH_SA_EMAIL, return_value=_SENTRY_SA)
     @patch(_PATCH_VERIFY, return_value=_denied_result())

--- a/tests/sentry/integrations/gcp/test_integration.py
+++ b/tests/sentry/integrations/gcp/test_integration.py
@@ -20,7 +20,6 @@ from sentry.integrations.gcp.utils import (
     GCP_STATUS_UNVERIFIED,
     parse_customer_sa_email,
     parse_gcp_project_ids,
-    resolve_project_error_detail,
     validate_gcp_project_id,
 )
 from sentry.integrations.models.gcp_service_account import GcpServiceAccount
@@ -91,6 +90,10 @@ class GcpIntegrationTest(TestCase):
                 {
                     "gcp_project_id": project_id,
                     "connection_status": connection_status,
+                    "services": [
+                        {"service": service, "status": connection_status, "error_detail": None}
+                        for service in ("logging", "monitoring", "cloudtrace")
+                    ],
                     "error_detail": None,
                 }
                 for project_id in project_ids
@@ -217,7 +220,9 @@ class GcpIntegrationTest(TestCase):
     def _validated_verification(self, **overrides: object) -> GcpVerification:
         data: dict[str, Any] = {
             "connectionStatus": "connected",
-            "projects": [{"gcpProjectId": "my-gcp-project", "connectionStatus": "connected"}],
+            "projects": [
+                {"services": [], "gcpProjectId": "my-gcp-project", "connectionStatus": "connected"}
+            ],
         }
         data.update(overrides)
         serializer = GcpVerificationInputSerializer(data=data)
@@ -255,6 +260,7 @@ class GcpIntegrationTest(TestCase):
             "connection_status": "connected",
             "projects": [
                 {
+                    "services": [],
                     "gcp_project_id": "my-gcp-project",
                     "connection_status": "connected",
                     "error_detail": None,
@@ -274,6 +280,7 @@ class GcpIntegrationTest(TestCase):
                 connectionStatus="permission_denied",
                 projects=[
                     {
+                        "services": [],
                         "gcpProjectId": "my-gcp-project",
                         "connectionStatus": "permission_denied",
                         "errorDetail": "IAM roles not granted",
@@ -289,6 +296,7 @@ class GcpIntegrationTest(TestCase):
             "connection_status": "permission_denied",
             "projects": [
                 {
+                    "services": [],
                     "gcp_project_id": "my-gcp-project",
                     "connection_status": "permission_denied",
                     "error_detail": "IAM roles not granted",
@@ -308,7 +316,13 @@ class GcpIntegrationTest(TestCase):
 
         result = step.handle_post(
             self._validated_verification(
-                projects=[{"gcpProjectId": "project-prod", "connectionStatus": "connected"}]
+                projects=[
+                    {
+                        "services": [],
+                        "gcpProjectId": "project-prod",
+                        "connectionStatus": "connected",
+                    }
+                ]
             ),
             pipeline,
             Mock(),
@@ -323,7 +337,11 @@ class GcpIntegrationTest(TestCase):
             data={
                 "connectionStatus": "quota_exceeded",
                 "projects": [
-                    {"gcpProjectId": "my-gcp-project", "connectionStatus": "quota_exceeded"}
+                    {
+                        "services": [],
+                        "gcpProjectId": "my-gcp-project",
+                        "connectionStatus": "quota_exceeded",
+                    }
                 ],
             }
         )
@@ -337,6 +355,36 @@ class GcpIntegrationTest(TestCase):
         assert not serializer.is_valid()
         assert "projects" in serializer.errors
 
+    def test_verification_serializer_requires_services(self) -> None:
+        serializer = GcpVerificationInputSerializer(
+            data={
+                "connectionStatus": "connected",
+                "projects": [{"gcpProjectId": "my-gcp-project", "connectionStatus": "connected"}],
+            }
+        )
+
+        assert not serializer.is_valid()
+        assert serializer.errors["projects"][0]["services"][0].code == "required"
+
+    def test_verification_serializer_requires_service_identity_and_status(self) -> None:
+        serializer = GcpVerificationInputSerializer(
+            data={
+                "connectionStatus": "connected",
+                "projects": [
+                    {
+                        "gcpProjectId": "my-gcp-project",
+                        "connectionStatus": "connected",
+                        "services": [{}],
+                    }
+                ],
+            }
+        )
+
+        assert not serializer.is_valid()
+        errors = serializer.errors["projects"][0]["services"][0]
+        assert errors["service"][0].code == "required"
+        assert errors["status"][0].code == "required"
+
     def test_verification_step_normalizes_blank_error_detail(self) -> None:
         step = GcpVerificationApiStep()
         state: dict[str, object] = {
@@ -348,6 +396,7 @@ class GcpIntegrationTest(TestCase):
             self._validated_verification(
                 projects=[
                     {
+                        "services": [],
                         "gcpProjectId": "my-gcp-project",
                         "connectionStatus": "connected",
                         "errorDetail": "",
@@ -363,6 +412,80 @@ class GcpIntegrationTest(TestCase):
         assert verification["projects"][0]["error_detail"] is None
 
     # -- Build + install --
+
+    def test_service_results_survive_installation_and_config_reload(self) -> None:
+        state = self._state(projects=["project-prod", "project-staging"])
+        pipeline = self._make_pipeline(state=state)
+        verification = self._validated_verification(
+            connectionStatus="permission_denied",
+            projects=[
+                {
+                    "gcpProjectId": "project-prod",
+                    "connectionStatus": "connected",
+                    "services": [{"service": "logging", "status": "connected"}],
+                },
+                {
+                    "gcpProjectId": "project-staging",
+                    "connectionStatus": "permission_denied",
+                    "services": [
+                        {"service": "logging", "status": "connected", "errorDetail": None},
+                        {
+                            "service": "monitoring",
+                            "status": "api_disabled",
+                            "errorDetail": "Enable the Monitoring API.",
+                        },
+                        {
+                            "service": "cloudtrace",
+                            "status": "permission_denied",
+                            "errorDetail": "Check service account access.",
+                        },
+                    ],
+                },
+            ],
+        )
+        result = GcpVerificationApiStep().handle_post(verification, pipeline, Mock())
+        assert result == PipelineStepResult.advance()
+        built = self.provider.build_integration(state)
+        integration = self.create_integration(
+            organization=self.organization,
+            provider="gcp",
+            external_id=str(self.organization.id),
+            name="Google Cloud Platform",
+        )
+
+        self.provider.post_install(integration, self.organization, extra=built["post_install_data"])
+
+        installation = integration.get_installation(organization_id=self.organization.id)
+        assert isinstance(installation, GcpIntegration)
+        data = installation.get_config_data()
+        assert data["connection_status"] == "permission_denied"
+        assert data["last_verified_at"] is not None
+        assert data["project_statuses"] == [
+            {
+                "gcp_project_id": "project-prod",
+                "connection_status": "connected",
+                "services": [{"service": "logging", "status": "connected", "error_detail": None}],
+                "error_detail": None,
+            },
+            {
+                "gcp_project_id": "project-staging",
+                "connection_status": "permission_denied",
+                "services": [
+                    {"service": "logging", "status": "connected", "error_detail": None},
+                    {
+                        "service": "monitoring",
+                        "status": "api_disabled",
+                        "error_detail": "Enable the Monitoring API.",
+                    },
+                    {
+                        "service": "cloudtrace",
+                        "status": "permission_denied",
+                        "error_detail": "Check service account access.",
+                    },
+                ],
+                "error_detail": None,
+            },
+        ]
 
     def test_build_integration_returns_correct_data(self) -> None:
         result = self.provider.build_integration(self._state())
@@ -396,6 +519,7 @@ class GcpIntegrationTest(TestCase):
             "connection_status": "connected",
             "projects": [
                 {
+                    "services": [],
                     "gcp_project_id": "my-gcp-project",
                     "connection_status": "connected",
                     "error_detail": None,
@@ -448,6 +572,7 @@ class GcpIntegrationTest(TestCase):
                     "connection_status": "connected",
                     "projects": [
                         {
+                            "services": [],
                             "gcp_project_id": "my-gcp-project",
                             "connection_status": "connected",
                             "error_detail": None,
@@ -482,6 +607,7 @@ class GcpIntegrationTest(TestCase):
                     "connection_status": "permission_denied",
                     "projects": [
                         {
+                            "services": [],
                             "gcp_project_id": "my-gcp-project",
                             "connection_status": "permission_denied",
                             "error_detail": "IAM roles not granted",
@@ -498,6 +624,7 @@ class GcpIntegrationTest(TestCase):
         assert org_integration.config["connection_status"] == "permission_denied"
         assert org_integration.config["project_statuses"] == [
             {
+                "services": [],
                 "gcp_project_id": "my-gcp-project",
                 "connection_status": "permission_denied",
                 "error_detail": "IAM roles not granted",
@@ -533,6 +660,7 @@ class GcpIntegrationTest(TestCase):
         assert org_integration.config["last_verified_at"] is None
         assert org_integration.config["project_statuses"] == [
             {
+                "services": [],
                 "gcp_project_id": "my-gcp-project",
                 "connection_status": "error",
                 "error_detail": "Verification failed to run during setup.",
@@ -583,6 +711,7 @@ class GcpIntegrationTest(TestCase):
         assert config["last_verified_at"] is None
         assert config["project_statuses"] == [
             {
+                "services": [],
                 "gcp_project_id": "my-gcp-project",
                 "connection_status": GCP_STATUS_UNVERIFIED,
                 "error_detail": None,
@@ -626,6 +755,15 @@ class GcpIntegrationTest(TestCase):
         config = self._stored_config()
         assert config["connection_status"] == GCP_STATUS_UNVERIFIED
         assert config["last_verified_at"] is None
+        assert config["project_statuses"] == [
+            {
+                "gcp_project_id": project_id,
+                "connection_status": GCP_STATUS_UNVERIFIED,
+                "services": [],
+                "error_detail": None,
+            }
+            for project_id in ("project-staging", "project-new")
+        ]
 
     def test_update_config_rejects_a_string_of_projects(self) -> None:
         installation = self._create_installed_integration()
@@ -723,6 +861,11 @@ class GcpIntegrationTest(TestCase):
             {
                 "gcp_project_id": "my-gcp-project",
                 "connection_status": "connected",
+                "services": [
+                    {"service": "logging", "status": "connected", "error_detail": None},
+                    {"service": "monitoring", "status": "connected", "error_detail": None},
+                    {"service": "cloudtrace", "status": "connected", "error_detail": None},
+                ],
                 "error_detail": None,
             }
         ]
@@ -848,64 +991,6 @@ class GcpIntegrationTest(TestCase):
     def test_parse_customer_sa_email_rejects_overlong_values(self) -> None:
         with pytest.raises(IntegrationConfigurationError, match="at most"):
             parse_customer_sa_email("a" * 250 + "@customer.com")
-
-    def test_resolve_project_error_detail_prefers_the_project_level_message(self) -> None:
-        detail = resolve_project_error_detail(
-            {
-                "gcp_project_id": "project-a",
-                "connection_status": "permission_denied",
-                "error_detail": "SA impersonation chain failed",
-                "services": [
-                    {"service": "logging", "status": "permission_denied", "error_detail": "nope"}
-                ],
-            }
-        )
-        assert detail == "SA impersonation chain failed"
-
-    def test_resolve_project_error_detail_rolls_up_failing_services(self) -> None:
-        detail = resolve_project_error_detail(
-            {
-                "gcp_project_id": "project-a",
-                "connection_status": "error",
-                "error_detail": None,
-                "services": [
-                    {"service": "logging", "status": "connected", "error_detail": None},
-                    {
-                        "service": "monitoring",
-                        "status": "api_disabled",
-                        "error_detail": "API is disabled",
-                    },
-                    {
-                        "service": "cloudtrace",
-                        "status": "project_not_found",
-                        "error_detail": "Project not found",
-                    },
-                ],
-            }
-        )
-        assert detail == ("Cloud Monitoring: API is disabled; Cloud Trace: Project not found")
-
-    def test_resolve_project_error_detail_handles_unknown_service(self) -> None:
-        detail = resolve_project_error_detail(
-            {
-                "gcp_project_id": "project-a",
-                "connection_status": "error",
-                "error_detail": None,
-                "services": [{"service": "brand-new", "status": "error", "error_detail": None}],
-            }
-        )
-        assert detail == "brand-new: Unknown error"
-
-    def test_resolve_project_error_detail_is_none_when_connected(self) -> None:
-        detail = resolve_project_error_detail(
-            {
-                "gcp_project_id": "project-a",
-                "connection_status": "connected",
-                "error_detail": None,
-                "services": [{"service": "logging", "status": "connected", "error_detail": None}],
-            }
-        )
-        assert detail is None
 
     def test_validate_gcp_project_id_rejects_invalid_ids(self) -> None:
         for project_id in [


### PR DESCRIPTION
https://linear.app/getsentry/issue/CW-1986/polish-the-gcp-integration-onboarding-flow-before-releasing-to-users

GCP verification results are currently flattened into repeated error messages, and service-level details are discarded when saved. This PR preserves each project's service results through verification, installation, and configuration retrieval so the UI can group errors by affected projects and services.

Removes concatenated error summaries, requires `services` in installation verification submissions, and clears service results when connection settings change.