### PR TITLE
docs(api): complete public issue linking schemas

### DIFF
--- a/src/sentry/integrations/api/endpoints/organization_repositories.py
+++ b/src/sentry/integrations/api/endpoints/organization_repositories.py
@@ -76,6 +76,11 @@ class OrganizationRepositoriesEndpoint(OrganizationEndpoint):
                 description="Optional repository fields to expand, such as `settings`.",
             ),
             CursorQueryParam,
+            OpenApiParameter(
+                "per_page",
+                type=int,
+                description="The maximum number of repositories to return per page (1–100).",
+            ),
         ],
         responses={
             200: inline_sentry_response_serializer(

--- a/src/sentry/issues/endpoints/group_integration_details.py
+++ b/src/sentry/issues/endpoints/group_integration_details.py
@@ -389,6 +389,16 @@ class GroupIntegrationDetailsEndpoint(GroupEndpoint):
                     help_text="The identifier of the existing external issue to link, "
                     "as understood by the provider (such as a Jira issue key)."
                 ),
+                "repo": serializers.CharField(
+                    required=False,
+                    help_text="The repository containing the external issue, in owner/name format. "
+                    "Required by GitHub, GitHub Enterprise, and Bitbucket integrations.",
+                ),
+                "comment": serializers.CharField(
+                    required=False,
+                    help_text="An optional comment to post to the external issue when linking, "
+                    "if supported by the integration.",
+                ),
             },
         ),
         responses={

--- a/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
+++ b/src/sentry/sentry_apps/api/endpoints/group_external_issues.py
@@ -8,7 +8,7 @@ from sentry.api.base import cell_silo_endpoint
 from sentry.api.helpers.deprecation import deprecated
 from sentry.api.serializers import serialize
 from sentry.apidocs.examples.sentry_app_examples import SentryAppExamples
-from sentry.apidocs.parameters import GlobalParams, IssueParams
+from sentry.apidocs.parameters import CursorQueryParam, GlobalParams, IssueParams
 from sentry.apidocs.utils import inline_sentry_response_serializer
 from sentry.constants import CELL_API_DEPRECATION_DATE
 from sentry.issues.endpoints.bases.group import GroupEndpoint
@@ -33,6 +33,7 @@ class GroupExternalIssuesEndpoint(GroupEndpoint):
             GlobalParams.ORG_ID_OR_SLUG,
             IssueParams.ISSUES_OR_GROUPS,
             IssueParams.ISSUE_ID,
+            CursorQueryParam,
         ],
         responses={
             200: inline_sentry_response_serializer(

--- a/tests/apidocs/endpoints/integration_platform/test_group_integration_details.py
+++ b/tests/apidocs/endpoints/integration_platform/test_group_integration_details.py
@@ -49,12 +49,21 @@ class GroupIntegrationDetailsDocs(APIDocsTestCase):
         self.validate_schema(request, response)
 
     def test_put(self) -> None:
-        data = {"externalIssue": "APP-123"}
+        data = {
+            "externalIssue": "APP-123",
+            "repo": "example/project",
+            "comment": "Linked from Sentry",
+        }
         with self.feature("organizations:integrations-issue-basic"):
             response = self.client.put(self.base_url, data=data)
         request = RequestFactory().put(self.base_url, data=data)
 
         self.validate_schema(request, response)
+        schema = self.cached_schema.content()["paths"][
+            "/api/0/organizations/{organization_id_or_slug}/issues/{issue_id}/integrations/{integration_id}/"
+        ]["put"]["requestBody"]["content"]["application/json"]["schema"]
+        assert {"externalIssue", "repo", "comment"} <= schema["properties"].keys()
+        assert schema["required"] == ["externalIssue"]
 
     def test_delete(self) -> None:
         external_issue = ExternalIssue.objects.create(


### PR DESCRIPTION
The generated [@sentry/api](https://www.npmjs.com/package/@sentry/api) client is missing fields accepted by existing public issue-linking APIs. Document optional `repo` and `comment` on the native link PUT, `per_page` on the organization repository list, and `cursor` on the group's external issue list.

This changes schema declarations only. Endpoint visibility, runtime behavior, and permissions are unchanged; all six private operations discussed in #124068 remain excluded from the public schema.

Validation: four existing apidocs tests pass, including request-property and required-field assertions. OpenAPI generation, API examples, targeted mypy, and prek pass. The generated schema also confirms both pagination parameters and the continued exclusion of the six private operations.

The separate proposal to publish those private operations remains in #124068. This PR can merge independently.
