### PR TITLE
fix(java): serialize deeply nested view hierarchies despite orjson recursion limit

### DIFF
--- a/src/sentry/lang/java/view_hierarchies.py
+++ b/src/sentry/lang/java/view_hierarchies.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 import orjson
@@ -10,6 +9,7 @@ from sentry.attachments import (
 )
 from sentry.ingest.consumer.processors import CACHE_TIMEOUT
 from sentry.models.project import Project
+from sentry.utils import json as sentry_json
 
 
 def _serialize_view_hierarchy(view_hierarchy: Any) -> bytes:
@@ -23,7 +23,7 @@ def _serialize_view_hierarchy(view_hierarchy: Any) -> bytes:
     try:
         return orjson.dumps(view_hierarchy)
     except (orjson.JSONEncodeError, TypeError):
-        return json.dumps(view_hierarchy).encode("utf-8")
+        return sentry_json.dumps(view_hierarchy).encode("utf-8")
 
 
 class ViewHierarchies:

--- a/src/sentry/lang/java/view_hierarchies.py
+++ b/src/sentry/lang/java/view_hierarchies.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 
 import orjson
@@ -9,6 +10,20 @@ from sentry.attachments import (
 )
 from sentry.ingest.consumer.processors import CACHE_TIMEOUT
 from sentry.models.project import Project
+
+
+def _serialize_view_hierarchy(view_hierarchy: Any) -> bytes:
+    """Serialize a deobfuscated view hierarchy for storage.
+
+    View hierarchies reported by Android can nest deeper than orjson's fixed
+    serialization recursion limit (255 levels). The stdlib encoder recurses up
+    to Python's (much larger) stack limit, so fall back to it instead of
+    dropping the deobfuscated attachment.
+    """
+    try:
+        return orjson.dumps(view_hierarchy)
+    except (orjson.JSONEncodeError, TypeError):
+        return json.dumps(view_hierarchy).encode("utf-8")
 
 
 class ViewHierarchies:
@@ -60,7 +75,7 @@ class ViewHierarchies:
                     type=attachment.type,
                     name=attachment.name,
                     content_type=attachment.content_type,
-                    data=orjson.dumps(view_hierarchy),
+                    data=_serialize_view_hierarchy(view_hierarchy),
                     chunks=None,
                     stored_id=attachment.stored_id,
                 )

--- a/src/sentry/lang/java/view_hierarchies.py
+++ b/src/sentry/lang/java/view_hierarchies.py
@@ -78,6 +78,7 @@ class ViewHierarchies:
                     data=_serialize_view_hierarchy(view_hierarchy),
                     chunks=None,
                     stored_id=attachment.stored_id,
+                    retention_days=attachment.retention_days,
                 )
             )
 

--- a/tests/sentry/lang/java/test_view_hierarchies.py
+++ b/tests/sentry/lang/java/test_view_hierarchies.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import orjson
+import pytest
+
+from sentry.attachments import CachedAttachment
+from sentry.lang.java.view_hierarchies import ViewHierarchies, _serialize_view_hierarchy
+
+
+def _deep_windows(depth: int) -> list[dict[str, object]]:
+    """Build a chain of nested windows `depth` levels deep."""
+    windows: list[dict[str, object]] = [{"type": f"class_{depth - 1}"}]
+    for i in range(depth - 2, -1, -1):
+        windows = [{"type": f"class_{i}", "children": windows}]
+    return windows
+
+
+def _walk_depth(windows: list[dict[str, object]]) -> tuple[int, str]:
+    depth = 0
+    window = windows[0]
+    while "children" in window:
+        depth += 1
+        window = window["children"][0]
+    return depth, window.get("type", "")
+
+
+def test_serialize_view_hierarchy_falls_back_for_deep_nesting() -> None:
+    hierarchy = {"windows": _deep_windows(300)}
+
+    # Regression guard: this is the failure mode reported in gh-78685.
+    with pytest.raises((orjson.JSONEncodeError, TypeError)):
+        orjson.dumps(hierarchy)
+
+    payload = _serialize_view_hierarchy(hierarchy)
+
+    loaded = orjson.loads(payload)
+    depth, last_type = _walk_depth(loaded["windows"])
+    assert depth == 299
+    assert last_type == "class_299"
+
+
+def test_serialize_view_hierarchy_shallow_matches_orjson() -> None:
+    hierarchy = {"windows": [{"type": "a", "children": [{"type": "b"}]}]}
+
+    assert orjson.loads(_serialize_view_hierarchy(hierarchy)) == hierarchy
+
+
+def test_deobfuscate_and_save_deeply_nested_hierarchy(monkeypatch) -> None:
+    depth = 300
+    class_names = {f"class_{i}": f"mapped_{i}" for i in range(depth)}
+    hierarchy = {"windows": _deep_windows(depth)}
+    attachment = CachedAttachment(
+        key="key:1",
+        id=1,
+        type="event.view_hierarchy",
+        name="view_hierarchy.json",
+        content_type="application/json",
+        data=orjson.dumps(hierarchy),
+    )
+
+    stored: list[CachedAttachment] = []
+
+    def fake_get_attachments_for_event(event):
+        return [attachment]
+
+    def fake_store_attachments_for_event(project, event, attachments, timeout=None):
+        stored.extend(attachments)
+
+    monkeypatch.setattr(
+        "sentry.lang.java.view_hierarchies.get_attachments_for_event",
+        fake_get_attachments_for_event,
+    )
+    monkeypatch.setattr(
+        "sentry.lang.java.view_hierarchies.store_attachments_for_event",
+        fake_store_attachments_for_event,
+    )
+
+    ViewHierarchies(project=None, data={}).deobfuscate_and_save(class_names)
+
+    assert len(stored) == 1
+    loaded = orjson.loads(stored[0].data)
+    depth, last_type = _walk_depth(loaded["windows"])
+    assert depth == 299
+    assert last_type == "mapped_299"

