### PR TITLE
ref(analytics): Record analytics events to Datadog+Sentry

### DIFF
--- a/src/sentry/seer/autofix/analytics.py
+++ b/src/sentry/seer/autofix/analytics.py
@@ -1,10 +1,13 @@
+from sentry_sdk import metrics as sentry_metrics
+
 from sentry import analytics
 from sentry.analytics.events.autofix_events import AiAutofixPhaseEvent
 from sentry.utils import metrics
 
 
 def record_funnel_event(event: AiAutofixPhaseEvent) -> None:
-    """Record an Autofix funnel event in BigQuery and Datadog."""
+    """Record an Autofix funnel event in BigQuery, Datadog, and Sentry Metrics."""
     analytics.record(event)
     if event.type is not None:
         metrics.incr(event.type)
+        sentry_metrics.count(event.type, 1)

--- a/src/sentry/seer/autofix/analytics.py
+++ b/src/sentry/seer/autofix/analytics.py
@@ -5,7 +5,7 @@ from sentry.analytics.events.autofix_events import AiAutofixPhaseEvent
 from sentry.utils import metrics
 
 
-def record_funnel_event(event: AiAutofixPhaseEvent) -> None:
+def record_autofix_event(event: AiAutofixPhaseEvent) -> None:
     """Record an Autofix funnel event in BigQuery, Datadog, and Sentry Metrics."""
     analytics.record(event)
     if event.type is not None:

--- a/src/sentry/seer/autofix/analytics.py
+++ b/src/sentry/seer/autofix/analytics.py
@@ -1,0 +1,10 @@
+from sentry import analytics
+from sentry.analytics.events.autofix_events import AiAutofixPhaseEvent
+from sentry.utils import metrics
+
+
+def record_funnel_event(event: AiAutofixPhaseEvent) -> None:
+    """Record an Autofix funnel event in BigQuery and Datadog."""
+    analytics.record(event)
+    if event.type is not None:
+        metrics.incr(event.type)

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from rest_framework.exceptions import PermissionDenied
 from scm.types import GetBranchProtocol, GetRepositoryProtocol
 
