### PR TITLE
feat(seer): open the autofix drawer on the left

### DIFF
--- a/static/app/components/core/drawer/components.tsx
+++ b/static/app/components/core/drawer/components.tsx
@@ -40,7 +40,13 @@ export function useDrawerContentContext() {
  */
 interface DrawerPanelProps extends Pick<
   DrawerOptions,
-  'ariaLabel' | 'drawerKey' | 'drawerWidth' | 'drawerMaxWidth' | 'resizable' | 'onClose'
+  | 'ariaLabel'
+  | 'drawerKey'
+  | 'drawerWidth'
+  | 'drawerMaxWidth'
+  | 'position'
+  | 'resizable'
+  | 'onClose'
 > {
   children: React.ReactNode;
   /** Required — GlobalDrawer applies the default before passing it down. */
@@ -57,6 +63,7 @@ function DrawerPanel({
   drawerWidth,
   drawerMaxWidth,
   drawerKey,
+  position = 'right',
   resizable = true,
 }: DrawerPanelProps) {
   const {panelRef, resizeHandleRef, handleResizeStart, persistedWidthPercent, enabled} =
@@ -64,6 +71,7 @@ function DrawerPanel({
       drawerKey,
       drawerWidth,
       drawerMaxWidth,
+      position,
       enabled: resizable,
     });
   const [tooltipContainer, setTooltipContainer] = useState<HTMLDivElement | null>(null);
@@ -78,7 +86,7 @@ function DrawerPanel({
         <DrawerSlidePanel
           mode={mode}
           ariaLabel={ariaLabel}
-          position="right"
+          position={position}
           ref={mergeRefs(panelRef, ref, (node: HTMLDivElement | null) =>
             setTooltipContainer(node)
           )}
@@ -88,6 +96,8 @@ function DrawerPanel({
           {drawerKey && enabled && (
             <ResizeHandle
               ref={resizeHandleRef}
+              position={position}
+              data-test-id="drawer-resize-handle"
               onMouseDown={handleResizeStart}
               data-at-min-width={(persistedWidthPercent <= MIN_WIDTH_PERCENT).toString()}
               data-at-max-width={(
@@ -223,17 +233,36 @@ const DrawerContainer = styled('div')<{mode?: DrawerOptions['mode']}>`
 `;
 
 const DrawerSlidePanel = styled(SlideOverPanel)`
-  border-left: 1px solid ${p => p.theme.tokens.border.primary};
-  position: relative;
+  ${p =>
+    p.position === 'left'
+      ? css`
+          border-right: 1px solid ${p.theme.tokens.border.primary};
+
+          /* The base panel lays its left variant out in flow, for slideouts that
+             sit beside page content. A drawer overlays the page instead, so pin
+             it to the viewport edge and drop the in-flow variant's width floor.
+             Doubled selector to outrank the base panel's own rule. */
+          && {
+            position: fixed;
+            left: 0;
+            right: auto;
+            min-width: 0;
+          }
+        `
+      : css`
+          border-left: 1px solid ${p.theme.tokens.border.primary};
+          position: relative;
+        `}
   pointer-events: auto;
   height: 100%;
 
-  /* Extend the panel's background 20px past its right edge so the bounce-in
+  /* Extend the panel's background 20px past its outer edge so the bounce-in
      overshoot doesn't briefly expose the page beneath. A box-shadow is used
      (vs. a pseudo-element) because the panel's own overflow: auto would clip
      anything positioned outside its bounds. */
   box-shadow:
-    20px 0 0 ${p => p.theme.tokens.background.overlay},
+    ${p => (p.position === 'left' ? '-20px' : '20px')} 0 0
+      ${p => p.theme.tokens.background.overlay},
     ${p => p.theme.shadow.high};
 
   --drawer-width: ${DEFAULT_WIDTH_PERCENT}%;
@@ -280,21 +309,22 @@ const DrawerSlidePanel = styled(SlideOverPanel)`
   }
 `;
 
-const ResizeHandle = styled('div')`
+const ResizeHandle = styled('div')<{position: 'left' | 'right'}>`
   position: absolute;
-  left: -2px;
+  ${p => (p.position === 'left' ? 'right' : 'left')}: -2px;
   top: 0;
   bottom: 0;
   width: 8px;
   cursor: ew-resize;
   z-index: ${p => p.theme.zIndex.drawer + 2};
 
+  /* Only the direction that still has room to travel is offered. */
   &[data-at-min-width='true'] {
-    cursor: w-resize;
+    cursor: ${p => (p.position === 'left' ? 'e-resize' : 'w-resize')};
   }
 
   &[data-at-max-width='true'] {
-    cursor: e-resize;
+    cursor: ${p => (p.position === 'left' ? 'w-resize' : 'e-resize')};
   }
 
   &:hover,
@@ -307,7 +337,7 @@ const ResizeHandle = styled('div')`
   &::after {
     content: '';
     position: absolute;
-    left: 2px;
+    ${p => (p.position === 'left' ? 'right' : 'left')}: 2px;
     top: 0;
     bottom: 0;
     width: 4px;

--- a/static/app/components/core/drawer/index.spec.tsx
+++ b/static/app/components/core/drawer/index.spec.tsx
@@ -1,9 +1,11 @@
 import {Fragment} from 'react';
 
 import {
+  fireEvent,
   render,
   screen,
   userEvent,
+  waitFor,
   waitForDrawerToHide,
   within,
 } from 'sentry-test/reactTestingLibrary';
@@ -386,5 +388,49 @@ describe('GlobalDrawer', () => {
 
     expect(drawer.style.getPropertyValue('--drawer-width')).toBe('50%');
     expect(drawer.style.getPropertyValue('--drawer-max-width')).toBe('85%');
+  });
+
+  describe('resizing', () => {
+    // The pinned edge stays put, so the same cursor position means opposite
+    // widths depending on which edge the drawer is anchored to.
+    async function dragResizeHandleTo(
+      position: 'left' | 'right',
+      clientX: number
+    ): Promise<HTMLElement> {
+      render(
+        <GlobalDrawerTestComponent
+          config={{
+            renderer: () => (
+              <DrawerBody data-test-id="drawer-test-content">resize</DrawerBody>
+            ),
+            options: {ariaLabel, drawerKey: `drawer-test-resize-${position}`, position},
+          }}
+        />
+      );
+
+      await userEvent.click(screen.getByTestId('drawer-test-open'));
+      expect(await screen.findByTestId('drawer-test-content')).toBeInTheDocument();
+
+      fireEvent.mouseDown(screen.getByTestId('drawer-resize-handle'));
+      fireEvent.mouseMove(document, {clientX});
+
+      return screen.getByRole('complementary', {name: ariaLabel});
+    }
+
+    it('widens a right-anchored drawer as the cursor moves left', async () => {
+      const drawer = await dragResizeHandleTo('right', window.innerWidth * 0.25);
+
+      await waitFor(() =>
+        expect(drawer.style.getPropertyValue('--drawer-width')).toBe('75%')
+      );
+    });
+
+    it('widens a left-anchored drawer as the cursor moves right', async () => {
+      const drawer = await dragResizeHandleTo('left', window.innerWidth * 0.75);
+
+      await waitFor(() =>
+        expect(drawer.style.getPropertyValue('--drawer-width')).toBe('75%')
+      );
+    });
   });
 });

--- a/static/app/components/core/drawer/index.tsx
+++ b/static/app/components/core/drawer/index.tsx
@@ -56,6 +56,11 @@ export interface DrawerOptions {
    */
   onOpen?: () => void;
   /**
+   * Viewport edge the drawer is anchored to, and the edge it slides in from.
+   * Defaults to 'right'.
+   */
+  position?: 'left' | 'right';
+  /**
    * If true (default), allows the drawer to be resized - requires `drawerKey`
    * to be defined
    */
@@ -238,6 +243,7 @@ export function GlobalDrawer({children}: any) {
               drawerWidth={currentDrawerConfig?.options?.drawerWidth}
               drawerMaxWidth={currentDrawerConfig?.options?.drawerMaxWidth}
               drawerKey={currentDrawerConfig?.options?.drawerKey}
+              position={currentDrawerConfig?.options?.position}
               resizable={currentDrawerConfig?.options?.resizable}
             >
               {renderedChild}

--- a/static/app/components/core/drawer/useDrawerResizing.tsx
+++ b/static/app/components/core/drawer/useDrawerResizing.tsx
@@ -17,6 +17,7 @@ interface UseDrawerResizingOptions {
   drawerMaxWidth?: string;
   drawerWidth?: string;
   enabled?: boolean;
+  position?: 'left' | 'right';
 }
 
 interface UseDrawerResizingResult {
@@ -31,6 +32,7 @@ export function useDrawerResizing({
   drawerKey,
   drawerWidth,
   drawerMaxWidth,
+  position = 'right',
   enabled = true,
 }: UseDrawerResizingOptions): UseDrawerResizingResult {
   const theme = useTheme();
@@ -128,8 +130,11 @@ export function useDrawerResizing({
             return;
           }
 
-          const newWidthPercent =
-            ((viewportWidth - moveEvent.clientX) / viewportWidth) * 100;
+          // The pinned edge stays put, so width is the distance from it to the
+          // cursor.
+          const widthPx =
+            position === 'left' ? moveEvent.clientX : viewportWidth - moveEvent.clientX;
+          const newWidthPercent = (widthPx / viewportWidth) * 100;
 
           panel.style.setProperty('--drawer-width', `${newWidthPercent}%`);
 
@@ -170,7 +175,7 @@ export function useDrawerResizing({
       document.addEventListener('mousemove', handleMouseMove);
       document.addEventListener('mouseup', handleMouseUp);
     },
-    [isSmallScreen, enabled, setPersistedWidthPercent]
+    [isSmallScreen, enabled, position, setPersistedWidthPercent]
   );
 
   useLayoutEffect(() => {

--- a/static/app/views/issueDetails/sidebar/seerDrawer.tsx
+++ b/static/app/views/issueDetails/sidebar/seerDrawer.tsx
@@ -35,6 +35,7 @@ export const useOpenSeerDrawer = ({group, project}: {group: Group; project: Proj
       drawerKey: 'seer-autofix-drawer',
       drawerWidth: '80%',
       drawerMaxWidth: '1600px',
+      position: 'left',
       resizable: true,
       mode: 'passive',
       shouldCloseOnLocationChange: nextLocation => {


### PR DESCRIPTION
The Seer autofix drawer on the issue details page now opens against the left
edge of the viewport and slides in from the left, rather than the right.

The core drawer had `position="right"` hardcoded for every consumer, so the
side is not something a caller could choose. Rather than flip that constant —
which would move every drawer in the product — this adds a
`position: 'left' | 'right'` option to `DrawerOptions`, threaded through
`GlobalDrawer` to the panel. It defaults to `'right'`, so the only drawer that
changes is the autofix one, which opts in.

Anchoring to the opposite edge is not just a `left`/`right` swap, because three
things assumed a right-hand panel and each had to be mirrored:

- the divider border and the bounce-in overshoot shadow, which extend past the
  panel's outer edge
- the resize handle: which edge it sits on, and its directional cursors at the
  min and max width stops
- the resize drag math, which derived the new width from
  `viewportWidth - clientX`. The pinned edge stays put during a drag, so a
  left-anchored panel has to measure from the other side or it shrinks when you
  drag to widen it.

One further wrinkle: the shared `SlideOverPanel` already had a `left` variant,
but it lays that variant out in flow, for slideouts that sit *beside* page
content (the dashboard widget builder uses it that way). A drawer overlays the
page, so `DrawerSlidePanel` pins itself to the viewport edge on top of that
rather than reusing the in-flow geometry.

## Worth a look before this ships

**The drawer now covers the left navigation sidebar.** The drawer's z-index
(9999) is well above the nav's (1020), and the autofix drawer opens at 80%
width, so the primary and secondary nav are hidden for as long as it is open.
That is a real change in feel: this drawer is deliberately `mode: 'passive'` so
the page stays usable underneath it, and losing the nav cuts against that.

I kept the simple mirror — anchored to the viewport edge, exactly like the
right-hand side is — rather than deciding this for you. If it should instead
start after the nav, the follow-up is to offset the left edge by the nav width
(`PRIMARY_SIDEBAR_WIDTH` plus the secondary sidebar's persisted width, honoring
the collapsed/peek state), which is a bigger change than it sounds and probably
wants a designer's eye.

## Feature flags

None. This is unconditional for anyone who can open the autofix drawer, gated
only by the pre-existing `gen-ai-features` / `hideAiFeatures` checks that
already guard opening it.

## Screenshots

Not included — capturing one needs a running app pointed at a real issue with a
Seer run, which I could not reach from here. To see it: `pnpm dev-ui`, open any
issue with Seer enabled, and start Autofix.

Two tests in `drawer/index.spec.tsx` cover the drag direction for each anchor
edge; the left-hand one fails against the old width math, which is the part
most likely to regress silently.

https://claude.ai/code/session_01MsjhehBoC63VzssM1RvnJY
