### PR TITLE
fix(autofix): gracefully fail when manual feedback is not accepted

### DIFF
--- a/static/app/components/events/autofix/types.ts
+++ b/static/app/components/events/autofix/types.ts
@@ -181,6 +181,9 @@ export interface ProjectSeerPreferences {
 
 export const AUTOFIX_TTL_IN_DAYS = 30;
 
+// Keep in sync with the user_context serializer in src/sentry/seer/endpoints/group_ai_autofix.py.
+export const AUTOFIX_USER_CONTEXT_MAX_LENGTH = 1000;
+
 export function getCodingAgentName(provider: string | undefined): string {
   switch (provider) {
     case CodingAgentProvider.CURSOR_BACKGROUND_AGENT:

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -1171,7 +1171,7 @@ describe('useExplorerAutofix - startStep errors', () => {
       url: AUTOFIX_URL,
       method: 'POST',
       statusCode: 400,
-      body: {user_context: ['Ensure this field has no more than 1000 characters.']},
+      body: {userContext: ['Ensure this field has no more than 1000 characters.']},
     });
 
     const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -1161,7 +1161,7 @@ describe('useExplorerAutofix - startStep errors', () => {
     expect(result.current.runState).toEqual(existingRun);
   });
 
-  it('surfaces the message from a DRF field error', async () => {
+  it('does not surface a serializer validation error', async () => {
     MockApiClient.addMockResponse({
       url: AUTOFIX_URL,
       method: 'GET',
@@ -1187,9 +1187,7 @@ describe('useExplorerAutofix - startStep errors', () => {
       )
     ).rejects.toThrow();
 
-    expect(addErrorMessage).toHaveBeenCalledWith(
-      'Ensure this field has no more than 1000 characters.'
-    );
+    expect(addErrorMessage).toHaveBeenCalledWith('An error occurred');
     expect(result.current.runState).toEqual(existingRun);
   });
 

--- a/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.spec.tsx
@@ -1111,3 +1111,111 @@ describe('useExplorerAutofix - codingAgentErrors', () => {
     expect(result.current.codingAgentErrors.map(e => e.message)).toEqual(['a', 'c']);
   });
 });
+
+describe('useExplorerAutofix - startStep errors', () => {
+  const AUTOFIX_URL = `/organizations/org-slug/issues/${GROUP_ID}/autofix/`;
+  const existingRun = {
+    run_id: 42,
+    blocks: [
+      {
+        id: 'block-1',
+        message: {
+          role: 'assistant',
+          content: 'Here is the root cause',
+          metadata: {step: 'root_cause'},
+        },
+        timestamp: '2026-01-01T00:00:00Z',
+        loading: false,
+      },
+    ],
+    status: 'completed' as const,
+    updated_at: '2026-01-01T00:00:00Z',
+  };
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+  });
+
+  it('keeps the existing run and shows an error message when a step fails', async () => {
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'GET',
+      body: {autofix: existingRun},
+    });
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      statusCode: 400,
+      body: {detail: 'Something went wrong'},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));
+
+    await waitFor(() => expect(result.current.runState?.run_id).toBe(42));
+
+    await expect(
+      act(() => result.current.startStep('pr_iteration', {runId: 42}))
+    ).rejects.toThrow();
+
+    expect(addErrorMessage).toHaveBeenCalledWith('Something went wrong');
+    expect(result.current.runState).toEqual(existingRun);
+  });
+
+  it('surfaces the message from a DRF field error', async () => {
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'GET',
+      body: {autofix: existingRun},
+    });
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      statusCode: 400,
+      body: {user_context: ['Ensure this field has no more than 1000 characters.']},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));
+
+    await waitFor(() => expect(result.current.runState?.run_id).toBe(42));
+
+    await expect(
+      act(() =>
+        result.current.startStep('pr_iteration', {
+          runId: 42,
+          userContext: 'x'.repeat(1001),
+        })
+      )
+    ).rejects.toThrow();
+
+    expect(addErrorMessage).toHaveBeenCalledWith(
+      'Ensure this field has no more than 1000 characters.'
+    );
+    expect(result.current.runState).toEqual(existingRun);
+  });
+
+  it('falls back to the error state when a kickoff fails with no existing run', async () => {
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'GET',
+      body: {autofix: null},
+    });
+    MockApiClient.addMockResponse({
+      url: AUTOFIX_URL,
+      method: 'POST',
+      statusCode: 400,
+      body: {detail: 'Something went wrong'},
+    });
+
+    const {result} = renderHookWithProviders(() => useExplorerAutofix(MOCK_GROUP));
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await expect(act(() => result.current.startStep('root_cause'))).rejects.toThrow();
+
+    await waitFor(() => expect(result.current.runState?.status).toBe('error'));
+    expect(result.current.runState?.blocks[0]?.message.content).toBe(
+      'Error: Something went wrong'
+    );
+    expect(addErrorMessage).not.toHaveBeenCalled();
+  });
+});

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -258,6 +258,26 @@ const makeInitialExplorerAutofixData = (): ExplorerAutofixResponse => ({
   autofix: null,
 });
 
