### PR TITLE
fix(sentryapps): stop project and sentry app hook collisions

### DIFF
--- a/src/sentry/sentry_apps/tasks/sentry_apps.py
+++ b/src/sentry/sentry_apps/tasks/sentry_apps.py
@@ -407,6 +407,7 @@ def _load_service_hook(organization_id: int | None, installation_id: int) -> Ser
         service_hook = ServiceHook.objects.get(
             organization_id=organization_id,
             actor_id=installation_id,
+            project_id__isnull=True,
         )
         if service_hook.installation_id != service_hook.actor_id:
             logger.info(

--- a/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
+++ b/tests/sentry/sentry_apps/tasks/test_sentry_apps.py
@@ -999,13 +999,19 @@ class TestProcessResourceChange(TestCase):
             ServiceHookProject.objects.all().delete()
             ServiceHook.objects.all().delete()
 
+        # Sentry app hooks always have a NULL project_id in production; per-project
+        # filtering is expressed with ServiceHookProject rows, not the project_id column.
         self.create_service_hook(
-            project_ids=[self.project.id],  # matches project of issue
+            project_ids=[],
             installation=self.install,
             application=self.sentry_app,
             events=["issue.created"],
             org=self.organization,
             actor=self.install,
+        )
+        self.create_service_hook_project_for_installation(
+            project_id=self.project.id,  # matches project of issue
+            installation_id=self.install.id,
         )
 
         event = self.store_event(data={}, project_id=self.project.id)
@@ -1063,13 +1069,19 @@ class TestProcessResourceChange(TestCase):
             name="Bar2", slug="bar2", teams=[self.team], fire_project_created=False
         )
 
+        # Sentry app hooks always have a NULL project_id in production; per-project
+        # filtering is expressed with ServiceHookProject rows, not the project_id column.
         self.create_service_hook(
-            project_ids=[project_2.id],  # no match
+            project_ids=[],
             installation=self.install,
             application=self.sentry_app,
             events=["issue.created"],
             org=self.organization,
             actor=self.install,
+        )
+        self.create_service_hook_project_for_installation(
+            project_id=project_2.id,  # no match
+            installation_id=self.install.id,
         )
 
         event = self.store_event(data={}, project_id=self.project.id)


### PR DESCRIPTION
actor_id is also populated by the project servicehooks (dies) with a user_id, OTOH sentry apps populate actor_id with installation_id. So a user_id could collide with an installation_id and lead to the multiple objects error.

Attempts to fix [SENTRY-5MZH](https://sentry.sentry.io/issues/7390940120/?project=1&query=is:unresolved&sort=recommended&statsPeriod=7d)