### PR TITLE
feat(seer-infra-telemetry): Group GCP connection errors by affected projects and services

### DIFF
--- a/static/app/components/gcpVerificationResults.spec.tsx
+++ b/static/app/components/gcpVerificationResults.spec.tsx
@@ -1,0 +1,116 @@
+import {render, screen, userEvent, within} from 'sentry-test/reactTestingLibrary';
+
+import {GcpVerificationResults} from 'sentry/components/gcpVerificationResults';
+
+describe('GcpVerificationResults', () => {
+  it('shows one explanation and the affected services beside each project', async () => {
+    render(
+      <GcpVerificationResults
+        result={{
+          connectionStatus: 'permission_denied',
+          projects: [
+            ...['test-project-a', 'test-project-b'].map(gcpProjectId => ({
+              gcpProjectId,
+              connectionStatus: 'permission_denied',
+              services: ['logging', 'monitoring', 'cloudtrace'].map(service => ({
+                service,
+                status: 'permission_denied',
+                errorDetail: 'Check the project ID and service account access.',
+              })),
+            })),
+            {gcpProjectId: 'production', connectionStatus: 'connected', services: []},
+          ],
+        }}
+      />
+    );
+
+    expect(
+      screen.getAllByText('Check the project ID and service account access.')
+    ).toHaveLength(1);
+    expect(
+      screen.getByText('1 project connected · 2 projects need attention')
+    ).toBeInTheDocument();
+    const affected = screen.getByRole('list', {name: 'Affected projects'});
+    expect(within(affected).getAllByRole('listitem')).toHaveLength(2);
+    expect(
+      within(affected).getAllByText('Cloud Logging, Cloud Monitoring, Cloud Trace')
+    ).toHaveLength(2);
+    expect(within(affected).getByText('test-project-a')).toBeInTheDocument();
+    expect(within(affected).getByText('test-project-b')).toBeInTheDocument();
+    expect(within(affected).queryByText('production')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Connected projects'}));
+    expect(
+      within(screen.getByRole('list', {name: 'Connected projects'})).getByText(
+        'production'
+      )
+    ).toBeVisible();
+  });
+
+  it('separates mixed failures and shows project-level errors without services', () => {
+    render(
+      <GcpVerificationResults
+        result={{
+          connectionStatus: 'permission_denied',
+          projects: [
+            {
+              gcpProjectId: 'project-a',
+              connectionStatus: 'permission_denied',
+              services: [
+                {service: 'logging', status: 'connected'},
+                {
+                  service: 'monitoring',
+                  status: 'api_disabled',
+                  errorDetail: 'Enable the Monitoring API.',
+                },
+                {
+                  service: 'cloudtrace',
+                  status: 'permission_denied',
+                  errorDetail: 'Check trace access.',
+                },
+              ],
+            },
+            {
+              gcpProjectId: 'project-b',
+              connectionStatus: 'error',
+              services: [],
+              errorDetail: 'Verification did not run.',
+            },
+          ],
+        }}
+      />
+    );
+
+    const api = screen.getByRole('region', {name: 'API disabled'});
+    expect(within(api).getByText('Enable the Monitoring API.')).toBeInTheDocument();
+    expect(within(api).getByText('Cloud Monitoring')).toBeInTheDocument();
+    expect(within(api).queryByText('Cloud Trace')).not.toBeInTheDocument();
+    expect(
+      within(screen.getByRole('region', {name: 'Error'})).getByText('project-b')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Cloud Logging')).not.toBeInTheDocument();
+  });
+
+  it('distinguishes unverified projects from failures', () => {
+    render(
+      <GcpVerificationResults
+        result={{
+          connectionStatus: 'unverified',
+          projects: [
+            {
+              gcpProjectId: 'project-a',
+              connectionStatus: 'unverified',
+              services: [],
+            },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByText('1 project not verified')).toBeInTheDocument();
+    expect(screen.getByRole('list', {name: 'Projects not verified'})).toHaveTextContent(
+      'project-a'
+    );
+    expect(
+      screen.queryByRole('list', {name: 'Affected projects'})
+    ).not.toBeInTheDocument();
+  });
+});

--- a/static/app/components/gcpVerificationResults.tsx
+++ b/static/app/components/gcpVerificationResults.tsx
@@ -1,0 +1,167 @@
+import {Disclosure} from '@sentry/scraps/disclosure';
+import {Flex, Stack} from '@sentry/scraps/layout';
+import {StatusIndicator} from '@sentry/scraps/statusIndicator';
+import {Text} from '@sentry/scraps/text';
+
+import {t, tn} from 'sentry/locale';
+import {
+  getGcpErrorGroups,
+  getServiceLabel,
+  getStatusLabel,
+  getStatusVariant,
+  type GcpVerifyConnectionResponse,
+} from 'sentry/utils/seer/gcpConnection';
+
+export function GcpVerificationResults({result}: {result: GcpVerifyConnectionResponse}) {
+  const groups = getGcpErrorGroups(result);
+  const connected = result.projects.filter(
+    project => project.connectionStatus === 'connected'
+  );
+  const unverified = result.projects.filter(
+    project => project.connectionStatus === 'unverified'
+  );
+  const failedCount = result.projects.length - connected.length - unverified.length;
+  const summary = [
+    connected.length
+      ? tn('%s project connected', '%s projects connected', connected.length)
+      : null,
+    failedCount
+      ? tn('%s project needs attention', '%s projects need attention', failedCount)
+      : null,
+    unverified.length
+      ? tn('%s project not verified', '%s projects not verified', unverified.length)
+      : null,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <Stack gap="lg" minWidth="0" width="100%" containerType="inline-size">
+      <Stack gap="sm">
+        <Flex gap="sm" align="center">
+          <StatusIndicator
+            variant={getStatusVariant(result.connectionStatus)}
+            animationIterationCount={1}
+          />
+          <Text bold>
+            {groups.length
+              ? t('Connection needs attention')
+              : getStatusLabel(result.connectionStatus)}
+          </Text>
+        </Flex>
+        {summary && (
+          <Text size="sm" variant="muted">
+            {summary}
+          </Text>
+        )}
+      </Stack>
+
+      {groups.map(group => (
+        <Stack
+          key={group.key}
+          as="section"
+          aria-label={getStatusLabel(group.status)}
+          gap="md"
+          padding="lg"
+          border="primary"
+          radius="md"
+          minWidth="0"
+        >
+          <Stack gap="sm">
+            <Flex gap="sm" align="center">
+              <StatusIndicator
+                variant={getStatusVariant(group.status)}
+                animationIterationCount={1}
+              />
+              <Text bold>{getStatusLabel(group.status)}</Text>
+            </Flex>
+            <Text density="comfortable" wrap="pre-line" wordBreak="break-word">
+              {group.detail}
+            </Text>
+          </Stack>
+          {group.projects.length > 0 && (
+            <Stack
+              as="ul"
+              aria-label={t('Affected projects')}
+              gap="sm"
+              margin="0"
+              padding="0"
+            >
+              {group.projects.map(project => (
+                <Flex
+                  as="li"
+                  key={project.gcpProjectId}
+                  direction={{xs: 'column', sm: 'row'}}
+                  align={{xs: 'start', sm: 'baseline'}}
+                  gap="xs md"
+                  wrap="wrap"
+                  minWidth="0"
+                >
+                  <Text bold size="sm" wordBreak="break-word">
+                    {project.gcpProjectId}
+                  </Text>
+                  {project.services.length > 0 && (
+                    <Text
+                      size="sm"
+                      variant="muted"
+                      density="comfortable"
+                      wordBreak="break-word"
+                    >
+                      {project.services.map(getServiceLabel).join(', ')}
+                    </Text>
+                  )}
+                </Flex>
+              ))}
+            </Stack>
+          )}
+        </Stack>
+      ))}
+
+      {unverified.length > 0 && (
+        <Stack gap="sm">
+          <Text size="sm">
+            {t('Run a connection check to verify access to these projects.')}
+          </Text>
+          <Stack
+            as="ul"
+            aria-label={t('Projects not verified')}
+            gap="xs"
+            margin="0"
+            padding="0"
+          >
+            {unverified.map(project => (
+              <Flex as="li" key={project.gcpProjectId} minWidth="0">
+                <Text size="sm" wordBreak="break-word">
+                  {project.gcpProjectId}
+                </Text>
+              </Flex>
+            ))}
+          </Stack>
+        </Stack>
+      )}
+
+      {connected.length > 0 && (
+        <Disclosure defaultExpanded={!groups.length} size="sm">
+          <Disclosure.Title>{t('Connected projects')}</Disclosure.Title>
+          <Disclosure.Content>
+            <Stack
+              as="ul"
+              aria-label={t('Connected projects')}
+              gap="xs"
+              margin="0"
+              padding="0"
+            >
+              {connected.map(project => (
+                <Flex as="li" key={project.gcpProjectId} minWidth="0">
+                  <Text size="sm" wordBreak="break-word">
+                    {project.gcpProjectId}
+                  </Text>
+                </Flex>
+              ))}
+            </Stack>
+          </Disclosure.Content>
+        </Disclosure>
+      )}
+    </Stack>
+  );
+}

--- a/static/app/components/pipeline/integrationGcp/index.spec.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.spec.tsx
@@ -205,7 +205,7 @@ describe('GcpVerificationStep', () => {
       {
         gcpProjectId: 'my-project-prod',
         connectionStatus: 'permission_denied',
-        errorDetail: 'Cloud Trace: IAM roles not granted',
+        errorDetail: null,
         services: [
           {service: 'logging', status: 'connected'},
           {
@@ -280,6 +280,7 @@ describe('GcpVerificationStep', () => {
           gcpProjectId: 'my-project-prod',
           connectionStatus: 'connected',
           errorDetail: null,
+          services: connectedResponse.projects[0]!.services,
         },
       ],
     });
@@ -320,9 +321,9 @@ describe('GcpVerificationStep', () => {
     render(<GcpVerificationStep {...makeVerificationStepProps({stepData})} />);
 
     expect(await screen.findByText('Permission denied')).toBeInTheDocument();
-    expect(screen.getByText('Cloud Trace: IAM roles not granted')).toBeInTheDocument();
+    expect(screen.getByText('IAM roles not granted')).toBeInTheDocument();
     // Services that passed are not listed.
-    expect(screen.queryByText(/^Cloud Logging:/)).not.toBeInTheDocument();
+    expect(screen.queryByText('Cloud Logging')).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Continue Anyway'})).toBeEnabled();
   });
 
@@ -344,13 +345,14 @@ describe('GcpVerificationStep', () => {
         {
           gcpProjectId: 'my-project-prod',
           connectionStatus: 'permission_denied',
-          errorDetail: 'Cloud Trace: IAM roles not granted',
+          errorDetail: null,
+          services: deniedResponse.projects[0]!.services,
         },
       ],
     });
   });
 
-  it('forwards a project detail with no failing services of its own', async () => {
+  it('forwards a shared authentication failure without repeating its explanation', async () => {
     MockApiClient.addMockResponse({
       url: VERIFY_URL,
       method: 'POST',
@@ -377,6 +379,7 @@ describe('GcpVerificationStep', () => {
 
     render(<GcpVerificationStep {...makeVerificationStepProps({stepData, advance})} />);
 
+    expect(await screen.findAllByText('SA impersonation chain failed')).toHaveLength(1);
     await userEvent.click(await screen.findByRole('button', {name: 'Continue Anyway'}));
 
     expect(advance).toHaveBeenCalledWith({
@@ -386,6 +389,13 @@ describe('GcpVerificationStep', () => {
           gcpProjectId: 'my-project-prod',
           connectionStatus: 'permission_denied',
           errorDetail: 'SA impersonation chain failed',
+          services: [
+            {
+              service: 'logging',
+              status: 'permission_denied',
+              errorDetail: 'SA impersonation chain failed',
+            },
+          ],
         },
       ],
     });
@@ -432,6 +442,39 @@ describe('GcpVerificationStep', () => {
         {
           gcpProjectId: 'my-project-prod',
           connectionStatus: 'error',
+          errorDetail: 'Verification could not be completed.',
+          services: [],
+        },
+      ],
+    });
+  });
+
+  it('does not reuse an earlier successful result after a failed re-test request', async () => {
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: connectedResponse,
+    });
+    const advance = jest.fn();
+    render(<GcpVerificationStep {...makeVerificationStepProps({stepData, advance})} />);
+    expect(await screen.findByText('Connected')).toBeInTheDocument();
+
+    MockApiClient.addMockResponse({url: VERIFY_URL, method: 'POST', statusCode: 502});
+    await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
+    expect(
+      await screen.findByText(
+        'We could not complete the connection test. You can finish setup and re-test from the integration settings page.'
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', {name: 'Continue Anyway'}));
+    expect(advance).toHaveBeenCalledWith({
+      connectionStatus: 'error',
+      projects: [
+        {
+          gcpProjectId: 'my-project-prod',
+          connectionStatus: 'error',
+          services: [],
           errorDetail: 'Verification could not be completed.',
         },
       ],

--- a/static/app/components/pipeline/integrationGcp/index.tsx
+++ b/static/app/components/pipeline/integrationGcp/index.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useEffect, useRef} from 'react';
+import {useEffect, useRef} from 'react';
 import {useMutation} from '@tanstack/react-query';
 import {z} from 'zod';
 
@@ -7,9 +7,9 @@ import {Button} from '@sentry/scraps/button';
 import {InlineCode} from '@sentry/scraps/code';
 import {defaultFormOptions, setFieldErrors, useScrapsForm} from '@sentry/scraps/form';
 import {Flex, Stack} from '@sentry/scraps/layout';
-import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 import {Text} from '@sentry/scraps/text';
 
+import {GcpVerificationResults} from 'sentry/components/gcpVerificationResults';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {
   PipelineDefinition,
@@ -24,15 +24,8 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {requestErrorToFieldErrors} from 'sentry/utils/requestError/requestErrorToFieldErrors';
 import type {
-  GcpProjectResult,
   GcpVerificationInput,
   GcpVerifyConnectionResponse,
-} from 'sentry/utils/seer/gcpConnection';
-import {
-  describeService,
-  getFailedServices,
-  getStatusLabel,
-  getStatusVariant,
 } from 'sentry/utils/seer/gcpConnection';
 import {useOrganization} from 'sentry/utils/useOrganization';
 
@@ -219,30 +212,6 @@ interface GcpVerificationStepData {
   projects: string[];
 }
 
-function GcpProjectStatus({project}: {project: GcpProjectResult}) {
-  const failedServices = getFailedServices(project);
-
-  return (
-    <Stack gap="xs">
-      <Flex gap="sm" align="center">
-        <StatusIndicator
-          variant={getStatusVariant(project.connectionStatus)}
-          animationIterationCount={1}
-        />
-        <Text bold>{project.gcpProjectId}</Text>
-        <Text variant="muted" size="sm">
-          {getStatusLabel(project.connectionStatus)}
-        </Text>
-      </Flex>
-      {failedServices.map(service => (
-        <Text key={service.service} variant="muted" size="sm">
-          {describeService(service)}
-        </Text>
-      ))}
-    </Stack>
-  );
-}
-
 function GcpVerificationStep({
   advance,
   isAdvancing,
@@ -292,6 +261,7 @@ function GcpVerificationStep({
         projects: result.projects.map(project => ({
           gcpProjectId: project.gcpProjectId,
           connectionStatus: project.connectionStatus,
+          services: project.services,
           errorDetail: project.errorDetail ?? null,
         })),
       });
@@ -305,6 +275,7 @@ function GcpVerificationStep({
       projects: (projects ?? []).map(gcpProjectId => ({
         gcpProjectId,
         connectionStatus: 'error' as const,
+        services: [],
         errorDetail: 'Verification could not be completed.',
       })),
     });
@@ -331,22 +302,19 @@ function GcpVerificationStep({
             )}
           </Alert>
         ) : result ? (
-          <Fragment>
-            <Alert variant={isConnected ? 'success' : 'warning'}>
-              {isConnected
-                ? t('Sentry can read telemetry from all of your connected GCP projects.')
-                : t(
-                    'Sentry could not read telemetry from every project. IAM changes can take a couple of minutes to take effect, so re-testing may help. You can also finish setup and re-test from the integration settings page.'
-                  )}
-            </Alert>
-            {result.projects.map(project => (
-              <GcpProjectStatus key={project.gcpProjectId} project={project} />
-            ))}
-          </Fragment>
+          <GcpVerificationResults result={result} />
         ) : null}
       </Stack>
 
-      <Flex gap="md">
+      {!isChecking && !isConnected && !isError && result && (
+        <Text size="sm" variant="muted" density="comfortable">
+          {t(
+            'You can finish setup and re-test from the integration settings page after resolving these issues.'
+          )}
+        </Text>
+      )}
+
+      <Flex gap="md" wrap="wrap">
         <Button
           variant="primary"
           onClick={handleContinue}

--- a/static/app/utils/seer/gcpConnection.spec.ts
+++ b/static/app/utils/seer/gcpConnection.spec.ts
@@ -1,0 +1,225 @@
+import {
+  getGcpErrorGroups,
+  getGcpProjectResults,
+  getStatusLabel,
+  getStatusVariant,
+  type GcpProjectResult,
+} from 'sentry/utils/seer/gcpConnection';
+
+function project(overrides: Partial<GcpProjectResult> = {}): GcpProjectResult {
+  return {
+    gcpProjectId: 'project-a',
+    connectionStatus: 'permission_denied',
+    services: [
+      {service: 'logging', status: 'permission_denied', errorDetail: 'Check access.'},
+    ],
+    ...overrides,
+  };
+}
+
+describe('getGcpErrorGroups', () => {
+  it('groups equivalent errors across projects and sorts and deduplicates services', () => {
+    const services = ['cloudtrace', 'logging', 'monitoring', 'logging'].map(service => ({
+      service,
+      status: 'permission_denied',
+      errorDetail: ' Check access. ',
+    }));
+    const groups = getGcpErrorGroups({
+      connectionStatus: 'permission_denied',
+      projects: [project({services}), project({gcpProjectId: 'project-b'})],
+    });
+    expect(groups).toEqual([
+      {
+        key: expect.any(String),
+        status: 'permission_denied',
+        detail: 'Check access.',
+        projects: [
+          {gcpProjectId: 'project-a', services: ['logging', 'monitoring', 'cloudtrace']},
+          {gcpProjectId: 'project-b', services: ['logging']},
+        ],
+      },
+    ]);
+  });
+
+  it('keeps different explanations and statuses separate, even on the same project', () => {
+    const groups = getGcpErrorGroups({
+      connectionStatus: 'permission_denied',
+      projects: [
+        project({
+          services: [
+            {service: 'logging', status: 'connected'},
+            {
+              service: 'monitoring',
+              status: 'api_disabled',
+              errorDetail: 'Enable the API.',
+            },
+            {
+              service: 'cloudtrace',
+              status: 'permission_denied',
+              errorDetail: 'Check access.',
+            },
+            {service: 'new-service', status: 'error', errorDetail: 'Check access.'},
+            {
+              service: 'another-service',
+              status: 'permission_denied',
+              errorDetail: 'Check impersonation.',
+            },
+          ],
+        }),
+      ],
+    });
+    expect(
+      groups.map(({status, detail, projects}) => ({status, detail, projects}))
+    ).toEqual([
+      {
+        status: 'api_disabled',
+        detail: 'Enable the API.',
+        projects: [{gcpProjectId: 'project-a', services: ['monitoring']}],
+      },
+      {
+        status: 'permission_denied',
+        detail: 'Check access.',
+        projects: [{gcpProjectId: 'project-a', services: ['cloudtrace']}],
+      },
+      {
+        status: 'error',
+        detail: 'Check access.',
+        projects: [{gcpProjectId: 'project-a', services: ['new-service']}],
+      },
+      {
+        status: 'permission_denied',
+        detail: 'Check impersonation.',
+        projects: [{gcpProjectId: 'project-a', services: ['another-service']}],
+      },
+    ]);
+  });
+
+  it('shows a shared authentication error once without losing affected projects', () => {
+    const groups = getGcpErrorGroups({
+      connectionStatus: 'permission_denied',
+      errorDetail: 'Check access.',
+      projects: [
+        project({errorDetail: 'Check access.'}),
+        project({gcpProjectId: 'project-b', errorDetail: 'Check access.'}),
+      ],
+    });
+    expect(groups).toHaveLength(1);
+    expect(groups[0]!.projects).toHaveLength(2);
+  });
+
+  it('preserves distinct project and overall errors alongside service errors', () => {
+    const groups = getGcpErrorGroups({
+      connectionStatus: 'error',
+      errorDetail: 'Some checks failed.',
+      projects: [project({errorDetail: 'Check the project setup.'})],
+    });
+    expect(groups.map(group => group.detail)).toEqual([
+      'Check access.',
+      'Check the project setup.',
+      'Some checks failed.',
+    ]);
+    expect(groups[1]!.projects).toEqual([{gcpProjectId: 'project-a', services: []}]);
+  });
+
+  it('only deduplicates a project error when its status and explanation both match', () => {
+    const groups = getGcpErrorGroups({
+      connectionStatus: 'permission_denied',
+      errorDetail: 'Check configuration.',
+      projects: [
+        project({
+          errorDetail: 'Check configuration.',
+          services: [
+            {service: 'logging', status: 'error', errorDetail: 'Check configuration.'},
+            {
+              service: 'monitoring',
+              status: 'permission_denied',
+              errorDetail: 'Check project access.',
+            },
+          ],
+        }),
+      ],
+    });
+    expect(groups).toHaveLength(3);
+    expect(groups[2]).toEqual(
+      expect.objectContaining({
+        status: 'permission_denied',
+        detail: 'Check configuration.',
+        projects: [{gcpProjectId: 'project-a', services: []}],
+      })
+    );
+  });
+
+  it('excludes healthy and unverified projects from errors', () => {
+    const groups = getGcpErrorGroups({
+      connectionStatus: 'permission_denied',
+      projects: [
+        project(),
+        project({gcpProjectId: 'healthy', connectionStatus: 'connected'}),
+        project({gcpProjectId: 'unchecked', connectionStatus: 'unverified'}),
+      ],
+    });
+    expect(groups[0]!.projects).toEqual([
+      {gcpProjectId: 'project-a', services: ['logging']},
+    ]);
+  });
+
+  it.each([null, undefined, '   '])(
+    'provides guidance for missing or blank service details (%s)',
+    errorDetail => {
+      const groups = getGcpErrorGroups({
+        connectionStatus: 'permission_denied',
+        projects: [
+          project({
+            services: [{service: 'logging', status: 'permission_denied', errorDetail}],
+          }),
+        ],
+      });
+      expect(groups[0]!.detail).toContain('The project may not exist');
+    }
+  );
+
+  it('shows project-only failures and gives unknown statuses a safe fallback', () => {
+    const groups = getGcpErrorGroups({
+      connectionStatus: 'new_status',
+      projects: [
+        project({connectionStatus: 'new_status', services: []}),
+        project({
+          gcpProjectId: 'project-b',
+          services: [],
+          errorDetail: 'Verification did not run.',
+        }),
+      ],
+    });
+    expect(groups.map(group => group.detail)).toEqual([
+      "Sentry couldn't complete verification. Re-test the connection.",
+      'Verification did not run.',
+    ]);
+    expect(getStatusLabel('toString')).toBe('Error');
+    expect(getStatusVariant('toString')).toBe('danger');
+  });
+
+  it('displays an overall failure even when no project results are available', () => {
+    expect(getGcpErrorGroups({connectionStatus: 'error', projects: []})[0]!.detail).toBe(
+      "Sentry couldn't complete verification. Re-test the connection."
+    );
+  });
+});
+
+it('converts saved service and project details for display', () => {
+  expect(
+    getGcpProjectResults([
+      {
+        gcp_project_id: 'project-a',
+        connection_status: 'permission_denied',
+        error_detail: null,
+        services: [
+          {
+            service: 'logging',
+            status: 'permission_denied',
+            error_detail: 'Check access.',
+          },
+        ],
+      },
+    ])
+  ).toEqual([project({errorDetail: null})]);
+});

--- a/static/app/utils/seer/gcpConnection.ts
+++ b/static/app/utils/seer/gcpConnection.ts
@@ -22,7 +22,7 @@ type GcpConnectionStatus = keyof typeof GCP_STATUS_VARIANTS;
 type GcpStatusVariant = (typeof GCP_STATUS_VARIANTS)[GcpConnectionStatus];
 
 function isKnownStatus(status: string): status is GcpConnectionStatus {
-  return status in GCP_STATUS_VARIANTS;
+  return Object.hasOwn(GCP_STATUS_VARIANTS, status);
 }
 
 /** One MCP server's result, as returned by Seer's verification endpoint. */
@@ -48,7 +48,7 @@ export interface GcpVerifyConnectionResponse {
 
 interface GcpProjectVerification extends Pick<
   GcpProjectResult,
-  'gcpProjectId' | 'connectionStatus'
+  'gcpProjectId' | 'connectionStatus' | 'services'
 > {
   errorDetail: string | null;
 }
@@ -86,7 +86,7 @@ export function getStatusLabel(status: string): string {
   }
 }
 
-function getServiceLabel(service: string): string {
+export function getServiceLabel(service: string): string {
   switch (service) {
     case 'logging':
       return t('Cloud Logging');
@@ -97,16 +97,6 @@ function getServiceLabel(service: string): string {
     default:
       return service;
   }
-}
-
-export function getFailedServices(project: GcpProjectResult): GcpServiceResult[] {
-  return project.services.filter(service => service.status !== 'connected');
-}
-
-export function describeService(service: GcpServiceResult): string {
-  return `${getServiceLabel(service.service)}: ${
-    service.errorDetail ?? getStatusLabel(service.status)
-  }`;
 }
 
 export function buildGcpVerifyPayload(
@@ -128,20 +118,137 @@ export function buildGcpVerifyPayload(
   return {customerSaEmail, gcpProjectIds};
 }
 
-export function getConnectionErrorDetails(projectStatuses: unknown): string[] {
-  if (!Array.isArray(projectStatuses)) {
-    return [];
+export interface GcpStoredProjectResult {
+  connection_status: string;
+  error_detail: string | null;
+  gcp_project_id: string;
+  services: Array<{
+    error_detail: string | null;
+    service: string;
+    status: string;
+  }>;
+}
+
+export function getGcpProjectResults(
+  projects: GcpStoredProjectResult[]
+): GcpProjectResult[] {
+  return projects.map(project => ({
+    gcpProjectId: project.gcp_project_id,
+    connectionStatus: project.connection_status,
+    errorDetail: project.error_detail,
+    services: project.services.map(service => ({
+      service: service.service,
+      status: service.status,
+      errorDetail: service.error_detail,
+    })),
+  }));
+}
+
+export interface GcpErrorGroup {
+  detail: string;
+  key: string;
+  projects: Array<{gcpProjectId: string; services: string[]}>;
+  status: string;
+}
+
+function getErrorGuidance(status: string): string {
+  switch (status) {
+    case 'permission_denied':
+      return t(
+        "The project may not exist, or your service account may not have the required access. Check the project ID and the service account's permissions."
+      );
+    case 'api_disabled':
+      return t('Enable the affected Google Cloud APIs for this project, then re-test.');
+    case 'project_not_found':
+      return t('Check the project ID and make sure your service account can access it.');
+    case 'unverified':
+      return t('Run a connection check to verify access.');
+    default:
+      return t("Sentry couldn't complete verification. Re-test the connection.");
+  }
+}
+
+export function getGcpErrorGroups(result: GcpVerifyConnectionResponse): GcpErrorGroup[] {
+  const groups = new Map<string, GcpErrorGroup>();
+  function add(status: string, detail: string, projectId?: string, service?: string) {
+    const key = JSON.stringify([status, detail]);
+    let group = groups.get(key);
+    if (!group) {
+      group = {key, status, detail, projects: []};
+      groups.set(key, group);
+    }
+    if (projectId === undefined) {
+      return;
+    }
+    let project = group.projects.find(item => item.gcpProjectId === projectId);
+    if (!project) {
+      project = {gcpProjectId: projectId, services: []};
+      group.projects.push(project);
+    }
+    if (service && !project.services.includes(service)) {
+      project.services.push(service);
+    }
   }
 
-  const details = projectStatuses
-    .map(status =>
-      status !== null && typeof status === 'object' && 'error_detail' in status
-        ? status.error_detail
-        : null
-    )
-    .filter(
-      (detail): detail is string => typeof detail === 'string' && detail.length > 0
-    );
+  for (const project of result.projects) {
+    if (['connected', 'unverified'].includes(project.connectionStatus)) {
+      continue;
+    }
+    const failures = project.services.filter(service => service.status !== 'connected');
+    for (const service of failures) {
+      add(
+        service.status,
+        service.errorDetail?.trim() || getErrorGuidance(service.status),
+        project.gcpProjectId,
+        service.service
+      );
+    }
+    const detail = project.errorDetail?.trim();
+    if (detail) {
+      // Authentication failures can repeat the project explanation on every service.
+      if (
+        !failures.some(
+          service =>
+            service.status === project.connectionStatus &&
+            service.errorDetail?.trim() === detail
+        )
+      ) {
+        add(project.connectionStatus, detail, project.gcpProjectId);
+      }
+    } else if (!failures.length) {
+      add(
+        project.connectionStatus,
+        getErrorGuidance(project.connectionStatus),
+        project.gcpProjectId
+      );
+    }
+  }
 
-  return [...new Set(details)];
+  const overallDetail = result.errorDetail?.trim();
+  if (
+    overallDetail &&
+    ![...groups.values()].some(
+      group => group.status === result.connectionStatus && group.detail === overallDetail
+    )
+  ) {
+    add(result.connectionStatus, overallDetail);
+  }
+  if (!groups.size && !['connected', 'unverified'].includes(result.connectionStatus)) {
+    add(result.connectionStatus, getErrorGuidance(result.connectionStatus));
+  }
+
+  const serviceOrder = ['logging', 'monitoring', 'cloudtrace'];
+  for (const group of groups.values()) {
+    for (const project of group.projects) {
+      project.services.sort((a, b) => {
+        const aIndex = serviceOrder.indexOf(a);
+        const bIndex = serviceOrder.indexOf(b);
+        return (
+          (aIndex === -1 ? serviceOrder.length : aIndex) -
+            (bIndex === -1 ? serviceOrder.length : bIndex) || a.localeCompare(b)
+        );
+      });
+    }
+  }
+  return [...groups.values()];
 }

--- a/static/app/utils/seer/gcpConnection.ts
+++ b/static/app/utils/seer/gcpConnection.ts
@@ -1,3 +1,5 @@
+import {z} from 'zod';
+
 import {t} from 'sentry/locale';
 import {unreachable} from 'sentry/utils/unreachable';
 
@@ -26,7 +28,7 @@ function isKnownStatus(status: string): status is GcpConnectionStatus {
 }
 
 /** One MCP server's result, as returned by Seer's verification endpoint. */
-export interface GcpServiceResult {
+interface GcpServiceResult {
   service: string;
   status: string;
   errorDetail?: string | null;
@@ -118,21 +120,27 @@ export function buildGcpVerifyPayload(
   return {customerSaEmail, gcpProjectIds};
 }
 
-export interface GcpStoredProjectResult {
-  connection_status: string;
-  error_detail: string | null;
-  gcp_project_id: string;
-  services: Array<{
-    error_detail: string | null;
-    service: string;
-    status: string;
-  }>;
-}
+const gcpStoredProjectResultsSchema = z.array(
+  z.object({
+    gcp_project_id: z.string(),
+    connection_status: z.string(),
+    error_detail: z.string().nullable(),
+    services: z.array(
+      z.object({
+        service: z.string(),
+        status: z.string(),
+        error_detail: z.string().nullable(),
+      })
+    ),
+  })
+);
 
-export function getGcpProjectResults(
-  projects: GcpStoredProjectResult[]
-): GcpProjectResult[] {
-  return projects.map(project => ({
+export function getGcpProjectResults(projects: unknown): GcpProjectResult[] | null {
+  const parsed = gcpStoredProjectResultsSchema.safeParse(projects);
+  if (!parsed.success) {
+    return null;
+  }
+  return parsed.data.map(project => ({
     gcpProjectId: project.gcp_project_id,
     connectionStatus: project.connection_status,
     errorDetail: project.error_detail,

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.spec.tsx
@@ -409,7 +409,7 @@ describe('ConfigureIntegration GCP re-verification', () => {
   }: {
     connectionStatus?: string;
     providerKey?: string;
-    verifyDelay?: number;
+    verifyDelay?: number | Promise<void>;
   } = {}) {
     const organization = OrganizationFixture({
       access: ['org:integrations', 'org:write'],
@@ -576,7 +576,8 @@ describe('ConfigureIntegration GCP re-verification', () => {
   });
 
   it('reports the check as running instead of the interim unverified status', async () => {
-    setup({connectionStatus: 'unverified', verifyDelay: 50});
+    const verification = Promise.withResolvers<void>();
+    setup({connectionStatus: 'unverified', verifyDelay: verification.promise});
 
     expect(await screen.findByText('Not verified')).toBeInTheDocument();
 
@@ -585,6 +586,7 @@ describe('ConfigureIntegration GCP re-verification', () => {
     expect(await screen.findByText('Checking connection...')).toBeInTheDocument();
     expect(screen.queryByText('Not verified')).not.toBeInTheDocument();
 
+    verification.resolve();
     expect(await screen.findByText('Connected')).toBeInTheDocument();
   });
 
@@ -595,5 +597,63 @@ describe('ConfigureIntegration GCP re-verification', () => {
 
     await waitFor(() => expect(saveRequest).toHaveBeenCalled());
     expect(verifyRequest).not.toHaveBeenCalled();
+  });
+
+  it('shows an automatic verification failure and clears it after a successful re-test', async () => {
+    const {saveRequest} = setup();
+    const url = '/organizations/org-slug/monitoring-providers/gcp/verify-connection/';
+    MockApiClient.addMockResponse({url, method: 'POST', statusCode: 502});
+
+    await saveNewSaEmail('new-sa@my-project.iam.gserviceaccount.com');
+
+    expect(
+      await screen.findByText("The connection check couldn't be completed. Try again.")
+    ).toBeInTheDocument();
+    expect(saveRequest).toHaveBeenCalled();
+    MockApiClient.addMockResponse({
+      url,
+      method: 'POST',
+      body: {connectionStatus: 'connected', projects: []},
+    });
+    await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Re-test'})).toBeEnabled()
+    );
+    expect(
+      screen.queryByText("The connection check couldn't be completed. Try again.")
+    ).not.toBeInTheDocument();
+  });
+
+  it('clears a failed manual check when saved settings trigger a new check', async () => {
+    const {setStoredConfig} = setup();
+    const url = '/organizations/org-slug/monitoring-providers/gcp/verify-connection/';
+    MockApiClient.addMockResponse({url, method: 'POST', statusCode: 502});
+    await userEvent.click(await screen.findByRole('button', {name: 'Re-test'}));
+    expect(await screen.findByText('Previous verification result')).toBeInTheDocument();
+
+    const verification = Promise.withResolvers<void>();
+    MockApiClient.addMockResponse({
+      url,
+      method: 'POST',
+      asyncDelay: verification.promise,
+      body: () => {
+        setStoredConfig({connection_status: 'connected', project_statuses: []});
+        return {connectionStatus: 'connected', projects: []};
+      },
+    });
+    await saveNewSaEmail('new-sa@my-project.iam.gserviceaccount.com');
+    expect(await screen.findByText('Checking connection...')).toBeInTheDocument();
+    expect(
+      screen.queryByText("The connection check couldn't be completed. Try again.")
+    ).not.toBeInTheDocument();
+    verification.resolve();
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Re-test'})).toBeEnabled()
+    );
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+    expect(screen.queryByText('Previous verification result')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("The connection check couldn't be completed. Try again.")
+    ).not.toBeInTheDocument();
   });
 });

--- a/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
+++ b/static/app/views/settings/organizationIntegrations/configureIntegration.tsx
@@ -187,6 +187,7 @@ function ConfigureIntegration() {
   const {projects} = useProjects();
 
   const [isVerifyingGcp, setIsVerifyingGcp] = useState(false);
+  const [gcpVerificationError, setGcpVerificationError] = useState(false);
 
   useRouteAnalyticsEventNames(
     'integrations.details_viewed',
@@ -403,6 +404,7 @@ function ConfigureIntegration() {
       onSuccess: async () => {
         const verifiesConnection = provider.key === 'gcp';
         if (verifiesConnection) {
+          setGcpVerificationError(false);
           setIsVerifyingGcp(true);
         }
 
@@ -420,6 +422,7 @@ function ConfigureIntegration() {
               // The save itself succeeded; the connection stays recorded as unverified
               // and the customer can re-test, so don't report this as a failed save.
               Sentry.captureException(error);
+              setGcpVerificationError(true);
             }
           }
         } finally {
@@ -437,6 +440,8 @@ function ConfigureIntegration() {
             configData={integration.configData}
             organization={organization}
             isVerifying={isVerifyingGcp}
+            verificationError={gcpVerificationError}
+            onVerificationStarted={() => setGcpVerificationError(false)}
             onRetested={() => queryClient.invalidateQueries(integrationQueryOptions)}
           />
         )}

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
@@ -1,6 +1,12 @@
 import {OrganizationFixture} from 'sentry-fixture/organization';
 
-import {render, screen, userEvent, waitFor} from 'sentry-test/reactTestingLibrary';
+import {
+  render,
+  screen,
+  userEvent,
+  waitFor,
+  within,
+} from 'sentry-test/reactTestingLibrary';
 
 import type {OrganizationIntegration} from 'sentry/types/integrations';
 import {GcpConnectionStatus} from 'sentry/views/settings/organizationIntegrations/gcpConnectionStatus';
@@ -47,6 +53,7 @@ describe('GcpConnectionStatus', () => {
         connection_status: 'connected',
         project_statuses: [
           {
+            services: [],
             gcp_project_id: 'project-prod',
             connection_status: 'connected',
             error_detail: null,
@@ -68,6 +75,7 @@ describe('GcpConnectionStatus', () => {
         connection_status: 'permission_denied',
         project_statuses: [
           {
+            services: [],
             gcp_project_id: 'project-prod',
             connection_status: 'permission_denied',
             error_detail:
@@ -93,11 +101,13 @@ describe('GcpConnectionStatus', () => {
         connection_status: 'permission_denied',
         project_statuses: [
           {
+            services: [],
             gcp_project_id: 'project-prod',
             connection_status: 'permission_denied',
             error_detail: 'IAM roles not granted',
           },
           {
+            services: [],
             gcp_project_id: 'project-staging',
             connection_status: 'permission_denied',
             error_detail: 'IAM roles not granted',
@@ -110,6 +120,46 @@ describe('GcpConnectionStatus', () => {
     expect(screen.getAllByText('IAM roles not granted')).toHaveLength(1);
   });
 
+  it('groups saved service failures under the affected project IDs', () => {
+    renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'permission_denied',
+        project_statuses: [
+          ...['test-project-a', 'test-project-b'].map(gcp_project_id => ({
+            gcp_project_id,
+            connection_status: 'permission_denied',
+            error_detail: null,
+            services: ['logging', 'monitoring', 'cloudtrace'].map(service => ({
+              service,
+              status: 'permission_denied',
+              error_detail: 'Check the project ID and service account access.',
+            })),
+          })),
+          {
+            gcp_project_id: 'production',
+            connection_status: 'connected',
+            error_detail: null,
+            services: [],
+          },
+        ],
+      },
+    });
+
+    expect(
+      screen.getAllByText('Check the project ID and service account access.')
+    ).toHaveLength(1);
+    const affected = screen.getByRole('list', {name: 'Affected projects'});
+    const rows = within(affected).getAllByRole('listitem');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent('test-project-a');
+    expect(rows[1]).toHaveTextContent('test-project-b');
+    for (const row of rows) {
+      expect(row).toHaveTextContent('Cloud Logging, Cloud Monitoring, Cloud Trace');
+    }
+    expect(within(affected).queryByText('production')).not.toBeInTheDocument();
+  });
+
   it('reports an integration whose settings changed but was never re-checked', () => {
     renderStatus({
       configData: {
@@ -117,6 +167,7 @@ describe('GcpConnectionStatus', () => {
         connection_status: 'unverified',
         project_statuses: [
           {
+            services: [],
             gcp_project_id: 'project-prod',
             connection_status: 'unverified',
             error_detail: null,
@@ -178,6 +229,9 @@ describe('GcpConnectionStatus', () => {
 
     await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
 
+    expect(
+      await screen.findByText("The connection check couldn't be completed. Try again.")
+    ).toBeInTheDocument();
     await waitFor(() => expect(onRetested).toHaveBeenCalled());
   });
 
@@ -189,6 +243,7 @@ describe('GcpConnectionStatus', () => {
         connection_status: 'unverified',
         project_statuses: [
           {
+            services: [],
             gcp_project_id: 'project-prod',
             connection_status: 'permission_denied',
             error_detail: 'IAM roles not granted',
@@ -204,12 +259,49 @@ describe('GcpConnectionStatus', () => {
     expect(screen.getByRole('button', {name: 'Re-test'})).toBeDisabled();
   });
 
-  it('hides the previous result while a re-test is running', async () => {
+  it('labels previous results after a failed request and clears the warning on retry', async () => {
+    MockApiClient.addMockResponse({url: VERIFY_URL, method: 'POST', statusCode: 502});
+    renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'connected',
+        project_statuses: [],
+        last_verified_at: '2026-08-30T00:00:00+00:00',
+      },
+    });
+
+    await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
+    expect(await screen.findByText('Previous verification result')).toBeInTheDocument();
+    expect(screen.getByText('Connected')).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      "The connection check couldn't be completed. Try again."
+    );
+
+    const verification = Promise.withResolvers<void>();
     MockApiClient.addMockResponse({
       url: VERIFY_URL,
       method: 'POST',
       body: {connectionStatus: 'connected', projects: []},
-      asyncDelay: 50,
+      asyncDelay: verification.promise,
+    });
+    await userEvent.click(screen.getByRole('button', {name: 'Re-test'}));
+    expect(screen.getByText('Checking connection...')).toBeInTheDocument();
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(screen.queryByText('Previous verification result')).not.toBeInTheDocument();
+    verification.resolve();
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Re-test'})).toBeEnabled()
+    );
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('hides the previous result while a re-test is running', async () => {
+    const verification = Promise.withResolvers<void>();
+    MockApiClient.addMockResponse({
+      url: VERIFY_URL,
+      method: 'POST',
+      body: {connectionStatus: 'connected', projects: []},
+      asyncDelay: verification.promise,
     });
     renderStatus({
       configData: {
@@ -217,6 +309,7 @@ describe('GcpConnectionStatus', () => {
         connection_status: 'permission_denied',
         project_statuses: [
           {
+            services: [],
             gcp_project_id: 'project-prod',
             connection_status: 'permission_denied',
             error_detail: 'IAM roles not granted',
@@ -233,6 +326,10 @@ describe('GcpConnectionStatus', () => {
     expect(await screen.findByText('Checking connection...')).toBeInTheDocument();
     expect(screen.queryByText('IAM roles not granted')).not.toBeInTheDocument();
     expect(screen.queryByText(/Last checked/)).not.toBeInTheDocument();
+    verification.resolve();
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Re-test'})).toBeEnabled()
+    );
   });
 
   it('cannot be re-tested when the config is incomplete', () => {

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.spec.tsx
@@ -344,4 +344,28 @@ describe('GcpConnectionStatus', () => {
 
     expect(screen.getByRole('button', {name: 'Re-test'})).toBeDisabled();
   });
+
+  it('offers a re-test when saved results are malformed instead of showing a misleading success', () => {
+    renderStatus({
+      configData: {
+        ...baseConfig,
+        connection_status: 'connected',
+        project_statuses: [
+          {
+            gcp_project_id: 'project-prod',
+            connection_status: 'connected',
+            error_detail: null,
+            services: [{service: 'logging', error_detail: null}],
+          },
+        ],
+      },
+    });
+    expect(
+      screen.getByText(
+        "Saved connection results couldn't be loaded. Re-test the connection."
+      )
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Re-test'})).toBeEnabled();
+  });
 });

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
@@ -1,11 +1,14 @@
+import {useEffect} from 'react';
 import {useMutation} from '@tanstack/react-query';
 
+import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
 import {FieldGroup} from '@sentry/scraps/form';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {StatusIndicator} from '@sentry/scraps/statusIndicator';
 import {Text} from '@sentry/scraps/text';
 
+import {GcpVerificationResults} from 'sentry/components/gcpVerificationResults';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconRefresh} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
@@ -15,9 +18,8 @@ import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {
   buildGcpVerifyPayload,
-  getConnectionErrorDetails,
-  getStatusLabel,
-  getStatusVariant,
+  getGcpProjectResults,
+  type GcpStoredProjectResult,
 } from 'sentry/utils/seer/gcpConnection';
 
 interface GcpConnectionStatusProps {
@@ -25,6 +27,8 @@ interface GcpConnectionStatusProps {
   onRetested: () => void | Promise<void>;
   organization: Organization;
   isVerifying?: boolean;
+  onVerificationStarted?: () => void;
+  verificationError?: boolean;
 }
 
 export function GcpConnectionStatus({
@@ -32,20 +36,26 @@ export function GcpConnectionStatus({
   isVerifying = false,
   onRetested,
   organization,
+  verificationError = false,
+  onVerificationStarted,
 }: GcpConnectionStatusProps) {
   const status =
     typeof configData?.connection_status === 'string'
       ? configData.connection_status
       : 'unverified';
   const lastVerifiedAt = configData?.last_verified_at;
-  const isConnected = status === 'connected';
-  const errorDetails = isConnected
-    ? []
-    : getConnectionErrorDetails(configData?.project_statuses);
+  const projects = getGcpProjectResults(
+    (configData?.project_statuses as GcpStoredProjectResult[] | undefined) ?? []
+  );
 
   const payload = buildGcpVerifyPayload(configData);
 
-  const {mutate: retest, isPending: isRetesting} = useMutation({
+  const {
+    mutate: retest,
+    isPending: isRetesting,
+    isError,
+    reset,
+  } = useMutation({
     mutationFn: () =>
       fetchMutation({
         method: 'POST',
@@ -56,36 +66,46 @@ export function GcpConnectionStatus({
         data: payload ?? undefined,
       }),
     onSuccess: () => onRetested(),
+    onMutate: () => onVerificationStarted?.(),
     onError: () => onRetested(),
   });
 
+  useEffect(() => {
+    if (isVerifying) {
+      reset();
+    }
+  }, [isVerifying, reset]);
+
   const isPending = isRetesting || isVerifying;
-  const shownErrorDetails = isPending ? [] : errorDetails;
+  const hasRequestError = !isPending && (isError || verificationError);
 
   return (
     <FieldGroup title={t('Connection Status')}>
       <Stack gap="md" padding="xl">
-        <Flex gap="sm" align="center">
+        {hasRequestError && (
+          <Alert variant="warning" role="alert">
+            {t("The connection check couldn't be completed. Try again.")}
+          </Alert>
+        )}
+        <Stack gap="sm" role="status" aria-live="polite">
           {isPending ? (
-            <StatusIndicator variant="muted" />
+            <Flex gap="sm" align="center">
+              <StatusIndicator variant="muted" />
+              <Text bold>{t('Checking connection...')}</Text>
+            </Flex>
           ) : (
-            <StatusIndicator
-              variant={getStatusVariant(status)}
-              animationIterationCount={1}
-            />
+            <Stack gap="sm">
+              {hasRequestError && typeof lastVerifiedAt === 'string' && (
+                <Text size="sm" variant="muted">
+                  {t('Previous verification result')}
+                </Text>
+              )}
+              <GcpVerificationResults result={{connectionStatus: status, projects}} />
+            </Stack>
           )}
-          <Text bold>
-            {isPending ? t('Checking connection...') : getStatusLabel(status)}
-          </Text>
-        </Flex>
+        </Stack>
 
-        {shownErrorDetails.map(detail => (
-          <Text key={detail} variant="muted" size="sm">
-            {detail}
-          </Text>
-        ))}
-
-        <Flex gap="md" align="center" justify="between">
+        <Flex gap="md" align="center" justify="between" wrap="wrap">
           <Text variant="muted" size="sm">
             {isPending
               ? null

--- a/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
+++ b/static/app/views/settings/organizationIntegrations/gcpConnectionStatus.tsx
@@ -19,7 +19,6 @@ import {fetchMutation} from 'sentry/utils/queryClient';
 import {
   buildGcpVerifyPayload,
   getGcpProjectResults,
-  type GcpStoredProjectResult,
 } from 'sentry/utils/seer/gcpConnection';
 
 interface GcpConnectionStatusProps {
@@ -44,9 +43,7 @@ export function GcpConnectionStatus({
       ? configData.connection_status
       : 'unverified';
   const lastVerifiedAt = configData?.last_verified_at;
-  const projects = getGcpProjectResults(
-    (configData?.project_statuses as GcpStoredProjectResult[] | undefined) ?? []
-  );
+  const projects = getGcpProjectResults(configData?.project_statuses ?? []);
 
   const payload = buildGcpVerifyPayload(configData);
 
@@ -100,7 +97,15 @@ export function GcpConnectionStatus({
                   {t('Previous verification result')}
                 </Text>
               )}
-              <GcpVerificationResults result={{connectionStatus: status, projects}} />
+              {projects === null ? (
+                <Alert variant="warning">
+                  {t(
+                    "Saved connection results couldn't be loaded. Re-test the connection."
+                  )}
+                </Alert>
+              ) : (
+                <GcpVerificationResults result={{connectionStatus: status, projects}} />
+              )}
             </Stack>
           )}
         </Stack>


### PR DESCRIPTION
https://linear.app/getsentry/issue/CW-1986/polish-the-gcp-integration-onboarding-flow-before-releasing-to-users

Display each distinct verification error once, followed by the affected project IDs and services. Use the same display in setup and settings, with connected and unverified projects shown separately.

Preserve service-level results when completing setup, provide fallback guidance for missing details, and clearly distinguish failed re-test requests from previous saved results.

**Checking connection**

<img width="2236" height="164" alt="image" src="https://github.com/user-attachments/assets/c9bb9c7b-e68e-4743-8595-c14b028b5c95" />

**Connected 1 project successfully**

<img width="2237" height="250" alt="image" src="https://github.com/user-attachments/assets/397946af-0663-462d-aebb-ea7141ad5c0a" />

**1 project connected successfully, 1 project with errors**

<img width="2236" height="343" alt="image" src="https://github.com/user-attachments/assets/75d6689f-ba1e-4c84-958a-d8b9c4036a76" />

**1 project connected successfully, 2 projects with errors**

<img width="2235" height="364" alt="image" src="https://github.com/user-attachments/assets/37c8aea2-2606-4a90-89d1-b99d40278606" />

**2 projects with errors**

<img width="2237" height="292" alt="image" src="https://github.com/user-attachments/assets/dfc998e2-61b2-4fd6-82c6-143ce9b19dab" />
