### PR TITLE
ref(github): source required app permissions from the codebase, not an option

### DIFF
--- a/src/sentry/integrations/utils/github_permission_tiers.py
+++ b/src/sentry/integrations/utils/github_permission_tiers.py
@@ -1,0 +1,207 @@
+"""Which Sentry features a GitHub App installation loses when it is missing permissions.
+
+Every permission the app asks for arrived with a feature, and an installation
+sits at whichever version of the app it last accepted. Upgrades only ever raised
+requirements, so the tiers below are totally ordered by ``PermissionTier.order``
+and an installation should be a point on that order: satisfying one tier implies
+satisfying every lower one. An install is described by how far up it got, and
+the copy to show names the tiers above that point.
+
+``order`` is what encodes the chain, not the declaration order of ``TIERS``.
+A new feature gets the next number up; the numbers are spaced by one only
+because nothing has ever needed to slot in between.
+
+Tiers are keyed on scope *and* level, not scope alone. Several scopes were
+already held at ``read`` long before a later feature raised them to ``write``:
+``contents:read`` predates Seer entirely while ``contents:write`` is what lets
+Autofix push a branch, and the same split applies to ``pull_requests``. A tier
+declares only the raise it introduced; everything it inherits belongs to the
+lower tiers returned alongside it.
+
+``BASELINE_TIER`` sits at the bottom as the catchall. It declares no scopes and
+instead speaks for whatever the app requires that no other tier claims, which is
+both the permissions predating the history we have and any scope a future app
+version starts requiring before someone adds a tier for it.
+
+A set that is not a point on the order -- satisfying a tier while falling short
+of a lower one -- is a combination we do not understand, so it is logged and
+treated as nothing to say rather than guessed at. That is also what a missing
+tier declaration looks like from here, which is the point: drift surfaces as a
+warning instead of as confident but wrong copy.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from sentry.integrations.utils.github_permissions import PERMISSION_LEVELS
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PermissionTier:
+    key: str
+    # Position on the chain. Higher is newer, and satisfying this tier means
+    # satisfying every tier below it.
+    order: int
+    name: str
+    description: str
+    # The permission raise this tier introduced, as scope -> minimum level. Not
+    # the full set the feature needs: the rest came with lower tiers. Empty on
+    # BASELINE_TIER, whose requirements are derived by exclusion instead.
+    introduced: Mapping[str, str] = field(default_factory=dict)
+
+
+BASELINE_TIER = PermissionTier(
+    key="baseline",
+    order=0,
+    name="Various earlier features",
+    description=(
+        "Including issue linking, commit tracking, and keeping repository data up to date."
+    ),
+)
+
+PR_COMMENTS_TIER = PermissionTier(
+    key="pull_request_comments",
+    order=1,
+    name="Pull request comments",
+    description="Comment on pull requests to link them to the Sentry issues they caused.",
+    introduced={"pull_requests": "write"},
+)
+
+CODE_REVIEW_TIER = PermissionTier(
+    key="code_review",
+    order=2,
+    name="Seer Code Review",
+    description="Review your pull requests and report the result as a check run.",
+    introduced={"checks": "write", "statuses": "write"},
+)
+
+AUTOFIX_PULL_REQUESTS_TIER = PermissionTier(
+    key="autofix_pull_requests",
+    order=3,
+    name="Autofix pull requests",
+    description="Push a branch and open a pull request with a fix for an issue.",
+    introduced={"contents": "write"},
+)
+
+PR_ITERATION_TIER = PermissionTier(
+    key="pr_iteration",
+    order=4,
+    name="Pull request iteration",
+    description=(
+        "Read GitHub Actions logs and re-run jobs, so Seer can get a pull "
+        "request it opened to a passing build."
+    ),
+    introduced={
+        "actions": "write",
+        "code_quality": "read",
+        "security_events": "read",
+    },
+)
+
+TIERS: tuple[PermissionTier, ...] = tuple(
+    sorted(
+        (
+            BASELINE_TIER,
+            PR_COMMENTS_TIER,
+            CODE_REVIEW_TIER,
+            AUTOFIX_PULL_REQUESTS_TIER,
+            PR_ITERATION_TIER,
+        ),
+        key=lambda tier: tier.order,
+        reverse=True,
+    )
+)
+
+
+def _level(level: str | None) -> int:
+    return PERMISSION_LEVELS.get(level or "", 0)
+
+
+def _falls_short(permissions: Mapping[str, str], requirements: Mapping[str, str]) -> bool:
+    return any(
+        _level(permissions.get(scope)) < _level(level) for scope, level in requirements.items()
+    )
+
+
+def _baseline_tier_reqs(required_permissions: Mapping[str, str]) -> dict[str, str]:
+    """The requirements in ``required_permissions`` that no tier claims a scope for.
+
+    These are what ``BASELINE_TIER`` speaks for. A scope showing up here that we
+    did not expect to means the app started requiring something new and nobody
+    added a tier for it, so users are being asked to accept a permission we
+    cannot name a feature for.
+    """
+    claimed: dict[str, int] = {}
+    for tier in TIERS:
+        for scope, level in tier.introduced.items():
+            claimed[scope] = max(claimed.get(scope, 0), _level(level))
+
+    return {
+        scope: level
+        for scope, level in required_permissions.items()
+        if claimed.get(scope, 0) < _level(level)
+    }
+
+
+def _requirements(
+    tier: PermissionTier, required_permissions: Mapping[str, str]
+) -> Mapping[str, str]:
+    if tier is BASELINE_TIER:
+        return _baseline_tier_reqs(required_permissions)
+
+    return tier.introduced
+
+
+def get_permission_tiers(
+    permissions: Mapping[str, str], required_permissions: Mapping[str, str]
+) -> list[PermissionTier]:
+    """Tiers an install holding ``permissions`` falls short of, highest order first.
+
+    ``permissions`` is the installation's own scope -> level map as GitHub
+    reports it in ``Integration.metadata["permissions"]``; ``required_permissions``
+    is what the current app version asks for, from the
+    ``github-app.required-permissions`` option.
+
+    Empty when the install is current. When its permissions are not a point on
+    the order we cannot trust the state, so rather than guess we log it and
+    conservatively assume every tier is missing, returning them all. That covers
+    both an inconsistent set and falling short of ``BASELINE_TIER``, whose
+    permissions predate everything. Scopes beyond what any tier asks for are
+    ignored. A level we do not recognise counts as not held.
+    """
+    behind = [
+        tier
+        for tier in TIERS
+        if _falls_short(permissions, _requirements(tier, required_permissions))
+    ]
+    if not behind:
+        return []
+
+    if BASELINE_TIER in behind:
+        logger.warning(
+            "github_permission_tiers.short_of_baseline",
+            extra={
+                "expected_permissions": dict(_baseline_tier_reqs(required_permissions)),
+                "permissions": dict(permissions),
+            },
+        )
+        return list(TIERS)
+
+    lowest = min(tier.order for tier in behind)
+    expected = {tier.order for tier in TIERS if tier.order >= lowest}
+    if {tier.order for tier in behind} != expected:
+        logger.warning(
+            "github_permission_tiers.inconsistent_permissions",
+            extra={
+                "behind_tiers": [tier.key for tier in behind],
+                "permissions": dict(permissions),
+            },
+        )
+        return list(TIERS)
+
+    return behind

--- a/src/sentry/integrations/utils/github_permissions.py
+++ b/src/sentry/integrations/utils/github_permissions.py
@@ -1,21 +1,20 @@
-"""
-when you update the app, if and only if you want warnings to show in different places in the UI
-then you should update the option with the new expected required permissions and their required level
+"""The permissions the current GitHub App version requests, and helpers to
+compare an installation against them.
 
-if you don't update the option, nothing will break since the option only lists out required permissions:
-if the user's integration contains more permissions than we expect we just ignore it, since there are
-inconsistencies with what permissions we store in the metadata anyways based on whether the integration
-is for an org or a single user
+``GITHUB_APP_REQUIRED_PERMISSIONS`` is the source of truth for what the app asks
+for. It lives in the codebase (it used to be the ``github-app.required-permissions``
+option) because it is not a secret and has to stay in lockstep with the app's
+declared permissions and the tiers in ``github_permission_tiers``. Update it
+whenever the app's required permissions change.
 
-at the moment there's no way to gate warnings in the UI by which perm is missing, but we can add that
-where the warnings are implemented since this API returns the list of missing scopes / levels
+We only ever compare against it as a floor: an installation holding *more* than
+we expect is ignored, since what GitHub reports in the integration metadata
+already varies by whether the install is for an org or a single user.
 """
 
 import logging
 from collections.abc import Mapping
 from typing import Any, TypedDict
