### PR TITLE
fix(hybridcloud): Read the rate window without a pipelined mget

### DIFF
--- a/src/sentry/hybridcloud/webhook_mailbox_sizing.py
+++ b/src/sentry/hybridcloud/webhook_mailbox_sizing.py
@@ -173,10 +173,20 @@ def _record_and_read_window(counter_key: str) -> int | None:
         pipe = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER).pipeline()
         pipe.incr(current_key)
         pipe.expire(current_key, SHARD_TTL_SECONDS)
-        pipe.mget(older_keys)
-        current, _, older = pipe.execute()
+        # One GET per shard, not one MGET over them. `ClusterPipeline` replaces `mget`
+        # with an unconditional raise -- a guard against a cross-slot fanout that
+        # `_shard_key`'s hash tag has already ruled out, since it never consults the
+        # slot to decide. The shards share a slot, so the pipeline still packs every
+        # command into a single write to one node; only server-side atomicity across
+        # the reads is lost, which a sum of forward-only counters does not need.
+        for key in older_keys:
+            pipe.get(key)
+        results = pipe.execute(raise_on_error=True)
+        assert len(results) == 2 + len(older_keys)
+
+        current, older = results[0], results[2:]
         return int(current) + sum(int(count) for count in older if count is not None)
-    except (*REDIS_ERRORS, TypeError, ValueError, IndexError):
+    except (*REDIS_ERRORS, AssertionError, TypeError, ValueError, IndexError):
         logger.exception(
             "hybridcloud.webhook_mailbox_sizing.unavailable",
             extra={"counter_key": counter_key},

--- a/src/sentry/hybridcloud/webhook_mailbox_sizing.py
+++ b/src/sentry/hybridcloud/webhook_mailbox_sizing.py
@@ -173,12 +173,7 @@ def _record_and_read_window(counter_key: str) -> int | None:
         pipe = redis.redis_clusters.get(settings.SENTRY_RATE_LIMIT_REDIS_CLUSTER).pipeline()
         pipe.incr(current_key)
         pipe.expire(current_key, SHARD_TTL_SECONDS)
-        # One GET per shard, not one MGET over them. `ClusterPipeline` replaces `mget`
-        # with an unconditional raise -- a guard against a cross-slot fanout that
-        # `_shard_key`'s hash tag has already ruled out, since it never consults the
-        # slot to decide. The shards share a slot, so the pipeline still packs every
-        # command into a single write to one node; only server-side atomicity across
-        # the reads is lost, which a sum of forward-only counters does not need.
+        # One GET per shard, as redis cluster does not support pipelining MGET
         for key in older_keys:
             pipe.get(key)
         results = pipe.execute(raise_on_error=True)

--- a/tests/sentry/hybridcloud/test_webhook_mailbox_sizing.py
+++ b/tests/sentry/hybridcloud/test_webhook_mailbox_sizing.py
@@ -263,11 +263,6 @@ class MailboxBucketCountTest(TestCase):
             assert mailbox_bucket_count(MAILBOX) == _max_buckets()
 
     def test_the_window_is_read_without_a_multi_key_command(self) -> None:
-        """`ClusterPipeline` blocks `mget` outright, and dev and CI cannot catch that:
-        a single-host `redis.clusters` entry has no `is_redis_cluster`, so the client
-        here is a plain `StrictRedis` whose pipeline takes `mget` happily. Production
-        is the only place the cluster client is built, so the command shape is asserted
-        rather than exercised."""
         pipeline = MagicMock()
         pipeline.execute.return_value = [1, True] + ["1"] * (SHARD_COUNT - 1)
 

--- a/tests/sentry/hybridcloud/test_webhook_mailbox_sizing.py
+++ b/tests/sentry/hybridcloud/test_webhook_mailbox_sizing.py
@@ -211,9 +211,10 @@ class MailboxBucketCountTest(TestCase):
 
         assert count == _max_buckets()
 
-    def test_a_reply_that_does_not_destructure_sizes_to_the_cap(self) -> None:
+    def test_a_reply_with_the_wrong_length_sizes_to_the_cap(self) -> None:
         """Sizing runs before the payload row is written, so a reply we cannot read has
-        to fail the same way an outage does rather than 500 a webhook we could queue."""
+        to fail the same way an outage does rather than 500 a webhook we could queue.
+        A reply whose length does not match the commands queued is one we cannot read."""
         pipeline = MagicMock()
         pipeline.execute.return_value = [1]
 
@@ -225,7 +226,8 @@ class MailboxBucketCountTest(TestCase):
 
     def test_a_reply_that_does_not_coerce_sizes_to_the_cap(self) -> None:
         pipeline = MagicMock()
-        pipeline.execute.return_value = ["not-a-number", True, []]
+        # Full length, so it is the coercion that fails rather than the length check.
+        pipeline.execute.return_value = ["not-a-number", True] + ["1"] * (SHARD_COUNT - 1)
 
         with patch(
             "sentry.hybridcloud.webhook_mailbox_sizing.redis.redis_clusters.get",
@@ -259,3 +261,21 @@ class MailboxBucketCountTest(TestCase):
             side_effect=RuntimeError("something unforeseen"),
         ):
             assert mailbox_bucket_count(MAILBOX) == _max_buckets()
+
+    def test_the_window_is_read_without_a_multi_key_command(self) -> None:
+        """`ClusterPipeline` blocks `mget` outright, and dev and CI cannot catch that:
+        a single-host `redis.clusters` entry has no `is_redis_cluster`, so the client
+        here is a plain `StrictRedis` whose pipeline takes `mget` happily. Production
+        is the only place the cluster client is built, so the command shape is asserted
+        rather than exercised."""
+        pipeline = MagicMock()
+        pipeline.execute.return_value = [1, True] + ["1"] * (SHARD_COUNT - 1)
+
+        with patch(
+            "sentry.hybridcloud.webhook_mailbox_sizing.redis.redis_clusters.get",
+            return_value=MagicMock(pipeline=MagicMock(return_value=pipeline)),
+        ):
+            mailbox_bucket_count(MAILBOX)
+
+        pipeline.mget.assert_not_called()
+        assert pipeline.get.call_count == SHARD_COUNT - 1


### PR DESCRIPTION
pipelined mget doesn't work against redis clusters in sentry because our client doesn't support it

instead of trying to get our client to support it, i'm just having this mailbox sizing functionality match existing pipeline logic where we do a bunch of gets in the pipeline instead (which is what our mget does against redis clusters anyways, we just error out when it's in a pipeline)

the sharding for the keys uses this `{...}` syntax that makes it so the shard we compute only uses the contents contained within the curly braces, so we end up mapping all of the keys to the same node anyways, so the pipeline shouldn't be spread across nodes