+/**
+ * Pulls a readable message out of an API error, falling back to `fallback`.
+ * Handles both `{detail: "..."}` and DRF field errors like
+ * `{user_context: ["Ensure this field has no more than 1000 characters."]}`.
+ */
+function getApiErrorMessage(e: any, fallback = 'An error occurred'): string {
+  const responseJSON = e?.responseJSON;
+  if (isString(responseJSON?.detail)) {
+    return responseJSON.detail;
+  }
+  if (responseJSON && typeof responseJSON === 'object') {
+    for (const value of Object.values(responseJSON)) {
+      if (isArrayOf(value, isString) && value.length > 0) {
+        return value[0]!;
+      }
+    }
+  }
+  return fallback;
+}
+
 const makeErrorExplorerAutofixData = (errorMessage: string): ExplorerAutofixResponse => ({
   autofix: {
     run_id: 0,
@@ -772,15 +792,17 @@ export function useExplorerAutofix(
         return getAutofixRunId(response)!;
       } catch (e: any) {
         setWaitingForResponse(false);
-        queryClient.setQueryData(
-          explorerAutofixApiOptions(orgSlug, groupId).queryKey,
-          prev => ({
+        const errorMessage = getApiErrorMessage(e);
+        const queryKey = explorerAutofixApiOptions(orgSlug, groupId).queryKey;
+        // Replacing the cached run would wipe out the blocks of a run that already exists.
+        if (defined(queryClient.getQueryData(queryKey)?.json?.autofix)) {
+          addErrorMessage(errorMessage);
+        } else {
+          queryClient.setQueryData(queryKey, prev => ({
             headers: prev?.headers ?? {},
-            json: makeErrorExplorerAutofixData(
-              e?.responseJSON?.detail ?? 'An error occurred'
-            ),
-          })
-        );
+            json: makeErrorExplorerAutofixData(errorMessage),
+          }));
+        }
         throw e;
       }
     },
@@ -828,7 +850,7 @@ export function useExplorerAutofix(
           queryKey: explorerAutofixApiOptions(orgSlug, groupId).queryKey,
         });
       } catch (e: any) {
-        addErrorMessage(e?.responseJSON?.detail ?? 'Failed to create PR');
+        addErrorMessage(getApiErrorMessage(e, 'Failed to create PR'));
         throw e;
       }
     },
@@ -949,9 +971,7 @@ export function useExplorerAutofix(
           window.location.href = `/remote/github-copilot/oauth/?next=${encodeURIComponent(currentUrl)}`;
           return;
         }
