### PR TITLE
test(ai-monitoring): Remove duplicate conversation tests

### DIFF
--- a/tests/sentry/ai_monitoring/test_message_normalizer.py
+++ b/tests/sentry/ai_monitoring/test_message_normalizer.py
@@ -83,14 +83,6 @@ class TestNormalizeContentParts:
 
 
 class TestNormalizeToMessages:
-    def test_old_format_content(self) -> None:
-        messages = json_string([{"role": "user", "content": "Hello"}])
-        assert normalize_to_messages(messages, "user") == [{"role": "user", "content": "Hello"}]
-
-    def test_new_format_parts(self) -> None:
-        messages = json_string([{"role": "user", "parts": [{"type": "text", "content": "Hello"}]}])
-        assert normalize_to_messages(messages, "user") == [{"role": "user", "content": "Hello"}]
-
     def test_prefers_parts_format_when_both_exist(self) -> None:
         messages = json_string(
             [
@@ -170,13 +162,6 @@ class TestExtractAssistantOutput:
             "assistant",
         )
         assert result["response_text"] == "New"
-
-    def test_prefers_new_format_content(self) -> None:
-        result = extract_assistant_output(
-            json_string([{"role": "assistant", "content": "New content"}]),
-            "assistant",
-        )
-        assert result["response_text"] == "New content"
 
     def test_parses_json_encoded_content_string(self) -> None:
         result = extract_assistant_output(

--- a/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversation_details.py
@@ -1256,24 +1256,6 @@ class OrganizationAIConversationDetailsEndpointTest(BaseAIConversationsTestCase)
         ]
         assert response.data["webUrl"].endswith(f"/{conversation_id}/?project={self.project.id}")
 
-    def test_empty_conversation_returns_envelope(self) -> None:
-        now = before_now(days=5).replace(microsecond=0)
-        conversation_id = uuid4().hex
-
-        self._store_conversation_span(uuid4().hex, now)
-
-        query = {
-            "project": [self.project.id],
-            "start": (now - timedelta(hours=1)).isoformat(),
-            "end": (now + timedelta(hours=1)).isoformat(),
-        }
-
-        response = self.do_request(conversation_id, query)
-        assert response.status_code == 200
-        assert response.data["conversationId"] == conversation_id
-        assert response.data["title"] is None
-        assert response.data["spans"] == []
-
     def test_paginates_with_title(self) -> None:
         now = before_now(days=5).replace(microsecond=0)
         conversation_id = uuid4().hex

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -191,30 +191,6 @@ class TestConversationSortSerializer:
         assert serializer.validated_data["sort"] == ["-conversation.age"]
 
 
-@patch("sentry.ai_monitoring.endpoints.organization_ai_conversations.Spans.run_table_query")
-def test_candidate_query_accepts_multiple_sorts(run_table_query: MagicMock) -> None:
-    OrganizationAIConversationsEndpoint()._fetch_conversation_ids(
-        snuba_params=SnubaParams(),
-        query_string="has:gen_ai.conversation.id has:gen_ai.operation.type",
-        offset=0,
-        limit=10,
-        sampling_mode="HIGHEST_ACCURACY",
-        sorts=[
-            "-conversation.totalCost",
-            "conversation.age",
-            "-conversation.conversationId",
-        ],
-    )
-
-    query = run_table_query.call_args.kwargs
-    assert query["selected_columns"] == [
-        "gen_ai.conversation.id",
-        "max(timestamp)",
-        "sum_if(gen_ai.cost.total_tokens,gen_ai.operation.type,equals,ai_client) as total_cost",
-    ]
-    assert query["orderby"] == ["-total_cost", "max(timestamp)", "-gen_ai.conversation.id"]
-
-
 @patch(
     "sentry.ai_monitoring.endpoints.organization_ai_conversations.Spans.run_bulk_table_queries",
     return_value={
@@ -1173,52 +1149,6 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         conversation = response.data[0]
         assert conversation["errors"] == 3
 
-    def test_flow_ordering(self) -> None:
-        """Test that flow agents are ordered by timestamp"""
-        now = before_now(days=28).replace(microsecond=0)
-        conversation_id = uuid4().hex
-        trace_id = uuid4().hex
-
-        agents = [
-            ("Agent A", now - timedelta(seconds=5)),
-            ("Agent B", now - timedelta(seconds=3)),
-            ("Agent C", now - timedelta(seconds=1)),
-        ]
-
-        for agent_name, timestamp in agents:
-            self.store_ai_span(
-                conversation_id=conversation_id,
-                timestamp=timestamp,
-                op="gen_ai.invoke_agent",
-                operation_type="agent",
-                description=agent_name,
-                agent_name=agent_name,
-                trace_id=trace_id,
-            )
-
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now,
-            op="gen_ai.chat",
-            operation_type="ai_client",
-            trace_id=trace_id,
-            messages=[{"role": "user", "content": "test"}],
-            response_text="test response",
-        )
-
-        query = {
-            "project": [self.project.id],
-            "start": (now - timedelta(hours=1)).isoformat(),
-            "end": (now + timedelta(hours=1)).isoformat(),
-        }
-
-        response = self.do_request(query)
-        assert response.status_code == 200
-        assert len(response.data) == 1
-
-        conversation = response.data[0]
-        assert conversation["flow"] == ["Agent A", "Agent B", "Agent C"]
-
     def test_complete_conversation_data_across_time_range(self) -> None:
         """Test that conversations show complete data even when spans are outside time range"""
         now = before_now(days=15).replace(microsecond=0)
@@ -1271,68 +1201,6 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert conversation["inputTokens"] == 35
         assert conversation["outputTokens"] == 15
         assert conversation["totalCost"] == 0.005
-
-    def test_first_input_last_output(self) -> None:
-        """Test firstInput and lastOutput are correctly populated from ai_client spans"""
-        now = before_now(days=11).replace(microsecond=0)
-        conversation_id = uuid4().hex
-        trace_id = uuid4().hex
-
-        first_user_content = "What is the weather?"
-        last_response_text = "The weather is sunny!"
-
-        # First ai_client span with input
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=3),
-            op="gen_ai.chat",
-            operation_type="ai_client",
-            trace_id=trace_id,
-            messages=[{"role": "user", "content": first_user_content}],
-            response_text="Let me check...",
-        )
-
-        # Middle ai_client span
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=2),
-            op="gen_ai.chat",
-            operation_type="ai_client",
-            trace_id=trace_id,
-            messages=[
-                {"role": "user", "content": "What is the weather?"},
-                {"role": "assistant", "content": "Let me check..."},
-                {"role": "user", "content": "Thanks"},
-            ],
-            response_text="Processing your request...",
-        )
-
-        # Last ai_client span with output
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=1),
-            op="gen_ai.chat",
-            operation_type="ai_client",
-            trace_id=trace_id,
-            messages=[{"role": "user", "content": "Any updates?"}],
-            response_text=last_response_text,
-        )
-
-        query = {
-            "project": [self.project.id],
-            "start": (now - timedelta(hours=1)).isoformat(),
-            "end": (now + timedelta(hours=1)).isoformat(),
-        }
-
-        response = self.do_request(query)
-        assert response.status_code == 200
-        assert len(response.data) == 1
-
-        conversation = response.data[0]
-        # firstInput: first user message content from first ai_client span
-        # lastOutput: gen_ai.response.text from last ai_client span
-        assert conversation["firstInput"] == first_user_content
-        assert conversation["lastOutput"] == last_response_text
 
     def test_conversation_without_ai_client_spans_included(self) -> None:
         """Conversations are surfaced based on gen_ai.operation.type, even without LLM I/O"""
