### PR TITLE
fix(issues): Drop the 100vh content floor when the sidebar stacks

### DIFF
--- a/static/app/views/issueDetails/groupDetailsLayout.tsx
+++ b/static/app/views/issueDetails/groupDetailsLayout.tsx
@@ -161,7 +161,14 @@ const NavigationSidebarWrapper = styled('div')<{
 `;
 
 const ContentPadding = styled('div')`
-  min-height: 100vh;
   padding: 0 var(--issue-details-inset, ${p => p.theme.space['2xl']})
     ${p => p.theme.space['2xl']} var(--issue-details-inset, ${p => p.theme.space['2xl']});
+
+  /* Fill the column beside the sidebar so a short tab keeps the secondary
+     background and the scroll position stable. Below this width the sidebar
+     stacks under the content, and the floor would only push it a full viewport
+     down. That is the common case once the Seer panel narrows the app content. */
+  @container (min-width: ${p => p.theme.container['4xl']}) {
+    min-height: 100vh;
+  }
 `;


### PR DESCRIPTION
On issue details the event content column keeps a `min-height: 100vh` so a short tab (tags, replays, a one-line breadcrumb list) still fills the space beside the issue sidebar. The layout stacks the sidebar under the content once the query container is narrower than `4xl`, and there the floor only pushes the sidebar a full viewport down, leaving a tall empty band above it. With the Seer panel open in sidebar mode (`seer-explorer-persistent-sidebar`) the app content loses the panel's width, so the stacked layout, and the empty band, become the common case.

| > 4xl width | Seer Panel causes < 4xl width | Narrow window causes <4xl width |
| --- | --- | --- |
| <img width="1267" height="1256" alt="SCR-20260910-kofj" src="https://github.com/user-attachments/assets/9b620289-721d-418f-a660-50566f65637d" /> | <img width="1267" height="1256" alt="SCR-20260910-kohc" src="https://github.com/user-attachments/assets/6da83bce-51d7-4b5b-b998-753bdfb31fa9" /> | <img width="875" height="1256" alt="SCR-20260910-koig" src="https://github.com/user-attachments/assets/8a920806-5406-4eb9-8b04-d63422c5798b" />


The floor now sits behind the same `4xl` container query that `GroupLayoutBody` uses to decide whether the sidebar goes beside or below the content. Side-by-side layouts keep the current behavior. Stacked layouts (Seer docked, or a narrow window without Seer) drop the floor, so the sidebar follows the content directly.

I considered gating the floor on the Seer panel's open state from React instead. That would couple the issue layout to Seer for what is really a width question, and would leave the same gap in a narrow window without Seer. The container query is the minimal form of the fix and reuses the breakpoint the layout already keys on.

Feature flag to test with: `seer-explorer-persistent-sidebar` (plus `seer-explorer` and `gen-ai-features`). Open an issue, open the Seer panel, and switch to a short tab such as Tags. No screenshot yet; jsdom does not evaluate `@container`, so this is CSS-only with the existing layout spec passing.

https://claude.ai/code/session_018wPGgCfWNWi8JuK2yLqVxa
