### PR TITLE
feat(onboarding): Add SCM messaging step funnel analytics

### DIFF
--- a/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
@@ -8,7 +8,6 @@ import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
-import * as analytics from 'sentry/utils/analytics';
 
 import {useScmProjectCreation} from './useScmProjectCreation';
 
@@ -49,10 +48,7 @@ describe('useScmProjectCreation', () => {
     });
   }
 
-  let trackAnalyticsSpy: jest.SpyInstance;
-
   beforeEach(() => {
-    trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     TeamStore.loadInitialData([adminTeam]);
     ProjectsStore.loadInitialData([]);
     MockApiClient.addMockResponse({
@@ -71,7 +67,6 @@ describe('useScmProjectCreation', () => {
   });
 
   afterEach(() => {
-    trackAnalyticsSpy.mockRestore();
     TeamStore.reset();
     ProjectsStore.reset();
     MockApiClient.clearMockResponses();
@@ -111,14 +106,6 @@ describe('useScmProjectCreation', () => {
     expect(onCreatedProjectChange.mock.invocationCallOrder[0]).toBeLessThan(
       onSuccess.mock.invocationCallOrder[0]!
     );
-    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
-      'onboarding.scm_project_created',
-      expect.objectContaining({
-        platform: 'python',
-        project_id: createdProject.id,
-        notification: 'email_only',
-      })
-    );
   });
 
   it('reuses the created project when the platform is unchanged', async () => {
@@ -139,10 +126,6 @@ describe('useScmProjectCreation', () => {
     expect(createRequest).not.toHaveBeenCalled();
     expect(onSuccess).toHaveBeenCalledWith(
       expect.objectContaining({project: createdProject, reused: true})
-    );
-    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
-      'onboarding.scm_project_created',
-      expect.anything()
     );
   });
 
@@ -242,10 +225,6 @@ describe('useScmProjectCreation', () => {
     expect(outcome).toBeUndefined();
     expect(onCreatedProjectChange).not.toHaveBeenCalled();
     expect(onSuccess).not.toHaveBeenCalled();
-    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
-      'onboarding.scm_project_created',
-      expect.anything()
-    );
   });
 
   describe('messaging destination on reuse', () => {

--- a/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.spec.tsx
@@ -8,6 +8,7 @@ import {act, renderHookWithProviders} from 'sentry-test/reactTestingLibrary';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import * as analytics from 'sentry/utils/analytics';
 
 import {useScmProjectCreation} from './useScmProjectCreation';
 
@@ -48,7 +49,10 @@ describe('useScmProjectCreation', () => {
     });
   }
 
+  let trackAnalyticsSpy: jest.SpyInstance;
+
   beforeEach(() => {
+    trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     TeamStore.loadInitialData([adminTeam]);
     ProjectsStore.loadInitialData([]);
     MockApiClient.addMockResponse({
@@ -67,6 +71,7 @@ describe('useScmProjectCreation', () => {
   });
 
   afterEach(() => {
+    trackAnalyticsSpy.mockRestore();
     TeamStore.reset();
     ProjectsStore.reset();
     MockApiClient.clearMockResponses();
@@ -106,6 +111,14 @@ describe('useScmProjectCreation', () => {
     expect(onCreatedProjectChange.mock.invocationCallOrder[0]).toBeLessThan(
       onSuccess.mock.invocationCallOrder[0]!
     );
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.scm_project_created',
+      expect.objectContaining({
+        platform: 'python',
+        project_id: createdProject.id,
+        notification: 'email_only',
+      })
+    );
   });
 
   it('reuses the created project when the platform is unchanged', async () => {
@@ -126,6 +139,10 @@ describe('useScmProjectCreation', () => {
     expect(createRequest).not.toHaveBeenCalled();
     expect(onSuccess).toHaveBeenCalledWith(
       expect.objectContaining({project: createdProject, reused: true})
+    );
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'onboarding.scm_project_created',
+      expect.anything()
     );
   });
 
@@ -225,6 +242,10 @@ describe('useScmProjectCreation', () => {
     expect(outcome).toBeUndefined();
     expect(onCreatedProjectChange).not.toHaveBeenCalled();
     expect(onSuccess).not.toHaveBeenCalled();
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'onboarding.scm_project_created',
+      expect.anything()
+    );
   });
 
   describe('messaging destination on reuse', () => {

--- a/static/app/components/onboarding/scm/useScmProjectCreation.ts
+++ b/static/app/components/onboarding/scm/useScmProjectCreation.ts
@@ -11,6 +11,7 @@ import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
 import type {Team} from 'sentry/types/organization';
 import type {Project} from 'sentry/types/project';
+import {trackAnalytics} from 'sentry/utils/analytics';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {useProjects} from 'sentry/utils/useProjects';
 import {useTeams} from 'sentry/utils/useTeams';
@@ -181,6 +182,15 @@ export function useScmProjectCreation({
           messagingSelection: stagedSelection,
         });
 
+        // Recorded before the best-effort repository link: the project and its
+        // rules exist at this point whatever linking does.
+        trackAnalytics('onboarding.scm_project_created', {
+          organization,
+          platform: platform.key,
+          project_id: creation.project.id,
+          notification: creation.notificationRule ? 'integration' : 'email_only',
+        });
+
         if (selectedRepository?.id) {
           await linkProjectToRepository({
             orgSlug: organization.slug,
@@ -206,7 +216,7 @@ export function useScmProjectCreation({
       createProjectAndRules,
       createdProject,
       onCreatedProjectChange,
-      organization.slug,
+      organization,
       projects,
       selectedRepository,
       teams,

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -1,3 +1,9 @@
+/**
+ * Where the created project's issue alerts go: the server-created email rule
+ * only, or that plus a messaging integration workflow.
+ */
+export type ScmMessagingNotification = 'email_only' | 'integration';
+
 export type OnboardingEventParameters = {
   'onboarding.ai_prompt_copied': {
     platform: string;
@@ -79,6 +85,10 @@ export type OnboardingEventParameters = {
     platform: string;
     project_id: string;
   };
+  'onboarding.scm_messaging_completed': {
+    notification: ScmMessagingNotification;
+  };
+  'onboarding.scm_messaging_step_viewed': Record<string, unknown>;
   'onboarding.scm_next_step_clicked': {
     newOrg: boolean;
     platform: string;
@@ -96,6 +106,11 @@ export type OnboardingEventParameters = {
   'onboarding.scm_platform_selected': {
     platform: string;
     source: 'detected' | 'manual';
+  };
+  'onboarding.scm_project_created': {
+    notification: ScmMessagingNotification;
+    platform: string;
+    project_id: string;
   };
   'onboarding.scm_select_framework_modal_rendered': {
     platform: string;
@@ -203,6 +218,8 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.scm_dsn_copied': 'Onboarding: SCM DSN Copied',
   'onboarding.scm_js_loader_npm_docs_shown':
     'Onboarding: SCM JS Loader Switch to npm Instructions',
+  'onboarding.scm_messaging_completed': 'Onboarding: SCM Messaging Completed',
+  'onboarding.scm_messaging_step_viewed': 'Onboarding: SCM Messaging Step Viewed',
   'onboarding.scm_next_step_clicked': 'Onboarding: SCM Next Step Clicked',
   'onboarding.scm_select_framework_modal_rendered':
     'Onboarding: SCM Framework Modal Rendered',
@@ -219,6 +236,7 @@ export const onboardingEventMap: Record<keyof OnboardingEventParameters, string>
   'onboarding.scm_platform_features_step_viewed':
     'Onboarding: SCM Platform Features Step Viewed',
   'onboarding.scm_platform_selected': 'Onboarding: SCM Platform Selected',
+  'onboarding.scm_project_created': 'Onboarding: SCM Project Created',
   'onboarding.scm_skip_detection_clicked': 'Onboarding: SCM Skip Detection Clicked',
   'onboarding.scm_setup_platform_later_clicked':
     'Onboarding: SCM Setup Platform Later Clicked',

--- a/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
+++ b/static/app/utils/analytics/onboardingAnalyticsEvents.tsx
@@ -2,7 +2,7 @@
  * Where the created project's issue alerts go: the server-created email rule
  * only, or that plus a messaging integration workflow.
  */
-export type ScmMessagingNotification = 'email_only' | 'integration';
+type ScmMessagingNotification = 'email_only' | 'integration';
 
 export type OnboardingEventParameters = {
   'onboarding.ai_prompt_copied': {

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -580,11 +580,6 @@ describe('ScmMessaging', () => {
     expect(await screen.findByText('slack')).toBeInTheDocument();
     expect(screen.getByText('discord')).toBeInTheDocument();
     expect(screen.getByText('msteams')).toBeInTheDocument();
-    const stepViewedCalls = trackAnalyticsSpy.mock.calls.filter(
-      ([event]) => event === 'onboarding.scm_messaging_step_viewed'
-    );
-    expect(stepViewedCalls).toHaveLength(1);
-    expect(stepViewedCalls[0]![1]).toEqual({organization});
   });
 
   it('Continue is not rendered when no destination is configured', () => {

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -28,6 +28,7 @@ import * as pipelineModal from 'sentry/components/pipeline/modal';
 import {ProjectsStore} from 'sentry/stores/projectsStore';
 import {TeamStore} from 'sentry/stores/teamStore';
 import type {OrganizationIntegration} from 'sentry/types/integrations';
+import * as analytics from 'sentry/utils/analytics';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 
 import {ScmMessaging} from './scmMessaging';
@@ -160,7 +161,10 @@ function renderMessaging({
 }
 
 describe('ScmMessaging', () => {
+  let trackAnalyticsSpy: jest.SpyInstance;
+
   beforeEach(() => {
+    trackAnalyticsSpy = jest.spyOn(analytics, 'trackAnalytics');
     TeamStore.loadInitialData([adminTeam]);
     ProjectsStore.loadInitialData([]);
     mockProviderQueries();
@@ -179,6 +183,7 @@ describe('ScmMessaging', () => {
   });
 
   afterEach(() => {
+    trackAnalyticsSpy.mockRestore();
     cleanup();
     TeamStore.reset();
     ProjectsStore.reset();
@@ -575,6 +580,11 @@ describe('ScmMessaging', () => {
     expect(await screen.findByText('slack')).toBeInTheDocument();
     expect(screen.getByText('discord')).toBeInTheDocument();
     expect(screen.getByText('msteams')).toBeInTheDocument();
+    expect(
+      trackAnalyticsSpy.mock.calls.filter(
+        ([key]) => key === 'onboarding.scm_messaging_step_viewed'
+      )
+    ).toEqual([['onboarding.scm_messaging_step_viewed', {organization}]]);
   });
 
   it('Continue is not rendered when no destination is configured', () => {
@@ -699,6 +709,18 @@ describe('ScmMessaging', () => {
     expect(onCreatedProjectChange.mock.invocationCallOrder[0]).toBeLessThan(
       onComplete.mock.invocationCallOrder[0]!
     );
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.scm_project_created',
+      expect.objectContaining({
+        platform: selectedPlatform.key,
+        project_id: createdProject.id,
+        notification: 'integration',
+      })
+    );
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.scm_messaging_completed',
+      expect.objectContaining({notification: 'integration'})
+    );
   });
 
   it('Continue targets an MS Teams channel by its name', async () => {
@@ -804,6 +826,10 @@ describe('ScmMessaging', () => {
       slug: createdProject.slug,
       messagingSelection: undefined,
     });
+    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
+      'onboarding.scm_messaging_completed',
+      expect.objectContaining({notification: 'email_only'})
+    );
   });
 
   it('stays on the step with the destination staged when project creation fails', async () => {
@@ -829,6 +855,10 @@ describe('ScmMessaging', () => {
     expect(onMessagingSetupChange).not.toHaveBeenCalled();
     expect(onCreatedProjectChange).not.toHaveBeenCalled();
     expect(onComplete).not.toHaveBeenCalled();
+    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+      'onboarding.scm_messaging_completed',
+      expect.anything()
+    );
   });
 
   it('Set up later keeps the staged destination when project creation fails', async () => {
@@ -945,6 +975,10 @@ describe('ScmMessaging', () => {
       expect(createProjectRequest).not.toHaveBeenCalled();
       expect(createWorkflowRequest).not.toHaveBeenCalled();
       expect(onCreatedProjectChange).not.toHaveBeenCalled();
+      expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
+        'onboarding.scm_messaging_completed',
+        expect.anything()
+      );
     });
 
     it('Set up later completes without any requests whatever the project was created for', async () => {

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -580,11 +580,11 @@ describe('ScmMessaging', () => {
     expect(await screen.findByText('slack')).toBeInTheDocument();
     expect(screen.getByText('discord')).toBeInTheDocument();
     expect(screen.getByText('msteams')).toBeInTheDocument();
-    expect(
-      trackAnalyticsSpy.mock.calls.filter(
-        ([key]) => key === 'onboarding.scm_messaging_step_viewed'
-      )
-    ).toEqual([['onboarding.scm_messaging_step_viewed', {organization}]]);
+    const stepViewedCalls = trackAnalyticsSpy.mock.calls.filter(
+      ([event]) => event === 'onboarding.scm_messaging_step_viewed'
+    );
+    expect(stepViewedCalls).toHaveLength(1);
+    expect(stepViewedCalls[0]![1]).toEqual({organization});
   });
 
   it('Continue is not rendered when no destination is configured', () => {

--- a/static/app/views/onboarding/scmMessaging.spec.tsx
+++ b/static/app/views/onboarding/scmMessaging.spec.tsx
@@ -705,14 +705,6 @@ describe('ScmMessaging', () => {
       onComplete.mock.invocationCallOrder[0]!
     );
     expect(trackAnalyticsSpy).toHaveBeenCalledWith(
-      'onboarding.scm_project_created',
-      expect.objectContaining({
-        platform: selectedPlatform.key,
-        project_id: createdProject.id,
-        notification: 'integration',
-      })
-    );
-    expect(trackAnalyticsSpy).toHaveBeenCalledWith(
       'onboarding.scm_messaging_completed',
       expect.objectContaining({notification: 'integration'})
     );
@@ -850,10 +842,6 @@ describe('ScmMessaging', () => {
     expect(onMessagingSetupChange).not.toHaveBeenCalled();
     expect(onCreatedProjectChange).not.toHaveBeenCalled();
     expect(onComplete).not.toHaveBeenCalled();
-    expect(trackAnalyticsSpy).not.toHaveBeenCalledWith(
-      'onboarding.scm_messaging_completed',
-      expect.anything()
-    );
   });
 
   it('Set up later keeps the staged destination when project creation fails', async () => {

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -27,6 +27,8 @@ import {IconMail} from 'sentry/icons/iconMail';
 import {t} from 'sentry/locale';
 import type {Repository} from 'sentry/types/integrations';
 import type {OnboardingSelectedSDK} from 'sentry/types/onboarding';
+import {trackAnalytics} from 'sentry/utils/analytics';
+import {useOrganization} from 'sentry/utils/useOrganization';
 import {SCM_STEP_CONTENT_WIDTH} from 'sentry/views/onboarding/consts';
 import {
   buildIntegrationAction,
@@ -70,6 +72,7 @@ export function ScmMessaging({
   selectedPlatform,
   selectedRepository,
 }: ScmMessagingProps) {
+  const organization = useOrganization();
   const {createOrReuseProject, isCreating, isDataPending} = useScmProjectCreation({
     createdProject,
     onCreatedProjectChange,
@@ -95,6 +98,10 @@ export function ScmMessaging({
   } = useScmMessagingProviders();
 
   const [activeRow, setActiveRow] = useState<ScmMessagingActiveRow>(null);
+
+  useEffect(() => {
+    trackAnalytics('onboarding.scm_messaging_step_viewed', {organization});
+  }, [organization]);
 
   const validatedActiveRow = validateActiveRow(activeRow, providers, messagingSetup);
   const visibleProviders = listedProviders(providers, validatedActiveRow, messagingSetup);
@@ -153,11 +160,19 @@ export function ScmMessaging({
         : {defaultRules: true},
       getIntegrationAction: includeMessagingRule ? getIntegrationAction : undefined,
       stagedSelection,
-      onSuccess: () => {
+      onSuccess: ({reused}) => {
         // Record the skip only on success: a failed creation keeps the staged
         // destination (and the Continue button) intact on the step.
         if (!includeMessagingRule) {
           onMessagingSetupChange({mode: 'skipped'});
+        }
+        // An unchanged Back-navigation reuse completes the step again but
+        // creates nothing, so it is not a second completion.
+        if (!reused) {
+          trackAnalytics('onboarding.scm_messaging_completed', {
+            organization,
+            notification: includeMessagingRule ? 'integration' : 'email_only',
+          });
         }
         onComplete(selectedPlatform, {
           product: selectedFeatures ?? DEFAULT_SCM_FEATURES,

--- a/static/app/views/onboarding/scmMessaging.tsx
+++ b/static/app/views/onboarding/scmMessaging.tsx
@@ -160,7 +160,7 @@ export function ScmMessaging({
         : {defaultRules: true},
       getIntegrationAction: includeMessagingRule ? getIntegrationAction : undefined,
       stagedSelection,
-      onSuccess: ({reused}) => {
+      onSuccess: ({reused, notificationRule}) => {
         // Record the skip only on success: a failed creation keeps the staged
         // destination (and the Continue button) intact on the step.
         if (!includeMessagingRule) {
@@ -171,7 +171,11 @@ export function ScmMessaging({
         if (!reused) {
           trackAnalytics('onboarding.scm_messaging_completed', {
             organization,
-            notification: includeMessagingRule ? 'integration' : 'email_only',
+            // Read from the created rule, the same source
+            // scm_project_created reads, so the two events cannot disagree
+            // about one submission. `includeMessagingRule` is the intent, and
+            // an intent that builds no integration action creates no rule.
+            notification: notificationRule ? 'integration' : 'email_only',
           });
         }
         onComplete(selectedPlatform, {


### PR DESCRIPTION
The treatment messaging step now fires `onboarding.scm_messaging_step_viewed` on mount and `onboarding.scm_messaging_completed` after the blocking project and rule creation succeeds, with `notification` set to `email_only` or `integration`. The shared creation hook fires `onboarding.scm_project_created` for both arms with the same `notification` value, so control and treatment share one project outcome and nothing depends on the retired Project Details event names.

Neither event fires for an unchanged Back-navigation reuse, which creates nothing, and a creation failure fires nothing. The outcome is recorded before the best-effort repository link, so a link failure does not suppress it. Payloads carry the platform key, the project id, and the notification value only. Continue and Set up later clicks already fire through the Button analytics props and are unchanged. Interaction-level events on the step stay with VDY-164.

The assertions sit inside the existing creation, Set up later, failure, and reuse tests rather than in new ones.

Refs VDY-146