@@ -1418,44 +1286,6 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         assert response.status_code == 200
         assert len(response.data) == 1
         assert response.data[0]["conversationId"] == conversation_with_tool
-
-    def test_query_filter(self) -> None:
-        """Test that query parameter filters conversations"""
-        now = before_now(days=25).replace(microsecond=0)
-        conversation_id_1 = uuid4().hex
-        conversation_id_2 = uuid4().hex
-
-        # Conversation 1 with specific response text
-        self.store_ai_span(
-            conversation_id=conversation_id_1,
-            timestamp=now - timedelta(seconds=2),
-            op="gen_ai.chat",
-            operation_type="ai_client",
-            messages=[{"role": "user", "content": "What is the weather?"}],
-            response_text="It is sunny today",
-        )
-
-        # Conversation 2 with different response text
-        self.store_ai_span(
-            conversation_id=conversation_id_2,
-            timestamp=now - timedelta(seconds=1),
-            op="gen_ai.chat",
-            operation_type="ai_client",
-            messages=[{"role": "user", "content": "Tell me the news"}],
-            response_text="Here are the latest headlines",
-        )
-
-        query = {
-            "project": [self.project.id],
-            "start": (now - timedelta(hours=1)).isoformat(),
-            "end": (now + timedelta(hours=1)).isoformat(),
-            "query": f"gen_ai.conversation.id:{conversation_id_1}",
-        }
-
-        response = self.do_request(query)
-        assert response.status_code == 200
-        assert len(response.data) == 1
-        assert response.data[0]["conversationId"] == conversation_id_1
 
     def test_conversation_with_user_data(self) -> None:
         """Test that user data is extracted from spans and returned in the response"""
@@ -1696,51 +1526,6 @@ class OrganizationAIConversationsEndpointTest(BaseAIConversationsTestCase):
         # New format should take priority
         assert conversation["firstInput"] == new_user_content
         assert conversation["lastOutput"] == new_response_text
-
-    def test_new_format_parts_structure(self) -> None:
-        """Test that new format with parts structure works correctly"""
-        now = before_now(days=19).replace(microsecond=0)
-        conversation_id = uuid4().hex
-        trace_id = uuid4().hex
-
-        user_content = "Weather in Paris?"
-        response_content = "It's rainy, 57°F"
-
-        input_messages = [
-            {
-                "role": "user",
-                "parts": [{"type": "text", "content": user_content}],
-            }
-        ]
-        output_messages = [
-            {
-                "role": "assistant",
-                "parts": [{"type": "text", "content": response_content}],
-            }
-        ]
-
-        self.store_ai_span(
-            conversation_id=conversation_id,
-            timestamp=now - timedelta(seconds=1),
-            op="gen_ai.chat",
-            operation_type="ai_client",
-            trace_id=trace_id,
-            input_messages=input_messages,
-            output_messages=output_messages,
-        )
-
-        query = {
-            "project": [self.project.id],
-            "start": (now - timedelta(hours=1)).isoformat(),
-            "end": (now + timedelta(hours=1)).isoformat(),
-        }
-
-        response = self.do_request(query)
-        assert response.status_code == 200
-        assert len(response.data) == 1
-
-        assert response.data[0]["firstInput"] == user_content
-        assert response.data[0]["lastOutput"] == response_content
 
     def test_structured_user_part_populates_first_input(self) -> None:
         now = before_now(days=19).replace(microsecond=0)


### PR DESCRIPTION
Reduce redundant maintenance work for backend AI conversations. Conversation responses, filtering, ordering, and message handling remain unchanged.
