### PR TITLE
tests(issue-details): Avoid mocking router hooks in eventDetailsHeader.spec.tsx

### DIFF
--- a/static/app/views/issueDetails/eventDetailsHeader.spec.tsx
+++ b/static/app/views/issueDetails/eventDetailsHeader.spec.tsx
@@ -3,7 +3,6 @@ import {EventsStatsFixture} from 'sentry-fixture/events';
 import {GroupFixture} from 'sentry-fixture/group';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {ProjectFixture} from 'sentry-fixture/project';
-import {RouterFixture} from 'sentry-fixture/routerFixture';
 import {TagsFixture} from 'sentry-fixture/tags';
 
 import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
@@ -14,11 +13,6 @@ import {IssueCategory, IssueType} from 'sentry/types/group';
 import {GroupDataContextProvider} from 'sentry/views/issueDetails/groupDataContext';
 
 import {EventDetailsHeader} from './eventDetailsHeader';
-
-const mockUseNavigate = jest.fn();
-jest.mock('sentry/utils/useNavigate', () => ({
-  useNavigate: () => mockUseNavigate,
-}));
 
 describe('EventDetailsHeader', () => {
   const organization = OrganizationFixture();
@@ -35,7 +29,6 @@ describe('EventDetailsHeader', () => {
   });
 
   const defaultProps = {group, event, project};
-  const router = RouterFixture();
 
   beforeEach(() => {
     MockApiClient.clearMockResponses();
@@ -120,12 +113,6 @@ describe('EventDetailsHeader', () => {
 
   it('updates the query params with search tokens', async () => {
     const [tagKey, tagValue] = ['user.email', 's@s.io'];
-    const locationQuery = {
-      query: {
-        ...router.location.query,
-        query: `${tagKey}:${tagValue}`,
-      },
-    };
     MockApiClient.addMockResponse({
       url: `/organizations/${organization.slug}/tags/${tagKey}/values/`,
       body: [
@@ -138,7 +125,7 @@ describe('EventDetailsHeader', () => {
       method: 'GET',
     });
 
-    render(
+    const {router} = render(
       <GroupDataContextProvider group={group} project={group.project}>
         <EventDetailsHeader {...defaultProps} />
       </GroupDataContextProvider>,
@@ -152,10 +139,7 @@ describe('EventDetailsHeader', () => {
     await userEvent.type(search, `${tagKey}:`, {delay: null});
     await userEvent.click(await screen.findByRole('option', {name: tagValue}));
     await waitFor(() => {
-      expect(mockUseNavigate).toHaveBeenCalledWith(
-        expect.objectContaining(locationQuery),
-        {replace: true}
-      );
+      expect(router.location.query.query).toBe(`${tagKey}:${tagValue}`);
     });
   }, 20_000);
 


### PR DESCRIPTION
I am attempting to add a lint rule to disallow these kind of module mocks - this is one change of many to ensure those lint rules pass when added.