--- a/tests/sentry/lang/java/test_view_hierarchies.py
+++ b/tests/sentry/lang/java/test_view_hierarchies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from typing import Any
 from unittest import mock
 
 import orjson
@@ -9,21 +10,21 @@ from sentry.attachments import CachedAttachment
 from sentry.lang.java.view_hierarchies import ViewHierarchies, _serialize_view_hierarchy
 
 
-def _deep_windows(depth: int) -> list[dict[str, object]]:
+def _deep_windows(depth: int) -> list[dict[str, Any]]:
     """Build a chain of nested windows `depth` levels deep."""
-    windows: list[dict[str, object]] = [{"type": f"class_{depth - 1}"}]
+    windows: list[dict[str, Any]] = [{"type": f"class_{depth - 1}"}]
     for i in range(depth - 2, -1, -1):
         windows = [{"type": f"class_{i}", "children": windows}]
     return windows
 
 
-def _walk_depth(windows: list[dict[str, object]]) -> tuple[int, str]:
+def _walk_depth(windows: list[dict[str, Any]]) -> tuple[int, str]:
     depth = 0
     window = windows[0]
     while "children" in window:
         depth += 1
         window = window["children"][0]
-    return depth, window.get("type", "")
+    return depth, str(window.get("type", ""))
 
 
 def test_serialize_view_hierarchy_falls_back_for_deep_nesting() -> None:
@@ -47,7 +48,7 @@ def test_serialize_view_hierarchy_shallow_matches_orjson() -> None:
     assert orjson.loads(_serialize_view_hierarchy(hierarchy)) == hierarchy
 
 
-def test_deobfuscate_and_save_deeply_nested_hierarchy(monkeypatch) -> None:
+def test_deobfuscate_and_save_deeply_nested_hierarchy() -> None:
     depth = 300
     class_names = {f"class_{i}": f"mapped_{i}" for i in range(depth)}
     hierarchy = {"windows": _deep_windows(depth)}
@@ -60,17 +61,19 @@ def test_deobfuscate_and_save_deeply_nested_hierarchy(monkeypatch) -> None:
         data=orjson.dumps(hierarchy),
     )
 
-    monkeypatch.setattr(
-        "sentry.lang.java.view_hierarchies.get_attachments_for_event",
-        mock.Mock(return_value=[attachment]),
-    )
+    get_attachments = mock.Mock(return_value=[attachment])
     store_attachments = mock.Mock()
-    monkeypatch.setattr(
-        "sentry.lang.java.view_hierarchies.store_attachments_for_event",
-        store_attachments,
-    )
-
-    ViewHierarchies(project=None, data={}).deobfuscate_and_save(class_names)
+    with (
+        mock.patch(
+            "sentry.lang.java.view_hierarchies.get_attachments_for_event",
+            get_attachments,
+        ),
+        mock.patch(
+            "sentry.lang.java.view_hierarchies.store_attachments_for_event",
+            store_attachments,
+        ),
+    ):
+        ViewHierarchies(project=mock.Mock(), data={}).deobfuscate_and_save(class_names)
 
     store_attachments.assert_called_once()
     stored = store_attachments.call_args.args[2]

--- a/tests/sentry/lang/java/test_view_hierarchies.py
+++ b/tests/sentry/lang/java/test_view_hierarchies.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from unittest import mock
+
 import orjson
 import pytest
 
@@ -58,25 +60,20 @@ def test_deobfuscate_and_save_deeply_nested_hierarchy(monkeypatch) -> None:
         data=orjson.dumps(hierarchy),
     )
 
