### PR TITLE
fix(span-waterfall): Replace generic metrics calculation with eap

### DIFF
--- a/src/sentry/issues/endpoints/organization_event_details.py
+++ b/src/sentry/issues/endpoints/organization_event_details.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timedelta
 from typing import Any
 
 import sentry_sdk
@@ -30,7 +30,7 @@ def add_comparison_to_event(event, average_columns):
     if "spans" not in event.data:
         return
     group_to_span_map = defaultdict(list)
-    end = datetime.now(UTC)
+    end = datetime.now()
     start = end - timedelta(hours=24)
     for span in event.data["spans"]:
         group = span.get("sentry_tags", {}).get("group")

--- a/src/sentry/issues/endpoints/organization_event_details.py
+++ b/src/sentry/issues/endpoints/organization_event_details.py
@@ -1,11 +1,10 @@
 from collections import defaultdict
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import sentry_sdk
 from rest_framework.request import Request
 from rest_framework.response import Response
-from snuba_sdk import Column, Condition, Function, Op
 
 from sentry import features
 from sentry.api.api_publish_status import ApiPublishStatus
@@ -16,24 +15,22 @@ from sentry.api.serializers import serialize
 from sentry.api.serializers.models.event import SqlFormatEventSerializer
 from sentry.api.utils import handle_query_errors
 from sentry.constants import ObjectStatus
-from sentry.middleware import is_frontend_request
 from sentry.models.project import Project
-from sentry.search.events.builder.spans_metrics import SpansMetricsQueryBuilder
-from sentry.search.events.types import QueryBuilderConfig
+from sentry.search.eap.types import SearchResolverConfig
+from sentry.search.events.types import SnubaParams
 from sentry.services import eventstore
-from sentry.snuba.dataset import Dataset
-from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer
+from sentry.snuba.spans_rpc import Spans
 from sentry.utils.sdk import set_span_attribute
 
 VALID_AVERAGE_COLUMNS = {"span.self_time", "span.duration"}
 
 
-def add_comparison_to_event(event, average_columns, request: Request):
+def add_comparison_to_event(event, average_columns):
     if "spans" not in event.data:
         return
     group_to_span_map = defaultdict(list)
-    end = datetime.now()
+    end = datetime.now(UTC)
     start = end - timedelta(hours=24)
     for span in event.data["spans"]:
         group = span.get("sentry_tags", {}).get("group")
@@ -46,38 +43,24 @@ def add_comparison_to_event(event, average_columns, request: Request):
         return
 
     with handle_query_errors():
-        builder = SpansMetricsQueryBuilder(
-            dataset=Dataset.PerformanceMetrics,
-            params={
-                "start": start,
-                "end": end,
-                "project_objects": [event.project],
-                "organization_id": event.organization.id,
-            },
+        result = Spans.run_table_query(
+            params=SnubaParams(
+                start=start,
+                end=end,
+                projects=[event.project],
+                organization=event.organization,
+            ),
+            query_string=f"span.group:[{','.join(group_to_span_map.keys())}]",
             selected_columns=[
                 "span.group",
                 *[f"avg({average_column})" for average_column in average_columns],
             ],
-            config=QueryBuilderConfig(transform_alias_to_input_format=True),
-            # orderby shouldn't matter, just picking something so results are consistent
             orderby=["span.group"],
-        )
-        builder.add_conditions(
-            [
-                Condition(
-                    Column(builder.resolve_column_name("span.group")),
-                    Op.IN,
-                    Function("tuple", list(group_to_span_map.keys())),
-                )
-            ]
-        )
-        result = builder.process_results(
-            builder.run_query(
-                referrer=Referrer.API_INSIGHTS_ORG_EVENT_AVERAGE_SPAN.value,
-                query_source=(
-                    QuerySource.FRONTEND if is_frontend_request(request) else QuerySource.API
-                ),
-            )
+            offset=0,
+            limit=len(group_to_span_map),
+            referrer=Referrer.API_INSIGHTS_ORG_EVENT_AVERAGE_SPAN.value,
+            config=SearchResolverConfig(),
+            sampling_mode="NORMAL",
         )
         set_span_attribute("query.groups_found", len(result["data"]))
         for row in result["data"]:
@@ -155,7 +138,7 @@ class OrganizationEventDetailsEndpoint(OrganizationEventsEndpointBase):
             and len(average_columns) > 0
             and features.has("organizations:insight-modules", organization, actor=request.user)
         ):
-            add_comparison_to_event(event=event, average_columns=average_columns, request=request)
+            add_comparison_to_event(event=event, average_columns=average_columns)
 
         # TODO: Remove `for_group` check once performance issues are moved to the issue platform
         if hasattr(event, "for_group") and event.group:

--- a/src/sentry/issues/endpoints/organization_event_details.py
+++ b/src/sentry/issues/endpoints/organization_event_details.py
@@ -19,6 +19,7 @@ from sentry.models.project import Project
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.services import eventstore
+from sentry.services.eventstore.models import Event, GroupEvent
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.utils.sdk import set_span_attribute
@@ -26,7 +27,7 @@ from sentry.utils.sdk import set_span_attribute
 VALID_AVERAGE_COLUMNS = {"span.self_time", "span.duration"}
 
 
-def add_comparison_to_event(event, average_columns):
+def add_comparison_to_event(event: Event | GroupEvent, average_columns: list[str]):
     if "spans" not in event.data:
         return
     group_to_span_map = defaultdict(list)

--- a/src/sentry/issues/endpoints/organization_event_details.py
+++ b/src/sentry/issues/endpoints/organization_event_details.py
@@ -19,7 +19,7 @@ from sentry.models.project import Project
 from sentry.search.eap.types import SearchResolverConfig
 from sentry.search.events.types import SnubaParams
 from sentry.services import eventstore
-from sentry.services.eventstore.models import Event, GroupEvent
+from sentry.services.eventstore.models import BaseEvent
 from sentry.snuba.referrer import Referrer
 from sentry.snuba.spans_rpc import Spans
 from sentry.utils.sdk import set_span_attribute
@@ -27,7 +27,7 @@ from sentry.utils.sdk import set_span_attribute
 VALID_AVERAGE_COLUMNS = {"span.self_time", "span.duration"}
 
 
-def add_comparison_to_event(event: Event | GroupEvent, average_columns: list[str]):
+def add_comparison_to_event(event: BaseEvent, average_columns: list[str]):
     if "spans" not in event.data:
         return
     group_to_span_map = defaultdict(list)

--- a/src/sentry/issues/endpoints/organization_event_details.py
+++ b/src/sentry/issues/endpoints/organization_event_details.py
@@ -68,7 +68,7 @@ def add_comparison_to_event(event, average_columns):
             for span in group_to_span_map[group]:
                 average_results = {}
                 for col in row:
-                    if col.startswith("avg") and row is not None and row[col] > 0:
+                    if col.startswith("avg") and row[col] is not None and row[col] > 0:
                         average_results[col] = row[col]
                 if average_results:
                     span["span.averageResults"] = average_results

--- a/src/sentry/issues/endpoints/organization_event_details.py
+++ b/src/sentry/issues/endpoints/organization_event_details.py
@@ -68,7 +68,7 @@ def add_comparison_to_event(event, average_columns):
             for span in group_to_span_map[group]:
                 average_results = {}
                 for col in row:
-                    if col.startswith("avg") and row[col] > 0:
+                    if col.startswith("avg") and row is not None and row[col] > 0:
                         average_results[col] = row[col]
                 if average_results:
                     span["span.averageResults"] = average_results

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -340,7 +340,7 @@ class EventComparisonTest(APITestCase, SpanTestCase, SnubaTestCase):
         with self.feature({"organizations:insight-modules": False}):
             response = self.client.get(self.url, {"averageColumn": "span.self_time"})
         assert response.status_code == 200, response.content
-        entries = response.data["entries"]  # type: ignore[attr-defined]
+        entries = response.data["entries"]
         for entry in entries:
             if entry["type"] == "spans":
                 for span in entry["data"]:
@@ -350,7 +350,7 @@ class EventComparisonTest(APITestCase, SpanTestCase, SnubaTestCase):
         with self.feature("organizations:insight-modules"):
             response = self.client.get(self.url, {"averageColumn": "span.self_time"})
         assert response.status_code == 200, response.content
-        entries = response.data["entries"]  # type: ignore[attr-defined]
+        entries = response.data["entries"]
         for entry in entries:
             if entry["type"] == "spans":
                 for span in entry["data"]:
@@ -365,7 +365,7 @@ class EventComparisonTest(APITestCase, SpanTestCase, SnubaTestCase):
                 self.url, {"averageColumn": ["span.self_time", "span.duration"]}
             )
         assert response.status_code == 200, response.content
-        entries = response.data["entries"]  # type: ignore[attr-defined]
+        entries = response.data["entries"]
         for entry in entries:
             if entry["type"] == "spans":
                 for span in entry["data"]:
@@ -393,7 +393,7 @@ class EventComparisonTest(APITestCase, SpanTestCase, SnubaTestCase):
                 self.url, {"averageColumn": ["span.self_time", "span.duration"]}
             )
         assert response.status_code == 200, response.content
-        entries = response.data["entries"]  # type: ignore[attr-defined]
+        entries = response.data["entries"]
         for entry in entries:
             if entry["type"] == "spans":
                 for span in entry["data"]:
