### PR TITLE
tests(insights): Avoid mocking router hooks in useCrossPlatformProject.spec.tsx

### DIFF
--- a/static/app/views/insights/mobile/common/queries/useCrossPlatformProject.spec.tsx
+++ b/static/app/views/insights/mobile/common/queries/useCrossPlatformProject.spec.tsx
@@ -1,31 +1,23 @@
-import {LocationFixture} from 'sentry-fixture/locationFixture';
-import {PageFilterStateFixture} from 'sentry-fixture/pageFilters';
+import {PageFiltersFixture} from 'sentry-fixture/pageFilters';
 import {ProjectFixture} from 'sentry-fixture/project';
 
-import {renderHook} from 'sentry-test/reactTestingLibrary';
+import {renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 
-import {usePageFilters} from 'sentry/components/pageFilters/usePageFilters';
+import {PageFiltersStore} from 'sentry/components/pageFilters/store';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import type {Project} from 'sentry/types/project';
-import {useLocation} from 'sentry/utils/useLocation';
 import {useCrossPlatformProject} from 'sentry/views/insights/mobile/common/queries/useCrossPlatformProject';
 
-jest.mock('sentry/components/pageFilters/usePageFilters');
-jest.mock('sentry/utils/useLocation');
-
-function mockPageFilters(projects: number[]) {
-  jest.mocked(usePageFilters).mockReturnValue(
-    PageFilterStateFixture({
-      selection: {
-        datetime: {
-          period: '10d',
-          start: null,
-          end: null,
-          utc: false,
-        },
-        environments: [],
-        projects,
+function initializePageFilters(projects: number[]) {
+  PageFiltersStore.onInitializeUrlState(
+    PageFiltersFixture({
+      datetime: {
+        period: '10d',
+        start: null,
+        end: null,
+        utc: false,
       },
+      projects,
     })
   );
 }
@@ -33,17 +25,20 @@ function mockPageFilters(projects: number[]) {
 describe('useCrossPlatformProject', () => {
   let mockProject: Project;
   beforeEach(() => {
-    jest.clearAllMocks();
-
     mockProject = ProjectFixture({platform: 'flutter'});
-    jest.mocked(useLocation).mockReturnValue(LocationFixture());
+    PageFiltersStore.init();
     ProjectsStore.loadInitialData([mockProject]);
   });
 
-  it('returns null for project if >1 project is selected', () => {
-    mockPageFilters([1, 2, 3]);
+  afterEach(() => {
+    PageFiltersStore.reset();
+    ProjectsStore.reset();
+  });
 
-    const {result} = renderHook(useCrossPlatformProject);
+  it('returns null for project if >1 project is selected', () => {
+    initializePageFilters([1, 2, 3]);
+
+    const {result} = renderHookWithProviders(useCrossPlatformProject);
 
     const {project, isProjectCrossPlatform} = result.current;
 
@@ -52,9 +47,9 @@ describe('useCrossPlatformProject', () => {
   });
 
   it('returns the corresponding project data if a single project is selected', () => {
-    mockPageFilters([parseInt(mockProject.id, 10)]);
+    initializePageFilters([parseInt(mockProject.id, 10)]);
 
-    const {result} = renderHook(useCrossPlatformProject);
+    const {result} = renderHookWithProviders(useCrossPlatformProject);
 
     const {project, isProjectCrossPlatform, selectedPlatform} = result.current;
 
@@ -69,9 +64,9 @@ describe('useCrossPlatformProject', () => {
     const testProject = ProjectFixture({platform: 'python'});
 
     ProjectsStore.loadInitialData([testProject]);
-    mockPageFilters([parseInt(testProject.id, 10)]);
+    initializePageFilters([parseInt(testProject.id, 10)]);
 
-    const {result} = renderHook(useCrossPlatformProject);
+    const {result} = renderHookWithProviders(useCrossPlatformProject);
 
     const {project, isProjectCrossPlatform} = result.current;
 


### PR DESCRIPTION
I am attempting to add a lint rule to disallow these kind of module mocks - this is one change of many to ensure those lint rules pass when added.