-    stored: list[CachedAttachment] = []
-
-    def fake_get_attachments_for_event(event):
-        return [attachment]
-
-    def fake_store_attachments_for_event(project, event, attachments, timeout=None):
-        stored.extend(attachments)
-
     monkeypatch.setattr(
         "sentry.lang.java.view_hierarchies.get_attachments_for_event",
-        fake_get_attachments_for_event,
+        mock.Mock(return_value=[attachment]),
     )
+    store_attachments = mock.Mock()
     monkeypatch.setattr(
         "sentry.lang.java.view_hierarchies.store_attachments_for_event",
-        fake_store_attachments_for_event,
+        store_attachments,
     )
 
     ViewHierarchies(project=None, data={}).deobfuscate_and_save(class_names)
 
+    store_attachments.assert_called_once()
+    stored = store_attachments.call_args.args[2]
     assert len(stored) == 1
     loaded = orjson.loads(stored[0].data)
     depth, last_type = _walk_depth(loaded["windows"])

--- a/tests/sentry/lang/java/test_view_hierarchies.py
+++ b/tests/sentry/lang/java/test_view_hierarchies.py
@@ -60,6 +60,7 @@ def test_deobfuscate_and_save_deeply_nested_hierarchy() -> None:
         name="view_hierarchy.json",
         content_type="application/json",
         data=sentry_json.dumps(hierarchy).encode("utf-8"),
+        retention_days=90,
     )
 
     get_attachments = mock.Mock(return_value=[attachment])

--- a/tests/sentry/lang/java/test_view_hierarchies.py
+++ b/tests/sentry/lang/java/test_view_hierarchies.py
@@ -8,6 +8,7 @@ import pytest
 
 from sentry.attachments import CachedAttachment
 from sentry.lang.java.view_hierarchies import ViewHierarchies, _serialize_view_hierarchy
+from sentry.utils import json as sentry_json
 
 
 def _deep_windows(depth: int) -> list[dict[str, Any]]:
@@ -58,7 +59,7 @@ def test_deobfuscate_and_save_deeply_nested_hierarchy() -> None:
         type="event.view_hierarchy",
         name="view_hierarchy.json",
         content_type="application/json",
-        data=orjson.dumps(hierarchy),
+        data=sentry_json.dumps(hierarchy).encode("utf-8"),
     )
 
     get_attachments = mock.Mock(return_value=[attachment])

--- a/tests/sentry/lang/java/test_view_hierarchies.py
+++ b/tests/sentry/lang/java/test_view_hierarchies.py
@@ -80,7 +80,7 @@ def test_deobfuscate_and_save_deeply_nested_hierarchy() -> None:
     store_attachments.assert_called_once()
     stored = store_attachments.call_args.args[2]
     assert len(stored) == 1
-    loaded = orjson.loads(stored[0].data)
+    loaded = orjson.loads(stored[0].load_data())
     depth, last_type = _walk_depth(loaded["windows"])
     assert depth == 299
     assert last_type == "mapped_299"


### PR DESCRIPTION
## Summary

Fixes gh-78685: `orjson.dumps` aborts at a hardcoded serialization recursion limit of 255 nesting levels, so a deobfuscated Android view hierarchy deeper than that raised `TypeError` ("Recursion limit reached") out of `ViewHierarchies.deobfuscate_and_save` and the attachment was never persisted.

The fix keeps `orjson.dumps` for the common case and falls back to the stdlib `json.dumps` encoder (which recurses up to Python's stack limit, ~1000 levels by default) when orjson reports a recursion error. Content comes from `orjson.loads`, so only JSON-native values reach this path; if the stdlib encoder also fails, the original error semantics are preserved.

## Testing

New unit tests in `tests/sentry/lang/java/test_view_hierarchies.py`:

- `test_serialize_view_hierarchy_falls_back_for_deep_nesting` — a 300-level hierarchy fails with stock `orjson.dumps`, then round-trips through the fallback with all levels and types intact.
- `test_serialize_view_hierarchy_shallow_matches_orjson` — shallow hierarchies still serialize identically (semantically).
- `test_deobfuscate_and_save_deeply_nested_hierarchy` — end-to-end through `deobfuscate_and_save` with mocked attachment I/O: a 300-level tree is deobfuscated and persisted.

The fallback behavior was verified locally against `orjson==3.10.10` (the project pin) and 3.12.0: both raise for 300-level nesting, and `json.dumps` + `orjson.loads` round-trips the data losslessly.

Note: the full sentry pytest environment (devenv, Cython `sentry.monkey` extension) cannot run on this Windows host, so the committed tests are verified by CI; `ruff check` and `ruff format --check` pass locally on both files.