### PR TITLE
chore(workflow-engine): Handle duplicate all projects detectors

### DIFF
--- a/src/sentry/workflow_engine/defaults/detectors.py
+++ b/src/sentry/workflow_engine/defaults/detectors.py
@@ -37,7 +37,6 @@ from sentry.workflow_engine.models import (
     Detector,
 )
 from sentry.workflow_engine.models.data_condition import Condition
-from sentry.workflow_engine.processors.detector import query_all_projects_detector
 from sentry.workflow_engine.types import (
     ALL_PROJECTS_DETECTOR_NAME,
     ERROR_DETECTOR_NAME,
@@ -288,6 +287,8 @@ def ensure_default_all_projects_detector(organization_id: int) -> Detector:
 
     Raises on UnableToAcquireLockApiError
     """
+    from sentry.workflow_engine.processors.detector import query_all_projects_detector
+
     existing = query_all_projects_detector(organization_id=organization_id)
     if existing:
         return existing

--- a/src/sentry/workflow_engine/defaults/detectors.py
+++ b/src/sentry/workflow_engine/defaults/detectors.py
@@ -37,6 +37,7 @@ from sentry.workflow_engine.models import (
     Detector,
 )
 from sentry.workflow_engine.models.data_condition import Condition
+from sentry.workflow_engine.processors.detector import query_all_projects_detector
 from sentry.workflow_engine.types import (
     ALL_PROJECTS_DETECTOR_NAME,
     ERROR_DETECTOR_NAME,
@@ -285,13 +286,9 @@ def ensure_default_all_projects_detector(organization_id: int) -> Detector:
     Ensure that an org-scoped all-project detector exists for the organization.
     This detector has project=NULL and config={"organization_id": org_id}.
 
-    Raises on Detector.MultipleObjectsReturned, UnableToAcquireLockApiError
+    Raises on UnableToAcquireLockApiError
     """
-    existing = Detector.objects.get_or_none(
-        type=IssueStreamGroupType.slug,
-        project__isnull=True,
-        config__organization_id=organization_id,
-    )
+    existing = query_all_projects_detector(organization_id=organization_id)
     if existing:
         return existing
 
@@ -305,11 +302,7 @@ def ensure_default_all_projects_detector(organization_id: int) -> Detector:
             lock.blocking_acquire(initial_delay=0.1, timeout=3),
             transaction.atomic(router.db_for_write(Detector)),
         ):
-            existing = Detector.objects.get_or_none(
-                type=IssueStreamGroupType.slug,
-                project__isnull=True,
-                config__organization_id=organization_id,
-            )
+            existing = query_all_projects_detector(organization_id=organization_id)
             if existing:
                 return existing
 
@@ -326,7 +319,7 @@ def ensure_default_all_projects_detector(organization_id: int) -> Detector:
 
 def ensure_default_organization_detectors(organization: Organization) -> dict[str, Detector]:
     """
-    Raises on Detector.MultipleObjectsReturned, UnableToAcquireLockApiError
+    Raises on UnableToAcquireLockApiError
     """
     detectors: dict[str, Detector] = {}
     if options.get("workflow_engine.auto_creation.all_projects_detector"):

--- a/src/sentry/workflow_engine/defaults/workflows.py
+++ b/src/sentry/workflow_engine/defaults/workflows.py
@@ -208,7 +208,7 @@ def ensure_pull_request_workflow(organization: Organization, detector: Detector)
 
 def ensure_default_organization_workflows(organization: Organization) -> list[Workflow]:
     """
-    Raises on Workflow.MultipleObjectsReturned, Detector.MultipleObjectsReturned, UnableToAcquireLockApiError
+    Raises on Workflow.MultipleObjectsReturned, UnableToAcquireLockApiError
     """
     workflows: list[Workflow] = []
     if not options.get("workflow_engine.auto_creation.pull_request_workflow"):

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -42,6 +42,28 @@ def _get_all_projects_detector_cache_key(organization_id: int) -> str:
     return f"detector:all_projects:{organization_id}"
 
 