@@ -411,7 +411,7 @@ class EventComparisonTest(APITestCase, SpanTestCase, SnubaTestCase):
             self.url, {"averageColumn": ["span.self_time", "span.everything"]}
         )
         assert response.status_code == 200, response.content
-        entries = response.data["entries"]  # type: ignore[attr-defined]
+        entries = response.data["entries"]
         for entry in entries:
             if entry["type"] == "spans":
                 for span in entry["data"]:

--- a/tests/snuba/api/endpoints/test_organization_event_details.py
+++ b/tests/snuba/api/endpoints/test_organization_event_details.py
@@ -4,8 +4,7 @@ import pytest
 from django.urls import NoReverseMatch, reverse
 
 from sentry.models.group import Group
-from sentry.search.events import constants
-from sentry.testutils.cases import APITestCase, MetricsEnhancedPerformanceTestCase, SnubaTestCase
+from sentry.testutils.cases import APITestCase, SnubaTestCase, SpanTestCase
 from sentry.testutils.helpers.datetime import before_now
 from sentry.utils.samples import load_data
 from tests.sentry.issues.test_utils import OccurrenceTestMixin
@@ -307,11 +306,11 @@ class OrganizationEventDetailsEndpointTest(APITestCase, SnubaTestCase, Occurrenc
         assert response.data["occurrence"]["id"] == occurrence.id
 
 
-@pytest.mark.skip("Generic metrics sets, gauges, and distributions are no longer queryable")
-class EventComparisonTest(MetricsEnhancedPerformanceTestCase):
+class EventComparisonTest(APITestCase, SpanTestCase, SnubaTestCase):
     endpoint = "sentry-api-0-organization-event-details"
 
     def setUp(self) -> None:
+        super().setUp()
         self.init_snuba()
         self.ten_mins_ago = before_now(minutes=10)
         self.transaction_data = load_data("transaction", timestamp=self.ten_mins_ago)
@@ -326,11 +325,15 @@ class EventComparisonTest(MetricsEnhancedPerformanceTestCase):
             },
         )
         self.login_as(user=self.user)
-        self.store_span_metric(
-            1,
-            internal_metric=constants.SELF_TIME_LIGHT,
-            timestamp=self.ten_mins_ago,
-            tags={"span.group": "26b881987e4bad99"},
+        self.store_span(
+            self.create_span(
+                {
+                    "exclusive_time_ms": 1.0,
+                    "sentry_tags": {"group": "26b881987e4bad99"},
+                },
+                start_ts=self.ten_mins_ago,
+                duration=2,
+            )
         )
 
     def test_get_without_feature(self) -> None:
@@ -357,12 +360,6 @@ class EventComparisonTest(MetricsEnhancedPerformanceTestCase):
                         assert self.RESULT_COLUMN not in span
 
     def test_get_multiple_columns(self) -> None:
-        self.store_span_metric(
-            2,
-            internal_metric=constants.SPAN_METRICS_MAP["span.duration"],
-            timestamp=self.ten_mins_ago,
-            tags={"span.group": "26b881987e4bad99"},
-        )
         with self.feature("organizations:insight-modules"):
             response = self.client.get(
                 self.url, {"averageColumn": ["span.self_time", "span.duration"]}
@@ -380,8 +377,17 @@ class EventComparisonTest(MetricsEnhancedPerformanceTestCase):
                     if span["op"] == "django.middleware":
                         assert self.RESULT_COLUMN not in span
 
-    def test_nan_column(self) -> None:
-        # If there's nothing stored for a metric, span.duration in this case the query returns nan
+    def test_averages_include_zero_values(self) -> None:
+        self.store_span(
+            self.create_span(
+                {
+                    "exclusive_time_ms": 0.0,
+                    "sentry_tags": {"group": "26b881987e4bad99"},
+                },
+                start_ts=self.ten_mins_ago,
+                duration=0,
+            )
+        )
         with self.feature("organizations:insight-modules"):
             response = self.client.get(
                 self.url, {"averageColumn": ["span.self_time", "span.duration"]}
@@ -392,7 +398,10 @@ class EventComparisonTest(MetricsEnhancedPerformanceTestCase):
             if entry["type"] == "spans":
                 for span in entry["data"]:
                     if span["op"] == "db":
-                        assert span[self.RESULT_COLUMN] == {"avg(span.self_time)": 1.0}
+                        assert span[self.RESULT_COLUMN] == {
+                            "avg(span.self_time)": 0.5,
+                            "avg(span.duration)": 1.0,
+                        }
                     if span["op"] == "django.middleware":
                         assert self.RESULT_COLUMN not in span
 


### PR DESCRIPTION
This endpoint queries generic metrics, but since we've stopped allowing querying for generic metrics, this code path errors out. This PR replaces the calculation with an EAP request for the same data.

Fixes https://github.com/getsentry/self-hosted/issues/4491
