### PR TITLE
feat(auth): Include organization slug in SSO errors

### DIFF
--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -82,6 +82,7 @@ class SsoRequired(SentryAPIException):
         organization: Organization | RpcOrganization,
         request: HttpRequest,
         after_login_redirect=None,
+        include_organization_slug: bool = False,
     ):
         login_url = reverse("sentry-auth-organization", args=[organization.slug])
         if is_using_customer_domain(request):
@@ -91,7 +92,10 @@ class SsoRequired(SentryAPIException):
             query_params = {REDIRECT_FIELD_NAME: after_login_redirect}
             login_url = construct_link_with_query(path=login_url, query_params=query_params)
 
-        super().__init__(loginUrl=login_url)
+        organization_extra = (
+            {"organizationSlug": organization.slug} if include_organization_slug else {}
+        )
+        super().__init__(loginUrl=login_url, **organization_extra)
 
 
 class MemberDisabledOverLimit(SentryAPIException):

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -266,6 +266,7 @@ class SentryPermission(ScopedPermission):
                     organization=organization,
                     request=request,
                     after_login_redirect=after_login_redirect,
+                    include_organization_slug=True,
                 )
 
             if self.is_not_2fa_compliant(request, organization):

--- a/tests/integration/test_api.py
+++ b/tests/integration/test_api.py
@@ -87,6 +87,7 @@ class AuthenticationTest(AuthProviderTestCase):
             resp.json()["detail"]["extra"]["loginUrl"]
             == "/auth/login/foo/?next=%2Forganizations%2Ffoo%2Fteams"
         )
+        assert resp.json()["detail"]["extra"]["organizationSlug"] == self.organization.slug
 
     def test_sso_redirect_url_internal_with_domain(self) -> None:
         sso_session_expired = SsoSession(


### PR DESCRIPTION
Adds `organizationSlug` to `sso-required` errors raised by organization API permission checks so the frontend can open organization SSO in a modal without parsing `loginUrl`.

Auth-index and staff reauthentication retain their existing response contract because they use the legacy redirect flow.

## Test plan

- `.venv/bin/pytest -n3 -svv --reuse-db tests/integration/test_api.py tests/sentry/users/api/endpoints/test_auth_index.py`
- `.venv/bin/prek run -q --files src/sentry/api/exceptions.py src/sentry/api/permissions.py tests/integration/test_api.py tests/sentry/users/api/endpoints/test_auth_index.py`