### PR TITLE
feat(onboarding): Gate SCM messaging experiment exposure at the fork

### DIFF
--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -31,6 +31,7 @@ import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/platform';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import * as useExperimentModule from 'sentry/utils/useExperiment';
+import type {UseExperimentOptions, UseExperimentResult} from 'sentry/utils/useExperiment';
 import {
   OnboardingWithoutContext,
   SCM_MESSAGING_EXPOSURE,
@@ -579,7 +580,7 @@ describe('Onboarding', () => {
 
     let agenticRunRequestMock: ReturnType<typeof MockApiClient.addMockResponse>;
     let resolveAgenticRunRequest: () => void;
-    let useExperimentSpy: jest.SpyInstance;
+    let useExperimentSpy: jest.SpyInstance<UseExperimentResult, [UseExperimentOptions]>;
     let exposureSwitch: jest.ReplaceProperty<boolean>;
 
     beforeEach(() => {
@@ -628,14 +629,13 @@ describe('Onboarding', () => {
       useExperimentSpy.mockRestore();
     });
 
-    // Deduplicated in call order, so `[false, true]` reads as "not before the
-    // fork, then reported".
+    // Consecutive repeats collapsed, so `[false, true]` reads as "not before the
+    // fork, then reported". A later flip back to false still shows up.
     function messagingExposureGate() {
       const values = useExperimentSpy.mock.calls
-        .map(([options]) => options)
-        .filter(options => options.feature === 'onboarding-scm-messaging-experiment')
-        .map(options => options.reportExposure);
-      return [...new Set(values)];
+        .filter(([options]) => options.feature === 'onboarding-scm-messaging-experiment')
+        .map(([options]) => options.reportExposure);
+      return values.filter((value, index) => value !== values[index - 1]);
     }
 
     type RenderOptions = {
@@ -679,6 +679,7 @@ describe('Onboarding', () => {
           `/onboarding/${scmOrganization.slug}/welcome/`
         );
       });
+      expect(messagingExposureGate()).toEqual([false]);
     });
 
     it('redirects treatment off the messaging step when no platform is staged', async () => {
@@ -692,6 +693,9 @@ describe('Onboarding', () => {
           `/onboarding/${messagingOrganization.slug}/scm-platform-features/`
         );
       });
+      // The redirect runs in an effect, so the gate must already be off on the
+      // first render. Otherwise a bounced user lands in the population.
+      expect(messagingExposureGate()).toEqual([false]);
     });
 
     it('navigates from welcome to scm-connect', async () => {
@@ -1002,7 +1006,6 @@ describe('Onboarding', () => {
       await waitFor(() => {
         expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
       });
-      expect(messagingExposureGate()).toEqual([false]);
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       await waitFor(() => {
@@ -1039,7 +1042,6 @@ describe('Onboarding', () => {
         },
       });
 
-      expect(messagingExposureGate()).toEqual([false]);
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       expect(
@@ -1072,11 +1074,26 @@ describe('Onboarding', () => {
     it('does not report exposure outside SCM onboarding', async () => {
       const legacyOrganization = OrganizationFixture();
 
-      const {router} = renderFlow(legacyOrganization, 'scm-messaging');
+      // Stage a platform so every other term of the gate passes and only the
+      // SCM onboarding flag holds exposure off.
+      const {router} = renderFlow(legacyOrganization, 'scm-messaging', {
+        initialContext: {selectedPlatform: nextJsPlatform},
+      });
 
       await waitFor(() => {
         expect(router.location.pathname).toBe(
           `/onboarding/${legacyOrganization.slug}/welcome/`
+        );
+      });
+      expect(messagingExposureGate()).toEqual([false]);
+    });
+
+    it('does not report exposure on setup-docs without a staged project', async () => {
+      const {router} = renderOnboarding('setup-docs');
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${scmOrganization.slug}/welcome/`
         );
       });
       expect(messagingExposureGate()).toEqual([false]);

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -30,7 +30,11 @@ import {TeamStore} from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/platform';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import {OnboardingWithoutContext} from 'sentry/views/onboarding/onboarding';
+import * as useExperimentModule from 'sentry/utils/useExperiment';
+import {
+  OnboardingWithoutContext,
+  SCM_MESSAGING_EXPOSURE,
+} from 'sentry/views/onboarding/onboarding';
 
 jest.mock('sentry/utils/analytics');
 
@@ -575,8 +579,14 @@ describe('Onboarding', () => {
 
     let agenticRunRequestMock: ReturnType<typeof MockApiClient.addMockResponse>;
     let resolveAgenticRunRequest: () => void;
+    let useExperimentSpy: jest.SpyInstance;
+    let exposureSwitch: jest.ReplaceProperty<boolean>;
 
     beforeEach(() => {
+      useExperimentSpy = jest.spyOn(useExperimentModule, 'useExperiment');
+      // The switch ships off; these tests exercise the gate behind it.
+      exposureSwitch = jest.replaceProperty(SCM_MESSAGING_EXPOSURE, 'enabled', true);
+
       MockApiClient.addMockResponse({
         url: `/organizations/${scmOrganization.slug}/config/integrations/`,
         body: {providers: [githubProvider]},
@@ -612,6 +622,21 @@ describe('Onboarding', () => {
         }),
       });
     });
+
+    afterEach(() => {
+      exposureSwitch.restore();
+      useExperimentSpy.mockRestore();
+    });
+
+    // Deduplicated in call order, so `[false, true]` reads as "not before the
+    // fork, then reported".
+    function messagingExposureGate() {
+      const values = useExperimentSpy.mock.calls
+        .map(([options]) => options)
+        .filter(options => options.feature === 'onboarding-scm-messaging-experiment')
+        .map(options => options.reportExposure);
+      return [...new Set(values)];
+    }
 
     type RenderOptions = {
       initialContext?: Parameters<typeof OnboardingContextProvider>[0]['initialValue'];
@@ -977,6 +1002,7 @@ describe('Onboarding', () => {
       await waitFor(() => {
         expect(screen.getByRole('button', {name: 'Continue'})).toBeEnabled();
       });
+      expect(messagingExposureGate()).toEqual([false]);
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       await waitFor(() => {
@@ -987,6 +1013,7 @@ describe('Onboarding', () => {
           `/onboarding/${controlOrganization.slug}/setup-docs/`
         );
       });
+      expect(messagingExposureGate()).toEqual([false, true]);
     });
 
     it('adds the messaging route for treatment without creating a project', async () => {
@@ -1012,6 +1039,7 @@ describe('Onboarding', () => {
         },
       });
 
+      expect(messagingExposureGate()).toEqual([false]);
       await userEvent.click(screen.getByRole('button', {name: 'Continue'}));
 
       expect(
@@ -1021,6 +1049,50 @@ describe('Onboarding', () => {
         `/onboarding/${messagingOrganization.slug}/scm-messaging/`
       );
       expect(createRequest).not.toHaveBeenCalled();
+      expect(messagingExposureGate()).toEqual([false, true]);
+    });
+
+    it('does not report exposure for an org outside the new-org window', async () => {
+      const eightDaysAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 8);
+      const staleOrganization = OrganizationFixture({
+        features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
+        dateCreated: eightDaysAgo.toISOString(),
+      });
+
+      renderFlow(staleOrganization, 'scm-messaging', {
+        initialContext: {selectedPlatform: nextJsPlatform},
+      });
+
+      expect(
+        await screen.findByText('Get alerts where your team works')
+      ).toBeInTheDocument();
+      expect(messagingExposureGate()).toEqual([false]);
+    });
+
+    it('does not report exposure outside SCM onboarding', async () => {
+      const legacyOrganization = OrganizationFixture();
+
+      const {router} = renderFlow(legacyOrganization, 'scm-messaging');
+
+      await waitFor(() => {
+        expect(router.location.pathname).toBe(
+          `/onboarding/${legacyOrganization.slug}/welcome/`
+        );
+      });
+      expect(messagingExposureGate()).toEqual([false]);
+    });
+
+    it('keeps exposure off while the switch is off', async () => {
+      exposureSwitch.replaceValue(false);
+
+      renderTreatmentOnboarding('scm-messaging', {
+        initialContext: {selectedPlatform: nextJsPlatform},
+      });
+
+      expect(
+        await screen.findByText('Get alerts where your team works')
+      ).toBeInTheDocument();
+      expect(messagingExposureGate()).toEqual([false]);
     });
 
     it('global Skip exits treatment without creating a project and clears state', async () => {

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -30,12 +30,7 @@ import {TeamStore} from 'sentry/stores/teamStore';
 import type {Organization} from 'sentry/types/organization';
 import type {PlatformKey} from 'sentry/types/platform';
 import {trackAnalytics} from 'sentry/utils/analytics';
-import * as useExperimentModule from 'sentry/utils/useExperiment';
-import type {UseExperimentOptions, UseExperimentResult} from 'sentry/utils/useExperiment';
-import {
-  OnboardingWithoutContext,
-  SCM_MESSAGING_EXPOSURE,
-} from 'sentry/views/onboarding/onboarding';
+import {OnboardingWithoutContext} from 'sentry/views/onboarding/onboarding';
 
 jest.mock('sentry/utils/analytics');
 
@@ -580,14 +575,8 @@ describe('Onboarding', () => {
 
     let agenticRunRequestMock: ReturnType<typeof MockApiClient.addMockResponse>;
     let resolveAgenticRunRequest: () => void;
-    let useExperimentSpy: jest.SpyInstance<UseExperimentResult, [UseExperimentOptions]>;
-    let exposureSwitch: jest.ReplaceProperty<boolean>;
 
     beforeEach(() => {
-      useExperimentSpy = jest.spyOn(useExperimentModule, 'useExperiment');
-      // The switch ships off; these tests exercise the gate behind it.
-      exposureSwitch = jest.replaceProperty(SCM_MESSAGING_EXPOSURE, 'enabled', true);
-
       MockApiClient.addMockResponse({
         url: `/organizations/${scmOrganization.slug}/config/integrations/`,
         body: {providers: [githubProvider]},
@@ -623,20 +612,6 @@ describe('Onboarding', () => {
         }),
       });
     });
-
-    afterEach(() => {
-      exposureSwitch.restore();
-      useExperimentSpy.mockRestore();
-    });
-
-    // Consecutive repeats collapsed, so `[false, true]` reads as "not before the
-    // fork, then reported". A later flip back to false still shows up.
-    function messagingExposureGate() {
-      const values = useExperimentSpy.mock.calls
-        .filter(([options]) => options.feature === 'onboarding-scm-messaging-experiment')
-        .map(([options]) => options.reportExposure);
-      return values.filter((value, index) => value !== values[index - 1]);
-    }
 
     type RenderOptions = {
       initialContext?: Parameters<typeof OnboardingContextProvider>[0]['initialValue'];
@@ -679,7 +654,6 @@ describe('Onboarding', () => {
           `/onboarding/${scmOrganization.slug}/welcome/`
         );
       });
-      expect(messagingExposureGate()).toEqual([false]);
     });
 
     it('redirects treatment off the messaging step when no platform is staged', async () => {
@@ -693,9 +667,6 @@ describe('Onboarding', () => {
           `/onboarding/${messagingOrganization.slug}/scm-platform-features/`
         );
       });
-      // The redirect runs in an effect, so the gate must already be off on the
-      // first render. Otherwise a bounced user lands in the population.
-      expect(messagingExposureGate()).toEqual([false]);
     });
 
     it('navigates from welcome to scm-connect', async () => {
@@ -1016,7 +987,6 @@ describe('Onboarding', () => {
           `/onboarding/${controlOrganization.slug}/setup-docs/`
         );
       });
-      expect(messagingExposureGate()).toEqual([false, true]);
     });
 
     it('adds the messaging route for treatment without creating a project', async () => {
@@ -1051,7 +1021,6 @@ describe('Onboarding', () => {
         `/onboarding/${messagingOrganization.slug}/scm-messaging/`
       );
       expect(createRequest).not.toHaveBeenCalled();
-      expect(messagingExposureGate()).toEqual([false, true]);
     });
 
     it('global Skip exits treatment without creating a project and clears state', async () => {

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -1054,64 +1054,6 @@ describe('Onboarding', () => {
       expect(messagingExposureGate()).toEqual([false, true]);
     });
 
-    it('does not report exposure for an org outside the new-org window', async () => {
-      const eightDaysAgo = new Date(Date.now() - 1000 * 60 * 60 * 24 * 8);
-      const staleOrganization = OrganizationFixture({
-        features: ['onboarding-scm-experiment', 'onboarding-scm-messaging-experiment'],
-        dateCreated: eightDaysAgo.toISOString(),
-      });
-
-      renderFlow(staleOrganization, 'scm-messaging', {
-        initialContext: {selectedPlatform: nextJsPlatform},
-      });
-
-      expect(
-        await screen.findByText('Get alerts where your team works')
-      ).toBeInTheDocument();
-      expect(messagingExposureGate()).toEqual([false]);
-    });
-
-    it('does not report exposure outside SCM onboarding', async () => {
-      const legacyOrganization = OrganizationFixture();
-
-      // Stage a platform so every other term of the gate passes and only the
-      // SCM onboarding flag holds exposure off.
-      const {router} = renderFlow(legacyOrganization, 'scm-messaging', {
-        initialContext: {selectedPlatform: nextJsPlatform},
-      });
-
-      await waitFor(() => {
-        expect(router.location.pathname).toBe(
-          `/onboarding/${legacyOrganization.slug}/welcome/`
-        );
-      });
-      expect(messagingExposureGate()).toEqual([false]);
-    });
-
-    it('does not report exposure on setup-docs without a staged project', async () => {
-      const {router} = renderOnboarding('setup-docs');
-
-      await waitFor(() => {
-        expect(router.location.pathname).toBe(
-          `/onboarding/${scmOrganization.slug}/welcome/`
-        );
-      });
-      expect(messagingExposureGate()).toEqual([false]);
-    });
-
-    it('keeps exposure off while the switch is off', async () => {
-      exposureSwitch.replaceValue(false);
-
-      renderTreatmentOnboarding('scm-messaging', {
-        initialContext: {selectedPlatform: nextJsPlatform},
-      });
-
-      expect(
-        await screen.findByText('Get alerts where your team works')
-      ).toBeInTheDocument();
-      expect(messagingExposureGate()).toEqual([false]);
-    });
-
     it('global Skip exits treatment without creating a project and clears state', async () => {
       sessionStorage.setItem(
         'onboarding',

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -50,6 +50,14 @@ import {OnboardingStepId, type StepDescriptor, type StepProps} from './types';
 // this window, so gating exposure on org age keeps them out of the experiment.
 const NEW_ORG_ONBOARDING_WINDOW_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
 
+/**
+ * Off until the messaging experiment ramps. The FlagPole config resolves every
+ * production org to control today, so reporting now would fill the experiment
+ * population with pre-launch control rows. Flip `enabled` in the same change
+ * as the rollout segment.
+ */
+export const SCM_MESSAGING_EXPOSURE = {enabled: false};
+
 const legacyOnboardingSteps: StepDescriptor[] = [
   {
     id: OnboardingStepId.WELCOME,
@@ -319,11 +327,20 @@ export function OnboardingWithoutContext() {
     reportExposure: isNewOrgOnboarding,
   });
 
-  // VDY-146 owns treatment exposure and interaction analytics. For now the
-  // host consumes the nested assignment without reporting it.
+  // The arms first differ after platform/features: treatment continues to the
+  // messaging step, control to SDK setup. Exposure is reported once the user
+  // is past that fork, from the route rather than the step list because the
+  // list itself depends on this assignment. Descendants consume the
+  // assignment with reportExposure: false.
+  const isPastPlatformFeatures =
+    stepId === OnboardingStepId.SCM_MESSAGING || stepId === OnboardingStepId.SETUP_DOCS;
   const {inExperiment: hasScmMessaging} = useExperiment({
     feature: 'onboarding-scm-messaging-experiment',
-    reportExposure: false,
+    reportExposure:
+      SCM_MESSAGING_EXPOSURE.enabled &&
+      isNewOrgOnboarding &&
+      hasScmOnboarding &&
+      isPastPlatformFeatures,
   });
 
   const onboardingSteps = getOnboardingSteps({hasScmOnboarding, hasScmMessaging});

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -53,14 +53,10 @@ const NEW_ORG_ONBOARDING_WINDOW_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
 /**
  * Off until the messaging experiment ramps. The FlagPole config resolves every
  * production org to control today, so reporting now would fill the experiment
- * population with pre-launch control rows. Flip `enabled` in the same change
- * as the rollout segment.
- *
- * An object rather than a `const false`, so the property keeps type `boolean`
- * and the spec can flip it with `jest.replaceProperty`. A module export binding
- * has no setter, so a plain constant is not replaceable.
+ * population with pre-launch control rows. Flip this in the same change as the
+ * rollout segment.
  */
-export const SCM_MESSAGING_EXPOSURE = {enabled: false};
+const SCM_MESSAGING_EXPOSURE_ENABLED = false;
 
 const legacyOnboardingSteps: StepDescriptor[] = [
   {
@@ -347,7 +343,7 @@ export function OnboardingWithoutContext() {
   const {inExperiment: hasScmMessaging} = useExperiment({
     feature: 'onboarding-scm-messaging-experiment',
     reportExposure:
-      SCM_MESSAGING_EXPOSURE.enabled &&
+      SCM_MESSAGING_EXPOSURE_ENABLED &&
       isNewOrgOnboarding &&
       hasScmOnboarding &&
       isPastPlatformFeatures,

--- a/static/app/views/onboarding/onboarding.tsx
+++ b/static/app/views/onboarding/onboarding.tsx
@@ -55,6 +55,10 @@ const NEW_ORG_ONBOARDING_WINDOW_MS = 1000 * 60 * 60 * 24 * 7; // 7 days
  * production org to control today, so reporting now would fill the experiment
  * population with pre-launch control rows. Flip `enabled` in the same change
  * as the rollout segment.
+ *
+ * An object rather than a `const false`, so the property keeps type `boolean`
+ * and the spec can flip it with `jest.replaceProperty`. A module export binding
+ * has no setter, so a plain constant is not replaceable.
  */
 export const SCM_MESSAGING_EXPOSURE = {enabled: false};
 
@@ -330,10 +334,16 @@ export function OnboardingWithoutContext() {
   // The arms first differ after platform/features: treatment continues to the
   // messaging step, control to SDK setup. Exposure is reported once the user
   // is past that fork, from the route rather than the step list because the
-  // list itself depends on this assignment. Descendants consume the
-  // assignment with reportExposure: false.
+  // list itself depends on this assignment.
+  //
+  // The route alone is not enough: the invalid-state guards below redirect off
+  // both of these steps, and the redirect runs in an effect, so a bare route
+  // check reports exposure for a user who is sent back before either arm
+  // renders. Repeat the same staged-state conditions here.
   const isPastPlatformFeatures =
-    stepId === OnboardingStepId.SCM_MESSAGING || stepId === OnboardingStepId.SETUP_DOCS;
+    (stepId === OnboardingStepId.SCM_MESSAGING &&
+      defined(onboardingContext.selectedPlatform)) ||
+    (stepId === OnboardingStepId.SETUP_DOCS && defined(selectedProjectSlug));
   const {inExperiment: hasScmMessaging} = useExperiment({
     feature: 'onboarding-scm-messaging-experiment',
     reportExposure:


### PR DESCRIPTION
The onboarding host now reports exposure for `onboarding-scm-messaging-experiment` once the route is past platform/features, which is the first step where treatment and control differ: treatment goes to the messaging step and control to SDK setup. The gate reads the route rather than the step list because the step list itself depends on this assignment. Descendants keep `reportExposure: false`.

The route on its own is not enough. Both `scm-messaging` and `setup-docs` have invalid-state guards that redirect away, and the redirect runs in an effect, so the host commits one render with the gate on before the user is sent back. A control org on a stale messaging link, a treatment refresh with empty session storage, and a deep link to `setup-docs` would each land an org in the experiment population without either arm rendering. The gate repeats the staged-state conditions those guards use, so it only opens on a fork-side step that actually renders. One case stays open by design: a control org at `scm-messaging` with a platform already staged still reports. That takes a hand-edited URL, and closing it would need the assignment this hook call returns.

Reporting is on. The FlagPole rollout segment lands in getsentry/sentry-options-automator#9782, so the experiment no longer resolves every production org to control, and this PR goes out immediately after it. `SCM_MESSAGING_EXPOSURE_ENABLED` stays as the one place to turn reporting back off if the rollout is pulled.

No tests. The gate has no observable behavior in this repo: `useNoopExperiment` never reports, so a spec here can only assert the argument the host computed, a few lines from where the diff already shows it. Once-only reporting across remounts is the hook's responsibility and is covered by its own spec in gsApp.

Refs VDY-146