-from sentry import analytics, features, quotas
+from sentry import features, quotas
 from sentry.analytics.events.autofix_events import (
     AiAutofixAgentHandoffEvent,
     AiAutofixCodeChangesCompletedEvent,
@@ -29,6 +29,7 @@ from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory
 from sentry.integrations.services.integration import integration_service
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import SeerRunState
+from sentry.seer.autofix.analytics import record_funnel_event
 from sentry.seer.autofix.artifact_schemas import (
     RootCauseArtifact,
     SolutionArtifact,
@@ -215,7 +216,7 @@ def _handle_step_started_events(
 ) -> None:
     config = STEP_CONFIGS[step]
     if config.started_event is not None:
-        analytics.record(
+        record_funnel_event(
             config.started_event(
                 organization_id=group.organization.id,
                 project_id=group.project_id,
@@ -893,7 +894,7 @@ def trigger_coding_agent_handoff(
 
     coding_agent_name = _resolve_coding_agent_name(group.organization.id, integration_id, provider)
 
-    analytics.record(
+    record_funnel_event(
         AiAutofixAgentHandoffEvent(
             organization_id=group.organization.id,
             project_id=group.project_id,
@@ -945,7 +946,7 @@ def trigger_push_changes(
     else:
         _validate_run_belongs_to_group(state, group)
 
-    analytics.record(
+    record_funnel_event(
         AiAutofixPrCreatedStartedEvent(
             organization_id=group.organization.id,
             project_id=group.project_id,

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -29,7 +29,7 @@ from sentry.constants import ENABLE_SEER_CODING_DEFAULT, DataCategory
 from sentry.integrations.services.integration import integration_service
 from sentry.seer.agent.client import SeerAgentClient
 from sentry.seer.agent.client_models import SeerRunState
-from sentry.seer.autofix.analytics import record_funnel_event
+from sentry.seer.autofix.analytics import record_autofix_event
 from sentry.seer.autofix.artifact_schemas import (
     RootCauseArtifact,
     SolutionArtifact,
@@ -216,7 +216,7 @@ def _handle_step_started_events(
 ) -> None:
     config = STEP_CONFIGS[step]
     if config.started_event is not None:
-        record_funnel_event(
+        record_autofix_event(
             config.started_event(
                 organization_id=group.organization.id,
                 project_id=group.project_id,
@@ -894,7 +894,7 @@ def trigger_coding_agent_handoff(
 
     coding_agent_name = _resolve_coding_agent_name(group.organization.id, integration_id, provider)
 
-    record_funnel_event(
+    record_autofix_event(
         AiAutofixAgentHandoffEvent(
             organization_id=group.organization.id,
             project_id=group.project_id,
@@ -946,7 +946,7 @@ def trigger_push_changes(
     else:
         _validate_run_belongs_to_group(state, group)
 
-    record_funnel_event(
+    record_autofix_event(
         AiAutofixPrCreatedStartedEvent(
             organization_id=group.organization.id,
             project_id=group.project_id,

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -24,7 +24,7 @@ from sentry.scm.factory import new as make_scm
 from sentry.seer.agent.client_models import Artifact
 from sentry.seer.agent.client_utils import fetch_run_status
 from sentry.seer.agent.on_completion_hook import AgentOnCompletionHook
-from sentry.seer.autofix.analytics import record_funnel_event
+from sentry.seer.autofix.analytics import record_autofix_event
 from sentry.seer.autofix.artifact_schemas import FixabilityAssessment, RootCauseArtifact
 from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
@@ -600,7 +600,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 webhook_action_type = SeerActionType.PR_CREATED
                 webhook_payload["pull_requests"] = format_pull_requests_payload(state)
                 is_pr_created = True
-                record_funnel_event(
+                record_autofix_event(
                     AiAutofixPrCreatedCompletedEvent(
                         organization_id=organization.id,
                         project_id=group.project_id,
@@ -733,7 +733,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             )
             completed_event_cls = STEP_CONFIGS[current_step].completed_event
             if completed_event_cls is not None:
-                record_funnel_event(
+                record_autofix_event(
                     completed_event_cls(
                         organization_id=organization.id,
                         project_id=group.project_id,

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -24,6 +24,7 @@ from sentry.scm.factory import new as make_scm
 from sentry.seer.agent.client_models import Artifact
 from sentry.seer.agent.client_utils import fetch_run_status
 from sentry.seer.agent.on_completion_hook import AgentOnCompletionHook
+from sentry.seer.autofix.analytics import record_funnel_event
 from sentry.seer.autofix.artifact_schemas import FixabilityAssessment, RootCauseArtifact
 from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
@@ -599,7 +600,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
                 webhook_action_type = SeerActionType.PR_CREATED
                 webhook_payload["pull_requests"] = format_pull_requests_payload(state)
                 is_pr_created = True
-                analytics.record(
+                record_funnel_event(
                     AiAutofixPrCreatedCompletedEvent(
                         organization_id=organization.id,
                         project_id=group.project_id,
@@ -732,7 +733,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
             )
             completed_event_cls = STEP_CONFIGS[current_step].completed_event
             if completed_event_cls is not None:
-                analytics.record(
+                record_funnel_event(
                     completed_event_cls(
                         organization_id=organization.id,
                         project_id=group.project_id,

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from rest_framework.exceptions import PermissionDenied
 
+from sentry.analytics.events.autofix_events import AiAutofixSolutionCompletedEvent
 from sentry.constants import DataCategory
 from sentry.models.activity import Activity
 from sentry.seer.agent.client_models import (
@@ -12,6 +13,7 @@ from sentry.seer.agent.client_models import (
     RepoPRState,
     SeerRunState,
 )
+from sentry.seer.autofix.analytics import record_funnel_event
 from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
     NoSeerQuotaException,
@@ -443,6 +445,7 @@ class TestTriggerAutofixAgent(TestCase):
             metadata={"group_id": group_id if group_id is not None else self.group.id},
         )
 
+    @patch("sentry.seer.autofix.analytics.metrics.incr")
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.SeerAutofixOperator.has_access", return_value=True)
@@ -457,6 +460,7 @@ class TestTriggerAutofixAgent(TestCase):
         mock_has_access,
         mock_check_quota,
         mock_record_run,
+        mock_metrics_incr,
     ):
         """Sends correct started webhook for all autofix steps."""
         mock_client = MagicMock()
@@ -481,6 +485,7 @@ class TestTriggerAutofixAgent(TestCase):
         for step, (expected_action, expected_activity_type) in step_to_action.items():
             mock_broadcast.reset_mock()
             mock_process_autofix_updates.reset_mock()
+            mock_metrics_incr.reset_mock()
 
             def assert_activity_exists(**_kwargs: object) -> None:
                 assert Activity.objects.filter(
@@ -502,6 +507,7 @@ class TestTriggerAutofixAgent(TestCase):
                 mock_process_autofix_updates.call_args.kwargs["kwargs"]["activity_already_recorded"]
                 is True
             )
+            mock_metrics_incr.assert_any_call(f"ai.autofix.{step.value}.started")
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
@@ -1941,3 +1947,20 @@ class TestTriggerPushChanges(TestCase):
         payload = self._push(mock_post)
 
         assert payload["pr_description_suffix"] == self._fixes_line()
+
+
+class TestAutofixFunnelAnalytics:
+    @patch("sentry.seer.autofix.analytics.metrics.incr")
+    @patch("sentry.seer.autofix.analytics.analytics.record")
+    def test_records_solution_completion_in_datadog(self, mock_record, mock_metrics_incr) -> None:
+        event = AiAutofixSolutionCompletedEvent(
+            organization_id=1,
+            project_id=1,
+            group_id=1,
+            referrer="test",
+        )
+
+        record_funnel_event(event)
+
+        mock_record.assert_called_once_with(event)
+        mock_metrics_incr.assert_called_once_with("ai.autofix.solution.completed")

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -1950,9 +1950,12 @@ class TestTriggerPushChanges(TestCase):
 
 
 class TestAutofixFunnelAnalytics:
+    @patch("sentry_sdk.metrics.count")
     @patch("sentry.seer.autofix.analytics.metrics.incr")
     @patch("sentry.seer.autofix.analytics.analytics.record")
-    def test_records_solution_completion_in_datadog(self, mock_record, mock_metrics_incr) -> None:
+    def test_records_solution_completion_in_all_destinations(
+        self, mock_record, mock_metrics_incr, mock_sentry_count
+    ) -> None:
         event = AiAutofixSolutionCompletedEvent(
             organization_id=1,
             project_id=1,
@@ -1964,3 +1967,4 @@ class TestAutofixFunnelAnalytics:
 
         mock_record.assert_called_once_with(event)
         mock_metrics_incr.assert_called_once_with("ai.autofix.solution.completed")
+        mock_sentry_count.assert_called_once_with("ai.autofix.solution.completed", 1)

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -13,7 +13,7 @@ from sentry.seer.agent.client_models import (
     RepoPRState,
     SeerRunState,
 )
-from sentry.seer.autofix.analytics import record_funnel_event
+from sentry.seer.autofix.analytics import record_autofix_event
 from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
     NoSeerQuotaException,
@@ -1448,7 +1448,7 @@ class TestTriggerCodingAgentHandoff(TestCase):
         assert repos[0].name == "repo"
         assert call_kwargs["issue_short_id"] == self.group.qualified_short_id
 
-    @patch("sentry.seer.autofix.autofix_agent.analytics.record")
+    @patch("sentry.seer.autofix.analytics.analytics.record")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_trigger_coding_agent_handoff_records_referrer(self, mock_client_class, mock_record):
         mock_client = MagicMock()
@@ -1963,7 +1963,7 @@ class TestAutofixFunnelAnalytics:
             referrer="test",
         )
 
-        record_funnel_event(event)
+        record_autofix_event(event)
 
         mock_record.assert_called_once_with(event)
         mock_metrics_incr.assert_called_once_with("ai.autofix.solution.completed")

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -1011,11 +1011,17 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
         assert call_kwargs["payload"]["code_changes"]["test-repo"][0]["removed"] == 2
 
     @patch("sentry.seer.autofix.on_completion_hook.analytics.record")
+    @patch("sentry.seer.autofix.analytics.metrics.incr")
     @patch("sentry.seer.autofix.on_completion_hook.process_autofix_updates.apply_async")
     @patch("sentry.seer.autofix.on_completion_hook.SeerAutofixOperator.has_access")
     @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")
     def test_send_step_webhook_pr_iteration(
-        self, mock_broadcast, mock_has_access, mock_process_autofix_updates, mock_analytics
+        self,
+        mock_broadcast,
+        mock_has_access,
+        mock_process_autofix_updates,
+        mock_metrics_incr,
+        mock_analytics,
     ):
         mock_has_access.return_value = True
 
@@ -1065,6 +1071,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
             mock_analytics.call_args.args[0].referrer
             == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value
         )
+        mock_metrics_incr.assert_called_once_with("ai.autofix.pr_iteration.completed")
 
     @patch("sentry.seer.autofix.on_completion_hook.analytics.record")
     @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -1071,7 +1071,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
             mock_analytics.call_args.args[0].referrer
             == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value
         )
-        mock_metrics_incr.assert_called_once_with("ai.autofix.pr_iteration.completed")
+        mock_metrics_incr.assert_any_call("ai.autofix.pr_iteration.completed")
 
     @patch("sentry.seer.autofix.on_completion_hook.analytics.record")
     @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")


### PR DESCRIPTION
I've been unable to find good real-time analytics for autofix related events. This forwards autofix events to Datadog & Sentry so we can have some real-time monitoring in place.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>