+def query_all_projects_detector(organization_id: int) -> Detector | None:
+    try:
+        return Detector.objects.get_or_none(
+            type=IssueStreamGroupType.slug,
+            project__isnull=True,
+            config__organization_id=organization_id,
+        )
+    except Detector.MultipleObjectsReturned:
+        logger.warning(
+            "get_all_projects_detector.many_exist", extra={"organization_id": organization_id}
+        )
+        return (
+            Detector.objects.filter(
+                type=IssueStreamGroupType.slug,
+                project__isnull=True,
+                config__organization_id=organization_id,
+            )
+            .order_by("-date_added")
+            .first()
+        )
+
+
 def get_all_projects_detector(organization_id: int) -> Detector | None:
     with metrics.timer("workflow_engine.cache.all_projects_detector") as metrics_tags:
         cache_key = _get_all_projects_detector_cache_key(organization_id)
@@ -50,17 +72,7 @@ def get_all_projects_detector(organization_id: int) -> Detector | None:
             metrics_tags["cache_hit"] = "true"
             metrics_tags["detector_found"] = "true" if cached is not None else "false"
             return cached
-        try:
-            result = Detector.objects.get_or_none(
-                project__isnull=True,
-                type=IssueStreamGroupType.slug,
-                config__organization_id=organization_id,
-            )
-        except Detector.MultipleObjectsReturned:
-            logger.exception(
-                "get_all_projects_detector.many_exist", extra={"organization_id": organization_id}
-            )
-            result = None
+        result = query_all_projects_detector(organization_id=organization_id)
         metrics_tags["cache_hit"] = "false"
         metrics_tags["detector_found"] = "true" if result is not None else "false"
         cache.set(cache_key, result, Detector.CACHE_TTL)

--- a/src/sentry/workflow_engine/processors/detector.py
+++ b/src/sentry/workflow_engine/processors/detector.py
@@ -59,7 +59,7 @@ def query_all_projects_detector(organization_id: int) -> Detector | None:
                 project__isnull=True,
                 config__organization_id=organization_id,
             )
-            .order_by("-date_added")
+            .order_by("date_added")
             .first()
         )
 

--- a/tests/sentry/workflow_engine/defaults/test_detectors.py
+++ b/tests/sentry/workflow_engine/defaults/test_detectors.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
 
 import pytest
