### PR TITLE
feat(onboarding): Polish the welcome setup cards

### DIFF
--- a/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
+++ b/static/app/views/onboarding/agenticProgress/agenticProgressList.tsx
@@ -17,9 +17,10 @@ import {
   IconCircleDashed,
   IconFatal,
   IconNot,
-  IconPieHalf,
+  IconWarning,
 } from 'sentry/icons';
 import {t, tct, tn} from 'sentry/locale';
+import type {TagVariant} from 'sentry/utils/theme';
 import {useProjects} from 'sentry/utils/useProjects';
 
 import {FirstIssueCard} from './firstIssueCard';
@@ -50,17 +51,14 @@ const STATUS_LABELS: Record<AgenticProgressStageStatus, string> = {
   failed: t('Failed'),
 };
 
-const STATUS_VARIANTS: Record<
-  AgenticProgressStageStatus,
-  'promotion' | 'warning' | 'success' | 'muted' | 'danger'
-> = {
-  active: 'promotion',
+const STATUS_VARIANTS = {
+  active: 'info',
   waiting: 'warning',
   completed: 'success',
   skipped: 'muted',
   bypassed: 'muted',
   failed: 'danger',
-};
+} as const satisfies Record<AgenticProgressStageStatus, TagVariant>;
 
 function StageSymbol({status}: {status: AgenticProgressStageStatus | null}) {
   if (status === 'completed') {
@@ -80,7 +78,7 @@ function StageSymbol({status}: {status: AgenticProgressStageStatus | null}) {
   }
 
   if (status === 'waiting') {
-    return <IconPieHalf size="md" variant="warning" />;
+    return <IconWarning size="md" variant="warning" />;
   }
 
   if (status === 'active') {

--- a/static/app/views/onboarding/components/agentInfo.tsx
+++ b/static/app/views/onboarding/components/agentInfo.tsx
@@ -1,8 +1,8 @@
 import {InlineCode} from '@sentry/scraps/code';
+import {InfoText} from '@sentry/scraps/info';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
-import {Hovercard} from 'sentry/components/hovercard';
 import {IconCheckmark, IconInfo} from 'sentry/icons';
 import {t, tct} from 'sentry/locale';
 
@@ -19,9 +19,12 @@ interface AgentInfoProps {
 
 export function AgentInfo({onboardingCode}: AgentInfoProps) {
   return (
-    <Hovercard
+    <InfoText
       position="top"
-      body={
+      maxWidth={320}
+      size="md"
+      variant="muted"
+      title={
         <Stack gap="xl">
           <Stack gap="md">
             {AGENT_CAPABILITIES.map(capability => (
@@ -29,7 +32,7 @@ export function AgentInfo({onboardingCode}: AgentInfoProps) {
                 <Flex justify="center">
                   <IconCheckmark size="sm" variant="success" />
                 </Flex>
-                <Text variant="muted" size="sm">
+                <Text variant="muted" size="sm" align="left">
                   {capability}
                 </Text>
               </Grid>
@@ -40,7 +43,7 @@ export function AgentInfo({onboardingCode}: AgentInfoProps) {
               <Flex justify="center" paddingTop="2xs">
                 <IconInfo size="xs" variant="secondary" />
               </Flex>
-              <Text variant="muted" size="sm">
+              <Text variant="muted" size="sm" align="left">
                 {tct(
                   'Your agent uses ID [onboardingCode] to report setup progress here. Progress updates sent with this ID never include any part of your source code.',
                   {
@@ -53,9 +56,7 @@ export function AgentInfo({onboardingCode}: AgentInfoProps) {
         </Stack>
       }
     >
-      <Text size="md" variant="muted" underline="dotted">
-        {t('What your agent will do')}
-      </Text>
-    </Hovercard>
+      {t('What your agent will do')}
+    </InfoText>
   );
 }

--- a/static/app/views/onboarding/components/agentInfo.tsx
+++ b/static/app/views/onboarding/components/agentInfo.tsx
@@ -1,4 +1,3 @@
-import {Button} from '@sentry/scraps/button';
 import {InlineCode} from '@sentry/scraps/code';
 import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
@@ -54,11 +53,9 @@ export function AgentInfo({onboardingCode}: AgentInfoProps) {
         </Stack>
       }
     >
-      <Button variant="link" size="zero" icon={<IconInfo variant="secondary" />}>
-        <Text size="sm" variant="muted" underline="dotted">
-          {t('What will my agent do?')}
-        </Text>
-      </Button>
+      <Text size="md" variant="muted" underline="dotted">
+        {t('What your agent will do')}
+      </Text>
     </Hovercard>
   );
 }

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -1,3 +1,4 @@
+import {ThemeProvider, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
@@ -7,6 +8,7 @@ import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconBot} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {useInvertedTheme} from 'sentry/utils/theme/useInvertedTheme';
 import {AgentInfo} from 'sentry/views/onboarding/components/agentInfo';
 import {SETUP_CARD_ICON_PX, SETUP_CARD_ICON_SIZE} from 'sentry/views/onboarding/consts';
 
@@ -75,13 +77,13 @@ export function AgentSetupCard({
           <Container borderLeft="muted" />
         </Flex>
         <Container flexGrow={1} minWidth="0px" paddingTop="lg" paddingBottom="2xl">
-          <CodeBlock
+          <DarkCodeBlock
             alwaysShowCopyButton
             onCopy={() => onCopyCommand('install_command')}
             wrapMode="wrap"
           >
             {INSTALL_PLUGIN_COMMAND}
-          </CodeBlock>
+          </DarkCodeBlock>
         </Container>
       </Flex>
 
@@ -96,19 +98,40 @@ export function AgentSetupCard({
               {t('Point it to your project folder and paste this.')}
             </Text>
           </Stack>
-          <CodeBlock
+          <DarkCodeBlock
             alwaysShowCopyButton={!hasSetupFailed}
             hideCopyButton={hasSetupFailed}
             onCopy={() => onCopyCommand('prompt')}
             wrapMode="wrap"
           >
             {prompt}
-          </CodeBlock>
+          </DarkCodeBlock>
         </Stack>
       </Flex>
     </Stack>
   );
 }
+
+function DarkCodeBlock(props: React.ComponentProps<typeof CodeBlock>) {
+  const theme = useTheme();
+  const invertedTheme = useInvertedTheme();
+  const isInverted = theme.type === 'light';
+  return (
+    <ThemeProvider theme={isInverted ? invertedTheme : theme}>
+      <DarkCodeSurface isInverted={isInverted}>
+        <CodeBlock {...props} />
+      </DarkCodeSurface>
+    </ThemeProvider>
+  );
+}
+
+const DarkCodeSurface = styled('div')<{isInverted: boolean}>`
+  --prism-base: ${p => p.theme.tokens.syntax.base};
+  --prism-block-background: ${p =>
+    p.isInverted
+      ? p.theme.tokens.background.secondary
+      : p.theme.tokens.background.tertiary};
+`;
 
 const StepNumber = styled('span')`
   display: inline-flex;

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -2,7 +2,7 @@ import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {CodeBlock} from '@sentry/scraps/code';
-import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconBot} from 'sentry/icons';
@@ -39,32 +39,22 @@ export function AgentSetupCard({
   prompt,
 }: AgentSetupCardProps) {
   return (
-    <Grid
-      columns="max-content 1fr"
-      gap="lg xl"
-      border="primary"
-      radius="xl"
-      padding="xl 2xl"
-      areas={`
-        "icon    title"
-        ".       title"
-        "stepOne stepOneTitle"
-        "line    stepOneBody"
-        "stepTwo stepTwoTitle"
-        ".       stepTwoBody"
-      `}
-    >
-      <Flex area="icon" align="center" justify="center">
-        <IconBot size={ICON_SIZE} variant="secondary" />
-      </Flex>
-      <Stack area="title" paddingBottom="xl" gap="md">
+    <Stack border="primary" radius="xl" padding="xl 2xl" gap="0">
+      <Flex align="center" gap="xl">
+        <Flex width={ICON_PX} flexShrink={0} justify="center">
+          <IconBot size={ICON_SIZE} variant="secondary" />
+        </Flex>
         <Flex align="center" gap="md" wrap="wrap">
           <Heading as="h3" size="lg">
             {t('Set up with your coding agent')}
           </Heading>
           <Tag variant="info">{t('Recommended')}</Tag>
         </Flex>
-        <Stack area="meta" gap="xs">
+      </Flex>
+
+      <Flex gap="xl" paddingTop="md" paddingBottom="2xl">
+        <Container width={ICON_PX} flexShrink={0} />
+        <Stack gap="xs">
           <Flex align="center" gap="xs" wrap="wrap">
             <Text variant="muted" size="md">
               {t('Works with')}
@@ -75,47 +65,52 @@ export function AgentSetupCard({
             <AgentInfo onboardingCode={onboardingCode} />
           </Flex>
         </Stack>
-      </Stack>
-
-      <Flex area="stepOne" align="center" justify="center">
-        <StepNumber>1</StepNumber>
       </Flex>
-      <Container area="stepOneTitle">
+
+      <Flex align="center" gap="xl">
+        <Flex width={ICON_PX} flexShrink={0} justify="center">
+          <StepNumber>1</StepNumber>
+        </Flex>
         <Text size="md">{t('Install the Sentry plugin for your agent')}</Text>
-      </Container>
-      <Flex area="line" justify="center">
-        <Container borderLeft="muted" />
       </Flex>
-      <Container area="stepOneBody" paddingBottom="lg">
-        <CodeBlock
-          alwaysShowCopyButton
-          onCopy={() => onCopyCommand('install_command')}
-          wrapMode="wrap"
-        >
-          {INSTALL_PLUGIN_COMMAND}
-        </CodeBlock>
-      </Container>
 
-      <Flex area="stepTwo" align="center" justify="center">
-        <StepNumber>2</StepNumber>
+      <Flex gap="xl">
+        <Flex width={ICON_PX} flexShrink={0} justify="center" paddingTop="md">
+          <Container borderLeft="muted" />
+        </Flex>
+        <Container flexGrow={1} minWidth="0px" paddingTop="lg" paddingBottom="2xl">
+          <CodeBlock
+            alwaysShowCopyButton
+            onCopy={() => onCopyCommand('install_command')}
+            wrapMode="wrap"
+          >
+            {INSTALL_PLUGIN_COMMAND}
+          </CodeBlock>
+        </Container>
       </Flex>
-      <Container area="stepTwoTitle">
-        <Text size="md">{t('Ask your agent to set up Sentry')}</Text>
-      </Container>
-      <Stack area="stepTwoBody" gap="lg">
-        <Text variant="muted" size="md">
-          {t('Point it to your project folder and paste this.')}
-        </Text>
-        <CodeBlock
-          alwaysShowCopyButton={!hasSetupFailed}
-          hideCopyButton={hasSetupFailed}
-          onCopy={() => onCopyCommand('prompt')}
-          wrapMode="wrap"
-        >
-          {prompt}
-        </CodeBlock>
-      </Stack>
-    </Grid>
+
+      <Flex gap="xl" paddingTop="md">
+        <Flex width={ICON_PX} flexShrink={0} justify="center">
+          <StepNumber>2</StepNumber>
+        </Flex>
+        <Stack width="100%" gap="lg">
+          <Stack gap="sm">
+            <Text size="md">{t('Ask your agent to set up Sentry')}</Text>
+            <Text variant="muted" size="md">
+              {t('Point it to your project folder and paste this.')}
+            </Text>
+          </Stack>
+          <CodeBlock
+            alwaysShowCopyButton={!hasSetupFailed}
+            hideCopyButton={hasSetupFailed}
+            onCopy={() => onCopyCommand('prompt')}
+            wrapMode="wrap"
+          >
+            {prompt}
+          </CodeBlock>
+        </Stack>
+      </Flex>
+    </Stack>
   );
 }
 

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -6,17 +6,13 @@ import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconBot} from 'sentry/icons';
-import {SvgIcon} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
-import type {IconSize} from 'sentry/utils/theme';
 import {AgentInfo} from 'sentry/views/onboarding/components/agentInfo';
+import {SETUP_CARD_ICON_PX, SETUP_CARD_ICON_SIZE} from 'sentry/views/onboarding/consts';
 
 export type AgentSetupCopySource = 'install_command' | 'prompt';
 
 const INSTALL_PLUGIN_COMMAND = 'npx @sentry/agent-plugin install';
-
-const ICON_SIZE: IconSize = 'md';
-const ICON_PX = SvgIcon.ICON_SIZES[ICON_SIZE] as `${number}px`;
 
 const SUPPORTED_AGENTS = ['Claude Code', 'Codex', 'Cursor', 'Grok'];
 const SUPPORTED_AGENTS_LABEL = t(
@@ -41,8 +37,8 @@ export function AgentSetupCard({
   return (
     <Stack border="primary" radius="xl" padding="xl 2xl" gap="0">
       <Flex align="center" gap="xl">
-        <Flex width={ICON_PX} flexShrink={0} justify="center">
-          <IconBot size={ICON_SIZE} variant="secondary" />
+        <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center">
+          <IconBot size={SETUP_CARD_ICON_SIZE} variant="secondary" />
         </Flex>
         <Flex align="center" gap="md" wrap="wrap">
           <Heading as="h3" size="lg">
@@ -53,7 +49,7 @@ export function AgentSetupCard({
       </Flex>
 
       <Flex gap="xl" paddingTop="md" paddingBottom="2xl">
-        <Container width={ICON_PX} flexShrink={0} />
+        <Container width={SETUP_CARD_ICON_PX} flexShrink={0} />
         <Stack gap="xs">
           <Flex align="center" gap="xs" wrap="wrap">
             <Text variant="muted" size="md">
@@ -68,14 +64,14 @@ export function AgentSetupCard({
       </Flex>
 
       <Flex align="center" gap="xl">
-        <Flex width={ICON_PX} flexShrink={0} justify="center">
+        <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center">
           <StepNumber>1</StepNumber>
         </Flex>
         <Text size="md">{t('Install the Sentry plugin for your agent')}</Text>
       </Flex>
 
       <Flex gap="xl">
-        <Flex width={ICON_PX} flexShrink={0} justify="center" paddingTop="md">
+        <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center" paddingTop="md">
           <Container borderLeft="muted" />
         </Flex>
         <Container flexGrow={1} minWidth="0px" paddingTop="lg" paddingBottom="2xl">
@@ -90,7 +86,7 @@ export function AgentSetupCard({
       </Flex>
 
       <Flex gap="xl" paddingTop="md">
-        <Flex width={ICON_PX} flexShrink={0} justify="center">
+        <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center">
           <StepNumber>2</StepNumber>
         </Flex>
         <Stack width="100%" gap="lg">
@@ -119,8 +115,8 @@ const StepNumber = styled('span')`
   align-items: center;
   justify-content: center;
   flex-shrink: 0;
-  width: ${ICON_PX};
-  height: ${ICON_PX};
+  width: ${SETUP_CARD_ICON_PX};
+  height: ${SETUP_CARD_ICON_PX};
   border-radius: 50%;
   background: ${p => p.theme.tokens.background.warning.vibrant};
   color: ${p => p.theme.tokens.content.onVibrant.dark};

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -16,11 +16,10 @@ export type AgentSetupCopySource = 'install_command' | 'prompt';
 const INSTALL_PLUGIN_COMMAND = 'npx @sentry/agent-plugin install';
 
 const SUPPORTED_AGENTS = ['Claude Code', 'Codex', 'Cursor', 'Grok'];
-const SUPPORTED_AGENTS_LABEL = t(
-  '%s & %s',
-  SUPPORTED_AGENTS.slice(0, -1).join(', '),
-  SUPPORTED_AGENTS.at(-1)
-);
+const SUPPORTED_AGENTS_LABEL = new Intl.ListFormat(undefined, {
+  style: 'short',
+  type: 'conjunction',
+}).format(SUPPORTED_AGENTS);
 
 interface AgentSetupCardProps {
   onCopyCommand: (source: AgentSetupCopySource) => void;

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -1,6 +1,7 @@
 import {Tag} from '@sentry/scraps/badge';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Separator} from '@sentry/scraps/separator';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {List} from 'sentry/components/list';
@@ -35,7 +36,7 @@ export function AgentSetupCard({
   prompt,
 }: AgentSetupCardProps) {
   return (
-    <Stack border="primary" radius="xl" padding="xl 2xl" gap="0">
+    <Stack border="primary" radius="xl" padding="xl" gap="0">
       <Flex align="center" gap="md">
         <Flex width={SETUP_CARD_MARKER_PX} flexShrink={0} justify="center">
           <IconBot size={SETUP_CARD_ICON_SIZE} variant="secondary" />
@@ -65,7 +66,7 @@ export function AgentSetupCard({
 
       <List symbol="colored-numeric">
         <ListItem>
-          <Stack gap="lg" paddingBottom="2xl">
+          <Stack gap="lg" paddingTop="xs" paddingBottom="2xl">
             <Text size="md">{t('Install the Sentry plugin for your agent')}</Text>
             <CodeBlock
               dark
@@ -76,13 +77,26 @@ export function AgentSetupCard({
               {INSTALL_PLUGIN_COMMAND}
             </CodeBlock>
           </Stack>
+          <Flex
+            position="absolute"
+            top={SETUP_CARD_MARKER_PX}
+            bottom="0"
+            left="0"
+            width={SETUP_CARD_MARKER_PX}
+            paddingTop="xs"
+            justify="center"
+          >
+            <Separator orientation="vertical" border="muted" />
+          </Flex>
         </ListItem>
         <ListItem>
-          <Stack gap="lg">
-            <Text size="md">{t('Ask your agent to set up Sentry')}</Text>
-            <Text variant="muted" size="md">
-              {t('Point it to your project folder and paste this.')}
-            </Text>
+          <Stack gap="lg" paddingTop="xs">
+            <Stack gap="xs">
+              <Text size="md">{t('Ask your agent to set up Sentry')}</Text>
+              <Text variant="muted" size="md">
+                {t('Point it to your project folder and paste this.')}
+              </Text>
+            </Stack>
             <CodeBlock
               dark
               alwaysShowCopyButton={!hasSetupFailed}

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -1,14 +1,29 @@
+import styled from '@emotion/styled';
+
+import {Tag} from '@sentry/scraps/badge';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconBot} from 'sentry/icons';
+import {SvgIcon} from 'sentry/icons/svgIcon';
 import {t} from 'sentry/locale';
+import type {IconSize} from 'sentry/utils/theme';
 import {AgentInfo} from 'sentry/views/onboarding/components/agentInfo';
 
 export type AgentSetupCopySource = 'install_command' | 'prompt';
 
 const INSTALL_PLUGIN_COMMAND = 'npx @sentry/agent-plugin install';
+
+const ICON_SIZE: IconSize = 'md';
+const ICON_PX = SvgIcon.ICON_SIZES[ICON_SIZE] as `${number}px`;
+
+const SUPPORTED_AGENTS = ['Claude Code', 'Codex', 'Cursor', 'Grok'];
+const SUPPORTED_AGENTS_LABEL = t(
+  '%s & %s',
+  SUPPORTED_AGENTS.slice(0, -1).join(', '),
+  SUPPORTED_AGENTS.at(-1)
+);
 
 interface AgentSetupCardProps {
   onCopyCommand: (source: AgentSetupCopySource) => void;
@@ -24,68 +39,98 @@ export function AgentSetupCard({
   prompt,
 }: AgentSetupCardProps) {
   return (
-    <Stack border="primary" radius="xl" overflow="hidden" gap="0">
-      <Grid
-        columns="min-content 1fr"
-        gap="xl lg"
-        align="center"
-        padding="xl"
-        areas={`
-          "icon title"
-          ".    body"
-        `}
-      >
-        <Flex area="icon" align="center">
-          <IconBot size="sm" variant="secondary" />
-        </Flex>
-        <Container area="title">
+    <Grid
+      columns="max-content 1fr"
+      gap="lg xl"
+      border="primary"
+      radius="xl"
+      padding="xl 2xl"
+      areas={`
+        "icon    title"
+        ".       title"
+        "stepOne stepOneTitle"
+        "line    stepOneBody"
+        "stepTwo stepTwoTitle"
+        ".       stepTwoBody"
+      `}
+    >
+      <Flex area="icon" align="center" justify="center">
+        <IconBot size={ICON_SIZE} variant="secondary" />
+      </Flex>
+      <Stack area="title" paddingBottom="xl" gap="md">
+        <Flex align="center" gap="md" wrap="wrap">
           <Heading as="h3" size="lg">
             {t('Set up with your coding agent')}
           </Heading>
-        </Container>
-
-        <Stack area="body" gap="2xl">
-          <Stack gap="md">
-            <Text size="md">{t('First, install the Sentry plugin')}</Text>
-            <CodeBlock
-              alwaysShowCopyButton
-              onCopy={() => onCopyCommand('install_command')}
-              wrapMode="wrap"
-            >
-              {INSTALL_PLUGIN_COMMAND}
-            </CodeBlock>
-          </Stack>
-
-          <Stack gap="lg">
-            <Stack gap="md">
-              <Text size="md">{t('Then point your agent to your code and ask')}</Text>
-              <CodeBlock
-                alwaysShowCopyButton={!hasSetupFailed}
-                hideCopyButton={hasSetupFailed}
-                onCopy={() => onCopyCommand('prompt')}
-                wrapMode="wrap"
-              >
-                {prompt}
-              </CodeBlock>
-            </Stack>
-            <Flex>
-              <AgentInfo onboardingCode={onboardingCode} />
-            </Flex>
-          </Stack>
+          <Tag variant="info">{t('Recommended')}</Tag>
+        </Flex>
+        <Stack area="meta" gap="xs">
+          <Flex align="center" gap="xs" wrap="wrap">
+            <Text variant="muted" size="md">
+              {t('Works with')}
+            </Text>
+            <Text size="md">{SUPPORTED_AGENTS_LABEL}</Text>
+          </Flex>
+          <Flex>
+            <AgentInfo onboardingCode={onboardingCode} />
+          </Flex>
         </Stack>
-      </Grid>
+      </Stack>
 
-      <Flex
-        align="center"
-        justify="center"
-        background="secondary"
-        borderTop="muted"
-        padding="md xl"
-      >
-        <Text variant="muted" size="sm">
-          {t('Works with: Claude, Codex, Grok, and Cursor')}
-        </Text>
+      <Flex area="stepOne" align="center" justify="center">
+        <StepNumber>1</StepNumber>
       </Flex>
-    </Stack>
+      <Container area="stepOneTitle">
+        <Text size="md">{t('Install the Sentry plugin for your agent')}</Text>
+      </Container>
+      <Flex area="line" justify="center">
+        <Container borderLeft="muted" />
+      </Flex>
+      <Container area="stepOneBody" paddingBottom="lg">
+        <CodeBlock
+          alwaysShowCopyButton
+          onCopy={() => onCopyCommand('install_command')}
+          wrapMode="wrap"
+        >
+          {INSTALL_PLUGIN_COMMAND}
+        </CodeBlock>
+      </Container>
+
+      <Flex area="stepTwo" align="center" justify="center">
+        <StepNumber>2</StepNumber>
+      </Flex>
+      <Container area="stepTwoTitle">
+        <Text size="md">{t('Ask your agent to set up Sentry')}</Text>
+      </Container>
+      <Stack area="stepTwoBody" gap="lg">
+        <Text variant="muted" size="md">
+          {t('Point it to your project folder and paste this.')}
+        </Text>
+        <CodeBlock
+          alwaysShowCopyButton={!hasSetupFailed}
+          hideCopyButton={hasSetupFailed}
+          onCopy={() => onCopyCommand('prompt')}
+          wrapMode="wrap"
+        >
+          {prompt}
+        </CodeBlock>
+      </Stack>
+    </Grid>
   );
 }
+
+const StepNumber = styled('span')`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: ${ICON_PX};
+  height: ${ICON_PX};
+  border-radius: 50%;
+  background: ${p => p.theme.tokens.background.warning.vibrant};
+  color: ${p => p.theme.tokens.content.onVibrant.dark};
+  font-size: ${p => p.theme.font.size.xs};
+  font-weight: ${p => p.theme.font.weight.sans.medium};
+  line-height: 1;
+  box-shadow: 0 0 0 2px ${p => p.theme.tokens.border.warning.vibrant};
+`;

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -1,6 +1,6 @@
 import {Tag} from '@sentry/scraps/badge';
 import {CodeBlock} from '@sentry/scraps/code';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid, Stack} from '@sentry/scraps/layout';
 import {Separator} from '@sentry/scraps/separator';
 import {Heading, Text} from '@sentry/scraps/text';
 
@@ -36,79 +36,87 @@ export function AgentSetupCard({
   prompt,
 }: AgentSetupCardProps) {
   return (
-    <Stack border="primary" radius="xl" padding="xl" gap="0">
-      <Flex align="center" gap="md">
-        <Flex width={SETUP_CARD_MARKER_PX} flexShrink={0} justify="center">
-          <IconBot size={SETUP_CARD_ICON_SIZE} variant="secondary" />
-        </Flex>
-        <Flex align="center" gap="md" wrap="wrap">
-          <Heading as="h3" size="lg">
-            {t('Set up with your coding agent')}
-          </Heading>
-          <Tag variant="info">{t('Recommended')}</Tag>
-        </Flex>
+    <Grid
+      columns={`${SETUP_CARD_MARKER_PX} 1fr`}
+      gap="0 md"
+      border="primary"
+      radius="xl"
+      padding="xl"
+      areas={`
+        "icon  title"
+        ".     meta"
+        "steps steps"
+      `}
+    >
+      <Flex area="icon" align="center" justify="center">
+        <IconBot size={SETUP_CARD_ICON_SIZE} variant="secondary" />
+      </Flex>
+      <Flex area="title" align="center" gap="md" wrap="wrap">
+        <Heading as="h3" size="lg">
+          {t('Set up with your coding agent')}
+        </Heading>
+        <Tag variant="info">{t('Recommended')}</Tag>
       </Flex>
 
-      <Flex gap="md" paddingTop="md" paddingBottom="2xl">
-        <Container width={SETUP_CARD_MARKER_PX} flexShrink={0} />
-        <Stack gap="xs">
-          <Flex align="center" gap="xs" wrap="wrap">
-            <Text variant="muted" size="md">
-              {t('Works with')}
-            </Text>
-            <Text size="md">{SUPPORTED_AGENTS_LABEL}</Text>
-          </Flex>
-          <Flex>
-            <AgentInfo onboardingCode={onboardingCode} />
-          </Flex>
-        </Stack>
-      </Flex>
+      <Stack area="meta" gap="xs" paddingTop="md" paddingBottom="2xl">
+        <Flex align="center" gap="xs" wrap="wrap">
+          <Text variant="muted" size="md">
+            {t('Works with')}
+          </Text>
+          <Text size="md">{SUPPORTED_AGENTS_LABEL}</Text>
+        </Flex>
+        <Flex>
+          <AgentInfo onboardingCode={onboardingCode} />
+        </Flex>
+      </Stack>
 
-      <List symbol="colored-numeric">
-        <ListItem>
-          <Stack gap="lg" paddingTop="xs" paddingBottom="2xl">
-            <Text size="md">{t('Install the Sentry plugin for your agent')}</Text>
-            <CodeBlock
-              dark
-              alwaysShowCopyButton
-              onCopy={() => onCopyCommand('install_command')}
-              wrapMode="wrap"
-            >
-              {INSTALL_PLUGIN_COMMAND}
-            </CodeBlock>
-          </Stack>
-          <Flex
-            position="absolute"
-            top={SETUP_CARD_MARKER_PX}
-            bottom="0"
-            left="0"
-            width={SETUP_CARD_MARKER_PX}
-            paddingTop="xs"
-            justify="center"
-          >
-            <Separator orientation="vertical" border="muted" />
-          </Flex>
-        </ListItem>
-        <ListItem>
-          <Stack gap="lg" paddingTop="xs">
-            <Stack gap="xs">
-              <Text size="md">{t('Ask your agent to set up Sentry')}</Text>
-              <Text variant="muted" size="md">
-                {t('Point it to your project folder and paste this.')}
-              </Text>
+      <Container area="steps">
+        <List symbol="colored-numeric">
+          <ListItem>
+            <Stack gap="lg" paddingTop="xs" paddingBottom="2xl">
+              <Text size="md">{t('Install the Sentry plugin for your agent')}</Text>
+              <CodeBlock
+                dark
+                alwaysShowCopyButton
+                onCopy={() => onCopyCommand('install_command')}
+                wrapMode="wrap"
+              >
+                {INSTALL_PLUGIN_COMMAND}
+              </CodeBlock>
             </Stack>
-            <CodeBlock
-              dark
-              alwaysShowCopyButton={!hasSetupFailed}
-              hideCopyButton={hasSetupFailed}
-              onCopy={() => onCopyCommand('prompt')}
-              wrapMode="wrap"
+            <Flex
+              position="absolute"
+              top={SETUP_CARD_MARKER_PX}
+              bottom="0"
+              left="0"
+              width={SETUP_CARD_MARKER_PX}
+              paddingTop="xs"
+              justify="center"
             >
-              {prompt}
-            </CodeBlock>
-          </Stack>
-        </ListItem>
-      </List>
-    </Stack>
+              <Separator orientation="vertical" border="muted" />
+            </Flex>
+          </ListItem>
+          <ListItem>
+            <Stack gap="lg" paddingTop="xs">
+              <Stack gap="xs">
+                <Text size="md">{t('Ask your agent to set up Sentry')}</Text>
+                <Text variant="muted" size="md">
+                  {t('Point it to your project folder and paste this.')}
+                </Text>
+              </Stack>
+              <CodeBlock
+                dark
+                alwaysShowCopyButton={!hasSetupFailed}
+                hideCopyButton={hasSetupFailed}
+                onCopy={() => onCopyCommand('prompt')}
+                wrapMode="wrap"
+              >
+                {prompt}
+              </CodeBlock>
+            </Stack>
+          </ListItem>
+        </List>
+      </Container>
+    </Grid>
   );
 }

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -1,14 +1,13 @@
-import {ThemeProvider, useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Tag} from '@sentry/scraps/badge';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Separator} from '@sentry/scraps/separator';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import {IconBot} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {useInvertedTheme} from 'sentry/utils/theme/useInvertedTheme';
 import {AgentInfo} from 'sentry/views/onboarding/components/agentInfo';
 import {SETUP_CARD_ICON_PX, SETUP_CARD_ICON_SIZE} from 'sentry/views/onboarding/consts';
 
@@ -74,16 +73,17 @@ export function AgentSetupCard({
 
       <Flex gap="xl">
         <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center" paddingTop="md">
-          <Container borderLeft="muted" />
+          <Separator orientation="vertical" border="muted" />
         </Flex>
         <Container flexGrow={1} minWidth="0px" paddingTop="lg" paddingBottom="2xl">
-          <DarkCodeBlock
+          <CodeBlock
+            dark
             alwaysShowCopyButton
             onCopy={() => onCopyCommand('install_command')}
             wrapMode="wrap"
           >
             {INSTALL_PLUGIN_COMMAND}
-          </DarkCodeBlock>
+          </CodeBlock>
         </Container>
       </Flex>
 
@@ -98,40 +98,20 @@ export function AgentSetupCard({
               {t('Point it to your project folder and paste this.')}
             </Text>
           </Stack>
-          <DarkCodeBlock
+          <CodeBlock
+            dark
             alwaysShowCopyButton={!hasSetupFailed}
             hideCopyButton={hasSetupFailed}
             onCopy={() => onCopyCommand('prompt')}
             wrapMode="wrap"
           >
             {prompt}
-          </DarkCodeBlock>
+          </CodeBlock>
         </Stack>
       </Flex>
     </Stack>
   );
 }
-
-function DarkCodeBlock(props: React.ComponentProps<typeof CodeBlock>) {
-  const theme = useTheme();
-  const invertedTheme = useInvertedTheme();
-  const isInverted = theme.type === 'light';
-  return (
-    <ThemeProvider theme={isInverted ? invertedTheme : theme}>
-      <DarkCodeSurface isInverted={isInverted}>
-        <CodeBlock {...props} />
-      </DarkCodeSurface>
-    </ThemeProvider>
-  );
-}
-
-const DarkCodeSurface = styled('div')<{isInverted: boolean}>`
-  --prism-base: ${p => p.theme.tokens.syntax.base};
-  --prism-block-background: ${p =>
-    p.isInverted
-      ? p.theme.tokens.background.secondary
-      : p.theme.tokens.background.tertiary};
-`;
 
 const StepNumber = styled('span')`
   display: inline-flex;

--- a/static/app/views/onboarding/components/agentSetupCard.tsx
+++ b/static/app/views/onboarding/components/agentSetupCard.tsx
@@ -1,15 +1,14 @@
-import styled from '@emotion/styled';
-
 import {Tag} from '@sentry/scraps/badge';
 import {CodeBlock} from '@sentry/scraps/code';
 import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Separator} from '@sentry/scraps/separator';
 import {Heading, Text} from '@sentry/scraps/text';
 
+import {List} from 'sentry/components/list';
+import {ListItem} from 'sentry/components/list/listItem';
 import {IconBot} from 'sentry/icons';
 import {t} from 'sentry/locale';
 import {AgentInfo} from 'sentry/views/onboarding/components/agentInfo';
-import {SETUP_CARD_ICON_PX, SETUP_CARD_ICON_SIZE} from 'sentry/views/onboarding/consts';
+import {SETUP_CARD_ICON_SIZE, SETUP_CARD_MARKER_PX} from 'sentry/views/onboarding/consts';
 
 export type AgentSetupCopySource = 'install_command' | 'prompt';
 
@@ -37,8 +36,8 @@ export function AgentSetupCard({
 }: AgentSetupCardProps) {
   return (
     <Stack border="primary" radius="xl" padding="xl 2xl" gap="0">
-      <Flex align="center" gap="xl">
-        <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center">
+      <Flex align="center" gap="md">
+        <Flex width={SETUP_CARD_MARKER_PX} flexShrink={0} justify="center">
           <IconBot size={SETUP_CARD_ICON_SIZE} variant="secondary" />
         </Flex>
         <Flex align="center" gap="md" wrap="wrap">
@@ -49,8 +48,8 @@ export function AgentSetupCard({
         </Flex>
       </Flex>
 
-      <Flex gap="xl" paddingTop="md" paddingBottom="2xl">
-        <Container width={SETUP_CARD_ICON_PX} flexShrink={0} />
+      <Flex gap="md" paddingTop="md" paddingBottom="2xl">
+        <Container width={SETUP_CARD_MARKER_PX} flexShrink={0} />
         <Stack gap="xs">
           <Flex align="center" gap="xs" wrap="wrap">
             <Text variant="muted" size="md">
@@ -64,67 +63,38 @@ export function AgentSetupCard({
         </Stack>
       </Flex>
 
-      <Flex align="center" gap="xl">
-        <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center">
-          <StepNumber>1</StepNumber>
-        </Flex>
-        <Text size="md">{t('Install the Sentry plugin for your agent')}</Text>
-      </Flex>
-
-      <Flex gap="xl">
-        <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center" paddingTop="md">
-          <Separator orientation="vertical" border="muted" />
-        </Flex>
-        <Container flexGrow={1} minWidth="0px" paddingTop="lg" paddingBottom="2xl">
-          <CodeBlock
-            dark
-            alwaysShowCopyButton
-            onCopy={() => onCopyCommand('install_command')}
-            wrapMode="wrap"
-          >
-            {INSTALL_PLUGIN_COMMAND}
-          </CodeBlock>
-        </Container>
-      </Flex>
-
-      <Flex gap="xl" paddingTop="md">
-        <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center">
-          <StepNumber>2</StepNumber>
-        </Flex>
-        <Stack width="100%" gap="lg">
-          <Stack gap="sm">
+      <List symbol="colored-numeric">
+        <ListItem>
+          <Stack gap="lg" paddingBottom="2xl">
+            <Text size="md">{t('Install the Sentry plugin for your agent')}</Text>
+            <CodeBlock
+              dark
+              alwaysShowCopyButton
+              onCopy={() => onCopyCommand('install_command')}
+              wrapMode="wrap"
+            >
+              {INSTALL_PLUGIN_COMMAND}
+            </CodeBlock>
+          </Stack>
+        </ListItem>
+        <ListItem>
+          <Stack gap="lg">
             <Text size="md">{t('Ask your agent to set up Sentry')}</Text>
             <Text variant="muted" size="md">
               {t('Point it to your project folder and paste this.')}
             </Text>
+            <CodeBlock
+              dark
+              alwaysShowCopyButton={!hasSetupFailed}
+              hideCopyButton={hasSetupFailed}
+              onCopy={() => onCopyCommand('prompt')}
+              wrapMode="wrap"
+            >
+              {prompt}
+            </CodeBlock>
           </Stack>
-          <CodeBlock
-            dark
-            alwaysShowCopyButton={!hasSetupFailed}
-            hideCopyButton={hasSetupFailed}
-            onCopy={() => onCopyCommand('prompt')}
-            wrapMode="wrap"
-          >
-            {prompt}
-          </CodeBlock>
-        </Stack>
-      </Flex>
+        </ListItem>
+      </List>
     </Stack>
   );
 }
-
-const StepNumber = styled('span')`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
-  width: ${SETUP_CARD_ICON_PX};
-  height: ${SETUP_CARD_ICON_PX};
-  border-radius: 50%;
-  background: ${p => p.theme.tokens.background.warning.vibrant};
-  color: ${p => p.theme.tokens.content.onVibrant.dark};
-  font-size: ${p => p.theme.font.size.xs};
-  font-weight: ${p => p.theme.font.weight.sans.medium};
-  line-height: 1;
-  box-shadow: 0 0 0 2px ${p => p.theme.tokens.border.warning.vibrant};
-`;

--- a/static/app/views/onboarding/components/manualSetupCard.tsx
+++ b/static/app/views/onboarding/components/manualSetupCard.tsx
@@ -15,7 +15,7 @@ interface ManualSetupCardProps {
 export function ManualSetupCard({onSetupInBrowser}: ManualSetupCardProps) {
   return (
     <CardButton onClick={onSetupInBrowser} data-test-id="onboarding-setup-in-browser">
-      <Stack border="primary" radius="xl" padding="xl 2xl" gap="0" width="100%">
+      <Stack border="primary" radius="xl" padding="xl" gap="0" width="100%">
         <Flex align="center" gap="md">
           <Flex width={SETUP_CARD_MARKER_PX} flexShrink={0} justify="center">
             <IconSliders size={SETUP_CARD_ICON_SIZE} variant="secondary" />

--- a/static/app/views/onboarding/components/manualSetupCard.tsx
+++ b/static/app/views/onboarding/components/manualSetupCard.tsx
@@ -4,7 +4,7 @@ import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {ScmCardButton} from 'sentry/components/onboarding/scm/scmCardButton';
-import {IconSliders} from 'sentry/icons';
+import {IconChevron, IconSliders} from 'sentry/icons';
 import {t} from 'sentry/locale';
 
 interface ManualSetupCardProps {
@@ -15,16 +15,16 @@ export function ManualSetupCard({onSetupInBrowser}: ManualSetupCardProps) {
   return (
     <CardButton onClick={onSetupInBrowser} data-test-id="onboarding-setup-in-browser">
       <Grid
-        columns="min-content 1fr"
-        gap="md lg"
+        columns="min-content 1fr min-content"
+        gap="xs xl"
         align="center"
         border="primary"
         radius="xl"
         padding="xl"
         width="100%"
         areas={`
-          "icon title"
-          ".    body"
+          "icon title chevron"
+          ".    body  body"
         `}
       >
         <Flex area="icon" align="center">
@@ -32,9 +32,12 @@ export function ManualSetupCard({onSetupInBrowser}: ManualSetupCardProps) {
         </Flex>
         <Container area="title">
           <Text bold size="lg">
-            {t('Set up manually instead')}
+            {t('Set up manually')}
           </Text>
         </Container>
+        <Flex area="chevron" align="center">
+          <IconChevron direction="right" size="sm" variant="secondary" />
+        </Flex>
         <Container area="body">
           <Text variant="muted" size="md" density="comfortable" textWrap="pretty">
             {t(

--- a/static/app/views/onboarding/components/manualSetupCard.tsx
+++ b/static/app/views/onboarding/components/manualSetupCard.tsx
@@ -1,11 +1,12 @@
 import styled from '@emotion/styled';
 
-import {Container, Flex, Grid} from '@sentry/scraps/layout';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {ScmCardButton} from 'sentry/components/onboarding/scm/scmCardButton';
 import {IconChevron, IconSliders} from 'sentry/icons';
 import {t} from 'sentry/locale';
+import {SETUP_CARD_ICON_PX, SETUP_CARD_ICON_SIZE} from 'sentry/views/onboarding/consts';
 
 interface ManualSetupCardProps {
   onSetupInBrowser: () => void;
@@ -14,38 +15,36 @@ interface ManualSetupCardProps {
 export function ManualSetupCard({onSetupInBrowser}: ManualSetupCardProps) {
   return (
     <CardButton onClick={onSetupInBrowser} data-test-id="onboarding-setup-in-browser">
-      <Grid
-        columns="min-content 1fr min-content"
-        gap="xs xl"
-        align="center"
-        border="primary"
-        radius="xl"
-        padding="xl"
-        width="100%"
-        areas={`
-          "icon title chevron"
-          ".    body  body"
-        `}
-      >
-        <Flex area="icon" align="center">
-          <IconSliders size="sm" variant="secondary" />
+      <Stack border="primary" radius="xl" padding="xl 2xl" gap="0" width="100%">
+        <Flex align="center" gap="xl">
+          <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center">
+            <IconSliders size={SETUP_CARD_ICON_SIZE} variant="secondary" />
+          </Flex>
+          <Container flexGrow={1} minWidth="0px">
+            <Text bold size="lg">
+              {t('Set up manually')}
+            </Text>
+          </Container>
+          <Flex flexShrink={0} align="center">
+            <IconChevron
+              direction="right"
+              size={SETUP_CARD_ICON_SIZE}
+              variant="secondary"
+            />
+          </Flex>
         </Flex>
-        <Container area="title">
-          <Text bold size="lg">
-            {t('Set up manually')}
-          </Text>
-        </Container>
-        <Flex area="chevron" align="center">
-          <IconChevron direction="right" size="sm" variant="secondary" />
+
+        <Flex gap="xl" paddingTop="xs">
+          <Container width={SETUP_CARD_ICON_PX} flexShrink={0} />
+          <Container flexGrow={1} minWidth="0px">
+            <Text variant="muted" size="md" density="comfortable" textWrap="pretty">
+              {t(
+                'Connect a repo, choose what to instrument and where alerts land, then follow the instructions for your project'
+              )}
+            </Text>
+          </Container>
         </Flex>
-        <Container area="body">
-          <Text variant="muted" size="md" density="comfortable" textWrap="pretty">
-            {t(
-              'Connect a repo, choose what to instrument and where alerts land, then follow the instructions for your project'
-            )}
-          </Text>
-        </Container>
-      </Grid>
+      </Stack>
     </CardButton>
   );
 }

--- a/static/app/views/onboarding/components/manualSetupCard.tsx
+++ b/static/app/views/onboarding/components/manualSetupCard.tsx
@@ -1,12 +1,12 @@
 import styled from '@emotion/styled';
 
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Container, Flex, Grid} from '@sentry/scraps/layout';
 import {Text} from '@sentry/scraps/text';
 
 import {ScmCardButton} from 'sentry/components/onboarding/scm/scmCardButton';
 import {IconChevron, IconSliders} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {SETUP_CARD_MARKER_PX, SETUP_CARD_ICON_SIZE} from 'sentry/views/onboarding/consts';
+import {SETUP_CARD_ICON_SIZE, SETUP_CARD_MARKER_PX} from 'sentry/views/onboarding/consts';
 
 interface ManualSetupCardProps {
   onSetupInBrowser: () => void;
@@ -15,36 +15,41 @@ interface ManualSetupCardProps {
 export function ManualSetupCard({onSetupInBrowser}: ManualSetupCardProps) {
   return (
     <CardButton onClick={onSetupInBrowser} data-test-id="onboarding-setup-in-browser">
-      <Stack border="primary" radius="xl" padding="xl" gap="0" width="100%">
-        <Flex align="center" gap="md">
-          <Flex width={SETUP_CARD_MARKER_PX} flexShrink={0} justify="center">
-            <IconSliders size={SETUP_CARD_ICON_SIZE} variant="secondary" />
-          </Flex>
-          <Container flexGrow={1} minWidth="0px">
-            <Text bold size="lg">
-              {t('Set up manually')}
-            </Text>
-          </Container>
-          <Flex flexShrink={0} align="center">
-            <IconChevron
-              direction="right"
-              size={SETUP_CARD_ICON_SIZE}
-              variant="secondary"
-            />
-          </Flex>
+      <Grid
+        columns={`${SETUP_CARD_MARKER_PX} 1fr max-content`}
+        gap="0 md"
+        border="primary"
+        radius="xl"
+        padding="xl"
+        width="100%"
+        areas={`
+          "icon title chevron"
+          ".    body  body"
+        `}
+      >
+        <Flex area="icon" align="center" justify="center">
+          <IconSliders size={SETUP_CARD_ICON_SIZE} variant="secondary" />
         </Flex>
-
-        <Flex gap="md" paddingTop="xs">
-          <Container width={SETUP_CARD_MARKER_PX} flexShrink={0} />
-          <Container flexGrow={1} minWidth="0px">
-            <Text variant="muted" size="md" density="comfortable" textWrap="pretty">
-              {t(
-                'Connect a repo, choose what to instrument and where alerts land, then follow the instructions for your project'
-              )}
-            </Text>
-          </Container>
+        <Flex area="title" align="center">
+          <Text bold size="lg">
+            {t('Set up manually')}
+          </Text>
         </Flex>
-      </Stack>
+        <Flex area="chevron" align="center">
+          <IconChevron
+            direction="right"
+            size={SETUP_CARD_ICON_SIZE}
+            variant="secondary"
+          />
+        </Flex>
+        <Container area="body" paddingTop="xs">
+          <Text variant="muted" size="md" density="comfortable" textWrap="pretty">
+            {t(
+              'Connect a repo, choose what to instrument and where alerts land, then follow the instructions for your project'
+            )}
+          </Text>
+        </Container>
+      </Grid>
     </CardButton>
   );
 }

--- a/static/app/views/onboarding/components/manualSetupCard.tsx
+++ b/static/app/views/onboarding/components/manualSetupCard.tsx
@@ -6,7 +6,7 @@ import {Text} from '@sentry/scraps/text';
 import {ScmCardButton} from 'sentry/components/onboarding/scm/scmCardButton';
 import {IconChevron, IconSliders} from 'sentry/icons';
 import {t} from 'sentry/locale';
-import {SETUP_CARD_ICON_PX, SETUP_CARD_ICON_SIZE} from 'sentry/views/onboarding/consts';
+import {SETUP_CARD_MARKER_PX, SETUP_CARD_ICON_SIZE} from 'sentry/views/onboarding/consts';
 
 interface ManualSetupCardProps {
   onSetupInBrowser: () => void;
@@ -16,8 +16,8 @@ export function ManualSetupCard({onSetupInBrowser}: ManualSetupCardProps) {
   return (
     <CardButton onClick={onSetupInBrowser} data-test-id="onboarding-setup-in-browser">
       <Stack border="primary" radius="xl" padding="xl 2xl" gap="0" width="100%">
-        <Flex align="center" gap="xl">
-          <Flex width={SETUP_CARD_ICON_PX} flexShrink={0} justify="center">
+        <Flex align="center" gap="md">
+          <Flex width={SETUP_CARD_MARKER_PX} flexShrink={0} justify="center">
             <IconSliders size={SETUP_CARD_ICON_SIZE} variant="secondary" />
           </Flex>
           <Container flexGrow={1} minWidth="0px">
@@ -34,8 +34,8 @@ export function ManualSetupCard({onSetupInBrowser}: ManualSetupCardProps) {
           </Flex>
         </Flex>
 
-        <Flex gap="xl" paddingTop="xs">
-          <Container width={SETUP_CARD_ICON_PX} flexShrink={0} />
+        <Flex gap="md" paddingTop="xs">
+          <Container width={SETUP_CARD_MARKER_PX} flexShrink={0} />
           <Container flexGrow={1} minWidth="0px">
             <Text variant="muted" size="md" density="comfortable" textWrap="pretty">
               {t(

--- a/static/app/views/onboarding/components/welcomeAgentSetup.tsx
+++ b/static/app/views/onboarding/components/welcomeAgentSetup.tsx
@@ -155,7 +155,7 @@ export function WelcomeAgentSetup({
 
       <ScmCollapsibleReveal open={!showsProgress || hasRunFailed}>
         <Stack gap="2xl" align="center" width="100%">
-          <Text variant="muted" size="md" bold uppercase>
+          <Text variant="muted" size="md" bold>
             {t('or')}
           </Text>
 

--- a/static/app/views/onboarding/consts.ts
+++ b/static/app/views/onboarding/consts.ts
@@ -1,5 +1,8 @@
 import type {MotionProps} from 'framer-motion';
 
+import {SvgIcon} from 'sentry/icons/svgIcon';
+import type {IconSize} from 'sentry/utils/theme';
+
 export const ONBOARDING_WELCOME_SCREEN_SOURCE = 'targeted_onboarding';
 
 // Child element animation - used by each staggered item
@@ -20,3 +23,8 @@ export const ONBOARDING_WELCOME_STAGGER_ITEM: MotionProps = {
  * Matches the Figma content area width (516px).
  */
 export const SCM_STEP_CONTENT_WIDTH = '630px';
+
+export const SETUP_CARD_ICON_SIZE: IconSize = 'md';
+export const SETUP_CARD_ICON_PX = SvgIcon.ICON_SIZES[
+  SETUP_CARD_ICON_SIZE
+] as `${number}px`;

--- a/static/app/views/onboarding/consts.ts
+++ b/static/app/views/onboarding/consts.ts
@@ -1,6 +1,5 @@
 import type {MotionProps} from 'framer-motion';
 
-import {SvgIcon} from 'sentry/icons/svgIcon';
 import type {IconSize} from 'sentry/utils/theme';
 
 export const ONBOARDING_WELCOME_SCREEN_SOURCE = 'targeted_onboarding';
@@ -25,6 +24,4 @@ export const ONBOARDING_WELCOME_STAGGER_ITEM: MotionProps = {
 export const SCM_STEP_CONTENT_WIDTH = '630px';
 
 export const SETUP_CARD_ICON_SIZE: IconSize = 'md';
-export const SETUP_CARD_ICON_PX = SvgIcon.ICON_SIZES[
-  SETUP_CARD_ICON_SIZE
-] as `${number}px`;
+export const SETUP_CARD_MARKER_PX = '24px';

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -672,9 +672,7 @@ describe('Onboarding', () => {
     it('navigates from welcome to scm-connect', async () => {
       const {router} = renderOnboarding('welcome');
 
-      await userEvent.click(
-        await screen.findByRole('button', {name: /Set up manually instead/})
-      );
+      await userEvent.click(await screen.findByRole('button', {name: /Set up manually/}));
 
       // Wait for scm-connect to render and its queries to resolve so the
       // mounted-effect fetches hit the mocked endpoints before afterEach
@@ -692,9 +690,10 @@ describe('Onboarding', () => {
       expect(
         await screen.findByText('npx @sentry/agent-plugin install')
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', {name: /Set up manually instead/})
-      ).toBeInTheDocument();
+      expect(screen.getByText('Recommended')).toBeInTheDocument();
+      expect(screen.getByText('Claude Code, Codex, Cursor & Grok')).toBeInTheDocument();
+      expect(screen.getByText(/org slug: org-slug/)).toBeInTheDocument();
+      expect(screen.getByRole('button', {name: /Set up manually/})).toBeInTheDocument();
       expect(screen.queryByTestId('onboarding-welcome-start')).not.toBeInTheDocument();
       expect(screen.queryByText('Error monitoring')).not.toBeInTheDocument();
       expect(
@@ -722,7 +721,7 @@ describe('Onboarding', () => {
 
       expect(await screen.findByText('Agent Connected')).toBeInTheDocument();
       expect(
-        screen.queryByRole('button', {name: /Set up manually instead/})
+        screen.queryByRole('button', {name: /Set up manually/})
       ).not.toBeInTheDocument();
       expect(screen.queryByText('or')).not.toBeInTheDocument();
       expect(
@@ -789,9 +788,7 @@ describe('Onboarding', () => {
     it('fires scm_welcome_continue_clicked on browser setup click and not the legacy event', async () => {
       renderOnboarding('welcome');
 
-      await userEvent.click(
-        await screen.findByRole('button', {name: /Set up manually instead/})
-      );
+      await userEvent.click(await screen.findByRole('button', {name: /Set up manually/}));
 
       expect(trackAnalytics).toHaveBeenCalledWith(
         'onboarding.scm_welcome_continue_clicked',

--- a/static/app/views/onboarding/onboarding.spec.tsx
+++ b/static/app/views/onboarding/onboarding.spec.tsx
@@ -691,7 +691,7 @@ describe('Onboarding', () => {
         await screen.findByText('npx @sentry/agent-plugin install')
       ).toBeInTheDocument();
       expect(screen.getByText('Recommended')).toBeInTheDocument();
-      expect(screen.getByText('Claude Code, Codex, Cursor & Grok')).toBeInTheDocument();
+      expect(screen.getByText('Claude Code, Codex, Cursor, & Grok')).toBeInTheDocument();
       expect(screen.getByText(/org slug: org-slug/)).toBeInTheDocument();
       expect(screen.getByRole('button', {name: /Set up manually/})).toBeInTheDocument();
       expect(screen.queryByTestId('onboarding-welcome-start')).not.toBeInTheDocument();


### PR DESCRIPTION
Polish the welcome step's setup cards to match the updated design.

The agent card marks the agent path as recommended, lists the supported
agents under the title, and presents the install command and prompt as two
numbered steps that share a key line with the card icon. The manual card is
renamed to "Set up manually" and gets a trailing chevron so it reads as a
link into the step-by-step flow.

Both cards now use flex rows with explicit per-row spacing instead of one
grid gap, and read their icon size from a single constant so their key lines
stay aligned. The code blocks stay dark in both themes: inverted in light
mode, and on the tertiary surface in dark mode. No shared components or
global styles were touched.


| Before | After |
| ------ | ------ |
| <img width="1038" height="702" alt="2026-09-10 @ 13 35@2x" src="https://github.com/user-attachments/assets/e8c819dd-53d6-4c08-aa85-ba3d889fe3d9" /> | <img width="1042" height="750" alt="2026-09-10 @ 13 33@2x" src="https://github.com/user-attachments/assets/51740c7a-9d15-452a-84a8-1a4c1c6a042f" /> |