-        reportCodingAgentErrors([
-          e?.responseJSON?.detail ?? 'Failed to launch coding agent',
-        ]);
+        reportCodingAgentErrors([getApiErrorMessage(e, 'Failed to launch coding agent')]);
         throw e;
       } finally {
         clearIndicators();

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -260,27 +260,13 @@ const makeInitialExplorerAutofixData = (): ExplorerAutofixResponse => ({
 
 /**
  * Pulls a readable message out of an API error, falling back to `fallback`.
- * Handles both `{detail: "..."}` and DRF field errors like
- * `{user_context: ["Ensure this field has no more than 1000 characters."]}`.
+ * Only `{detail: "..."}` is surfaced; serializer validation errors are for us,
+ * not for the user, so they fall back too.
  */
 function getApiErrorMessage(e: unknown, fallback = 'An error occurred'): string {
-  const responseJSON = (e as {responseJSON?: unknown} | null | undefined)?.responseJSON;
-  if (responseJSON === null || typeof responseJSON !== 'object') {
-    return fallback;
-  }
-  const {detail} = responseJSON as {detail?: unknown};
-  if (isString(detail)) {
-    return detail;
-  }
-  for (const value of Object.values(responseJSON)) {
-    if (isArrayOf(value, isString)) {
-      const [first] = value;
-      if (isString(first)) {
-        return first;
-      }
-    }
-  }
-  return fallback;
+  const detail = (e as {responseJSON?: {detail?: unknown}} | null | undefined)
+    ?.responseJSON?.detail;
+  return isString(detail) ? detail : fallback;
 }
 
 const makeErrorExplorerAutofixData = (errorMessage: string): ExplorerAutofixResponse => ({

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -263,15 +263,20 @@ const makeInitialExplorerAutofixData = (): ExplorerAutofixResponse => ({
  * Handles both `{detail: "..."}` and DRF field errors like
  * `{user_context: ["Ensure this field has no more than 1000 characters."]}`.
  */
-function getApiErrorMessage(e: any, fallback = 'An error occurred'): string {
-  const responseJSON = e?.responseJSON;
-  if (isString(responseJSON?.detail)) {
-    return responseJSON.detail;
+function getApiErrorMessage(e: unknown, fallback = 'An error occurred'): string {
+  const responseJSON = (e as {responseJSON?: unknown} | null | undefined)?.responseJSON;
+  if (responseJSON === null || typeof responseJSON !== 'object') {
+    return fallback;
   }
-  if (responseJSON && typeof responseJSON === 'object') {
-    for (const value of Object.values(responseJSON)) {
-      if (isArrayOf(value, isString) && value.length > 0) {
-        return value[0]!;
+  const {detail} = responseJSON as {detail?: unknown};
+  if (isString(detail)) {
+    return detail;
+  }
+  for (const value of Object.values(responseJSON)) {
+    if (isArrayOf(value, isString)) {
+      const [first] = value;
+      if (isString(first)) {
+        return first;
       }
     }
   }

--- a/static/app/components/events/autofix/v3/autofixResetPrompt.tsx
+++ b/static/app/components/events/autofix/v3/autofixResetPrompt.tsx
@@ -5,6 +5,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {TextArea} from '@sentry/scraps/textarea';
 
+import {AUTOFIX_USER_CONTEXT_MAX_LENGTH} from 'sentry/components/events/autofix/types';
 import {IconClose} from 'sentry/icons/iconClose';
 import {IconRefresh} from 'sentry/icons/iconRefresh';
 import {t} from 'sentry/locale';
@@ -31,6 +32,7 @@ export function AutofixResetPrompt({
         autosize
         rows={2}
         autoFocus
+        maxLength={AUTOFIX_USER_CONTEXT_MAX_LENGTH}
         placeholder={placeholder}
         value={userContext}
         onChange={event => setUserContext(event.target.value)}

--- a/static/app/components/events/autofix/v3/nextStep.tsx
+++ b/static/app/components/events/autofix/v3/nextStep.tsx
@@ -10,6 +10,7 @@ import {DropdownMenu} from 'sentry/components/dropdownMenu';
 import {DropdownMenuFooter} from 'sentry/components/dropdownMenu/footer';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {hasCreatedPullRequests} from 'sentry/components/events/autofix/pullRequests';
+import {AUTOFIX_USER_CONTEXT_MAX_LENGTH} from 'sentry/components/events/autofix/types';
 import type {CodingAgentIntegration} from 'sentry/components/events/autofix/useAutofix';
 import {
   type PermissionsTarget,
@@ -464,6 +465,7 @@ function NextStepTemplate({
         <TextArea
           autosize
           rows={2}
+          maxLength={AUTOFIX_USER_CONTEXT_MAX_LENGTH}
           placeholder={placeholderPrompt}
           value={userContext}
           onChange={event => setUserContext(event.target.value)}

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.spec.tsx
@@ -101,7 +101,7 @@ describe('PrIterationFeedbackForm', () => {
     expect(screen.getByRole('button', {name: 'Submit'})).toBeEnabled();
   });
 
-  it('keeps the feedback and surfaces an error when submit fails', async () => {
+  it('keeps the feedback when submit fails', async () => {
     const autofix = makeAutofix({
       startStep: jest.fn().mockRejectedValue(new Error('boom')),
     });
@@ -118,9 +118,13 @@ describe('PrIterationFeedbackForm', () => {
     await userEvent.type(screen.getByRole('textbox'), 'make it blue');
     await userEvent.click(screen.getByRole('button', {name: 'Submit'}));
 
-    await waitFor(() => expect(addErrorMessage).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(screen.getByRole('button', {name: 'Submit'})).toBeEnabled()
+    );
     expect(onClose).not.toHaveBeenCalled();
     expect(screen.getByRole('textbox')).toHaveValue('make it blue');
     expect(trackAnalytics).not.toHaveBeenCalled();
+    // startStep owns the error message, so the form must not add its own.
+    expect(addErrorMessage).not.toHaveBeenCalled();
   });
 });

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -7,6 +7,7 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
+import {AUTOFIX_USER_CONTEXT_MAX_LENGTH} from 'sentry/components/events/autofix/types';
 import {
   isPrIterationPaused,
   type useExplorerAutofix,
@@ -91,6 +92,7 @@ export function PrIterationFeedbackForm({
           <InputGroup.TextArea
             autosize
             rows={2}
+            maxLength={AUTOFIX_USER_CONTEXT_MAX_LENGTH}
             placeholder={t(
               'Give Seer additional context to improve your pull request and make changes to your code. Hit ENTER to submit.'
             )}

--- a/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
+++ b/static/app/components/events/autofix/v3/prIterationFeedbackForm.tsx
@@ -7,7 +7,6 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 import {Tooltip} from '@sentry/scraps/tooltip';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {
   isPrIterationPaused,
   type useExplorerAutofix,
@@ -63,8 +62,8 @@ export function PrIterationFeedbackForm({
     try {
       await startStep('pr_iteration', {runId, userContext: feedback});
     } catch {
+      // startStep already reports why the request failed.
       setIsSubmitting(false);
-      addErrorMessage(t('Failed to submit feedback. Please try again.'));
       return;
     }
     trackAnalytics('autofix.pr_iteration.feedback', {

--- a/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
+++ b/static/app/components/events/autofix/v3/useResetAutofixStep.tsx
@@ -1,13 +1,11 @@
 import {useMemo, useState} from 'react';
 
-import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {
   type AutofixExplorerStep,
   type AutofixSection,
   type useExplorerAutofix,
 } from 'sentry/components/events/autofix/useExplorerAutofix';
-import {t} from 'sentry/locale';
 
 interface UseResetAutofixStepOptions {
   autofix: ReturnType<typeof useExplorerAutofix>;
@@ -44,8 +42,8 @@ export function useResetAutofixStep({
       try {
         await startStep(step, {runId, userContext, insertIndex: section.index});
       } catch {
+        // startStep already reports why the request failed.
         setShouldShowReset(true);
-        addErrorMessage(t('Failed to reset. Please try again.'));
       }
     };
   }, [startStep, step, runId, section.index]);


### PR DESCRIPTION
submitting more than 1000 characters in the autofix manual feedback in the UI would cause the whole autofix window to break.

<img width="1047" height="290" alt="image" src="https://github.com/user-attachments/assets/dfe5bc1a-6f74-459b-b47c-55aad28c0cb4" />

this was caused by `setQueryData` in the exception handler that would set the cached Seer Autofix state to the DRF error response, so nothing gets rendered as there are literally nothing in the state.

we fix this by only setting the cache when the appropriate data is in the returned json to render the autofix drawer. Also, we set a maxLength to the textbox for the PR iteration so we don't let users input more than 1000 characters in the first place.