-
-from sentry import options
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +37,29 @@ PERMISSION_LEVELS = {
     "admin": 3,
 }
 
+# The union of every permission the app's features expect, as scope -> minimum
+# level. Each scope is introduced by one of the tiers in github_permission_tiers,
+# except the last group, which predates them and is spoken for by BASELINE_TIER:
+#   actions:write, code_quality:read, security_events:read  -> PR iteration
+#   contents:write                                          -> Autofix pull requests
+#   checks:write, statuses:write                            -> Seer code review
+#   pull_requests:write                                     -> PR comments
+#   administration:read, issues:write, metadata:read,
+#   repository_hooks:write                                  -> baseline (earlier features)
+GITHUB_APP_REQUIRED_PERMISSIONS: dict[str, str] = {
+    "actions": "write",
+    "administration": "read",
+    "checks": "write",
+    "code_quality": "read",
+    "contents": "write",
+    "issues": "write",
+    "metadata": "read",
+    "pull_requests": "write",
+    "repository_hooks": "write",
+    "security_events": "read",
+    "statuses": "write",
+}
+
 
 def _quantify_github_app_permissions(
     permissions: Mapping[str, str],
@@ -48,18 +70,17 @@ def _quantify_github_app_permissions(
 def get_missing_github_app_permissions(
     metadata: Mapping[str, Any],
 ) -> list[MissingGithubAppPermission] | None:
-    required_permissions = options.get(GITHUB_APP_REQUIRED_PERMISSIONS_OPTION)
-    if not required_permissions:
-        return None
-
     try:
-        expected_permissions = _quantify_github_app_permissions(required_permissions)
+        expected_permissions = _quantify_github_app_permissions(GITHUB_APP_REQUIRED_PERMISSIONS)
         actual_permissions = _quantify_github_app_permissions(metadata.get("permissions", {}))
     except KeyError:
         # If either dict has an unknown permission level, don't enforce anything.
         logger.error(
             "github_permissions.malformed_permissions",
-            extra={"required": required_permissions, "actual": metadata.get("permissions")},
+            extra={
+                "required": GITHUB_APP_REQUIRED_PERMISSIONS,
+                "actual": metadata.get("permissions"),
+            },
         )
         return None
 

--- a/tests/sentry/integrations/api/serializers/models/test_integration.py
+++ b/tests/sentry/integrations/api/serializers/models/test_integration.py
@@ -1,12 +1,12 @@
+from unittest import mock
 from unittest.mock import call, patch
 
 from sentry.api.serializers import serialize
 from sentry.integrations.api.serializers.models.integration import IntegrationConfigSerializer
-from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS_OPTION
+from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS
 from sentry.organizations.services.organization import organization_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -29,7 +29,7 @@ class IntegrationSerializerTest(TestCase):
 
         assert result["outOfDate"] is None
 
-    @override_options({GITHUB_APP_REQUIRED_PERMISSIONS_OPTION: {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_github_out_of_date_when_missing_permissions(self) -> None:
         integration = self.create_provider_integration(
             provider="github",
@@ -42,7 +42,7 @@ class IntegrationSerializerTest(TestCase):
 
         assert result["outOfDate"] is True
 
-    @override_options({GITHUB_APP_REQUIRED_PERMISSIONS_OPTION: {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_github_not_out_of_date_when_permissions_satisfied(self) -> None:
         integration = self.create_provider_integration(
             provider="github",

--- a/tests/sentry/integrations/utils/test_github_permission_tiers.py
+++ b/tests/sentry/integrations/utils/test_github_permission_tiers.py
@@ -1,0 +1,174 @@
+from unittest import mock
+
+import pytest
+
+from sentry.integrations.utils.github_permission_tiers import (
+    BASELINE_TIER,
+    TIERS,
+    _baseline_tier_reqs,
+    get_permission_tiers,
+)
+
+REQUIRED_PERMISSIONS = {
+    "actions": "write",
+    "administration": "read",
+    "checks": "write",
+    "code_quality": "read",
+    "contents": "write",
+    "issues": "write",
+    "metadata": "read",
+    "pull_requests": "write",
+    "repository_hooks": "write",
+    "security_events": "read",
+    "statuses": "write",
+}
+
+UP_TO_DATE = REQUIRED_PERMISSIONS
+
+MISSING_PR_ITERATION = {
+    "administration": "read",
+    "checks": "write",
+    "contents": "write",
+    "issues": "write",
+    "metadata": "read",
+    "pull_requests": "write",
+    "repository_hooks": "write",
+    "statuses": "write",
+}
+
+MISSING_AUTOFIX_PRS = {**MISSING_PR_ITERATION, "contents": "read"}
+
+MISSING_CODE_REVIEW = {
+    "administration": "read",
+    "contents": "read",
+    "issues": "write",
+    "metadata": "read",
+    "pull_requests": "write",
+    "repository_hooks": "write",
+}
+
+MISSING_PR_COMMENTS = {**MISSING_CODE_REVIEW, "pull_requests": "read"}
+
+ALL_KEYS = [
+    "pr_iteration",
+    "autofix_pull_requests",
+    "code_review",
+    "pull_request_comments",
+    "baseline",
+]
+
+
+def _keys(permissions, required=None):
+    tiers = get_permission_tiers(permissions, required or REQUIRED_PERMISSIONS)
+    return [tier.key for tier in tiers]
+
+
+@pytest.mark.parametrize(
+    ("permissions", "expected"),
+    [
+        (UP_TO_DATE, []),
+        (MISSING_PR_ITERATION, ALL_KEYS[:1]),
+        (MISSING_AUTOFIX_PRS, ALL_KEYS[:2]),
+        (MISSING_CODE_REVIEW, ALL_KEYS[:3]),
+        (MISSING_PR_COMMENTS, ALL_KEYS[:4]),
+        ({}, ALL_KEYS),
+    ],
+)
+def test_tiers_for_production_permission_sets(permissions, expected) -> None:
+    assert _keys(permissions) == expected
+
+
+def test_scopes_beyond_what_any_tier_asks_for_are_ignored() -> None:
+    assert _keys({**UP_TO_DATE, "packages": "write", "pages": "admin"}) == []
+
+
+def test_a_level_above_the_watermark_still_satisfies_the_tier() -> None:
+    assert _keys({**UP_TO_DATE, "contents": "admin"}) == []
+
+
+def test_an_unrecognised_level_counts_as_not_held() -> None:
+    assert _keys({**UP_TO_DATE, "actions": "sudo"}) == ALL_KEYS[:1]
+
+
+def test_contents_read_falls_short_of_the_autofix_write_watermark() -> None:
+    assert _keys({**MISSING_PR_ITERATION, "contents": "write"}) == ALL_KEYS[:1]
+    assert _keys({**MISSING_PR_ITERATION, "contents": "read"}) == ALL_KEYS[:2]
+
+
+def test_pull_requests_read_falls_short_of_the_pr_comments_watermark() -> None:
+    assert _keys({**MISSING_CODE_REVIEW, "pull_requests": "write"}) == ALL_KEYS[:3]
+    assert _keys({**MISSING_CODE_REVIEW, "pull_requests": "read"}) == ALL_KEYS[:4]
+
+
+@mock.patch("sentry.integrations.utils.github_permission_tiers.logger.warning")
+def test_a_newer_tier_held_without_an_older_one_is_inconsistent(mock_warning) -> None:
+    assert _keys({**UP_TO_DATE, "contents": "read"}) == ALL_KEYS
+
+    assert mock_warning.call_args[0][0] == "github_permission_tiers.inconsistent_permissions"
+    assert mock_warning.call_args[1]["extra"]["behind_tiers"] == ["autofix_pull_requests"]
+
+
+@mock.patch("sentry.integrations.utils.github_permission_tiers.logger.warning")
+def test_a_gap_in_the_middle_of_the_chain_is_inconsistent(mock_warning) -> None:
+    assert _keys({**UP_TO_DATE, "actions": "read", "checks": "read"}) == ALL_KEYS
+
+    assert mock_warning.call_args[1]["extra"]["behind_tiers"] == ["pr_iteration", "code_review"]
+
+
+@mock.patch("sentry.integrations.utils.github_permission_tiers.logger.warning")
+def test_a_requirement_no_tier_claims_falls_short_of_baseline(
+    mock_warning,
+) -> None:
+    required = {**REQUIRED_PERMISSIONS, "packages": "write"}
+    assert _keys(UP_TO_DATE, required) == ALL_KEYS
+
+    assert mock_warning.call_args[0][0] == "github_permission_tiers.short_of_baseline"
+    assert mock_warning.call_args[1]["extra"]["expected_permissions"] == {
+        "administration": "read",
+        "issues": "write",
+        "metadata": "read",
+        "repository_hooks": "write",
+        "packages": "write",
+    }
+
+
+@mock.patch("sentry.integrations.utils.github_permission_tiers.logger.warning")
+def test_a_consistent_run_is_not_warned_about(mock_warning) -> None:
+    assert _keys(MISSING_AUTOFIX_PRS) == ALL_KEYS[:2]
+
+    mock_warning.assert_not_called()
+
+
+def test_unclaimed_requirements_is_what_the_baseline_speaks_for() -> None:
+    assert _baseline_tier_reqs(REQUIRED_PERMISSIONS) == {
+        "administration": "read",
+        "issues": "write",
+        "metadata": "read",
+        "repository_hooks": "write",
+    }
+
+
+def test_unclaimed_requirements_reports_a_raise_beyond_any_tier() -> None:
+    assert _baseline_tier_reqs({"contents": "admin"}) == {"contents": "admin"}
+    assert _baseline_tier_reqs({"contents": "write"}) == {}
+
+
+def test_every_tier_key_is_unique() -> None:
+    keys = [tier.key for tier in TIERS]
+    assert len(keys) == len(set(keys))
+
+
+def test_every_tier_order_is_unique() -> None:
+    orders = [tier.order for tier in TIERS]
+    assert len(orders) == len(set(orders))
+
+
+def test_tiers_are_exposed_highest_order_first() -> None:
+    orders = [tier.order for tier in TIERS]
+    assert orders == sorted(orders, reverse=True)
+    assert [tier.key for tier in TIERS] == ALL_KEYS
+
+
+def test_the_baseline_is_the_lowest_tier_and_claims_no_scopes() -> None:
+    assert BASELINE_TIER.order == min(tier.order for tier in TIERS)
+    assert BASELINE_TIER.introduced == {}

--- a/tests/sentry/integrations/utils/test_github_permissions.py
+++ b/tests/sentry/integrations/utils/test_github_permissions.py
@@ -1,18 +1,16 @@
+from unittest import mock
+
 import pytest
 
 from sentry.integrations.utils.github_permissions import (
-    GITHUB_APP_REQUIRED_PERMISSIONS_OPTION,
     get_github_permissions_update_url,
     get_missing_github_app_permissions,
 )
-from sentry.testutils.helpers.options import override_options
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     ("required_permissions", "permissions", "expected"),
     [
-        (None, {"contents": "read"}, None),
         ({}, {"contents": "read"}, None),
         (
             {"contents": "read", "pull_requests": "write"},
@@ -52,12 +50,11 @@ from sentry.testutils.helpers.options import override_options
     ],
 )
 def test_get_missing_github_app_permissions(required_permissions, permissions, expected) -> None:
-    options = (
-        {}
-        if required_permissions is None
-        else {GITHUB_APP_REQUIRED_PERMISSIONS_OPTION: required_permissions}
-    )
-    with override_options(options):
+    with mock.patch.dict(
+        "sentry.integrations.utils.github_permissions.GITHUB_APP_REQUIRED_PERMISSIONS",
+        required_permissions,
+        clear=True,
+    ):
         assert get_missing_github_app_permissions({"permissions": permissions}) == expected
 
 

--- a/tests/sentry/seer/autofix/test_github_perms.py
+++ b/tests/sentry/seer/autofix/test_github_perms.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from unittest import mock
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.seer.agent.client_models import (
@@ -22,7 +24,6 @@ from sentry.seer.autofix.github_perms import (
     get_missing_permissions_by_repo,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 
 REPO_NAME = "getsentry/sentry"
@@ -98,7 +99,7 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             integration_id=self.integration.id,
         )
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_a_pr_exists_and_feedback_is_queued(self) -> None:
         missing = get_blocked_pr_iteration_permissions(
             self.organization, _state(pr_number=7), has_actionable_feedback=True
@@ -109,7 +110,7 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
         assert missing[REPO_NAME].installation_id == "9999"
         assert missing[REPO_NAME].repository_id == self.repo.id
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_silent_without_actionable_feedback(self) -> None:
         assert (
             get_blocked_pr_iteration_permissions(
@@ -118,7 +119,7 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             == {}
         )
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_silent_before_the_pr_is_created(self) -> None:
         assert (
             get_blocked_pr_iteration_permissions(
@@ -127,7 +128,7 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             == {}
         )
 
-    @override_options({"github-app.required-permissions": {"contents": "read"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "read"}, clear=True)
     def test_silent_when_the_install_is_healthy(self) -> None:
         assert (
             get_blocked_pr_iteration_permissions(
@@ -153,7 +154,7 @@ class GetMissingPermissionsByRepoTest(TestCase):
             integration_id=self.integration.id,
         )
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_reports_the_repository_the_install_was_resolved_for(self) -> None:
         missing = get_missing_permissions_by_repo(self.organization, [REPO_NAME])
 
@@ -168,33 +169,33 @@ class GetMissingPermissionsByRepoTest(TestCase):
         assert logs.records[0].__dict__["reason"] == reason
         assert logs.records[0].__dict__["organization_id"] == organization.id
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_without_a_repository_row(self) -> None:
         self._assert_warns(self.organization, "org/unknown", "no_repository_row")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_repository_is_not_active(self) -> None:
         self.repo.update(status=ObjectStatus.PENDING_DELETION)
 
         self._assert_warns(self.organization, REPO_NAME, "no_repository_row")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_repository_belongs_to_another_org(self) -> None:
         self._assert_warns(self.create_organization(), REPO_NAME, "no_repository_row")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_repository_has_no_integration(self) -> None:
         Repository.objects.filter(id=self.repo.id).update(integration_id=None)
 
         self._assert_warns(self.organization, REPO_NAME, "no_integration_id")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_integration_is_gone(self) -> None:
         Repository.objects.filter(id=self.repo.id).update(integration_id=self.integration.id + 1000)
 
         self._assert_warns(self.organization, REPO_NAME, "integration_not_found")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_quiet_when_every_repo_resolves(self) -> None:
         with self.assertNoLogs(LOGGER_NAME, level="WARNING"):
             assert set(get_missing_permissions_by_repo(self.organization, [REPO_NAME])) == {


### PR DESCRIPTION
The GitHub App's required permissions aren't a secret and have to stay in
lockstep with the app's declared permissions and github_permission_tiers, so
hardcode them as GITHUB_APP_REQUIRED_PERMISSIONS instead of reading the
github-app.required-permissions option. The constant is the union of every
permission our features expect: the scopes each tier introduces plus the
baseline scopes that predate the tiers.

get_missing_github_app_permissions now compares against that constant. Tests
that injected a value through override_options patch the constant instead.

The github-app.required-permissions registration and its
sentry-options-automator entry come out in a follow-up.


Part of [AIML-3446](https://linear.app/getsentry/issue/AIML-3446/explain-missing-github-app-permissions-in-update-alerts)
