### PR TITLE
feat(action-log): Fold comment mutations into the comment they supersede

### DIFF
--- a/src/sentry/api/serializers/models/groupactionlogentry.py
+++ b/src/sentry/api/serializers/models/groupactionlogentry.py
@@ -15,9 +15,12 @@ from sentry.issues.action_log.read_metrics import (
 )
 from sentry.issues.action_log.types import (
     ACTION_TYPES_WITH_COMMIT_DATA,
+    COMMENT_MUTATION_ACTION_TYPES,
     COMMIT_ACTION_TYPES,
     PULL_REQUEST_ACTION_TYPES,
     CommentAction,
+    CommentDeleteAction,
+    CommentEditAction,
     GroupActionType,
     GroupActorType,
 )
@@ -92,6 +95,37 @@ def _serialized_id(obj: GroupActionLogEntry) -> str:
     return str(obj.id)
 
 
+def _fold_comment_mutations(
+    entries: Sequence[GroupActionLogEntry],
+) -> tuple[list[GroupActionLogEntry], dict[int, str | None]]:
+    """
+    Resolve COMMENT_EDIT and COMMENT_DELETE against the comments they supersede.
+
+    The log is append-only, so editing or deleting a comment appends an entry rather than
+    rewriting the COMMENT. Returns the entries to serialize — mutations dropped, deleted
+    comments removed — and the current text of each edited comment, keyed by the id of the
+    COMMENT itself, which is what a mutation's ``comment_id`` points at.
+    """
+    latest_text_by_comment: dict[int, str | None] = {}
+    deleted_comment_ids: set[int] = set()
+    for entry in entries:
+        if entry.type not in COMMENT_MUTATION_ACTION_TYPES:
+            continue
+        match entry.action:
+            case CommentEditAction(comment_id=comment_id, text=text):
+                # Entries arrive newest-first, so the first edit seen wins.
+                latest_text_by_comment.setdefault(comment_id, text)
+            case CommentDeleteAction(comment_id=comment_id):
+                deleted_comment_ids.add(comment_id)
+
+    kept = [
+        entry
+        for entry in entries
+        if entry.type not in COMMENT_MUTATION_ACTION_TYPES and entry.id not in deleted_comment_ids
+    ]
+    return kept, latest_text_by_comment
+
+
 def get_serialized_activity_items(
     group: "Group",
     user: User | RpcUser | AnonymousUser | None,
@@ -101,6 +135,9 @@ def get_serialized_activity_items(
 ) -> list[dict[str, Any]] | None:
     """
     Activity-shaped items for a group, read from the action log.
+
+    Comment edits and deletes are folded into the comments they supersede, so the window
+    reads the way Activity's mutable rows would.
 
     Returns None when the log can't back the response — either the gate is closed or it's
     open and the log is empty — and the caller should fall back to Activity. Reports the
@@ -120,8 +157,14 @@ def get_serialized_activity_items(
         )
         return None
 
+    entries, latest_text_by_comment = _fold_comment_mutations(action_log)
+    items = serialize(entries, user)
+    for entry, item in zip(entries, items):
+        if entry.id in latest_text_by_comment:
+            item["data"] = {**item["data"], "text": latest_text_by_comment[entry.id]}
+
     record_activity_read(endpoint, ActivityReadResult.GAL)
-    return [*serialize(action_log, user), serialize_first_seen_entry(group)]
+    return [*items, serialize_first_seen_entry(group)]
 
 
 @register(GroupActionLogEntry)

--- a/src/sentry/issues/action_log/types.py
+++ b/src/sentry/issues/action_log/types.py
@@ -165,6 +165,11 @@ ACTION_TYPES_WITH_COMMIT_DATA = {
     GroupActionType.SET_RESOLVED_IN_RELEASE.value,
 }
 
+COMMENT_MUTATION_ACTION_TYPES = {
+    GroupActionType.COMMENT_EDIT.value,
+    GroupActionType.COMMENT_DELETE.value,
+}
+
 PULL_REQUEST_ACTION_TYPES = {
     GroupActionType.RESOLVED_IN_PULL_REQUEST.value,
     GroupActionType.PULL_REQUEST_CLOSED.value,

--- a/tests/sentry/api/serializers/test_groupactionlogentry.py
+++ b/tests/sentry/api/serializers/test_groupactionlogentry.py
@@ -1,10 +1,15 @@
+from typing import Any
+
 from sentry.api.serializers import serialize
+from sentry.api.serializers.models.groupactionlogentry import get_serialized_activity_items
 from sentry.issues.action_log.types import GroupActionType, GroupActorType
+from sentry.issues.models.groupactionlogentry import GroupActionLogEntry
 from sentry.models.commit import Commit
 from sentry.models.group import GroupStatus
 from sentry.models.pullrequest import PullRequest
 from sentry.silo.base import SiloMode
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.action_log import action_log_activity_enabled
 from sentry.testutils.silo import assume_test_silo_mode
 
 
@@ -355,3 +360,101 @@ class GroupActionLogEntrySerializerTestCase(TestCase):
 
         result = serialize(edit, user)
         assert result["id"] == str(edit.id)
+
+    def _comment(self, comment_id: int, text: str) -> GroupActionLogEntry:
+        return self.create_group_action_log_entry(
+            type=GroupActionType.COMMENT,
+            actor_type=GroupActorType.USER,
+            actor_id=self.user.id,
+            data={"comment_id": comment_id, "text": text},
+        )
+
+    def _comment_mutation(
+        self, type: GroupActionType, comment: GroupActionLogEntry, **data: object
+    ) -> GroupActionLogEntry:
+        return self.create_group_action_log_entry(
+            type=type,
+            actor_type=GroupActorType.USER,
+            actor_id=self.user.id,
+            data={"comment_id": comment.id, **data},
+        )
+
+    def _activity_items(self) -> list[dict[str, Any]]:
+        with action_log_activity_enabled():
+            items = get_serialized_activity_items(self.group, self.user, endpoint="test")
+        assert items is not None
+        return items
+
+    def test_comment_edit_replaces_the_comment_text(self) -> None:
+        comment = self._comment(123, "original")
+        self._comment_mutation(GroupActionType.COMMENT_EDIT, comment, text="edited")
+
+        items = self._activity_items()
+
+        assert [item["type"] for item in items] == ["note", "first_seen"]
+        assert items[0]["id"] == "123"
+        assert items[0]["data"]["text"] == "edited"
+
+    def test_latest_comment_edit_wins(self) -> None:
+        comment = self._comment(123, "original")
+        self._comment_mutation(GroupActionType.COMMENT_EDIT, comment, text="first edit")
+        self._comment_mutation(GroupActionType.COMMENT_EDIT, comment, text="second edit")
+
+        items = self._activity_items()
+
+        assert [item["type"] for item in items] == ["note", "first_seen"]
+        assert items[0]["data"]["text"] == "second edit"
+
+    def test_comment_delete_removes_the_comment(self) -> None:
+        comment = self._comment(123, "original")
+        self._comment_mutation(GroupActionType.COMMENT_DELETE, comment)
+
+        items = self._activity_items()
+
+        assert [item["type"] for item in items] == ["first_seen"]
+
+    def test_comment_delete_wins_over_an_earlier_edit(self) -> None:
+        comment = self._comment(123, "original")
+        self._comment_mutation(GroupActionType.COMMENT_EDIT, comment, text="edited")
+        self._comment_mutation(GroupActionType.COMMENT_DELETE, comment)
+
+        items = self._activity_items()
+
+        assert [item["type"] for item in items] == ["first_seen"]
+
+    def test_only_the_named_comment_is_folded(self) -> None:
+        self._comment(123, "untouched")
+        edited = self._comment(456, "original")
+        self._comment_mutation(GroupActionType.COMMENT_EDIT, edited, text="edited")
+        deleted = self._comment(789, "doomed")
+        self._comment_mutation(GroupActionType.COMMENT_DELETE, deleted)
+        self.create_group_action_log_entry(
+            type=GroupActionType.TRIGGER_AUTOFIX,
+            actor_type=GroupActorType.USER,
+            actor_id=self.user.id,
+            data={"referrer": "slack"},
+        )
+
+        items = self._activity_items()
+
+        assert [item["type"] for item in items] == [
+            "trigger_autofix",
+            "note",
+            "note",
+            "first_seen",
+        ]
+        assert items[1]["id"] == "456"
+        assert items[1]["data"]["text"] == "edited"
+        assert items[2]["id"] == "123"
+        assert items[2]["data"]["text"] == "untouched"
+
+    def test_comment_mutations_are_dropped_without_their_comment(self) -> None:
+        # The COMMENT fell outside the window, or was never written. Either way the
+        # mutation has nothing to fold into and must not render on its own.
+        orphan = self._comment(123, "original")
+        self._comment_mutation(GroupActionType.COMMENT_EDIT, orphan, text="edited")
+        orphan.delete()
+
+        items = self._activity_items()
+
+        assert [item["type"] for item in items] == ["first_seen"]

--- a/tests/sentry/issues/endpoints/test_group_activities.py
+++ b/tests/sentry/issues/endpoints/test_group_activities.py
@@ -52,7 +52,7 @@ class GroupActivitiesEndpointTest(APITestCase):
             GroupActionLogEntry.objects.create(
                 group_id=group.id,
                 project_id=group.project_id,
-                type=GroupActionType.COMMENT_EDIT.value,
+                type=GroupActionType.RESOLVE.value,
                 actor_type=GroupActorType.SYSTEM,
                 actor_id=0,
                 source=ActionSource.API,

--- a/tests/sentry/issues/endpoints/test_group_details.py
+++ b/tests/sentry/issues/endpoints/test_group_details.py
@@ -201,9 +201,22 @@ class GroupDetailsTest(APITestCase, SnubaTestCase):
         assert response.data["id"] == note_id
         assert response.data["data"]["text"] == "edited"
 
+        # ... the feed folds the appended COMMENT_EDIT back into the comment ...
+        response = self.client.get(details_url, format="json")
+        assert response.status_code == 200, response.content
+        notes = [item for item in response.data["activity"] if item["type"] == "note"]
+        assert len(notes) == 1
+        assert notes[0]["id"] == note_id
+        assert notes[0]["data"]["text"] == "edited"
+
         # ... and delete
         response = self.client.delete(f"{comments_url}{note_id}/", format="json")
         assert response.status_code == 204, response.status_code
+
+        # ... after which the COMMENT_DELETE drops the comment from the feed
+        response = self.client.get(details_url, format="json")
+        assert response.status_code == 200, response.content
+        assert [item for item in response.data["activity"] if item["type"] == "note"] == []
 
     @action_log_activity_enabled()
     def test_group_action_log_served_when_enabled(self) -> None:


### PR DESCRIPTION
Resolves https://linear.app/getsentry/issue/ISWF-3447/fold-comment-edit-and-comment-delete-into-the-comment-they-supersede.

The GAL is append-only, so editing or deleting a comment appends a `COMMENT_EDIT` / `COMMENT_DELETE` entry rather than rewriting the `COMMENT`. All three are user-visible, so a GALE-backed activity response previously returned all three verbatim: edited comments showed their pre-edit text, deleted comments kept rendering, and the mutations reached the frontend as types it has no renderer for.

`get_serialized_activity_items()` now folds them in a single pass over the window it already fetched: latest edit's text applied to the comment, deleted comments dropped, mutation entries dropped. No extra queries: mutations are only ever published live, never backfilled, so they always sort newer than the comment they supersede.

Note that we still need a longer-term solution for how to handle comments alongside the Group Action Log - this may take the form of a separate `Comment` table (https://linear.app/getsentry/issue/ISWF-3428/move-comments-out-of-activity-into-a-dedicated-table).