### PR TITLE
feat(autofix): cap manual PR iteration feedback at 1000 characters

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -4205,6 +4205,14 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+# GitHub logins of bots exempt from MANUAL_FEEDBACK_MAX_LENGTH.
+register(
+    "autofix.pr-iteration.bot-feedback-allowlist",
+    type=Sequence,
+    default=[],
+    flags=FLAG_ALLOW_EMPTY | FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # TODO(telkins): Remove once we no longer need integration_id on SLO metrics
 register(
     "integrations.slo.integration-id-tag-enabled",

--- a/src/sentry/seer/autofix/pr_iteration/actors.py
+++ b/src/sentry/seer/autofix/pr_iteration/actors.py
@@ -1,0 +1,6 @@
+from __future__ import annotations
+
+
+def is_bot_login(login: str) -> bool:
+    """Whether a GitHub login belongs to an app identity, for example ``dependabot[bot]``."""
+    return login.lower().endswith("[bot]")

--- a/src/sentry/seer/autofix/pr_iteration/actors.py
+++ b/src/sentry/seer/autofix/pr_iteration/actors.py
@@ -1,6 +1,0 @@
-from __future__ import annotations
-
-
-def is_bot_login(login: str) -> bool:
-    """Whether a GitHub login belongs to an app identity, for example ``dependabot[bot]``."""
-    return login.lower().endswith("[bot]")

--- a/src/sentry/seer/autofix/pr_iteration/feedback_limits.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_limits.py
@@ -9,7 +9,7 @@ from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
 from sentry.utils import metrics
 
 # Keep in sync with AUTOFIX_USER_CONTEXT_MAX_LENGTH in the frontend autofix types.
-MANUAL_FEEDBACK_MAX_LENGTH = 3000
+MANUAL_FEEDBACK_MAX_LENGTH = 1000
 
 
 def _bot_feedback_allowlist() -> frozenset[str]:

--- a/src/sentry/seer/autofix/pr_iteration/feedback_limits.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_limits.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from typing import Any
+
+from sentry import options
+from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import Decision
+from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
+from sentry.utils import metrics
+
+# Keep in sync with AUTOFIX_USER_CONTEXT_MAX_LENGTH in the frontend autofix types.
+MANUAL_FEEDBACK_MAX_LENGTH = 3000
+
+
+def _bot_feedback_allowlist() -> frozenset[str]:
+    return frozenset(
+        login.lower()
+        for login in options.get("autofix.pr-iteration.bot-feedback-allowlist")
+        if isinstance(login, str)
+    )
+
+
+def check_feedback_length(log_ctx: PrIterationLogContext, feedback: Feedback) -> Decision:
+    """Decide whether one feedback item is too long.
+
+    Returns ``ok=True`` with ``reason="not_capped"`` for a source the cap does not
+    apply to, so the caller needs no special case.
+    """
+    source = feedback.source
+    if not source.length_capped:
+        return Decision(ok=True, reason="not_capped")
+
+    # ui_text is the author-written text. text adds the diff anchor.
+    length = len(feedback.ui_text)
+    if length <= MANUAL_FEEDBACK_MAX_LENGTH:
+        return Decision(ok=True, reason="within_limit")
+
+    actor = "bot" if source.actor_is_bot else "human"
+    login = source.actor_login
+    if actor == "bot" and login is not None and login.lower() in _bot_feedback_allowlist():
+        return Decision(ok=True, reason="bot_allowlisted")
+
+    metrics.incr(
+        "autofix.pr_iteration.feedback.over_length",
+        tags={"source": source.type, "actor": actor},
+    )
+    fields: dict[str, Any] = {
+        "feedback_source": source.type,
+        "feedback_id": feedback.feedback_id,
+        "feedback_length": length,
+        "limit": MANUAL_FEEDBACK_MAX_LENGTH,
+        "actor": actor,
+    }
+    if actor == "bot":
+        fields["bot_login"] = login
+    log_ctx.info("autofix.pr_iteration.feedback.over_length", **fields)
+    return Decision(ok=False, reason=f"over_length_{actor}")

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/base.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/base.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from pydantic import BaseModel, Field
 
 from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.autofix.pr_iteration.actors import is_bot_login
 
 
 class ConsumeTask:
@@ -80,6 +81,9 @@ class FeedbackSourceBase(BaseModel):
     # sources with none (UI) keep the UUID minted here.
     source_id: str = Field(default_factory=lambda: str(uuid4()))
 
+    # Per-subclass contract: False for text Sentry generated, True for text an actor wrote.
+    length_capped: ClassVar[bool] = False
+
     @property
     def text(self) -> str:
         """Verbatim text passed to the explorer agent in the prompt."""
@@ -89,6 +93,16 @@ class FeedbackSourceBase(BaseModel):
     def ui_text(self) -> str | None:
         """Text shown in the UI. ``None`` means fall back to ``text``."""
         return None
+
+    @property
+    def actor_login(self) -> str | None:
+        """The provider login of the actor that wrote this feedback."""
+        return None
+
+    @property
+    def actor_is_bot(self) -> bool:
+        login = self.actor_login
+        return self.is_automated or (login is not None and is_bot_login(login))
 
     @property
     def is_automated(self) -> bool:

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/base.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/base.py
@@ -8,7 +8,6 @@ from uuid import uuid4
 from pydantic import BaseModel, Field
 
 from sentry.seer.agent.client_models import SeerRunState
-from sentry.seer.autofix.pr_iteration.actors import is_bot_login
 
 
 class ConsumeTask:
@@ -101,8 +100,12 @@ class FeedbackSourceBase(BaseModel):
 
     @property
     def actor_is_bot(self) -> bool:
+        # Imported lazily: sentry.integrations.github pulls in the slack notification
+        # registry, and this module loads before it during app startup.
+        from sentry.integrations.github.utils import is_github_bot_login
+
         login = self.actor_login
-        return self.is_automated or (login is not None and is_bot_login(login))
+        return self.is_automated or is_github_bot_login(login)
 
     @property
     def is_automated(self) -> bool:

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/github_comment.py
@@ -73,6 +73,7 @@ class _GithubPrCommentFeedbackSourceBase(FeedbackSourceBase):
     # Per-subclass contract: must the comment be an ``@sentry`` iterate command?
     # Top-level PR comments require it; inline review comments don't.
     require_command: ClassVar[bool]
+    length_capped: ClassVar[bool] = True
     comment: GithubIssueComment
     # Derived from `comment` by `_parse_comment` — the single place a comment is
     # turned into feedback. Declared as a field (default "") so it serializes,
@@ -99,6 +100,10 @@ class _GithubPrCommentFeedbackSourceBase(FeedbackSourceBase):
     @property
     def text(self) -> str:
         return self.comment_feedback
+
+    @property
+    def actor_login(self) -> str | None:
+        return self.comment.user.login if self.comment.user else None
 
     def should_consume(self, run_state: SeerRunState) -> Decision:
         comment_id = self.comment.id
@@ -213,6 +218,7 @@ class GithubPrReviewBodyFeedbackSource(FeedbackSourceBase):
     """
 
     type: Literal["github-pr-review-body"] = "github-pr-review-body"
+    length_capped: ClassVar[bool] = True
     # The GitHub review id, used to dedupe re-delivered reviews.
     review_id: int | None = None
     # The submitted review's state — ``approved`` / ``changes_requested`` /
@@ -241,6 +247,10 @@ class GithubPrReviewBodyFeedbackSource(FeedbackSourceBase):
     @property
     def is_automated(self) -> bool:
         return self.author_is_bot
+
+    @property
+    def actor_login(self) -> str | None:
+        return self.user.login if self.user else None
 
     def should_consume(self, run_state: SeerRunState) -> Decision:
         if self.review_id is None:

--- a/src/sentry/seer/autofix/pr_iteration/feedback_sources/user_ui.py
+++ b/src/sentry/seer/autofix/pr_iteration/feedback_sources/user_ui.py
@@ -1,10 +1,11 @@
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import FeedbackSourceBase
 
 
 class UserUIFeedbackSource(FeedbackSourceBase):
     type: Literal["user-ui"] = "user-ui"
+    length_capped: ClassVar[bool] = True
     user_id: int
     user: Any = None
     # The feedback the user typed in the UI. Optional so feedback serialized

--- a/src/sentry/seer/autofix/pr_iteration/queue.py
+++ b/src/sentry/seer/autofix/pr_iteration/queue.py
@@ -8,7 +8,9 @@ from sentry.seer.agent.client_models import SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.emit import open_pr_iteration_details
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_limits import check_feedback_length
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
+from sentry.utils import metrics
 from sentry.utils.redis import load_redis_script, redis_clusters
 
 logger = logging.getLogger(__name__)
@@ -42,7 +44,10 @@ def try_enqueue_autofix_feedback(
     run_state: SeerRunState,
     actor_user_id: int | None = None,
 ) -> bool:
-    decision = feedback.source.should_queue(run_state)
+    feedback_length = len(feedback.ui_text)
+    decision = check_feedback_length(log_ctx, feedback)
+    if decision.ok:
+        decision = feedback.source.should_queue(run_state)
 
     if decision.ok:
         item = QueuedAutofixFeedback(
@@ -70,6 +75,16 @@ def try_enqueue_autofix_feedback(
                 group_id=group_id,
             )
 
+    metrics.distribution(
+        "autofix.pr_iteration.feedback.length",
+        feedback_length,
+        tags={
+            "source": feedback.source.type,
+            "actor": "bot" if feedback.source.actor_is_bot else "human",
+            "queued": "true" if decision.ok else "false",
+        },
+    )
+
     # One log name for both branches, emitted after the push so ``queued`` means
     # the feedback is actually in Redis: ``outcome`` says which way it went and
     # ``reason`` says what the gate read to get there.
@@ -79,6 +94,7 @@ def try_enqueue_autofix_feedback(
         reason=decision.reason,
         feedback_source=feedback.source.type,
         feedback_id=feedback.feedback_id,
+        feedback_length=feedback_length,
         referrer=referrer.value,
         actor_user_id=actor_user_id,
         **feedback.source.log_fields(run_state),

--- a/src/sentry/seer/autofix/pr_iteration/reviewer_candidates.py
+++ b/src/sentry/seer/autofix/pr_iteration/reviewer_candidates.py
@@ -50,6 +50,7 @@ from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.organization import Organization
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.repository import Repository
+from sentry.seer.autofix.pr_iteration.actors import is_bot_login
 from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker, record_run_marker
 from sentry.seer.models.run import SeerRun
 from sentry.seer.utils import get_github_username_for_user
@@ -159,7 +160,7 @@ def collect_reviewer_candidates(
         )
         for login in logins:
             key = login.lower()
-            if key in seen or key in excluded or _is_bot_login(login):
+            if key in seen or key in excluded or is_bot_login(login):
                 continue
             seen.add(key)
             candidates.append(ReviewerCandidate(login=login, source=source))
@@ -181,12 +182,6 @@ def collect_reviewer_candidates(
         resolve_source(source, resolve)
 
     return candidates[:MAX_CANDIDATES]
-
-
-def _is_bot_login(login: str) -> bool:
-    # GitHub app identities ("dependabot[bot]"). Human-named bot accounts are
-    # caught per source where richer data exists (e.g. the commit author type).
-    return login.lower().endswith("[bot]")
 
 
 def _triggering_user_logins(seer_run: SeerRun, organization: Organization) -> list[str]:

--- a/src/sentry/seer/autofix/pr_iteration/reviewer_candidates.py
+++ b/src/sentry/seer/autofix/pr_iteration/reviewer_candidates.py
@@ -42,6 +42,7 @@ from scm.helpers import iter_all_pages
 from scm.manager import SourceCodeManager
 from scm.types import GetCommitsByPathProtocol, GetPullRequestFilesProtocol, PullRequestFile
 
+from sentry.integrations.github.utils import is_github_bot_login
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.integrations.types import ExternalProviders
 from sentry.issues.ownership.grammar import get_codeowners_path_and_owners
@@ -50,7 +51,6 @@ from sentry.models.groupowner import GroupOwner, GroupOwnerType
 from sentry.models.organization import Organization
 from sentry.models.projectcodeowners import ProjectCodeOwners
 from sentry.models.repository import Repository
-from sentry.seer.autofix.pr_iteration.actors import is_bot_login
 from sentry.seer.autofix.pr_iteration.run_markers import get_run_marker, record_run_marker
 from sentry.seer.models.run import SeerRun
 from sentry.seer.utils import get_github_username_for_user
@@ -160,7 +160,7 @@ def collect_reviewer_candidates(
         )
         for login in logins:
             key = login.lower()
-            if key in seen or key in excluded or is_bot_login(login):
+            if key in seen or key in excluded or is_github_bot_login(login):
                 continue
             seen.add(key)
             candidates.append(ReviewerCandidate(login=login, source=source))

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -60,6 +60,9 @@ from sentry.seer.autofix.github_perms import (
     get_blocked_pr_iteration_permissions,
 )
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_limits import (
+    MANUAL_FEEDBACK_MAX_LENGTH,
+)
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
 from sentry.seer.autofix.pr_iteration.pause import (
     PAUSED_EXTRA,
@@ -165,7 +168,7 @@ class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
     )
     user_context = serializers.CharField(
         required=False,
-        max_length=1000,
+        max_length=MANUAL_FEEDBACK_MAX_LENGTH,
         help_text="Optional user context to append to the step prompt.",
         allow_blank=True,
     )

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -1201,7 +1201,7 @@ def trigger_pr_iteration_from_comment(
         raise ValueError(f"Missing group id in agent run {agent_state.run_id}")
 
     log_ctx = PrIterationLogContext.for_run(logger, agent_state, organization_id, group_id)
-    try_enqueue_autofix_feedback(
+    queued = try_enqueue_autofix_feedback(
         log_ctx=log_ctx,
         run_id=agent_state.run_id,
         organization_id=organization_id,
@@ -1211,6 +1211,10 @@ def trigger_pr_iteration_from_comment(
         run_state=agent_state,
         actor_user_id=resolved.actor_user.id if resolved.actor_user else None,
     )
+    # Nothing reached Redis, so an ack here acknowledges work that never happens.
+    if not queued:
+        return None
+
     trigger_consume_pr_iteration_feedback(
         log_ctx=log_ctx,
         run_id=agent_state.run_id,
@@ -1637,8 +1641,10 @@ def trigger_pr_iteration_from_review(
         raise ValueError(f"Missing group id in agent run {agent_state.run_id}")
 
     log_ctx = PrIterationLogContext.for_run(logger, agent_state, organization_id, group_id)
-    for feedback_obj in feedback_items:
-        try_enqueue_autofix_feedback(
+    queued_items = [
+        feedback_obj
+        for feedback_obj in feedback_items
+        if try_enqueue_autofix_feedback(
             log_ctx=log_ctx,
             run_id=agent_state.run_id,
             organization_id=organization_id,
@@ -1648,6 +1654,10 @@ def trigger_pr_iteration_from_review(
             run_state=agent_state,
             actor_user_id=actor_user.id if actor_user else None,
         )
+    ]
+    if not queued_items:
+        logger.info("autofix.pr_iteration.review_trigger.no_feedback_queued", extra=log_extra)
+        return None
 
     # A single consume pass drains everything queued above; trigger once using
     # the first item to decide the countdown (all share the same run).
@@ -1655,7 +1665,7 @@ def trigger_pr_iteration_from_review(
         log_ctx=log_ctx,
         run_id=agent_state.run_id,
         organization_id=organization_id,
-        feedback=feedback_items[0],
+        feedback=queued_items[0],
         run_state=agent_state,
     )
 
@@ -1664,7 +1674,7 @@ def trigger_pr_iteration_from_review(
     # comment consume will drop as stale.
     # TODO: doesn't cover consume's other drop paths (group missing, processing,
     # cap hit mid-drain) — reconcile with consume's outcome later.
-    for feedback_obj in feedback_items:
+    for feedback_obj in queued_items:
         source = feedback_obj.source
         if not isinstance(source, GithubPrReviewCommentFeedbackSource):
             continue

--- a/tests/sentry/seer/autofix/pr_iteration/test_feedback_limits.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_feedback_limits.py
@@ -1,0 +1,193 @@
+from unittest.mock import MagicMock, patch
+
+from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_limits import (
+    MANUAL_FEEDBACK_MAX_LENGTH,
+    check_feedback_length,
+)
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import Decision
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
+from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
+    GithubPrCommentFeedbackSource,
+    GithubPrReviewBodyFeedbackSource,
+    GithubPrReviewCommentFeedbackSource,
+)
+from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
+from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
+from sentry.testutils.cases import TestCase
+
+LIMITS_PATH = "sentry.seer.autofix.pr_iteration.feedback_limits"
+ALLOWLIST_OPTION = "autofix.pr-iteration.bot-feedback-allowlist"
+
+
+def _check_suite_event() -> dict:
+    return {
+        "check_suite": {
+            "id": 1,
+            "head_sha": "abc",
+            "check_runs_url": "https://github.com/owner/repo/check-runs",
+            "app": {"name": "CI"},
+            "updated_at": "2024-01-01T00:00:00Z",
+            "pull_requests": [{"id": 99}],
+        },
+        "repository": {
+            "html_url": "https://github.com/owner/repo",
+            "full_name": "owner/repo",
+            "id": 123,
+        },
+    }
+
+
+class CheckFeedbackLengthTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.log = MagicMock()
+        self.log_ctx = PrIterationLogContext(
+            self.log,
+            run_state=SeerRunState(
+                run_id=1,
+                blocks=[],
+                status="completed",
+                updated_at="2024-01-01T00:00:00Z",
+                repo_pr_states={},
+            ),
+            organization_id=self.organization.id,
+            group_id=1,
+        )
+
+    def _check(self, feedback: Feedback) -> tuple[Decision, MagicMock]:
+        with patch(f"{LIMITS_PATH}.metrics") as mock_metrics:
+            decision = check_feedback_length(self.log_ctx, feedback)
+        return decision, mock_metrics
+
+    def _ui_feedback(self, length: int) -> Feedback:
+        return Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="a" * length))
+
+    def _comment_feedback(self, length: int, *, login: str = "octocat") -> Feedback:
+        return Feedback(
+            source=GithubPrCommentFeedbackSource(
+                comment={"id": 5, "body": "@sentry " + "a" * length, "user": {"login": login}}
+            )
+        )
+
+    def test_a_length_at_the_limit_passes(self) -> None:
+        decision, _ = self._check(self._ui_feedback(MANUAL_FEEDBACK_MAX_LENGTH))
+
+        assert decision.ok is True
+        assert decision.reason == "within_limit"
+
+    def test_one_character_over_the_limit_is_blocked(self) -> None:
+        decision, _ = self._check(self._ui_feedback(MANUAL_FEEDBACK_MAX_LENGTH + 1))
+
+        assert decision.ok is False
+        assert decision.reason == "over_length_human"
+
+    def test_a_human_comment_over_the_limit_is_counted(self) -> None:
+        decision, mock_metrics = self._check(self._comment_feedback(MANUAL_FEEDBACK_MAX_LENGTH + 1))
+
+        assert decision.ok is False
+        assert decision.reason == "over_length_human"
+        mock_metrics.incr.assert_called_once_with(
+            "autofix.pr_iteration.feedback.over_length",
+            tags={"source": "github-pr-comment", "actor": "human"},
+        )
+
+    def test_a_bot_review_body_over_the_limit_is_counted_as_a_bot(self) -> None:
+        feedback = Feedback(
+            source=GithubPrReviewBodyFeedbackSource(
+                review_id=7,
+                body="a" * (MANUAL_FEEDBACK_MAX_LENGTH + 1),
+                user={"login": "coverage-bot-with-a-human-name"},
+                author_is_bot=True,
+            )
+        )
+
+        decision, mock_metrics = self._check(feedback)
+
+        assert decision.ok is False
+        assert decision.reason == "over_length_bot"
+        mock_metrics.incr.assert_called_once_with(
+            "autofix.pr_iteration.feedback.over_length",
+            tags={"source": "github-pr-review-body", "actor": "bot"},
+        )
+
+    def test_a_bot_login_suffix_is_enough_on_the_comment_path(self) -> None:
+        # The ``@sentry`` comment payload carries no ``author_is_bot`` field.
+        decision, mock_metrics = self._check(
+            self._comment_feedback(MANUAL_FEEDBACK_MAX_LENGTH + 1, login="codecov[bot]")
+        )
+
+        assert decision.ok is False
+        assert decision.reason == "over_length_bot"
+        mock_metrics.incr.assert_called_once_with(
+            "autofix.pr_iteration.feedback.over_length",
+            tags={"source": "github-pr-comment", "actor": "bot"},
+        )
+
+    def test_an_allowlisted_bot_passes_over_the_limit(self) -> None:
+        with self.options({ALLOWLIST_OPTION: ["codecov[bot]"]}):
+            decision, mock_metrics = self._check(
+                self._comment_feedback(MANUAL_FEEDBACK_MAX_LENGTH + 1, login="codecov[bot]")
+            )
+
+        assert decision.ok is True
+        assert decision.reason == "bot_allowlisted"
+        mock_metrics.incr.assert_not_called()
+
+    def test_the_allowlist_match_ignores_case(self) -> None:
+        with self.options({ALLOWLIST_OPTION: ["CodeCov[Bot]"]}):
+            decision, _ = self._check(
+                self._comment_feedback(MANUAL_FEEDBACK_MAX_LENGTH + 1, login="codecov[bot]")
+            )
+
+        assert decision.ok is True
+        assert decision.reason == "bot_allowlisted"
+
+    def test_the_allowlist_does_not_cover_a_human(self) -> None:
+        with self.options({ALLOWLIST_OPTION: ["octocat"]}):
+            decision, _ = self._check(
+                self._comment_feedback(MANUAL_FEEDBACK_MAX_LENGTH + 1, login="octocat")
+            )
+
+        assert decision.ok is False
+        assert decision.reason == "over_length_human"
+
+    def test_a_check_suite_is_not_capped(self) -> None:
+        event = _check_suite_event()
+        event["check_suite"]["app"]["name"] = "a" * (MANUAL_FEEDBACK_MAX_LENGTH + 1)
+        feedback = Feedback(source=CheckSuiteFeedbackSource(event=event))
+
+        decision, mock_metrics = self._check(feedback)
+
+        assert len(feedback.ui_text) > MANUAL_FEEDBACK_MAX_LENGTH
+
+        assert decision.ok is True
+        assert decision.reason == "not_capped"
+        mock_metrics.incr.assert_not_called()
+
+    def test_a_check_suite_actor_is_a_bot(self) -> None:
+        source = CheckSuiteFeedbackSource(event=_check_suite_event())
+
+        assert source.actor_is_bot is True
+
+    def test_an_inline_comment_measures_the_typed_body(self) -> None:
+        body = "a" * 20
+        feedback = Feedback(
+            source=GithubPrReviewCommentFeedbackSource(
+                comment={
+                    "id": 9,
+                    "body": body,
+                    "path": "src/sentry/foo.py",
+                    "diff_hunk": "d" * (MANUAL_FEEDBACK_MAX_LENGTH + 1),
+                    "user": {"login": "octocat"},
+                }
+            )
+        )
+
+        decision, mock_metrics = self._check(feedback)
+
+        assert decision.ok is True
+        assert decision.reason == "within_limit"
+        assert len(feedback.text) > MANUAL_FEEDBACK_MAX_LENGTH
+        mock_metrics.incr.assert_not_called()

--- a/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_feedback_queue.py
@@ -5,6 +5,7 @@ from sentry.seer.agent.client_models import RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.check_suites import CheckSuiteAutofixRun
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_limits import MANUAL_FEEDBACK_MAX_LENGTH
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import (
     CheckSuiteFeedbackSource,
 )
@@ -119,6 +120,51 @@ class TryEnqueueAutofixFeedbackTest(TestCase):
         queued = peek_queued_autofix_feedback(4242)
         assert len(queued) == 1
         assert queued[0].feedback.text == "fix it"
+
+    def test_blocks_feedback_over_the_length_limit(self) -> None:
+        feedback = Feedback(
+            source=UserUIFeedbackSource(
+                user_id=1, user_feedback="a" * (MANUAL_FEEDBACK_MAX_LENGTH + 1)
+            )
+        )
+
+        assert self._enqueue(run_id=5050, feedback=feedback) is False
+        assert peek_queued_autofix_feedback(5050) == []
+
+    def test_queues_feedback_at_the_length_limit_and_opens_the_buffer(self) -> None:
+        feedback = Feedback(
+            source=UserUIFeedbackSource(user_id=1, user_feedback="a" * MANUAL_FEEDBACK_MAX_LENGTH)
+        )
+
+        with patch(f"{QUEUE_PATH}.open_pr_iteration_details") as mock_open:
+            assert self._enqueue(run_id=5151, feedback=feedback) is True
+
+        assert len(peek_queued_autofix_feedback(5151)) == 1
+        mock_open.assert_called_once()
+
+    def test_records_the_length_of_every_arrival(self) -> None:
+        feedback = Feedback(source=UserUIFeedbackSource(user_id=1, user_feedback="fix it"))
+
+        with patch(f"{QUEUE_PATH}.metrics") as mock_metrics:
+            assert self._enqueue(run_id=5252, feedback=feedback) is True
+
+        mock_metrics.distribution.assert_called_once_with(
+            "autofix.pr_iteration.feedback.length",
+            len("fix it"),
+            tags={"source": "user-ui", "actor": "human", "queued": "true"},
+        )
+
+    def test_records_the_length_of_a_blocked_arrival(self) -> None:
+        feedback = Feedback(
+            source=UserUIFeedbackSource(
+                user_id=1, user_feedback="a" * (MANUAL_FEEDBACK_MAX_LENGTH + 1)
+            )
+        )
+
+        with patch(f"{QUEUE_PATH}.metrics") as mock_metrics:
+            assert self._enqueue(run_id=5353, feedback=feedback) is False
+
+        assert mock_metrics.distribution.call_args.kwargs["tags"]["queued"] == "false"
 
     def test_skips_stale_feedback(self) -> None:
         feedback = Feedback(source=_resolved_check_suite_source())

--- a/tests/sentry/seer/autofix/test_pr_iteration_review.py
+++ b/tests/sentry/seer/autofix/test_pr_iteration_review.py
@@ -8,12 +8,18 @@ from sentry.scm.types import PullRequestReviewEvent, SubscriptionEvent
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
+from sentry.seer.autofix.pr_iteration.feedback_limits import MANUAL_FEEDBACK_MAX_LENGTH
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewBodyFeedbackSource,
     GithubPrReviewCommentFeedbackSource,
 )
 from sentry.seer.autofix.pr_iteration.listeners.review import (
     handle_pull_request_review_for_autofix_iteration,
+)
+from sentry.seer.autofix.pr_iteration.queue import (
+    clear_queued_autofix_feedback,
+    peek_queued_autofix_feedback,
+    try_enqueue_autofix_feedback,
 )
 from sentry.tasks.seer.pr_iteration import _REVIEW_PAGE_SIZE, trigger_pr_iteration_from_review
 from sentry.testutils.cases import TestCase
@@ -813,6 +819,49 @@ class TriggerPrIterationFromReviewTest(TestCase):
         self.mock_enqueue.assert_called()
         self.mock_consume.assert_called_once()
         self.mock_actions.get_repository_user_permission.assert_not_called()
+
+    def _enqueue_for_real(self) -> None:
+        """Run the real queue gate, so the length cap applies to each item."""
+        clear_queued_autofix_feedback(67890)
+        self.addCleanup(clear_queued_autofix_feedback, 67890)
+        self.mock_enqueue.side_effect = try_enqueue_autofix_feedback
+
+    def test_an_over_long_inline_comment_is_dropped_and_the_rest_iterates(self) -> None:
+        self._enqueue_for_real()
+        self.mock_actions.get_review_comments.return_value = self._paginated(
+            [
+                self._review_comment(comment_id="1", body="a" * (MANUAL_FEEDBACK_MAX_LENGTH + 1)),
+                self._review_comment(comment_id="2", body="fix this"),
+            ]
+        )
+        self.mock_actions.get_pull_request_review.return_value = self._review_result(
+            {"id": "500", "html_url": "https://x/500", "body": ""}
+        )
+
+        self._run()
+
+        queued = peek_queued_autofix_feedback(67890)
+        assert [item.feedback.ui_text for item in queued] == ["fix this"]
+        self.mock_consume.assert_called_once()
+        # The dropped comment gets no ack: nothing reached Redis for it.
+        self.mock_actions.create_review_comment_reaction.assert_called_once()
+        assert self.mock_actions.create_review_comment_reaction.call_args.args[2] == "2"
+
+    def test_a_review_whose_every_item_is_over_long_queues_nothing(self) -> None:
+        self._enqueue_for_real()
+        long_text = "a" * (MANUAL_FEEDBACK_MAX_LENGTH + 1)
+        self.mock_actions.get_review_comments.return_value = self._paginated(
+            [self._review_comment(comment_id="1", body=long_text)]
+        )
+        self.mock_actions.get_pull_request_review.return_value = self._review_result(
+            {"id": "500", "html_url": "https://x/500", "body": long_text}
+        )
+
+        self._run()
+
+        assert peek_queued_autofix_feedback(67890) == []
+        self.mock_consume.assert_not_called()
+        self.mock_actions.create_review_comment_reaction.assert_not_called()
 
     def test_skips_review_with_no_author(self) -> None:
         # No author username means we can't check access, so drop without even

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -19,6 +19,7 @@ from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.github_perms import MissingGithubPermissions
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
+from sentry.seer.autofix.pr_iteration.feedback_limits import MANUAL_FEEDBACK_MAX_LENGTH
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import Decision
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
 from sentry.seer.autofix.pr_iteration.pause import (
@@ -852,6 +853,55 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
         assert mock_consume.call_args.kwargs["run_id"] == 123
         assert mock_consume.call_args.kwargs["organization_id"] == group.organization.id
         assert mock_consume.call_args.kwargs["bypass"] is True
+
+    @with_feature("organizations:autofix-pr-iteration-manual")
+    @patch("sentry.seer.endpoints.group_ai_autofix.trigger_consume_pr_iteration_feedback")
+    @patch("sentry.seer.endpoints.group_ai_autofix.try_enqueue_autofix_feedback")
+    @patch("sentry.seer.endpoints.group_ai_autofix.get_autofix_run_state")
+    def test_pr_iteration_accepts_user_context_at_the_limit(
+        self, mock_run_state, mock_try_enqueue, mock_consume
+    ):
+        group = self.create_group()
+        mock_run_state.return_value = SeerRunState(
+            run_id=123,
+            blocks=[],
+            status="completed",
+            updated_at="2024-01-01T00:00:00Z",
+            repo_pr_states={"owner/repo": RepoPRState(repo_name="owner/repo")},
+        )
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "pr_iteration",
+                "run_id": 123,
+                "user_context": "a" * MANUAL_FEEDBACK_MAX_LENGTH,
+            },
+            format="json",
+        )
+
+        assert response.status_code == 202, response.data
+        mock_try_enqueue.assert_called_once()
+
+    @with_feature("organizations:autofix-pr-iteration-manual")
+    @patch("sentry.seer.endpoints.group_ai_autofix.try_enqueue_autofix_feedback")
+    def test_pr_iteration_rejects_user_context_over_the_limit(self, mock_try_enqueue):
+        group = self.create_group()
+
+        self.login_as(user=self.user)
+        response = self.client.post(
+            self._get_url(group.id),
+            data={
+                "step": "pr_iteration",
+                "run_id": 123,
+                "user_context": "a" * (MANUAL_FEEDBACK_MAX_LENGTH + 1),
+            },
+            format="json",
+        )
+
+        assert response.status_code == 400, response.data
+        mock_try_enqueue.assert_not_called()
 
     @with_feature(
         {

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -1,7 +1,7 @@
 from contextlib import AbstractContextManager, nullcontext
 from datetime import timedelta
 from typing import Any, Literal
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from scm.errors import ResourceNotFound
@@ -24,6 +24,7 @@ from sentry.seer.autofix.pr_iteration.check_suites import CheckSuiteAutofixRun
 from sentry.seer.autofix.pr_iteration.details_store import open_iterations
 from sentry.seer.autofix.pr_iteration.emit import open_pr_iteration_details
 from sentry.seer.autofix.pr_iteration.feedback import Feedback, serialize_feedback
+from sentry.seer.autofix.pr_iteration.feedback_limits import MANUAL_FEEDBACK_MAX_LENGTH
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import (
     ConsumeTask,
     ConsumeTriggerSource,
@@ -47,6 +48,7 @@ from sentry.seer.autofix.pr_iteration.pause import (
 )
 from sentry.seer.autofix.pr_iteration.queue import (
     QueuedAutofixFeedback,
+    clear_queued_autofix_feedback,
     peek_queued_autofix_feedback,
     try_enqueue_autofix_feedback,
 )
@@ -205,6 +207,41 @@ class TriggerPrIterationFromCommentTest(TestCase):
             pr_number=7,
             comment_id=999,
             reaction="eyes",
+        )
+
+    @patch(f"{TASK_PATH}.metrics")
+    @patch(f"{TASK_PATH}._add_comment_reaction")
+    @patch(f"{TASK_PATH}._github_commenter_has_repo_write_access", return_value=True)
+    @patch(f"{TASK_PATH}.trigger_consume_pr_iteration_feedback")
+    @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")
+    def test_an_over_long_comment_queues_nothing_and_is_not_acked(
+        self,
+        mock_get_state: MagicMock,
+        mock_trigger_consume: MagicMock,
+        mock_has_access: MagicMock,
+        mock_reaction: MagicMock,
+        mock_metrics: MagicMock,
+    ) -> None:
+        mock_get_state.return_value = self._agent_state()
+        self.addCleanup(clear_queued_autofix_feedback, 67890)
+        self.feedback = Feedback(
+            source=GithubPrCommentFeedbackSource(
+                comment={
+                    "id": 999,
+                    "body": "@sentry " + "a" * (MANUAL_FEEDBACK_MAX_LENGTH + 1),
+                    "user": {"login": "octocat"},
+                }
+            )
+        )
+
+        self._call()
+
+        assert peek_queued_autofix_feedback(67890) == []
+        mock_trigger_consume.assert_not_called()
+        mock_reaction.assert_not_called()
+        assert (
+            call("autofix.pr_iteration.comment_trigger.success")
+            not in mock_metrics.incr.call_args_list
         )
 
     @patch(f"{TASK_PATH}.get_agent_state_from_pr_id")


### PR DESCRIPTION
Manual PR iteration feedback reaches the agent verbatim, so its length is an input-token cost. The drawer form capped `user_context` at 1000 characters. The `@sentry` comment and PR review paths had no cap.

- Enforce the existing 1000-character limit on every manual entry point at `try_enqueue_autofix_feedback`, the one function they all pass through.
- Over-long feedback is dropped. It is not acked with `:eyes:` and not counted as a trigger success.
- A bot whose login is in `autofix.pr-iteration.bot-feedback-allowlist` is exempt. Every other over-limit bot is blocked, with its login in the log. The human branch logs no identity.
- Record every item's length on `autofix.pr_iteration.feedback.length`, tagged by source, actor, and queued, so the limit can be tuned against the real distribution.

The cap is per item, so one over-long inline comment drops while the rest of a review still drives the iteration. The UI keeps returning 400 rather than dropping silently.

No frontend change is needed: `AUTOFIX_USER_CONTEXT_MAX_LENGTH` already matches at 1000.

https://claude.ai/code/session_01FWceLofCctKzK3pLAw14FP