+from django.utils import timezone
 
 from sentry.grouping.grouptype import ErrorGroupType
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import freeze_time
 from sentry.testutils.helpers.options import override_options
 from sentry.utils.locking import UnableToAcquireLock
 from sentry.workflow_engine.defaults.detectors import (
@@ -120,9 +122,12 @@ class TestEnsureDefaultAllProjectsDetector(TestCase):
 
     def test_duplicate_detectors_are_handled(self) -> None:
         org = self.create_organization()
-        first = self.create_all_projects_detector(org)
-        _second = self.create_all_projects_detector(org)
-        _third = self.create_all_projects_detector(org)
+        with freeze_time(timezone.now() - timezone.timedelta(hours=2)):
+            first = self.create_all_projects_detector(org)
+        with freeze_time(timezone.now() - timezone.timedelta(hours=1)):
+            _second = self.create_all_projects_detector(org)
+        with freeze_time(timezone.now()):
+            _third = self.create_all_projects_detector(org)
 
         result = ensure_default_all_projects_detector(org.id)
         assert result.id == first.id

--- a/tests/sentry/workflow_engine/defaults/test_detectors.py
+++ b/tests/sentry/workflow_engine/defaults/test_detectors.py
@@ -118,13 +118,14 @@ class TestEnsureDefaultAllProjectsDetector(TestCase):
             with pytest.raises(UnableToAcquireLockApiError):
                 ensure_default_all_projects_detector(self.organization.id)
 
-    def test_duplicate_detectors_raises(self) -> None:
+    def test_duplicate_detectors_are_handled(self) -> None:
         org = self.create_organization()
-        self.create_all_projects_detector(org)
-        self.create_all_projects_detector(org)
+        first = self.create_all_projects_detector(org)
+        _second = self.create_all_projects_detector(org)
+        _third = self.create_all_projects_detector(org)
 
-        with pytest.raises(Detector.MultipleObjectsReturned):
-            ensure_default_all_projects_detector(org.id)
+        result = ensure_default_all_projects_detector(org.id)
+        assert result.id == first.id
 
     def test_returns_none_when_option_disabled(self) -> None:
         result = ensure_default_organization_detectors(self.organization)

--- a/tests/sentry/workflow_engine/defaults/test_detectors.py
+++ b/tests/sentry/workflow_engine/defaults/test_detectors.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 import pytest
@@ -122,9 +123,9 @@ class TestEnsureDefaultAllProjectsDetector(TestCase):
 
     def test_duplicate_detectors_are_handled(self) -> None:
         org = self.create_organization()
-        with freeze_time(timezone.now() - timezone.timedelta(hours=2)):
+        with freeze_time(timezone.now() - timedelta(hours=2)):
             first = self.create_all_projects_detector(org)
-        with freeze_time(timezone.now() - timezone.timedelta(hours=1)):
+        with freeze_time(timezone.now() - timedelta(hours=1)):
             _second = self.create_all_projects_detector(org)
         with freeze_time(timezone.now()):
             _third = self.create_all_projects_detector(org)

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1265,9 +1265,12 @@ class TestQueryAllProjectsDetector(TestCase):
         assert query_all_projects_detector(self.organization.id) == detector
 
     def test_returns_first_when_many_exist(self) -> None:
-        first = self.create_all_projects_detector(self.organization)
-        _second = self.create_all_projects_detector(self.organization)
-        _third = self.create_all_projects_detector(self.organization)
+        with freeze_time(timezone.now() - timezone.timedelta(hours=2)):
+            first = self.create_all_projects_detector(self.organization)
+        with freeze_time(timezone.now() - timezone.timedelta(hours=1)):
+            _second = self.create_all_projects_detector(self.organization)
+        with freeze_time(timezone.now()):
+            _third = self.create_all_projects_detector(self.organization)
         result = query_all_projects_detector(self.organization.id)
         assert result is not None
         assert result.id == first.id
@@ -1316,9 +1319,12 @@ class TestEventDetectorsAllProject(TestCase):
         assert get_all_projects_detector(self.organization.id) is None
 
     def test_many_all_projects_detectors(self) -> None:
-        first = self.create_all_projects_detector(self.organization)
-        _second = self.create_all_projects_detector(self.organization)
-        _third = self.create_all_projects_detector(self.organization)
+        with freeze_time(timezone.now() - timezone.timedelta(hours=2)):
+            first = self.create_all_projects_detector(self.organization)
+        with freeze_time(timezone.now() - timezone.timedelta(hours=1)):
+            _second = self.create_all_projects_detector(self.organization)
+        with freeze_time(timezone.now()):
+            _third = self.create_all_projects_detector(self.organization)
         cache.clear()
         result = get_all_projects_detector(self.organization.id)
         assert result is not None

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -38,6 +38,7 @@ from sentry.workflow_engine.processors.detector import (
     get_detectors_for_event_data,
     get_preferred_detector,
     process_detectors,
+    query_all_projects_detector,
 )
 from sentry.workflow_engine.processors.evaluation_logging import emit_detector_evaluation_logs
 from sentry.workflow_engine.processors.evaluations import (
@@ -1255,6 +1256,31 @@ class TestGetDetectorsForEvent(TestCase):
         assert result is None
 
 
+class TestQueryAllProjectsDetector(TestCase):
+    def test_returns_none_when_missing(self) -> None:
+        assert query_all_projects_detector(self.organization.id) is None
+
+    def test_returns_detector_when_exists(self) -> None:
+        detector = ensure_default_all_projects_detector(self.organization.id)
+        assert query_all_projects_detector(self.organization.id) == detector
+
+    def test_returns_first_when_many_exist(self) -> None:
+        first = self.create_all_projects_detector(self.organization)
+        _second = self.create_all_projects_detector(self.organization)
+        _third = self.create_all_projects_detector(self.organization)
+        result = query_all_projects_detector(self.organization.id)
+        assert result is not None
+        assert result.id == first.id
+
+    def test_separate_orgs_unaffected(self) -> None:
+        org1 = self.create_organization()
+        org2 = self.create_organization()
+        d1 = ensure_default_all_projects_detector(org1.id)
+        d2 = ensure_default_all_projects_detector(org2.id)
+        assert query_all_projects_detector(org1.id) == d1
+        assert query_all_projects_detector(org2.id) == d2
+
+
 class TestEventDetectorsAllProject(TestCase):
     def setUp(self) -> None:
         self.issue_stream_detector = self.create_detector(
@@ -1290,11 +1316,13 @@ class TestEventDetectorsAllProject(TestCase):
         assert get_all_projects_detector(self.organization.id) is None
 
     def test_many_all_projects_detectors(self) -> None:
-        self.create_all_projects_detector(self.organization)
-        self.create_all_projects_detector(self.organization)
-        self.create_all_projects_detector(self.organization)
+        first = self.create_all_projects_detector(self.organization)
+        _second = self.create_all_projects_detector(self.organization)
+        _third = self.create_all_projects_detector(self.organization)
         cache.clear()
-        assert get_all_projects_detector(self.organization.id) is None
+        result = get_all_projects_detector(self.organization.id)
+        assert result is not None
+        assert result.id == first.id
 
     def test_cached_miss_is_invalidated_when_detector_is_created(self) -> None:
         self.all_projects_detector.delete()

--- a/tests/sentry/workflow_engine/processors/test_detector.py
+++ b/tests/sentry/workflow_engine/processors/test_detector.py
@@ -1,6 +1,7 @@
 import unittest
 import uuid
 from dataclasses import replace
+from datetime import timedelta
 from typing import Any
 from unittest import mock
 from unittest.mock import MagicMock, call, patch
@@ -1265,9 +1266,9 @@ class TestQueryAllProjectsDetector(TestCase):
         assert query_all_projects_detector(self.organization.id) == detector
 
     def test_returns_first_when_many_exist(self) -> None:
-        with freeze_time(timezone.now() - timezone.timedelta(hours=2)):
+        with freeze_time(timezone.now() - timedelta(hours=2)):
             first = self.create_all_projects_detector(self.organization)
-        with freeze_time(timezone.now() - timezone.timedelta(hours=1)):
+        with freeze_time(timezone.now() - timedelta(hours=1)):
             _second = self.create_all_projects_detector(self.organization)
         with freeze_time(timezone.now()):
             _third = self.create_all_projects_detector(self.organization)
@@ -1319,9 +1320,9 @@ class TestEventDetectorsAllProject(TestCase):
         assert get_all_projects_detector(self.organization.id) is None
 
     def test_many_all_projects_detectors(self) -> None:
-        with freeze_time(timezone.now() - timezone.timedelta(hours=2)):
+        with freeze_time(timezone.now() - timedelta(hours=2)):
             first = self.create_all_projects_detector(self.organization)
-        with freeze_time(timezone.now() - timezone.timedelta(hours=1)):
+        with freeze_time(timezone.now() - timedelta(hours=1)):
             _second = self.create_all_projects_detector(self.organization)
         with freeze_time(timezone.now()):
             _third = self.create_all_projects_detector(self.organization)


### PR DESCRIPTION
Consistently grab the first one and log the organization_Id for debugging, but should let us keep connecting this detector to workflows and what not as we release.

Fixes SENTRY-5VHD, though how a duplicate was created around the lock contention is still confusing.