### PR TITLE
feat(workflow-engine): Add detector and action filters

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -581,6 +581,14 @@ Prefix with `-` to sort in descending order.
         description="Filter by monitor type(s). Can be specified multiple times.",
     )
 
+    ENABLED = OpenApiParameter(
+        name="enabled",
+        location="query",
+        required=False,
+        type=bool,
+        description="Filter by whether monitors are enabled.",
+    )
+
 
 class WorkflowParams:
     WORKFLOW_ID = OpenApiParameter(

--- a/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_available_action_index.py
@@ -1,7 +1,8 @@
 from collections import defaultdict
 from typing import TypedDict
 
-from drf_spectacular.utils import extend_schema
+from drf_spectacular.utils import OpenApiParameter, extend_schema
+from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 from rest_framework.response import Response
 
@@ -38,6 +39,22 @@ from sentry.workflow_engine.processors.action import (
 from sentry.workflow_engine.registry import action_handler_registry
 from sentry.workflow_engine.types import ActionHandler
 
+AVAILABLE_ACTION_TYPES = tuple(
+    action_type for action_type in Action.Type if action_type not in DEPRECATED_ACTION_TYPES
+)
+AVAILABLE_ACTION_TYPE_VALUES = frozenset(
+    action_type.value for action_type in AVAILABLE_ACTION_TYPES
+)
+AVAILABLE_ACTION_TYPE_PARAMETER = OpenApiParameter(
+    name="type",
+    location="query",
+    required=False,
+    type=str,
+    enum=[action_type.value for action_type in AVAILABLE_ACTION_TYPES],
+    many=True,
+    description="Filter by action type. Can be specified multiple times.",
+)
+
 
 class AvailableIntegration(TypedDict):
     integration: RpcIntegration
@@ -55,6 +72,7 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
         operation_id="Fetch Available Actions",
         parameters=[
             GlobalParams.ORG_ID_OR_SLUG,
+            AVAILABLE_ACTION_TYPE_PARAMETER,
         ],
         responses={
             201: inline_sentry_response_serializer(
@@ -72,6 +90,18 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
         """
         Returns a list of available actions for a given org
         """
+        requested_action_types = set(request.GET.getlist("type"))
+        invalid_action_types = requested_action_types - AVAILABLE_ACTION_TYPE_VALUES
+        if invalid_action_types:
+            raise ValidationError(
+                {
+                    "type": [
+                        f"Invalid action type: {action_type}"
+                        for action_type in sorted(invalid_action_types)
+                    ]
+                }
+            )
+
         can_create_tickets = features.has("organizations:integrations-ticket-rules", organization)
 
         integration_services = get_integration_services(organization.id)
@@ -109,6 +139,9 @@ class OrganizationAvailableActionIndexEndpoint(OrganizationEndpoint):
 
         actions = []
         for action_type, handler in action_handler_registry.registrations.items():
+            if requested_action_types and str(action_type) not in requested_action_types:
+                continue
+
             # skip ticket creation actions if organization doesn't have the feature
             if not can_create_tickets and handler.group == ActionHandler.Group.TICKET_CREATION:
                 continue

--- a/src/sentry/workflow_engine/endpoints/organization_detector_index.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_index.py
@@ -267,6 +267,8 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             DetectorParams.QUERY,
             DetectorParams.SORT,
             DetectorParams.ID,
+            DetectorParams.TYPE,
+            DetectorParams.ENABLED,
             VisibilityParams.PER_PAGE,
             CursorQueryParam,
         ],
@@ -291,6 +293,19 @@ class OrganizationDetectorIndexEndpoint(OrganizationEndpoint):
             return self.respond(status=status.HTTP_401_UNAUTHORIZED)
 
         queryset = self.filter_detectors(request, organization)
+
+        if detector_types := request.GET.getlist("type"):
+            detector_types = [DETECTOR_TYPE_ALIASES.get(value, value) for value in detector_types]
+            queryset = queryset.filter(type__in=detector_types)
+
+        raw_enabled = request.GET.get("enabled")
+        if raw_enabled is not None:
+            try:
+                enabled = serializers.BooleanField().run_validation(raw_enabled)
+            except ValidationError as error:
+                raise ValidationError({"enabled": error.detail}) from error
+            queryset = queryset.filter(enabled=enabled)
+
         queryset = exclude_disallowed_metric_detectors(queryset, organization)
 
         sort_by = request.GET.get("sortBy", "id")

--- a/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_available_action_index.py
@@ -292,6 +292,49 @@ class OrganizationAvailableActionAPITestCase(APITestCase):
             },
         ]
 
+    def test_filter_by_type(self) -> None:
+        self.setup_integrations()
+        self.setup_email()
+
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"type": Action.Type.SLACK},
+            status_code=200,
+        )
+        assert response.data == [
+            {
+                "type": Action.Type.SLACK,
+                "handlerGroup": ActionHandler.Group.NOTIFICATION.value,
+                "configSchema": {},
+                "dataSchema": {},
+                "integrations": [
+                    {"id": str(self.slack_integration.id), "name": self.slack_integration.name}
+                ],
+            }
+        ]
+
+    def test_filter_by_multiple_types(self) -> None:
+        self.setup_integrations()
+        self.setup_email()
+
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={"type": [Action.Type.EMAIL, Action.Type.GITHUB]},
+            status_code=200,
+        )
+        assert [action["type"] for action in response.data] == [
+            Action.Type.EMAIL,
+            Action.Type.GITHUB,
+        ]
+
+    def test_invalid_type_filter(self) -> None:
+        response = self.get_error_response(
+            self.organization.slug,
+            qs_params={"type": "carrier_pigeon"},
+            status_code=400,
+        )
+        assert response.data == {"type": ["Invalid action type: carrier_pigeon"]}
+
     @with_feature({"organizations:integrations-ticket-rules": False})
     def test_does_not_return_ticket_actions_without_feature(self) -> None:
         self.setup_integrations()

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_index.py
@@ -187,6 +187,41 @@ class OrganizationDetectorIndexGetTest(OrganizationDetectorIndexBaseTest):
         assert "id" in response.data
         assert "not a valid integer id" in str(response.data["id"])
 
+    def test_filter_by_type_and_enabled(self) -> None:
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={
+                "project": self.project.id,
+                "type": [ErrorGroupType.slug, IssueStreamGroupType.slug],
+                "enabled": "true",
+            },
+        )
+        assert {detector["id"] for detector in response.data} == {
+            str(self.error_detector.id),
+            str(self.issue_stream_detector.id),
+        }
+
+        self.issue_stream_detector.update(enabled=False)
+        response = self.get_success_response(
+            self.organization.slug,
+            qs_params={
+                "project": self.project.id,
+                "type": IssueStreamGroupType.slug,
+                "enabled": "false",
+            },
+        )
+        assert [detector["id"] for detector in response.data] == [
+            str(self.issue_stream_detector.id)
+        ]
+
+    def test_invalid_enabled_filter(self) -> None:
+        response = self.get_error_response(
+            self.organization.slug,
+            qs_params={"enabled": "sometimes"},
+            status_code=400,
+        )
+        assert "enabled" in response.data
+
     def test_invalid_sort_by(self) -> None:
         response = self.get_error_response(
             self.organization.slug,


### PR DESCRIPTION
Add repeatable `type` filters to the organization detector and available-action endpoints, plus an `enabled` filter for detectors. API consumers can now request only enabled issue-stream detectors or one action/integration kind such as Slack instead of fetching every resource and filtering client-side.

The parameters are additive and omitted filters preserve existing behavior. Available-action types are constrained to supported, non-deprecated values, and malformed boolean or action-type values return a 400 response.