### PR TITLE
feat(workflows): add project scope endpoint

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_workflow_project_scope.py
+++ b/src/sentry/workflow_engine/endpoints/organization_workflow_project_scope.py
@@ -1,0 +1,65 @@
+from typing import TypedDict
+
+from drf_spectacular.utils import extend_schema
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from sentry.api.api_owners import ApiOwner
+from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.base import cell_silo_endpoint
+from sentry.apidocs.constants import RESPONSE_FORBIDDEN, RESPONSE_NOT_FOUND, RESPONSE_UNAUTHORIZED
+from sentry.apidocs.parameters import GlobalParams, WorkflowParams
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.models.organization import Organization
+from sentry.workflow_engine.endpoints.organization_workflow_index import (
+    OrganizationWorkflowEndpoint,
+)
+from sentry.workflow_engine.models import DetectorWorkflow, Workflow
+
+
+class WorkflowProjectScopeResponse(TypedDict):
+    projectIds: list[str]
+    includesAllProjects: bool
+
+
+@cell_silo_endpoint
+@extend_schema(tags=["Monitors"])
+class OrganizationWorkflowProjectScopeEndpoint(OrganizationWorkflowEndpoint):
+    publish_status = {
+        "GET": ApiPublishStatus.PRIVATE,
+    }
+    owner = ApiOwner.ALERTS_MONITORS
+
+    @extend_schema(
+        operation_id="getOrganizationWorkflowProjectScope",
+        summary="Get a list of projects which are associated with an Alert through its connected Monitors.",
+        parameters=[
+            GlobalParams.ORG_ID_OR_SLUG,
+            WorkflowParams.WORKFLOW_ID,
+        ],
+        responses={
+            200: inline_sentry_response_serializer(
+                "WorkflowProjectScopeResponse", WorkflowProjectScopeResponse
+            ),
+            401: RESPONSE_UNAUTHORIZED,
+            403: RESPONSE_FORBIDDEN,
+            404: RESPONSE_NOT_FOUND,
+        },
+    )
+    def get(
+        self, request: Request, organization: Organization, workflow: Workflow
+    ) -> Response[WorkflowProjectScopeResponse]:
+        project_ids = list(
+            DetectorWorkflow.objects.filter(workflow=workflow)
+            .order_by("detector__project_id")
+            .values_list("detector__project_id", flat=True)
+            .distinct()
+        )
+        includes_all_projects = None in project_ids
+        response: WorkflowProjectScopeResponse = {
+            "projectIds": (
+                [] if includes_all_projects else [str(project_id) for project_id in project_ids]
+            ),
+            "includesAllProjects": includes_all_projects,
+        }
+        return Response(response)

--- a/src/sentry/workflow_engine/endpoints/urls.py
+++ b/src/sentry/workflow_engine/endpoints/urls.py
@@ -18,6 +18,7 @@ from .organization_test_fire_action import OrganizationTestFireActionsEndpoint
 from .organization_workflow_details import OrganizationWorkflowDetailsEndpoint
 from .organization_workflow_group_history import OrganizationWorkflowGroupHistoryEndpoint
 from .organization_workflow_index import OrganizationWorkflowIndexEndpoint
+from .organization_workflow_project_scope import OrganizationWorkflowProjectScopeEndpoint
 from .organization_workflow_stats import OrganizationWorkflowStatsEndpoint
 
 organization_urlpatterns = [
@@ -60,6 +61,11 @@ organization_urlpatterns = [
         r"^(?P<organization_id_or_slug>[^/]+)/workflows/(?P<workflow_id>\d+)/group-history/$",
         OrganizationWorkflowGroupHistoryEndpoint.as_view(),
         name="sentry-api-0-organization-workflow-group-history",
+    ),
+    re_path(
+        r"^(?P<organization_id_or_slug>[^/]+)/workflows/(?P<workflow_id>\d+)/project-scope/$",
+        OrganizationWorkflowProjectScopeEndpoint.as_view(),
+        name="sentry-api-0-organization-workflow-project-scope",
     ),
     re_path(
         r"^(?P<organization_id_or_slug>[^/]+)/workflows/(?P<workflow_id>[^/]+)/stats/$",

--- a/static/app/utils/api/knownSentryApiUrls.generated.ts
+++ b/static/app/utils/api/knownSentryApiUrls.generated.ts
@@ -431,6 +431,7 @@ export type KnownSentryApiUrls =
   | '/organizations/$organizationIdOrSlug/workflows/'
   | '/organizations/$organizationIdOrSlug/workflows/$workflowId/'
   | '/organizations/$organizationIdOrSlug/workflows/$workflowId/group-history/'
+  | '/organizations/$organizationIdOrSlug/workflows/$workflowId/project-scope/'
   | '/organizations/$organizationIdOrSlug/workflows/$workflowId/stats/'
   | '/projects/'
   | '/projects/$organizationIdOrSlug/$projectIdOrSlug/'

--- a/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_workflow_details.py
@@ -81,6 +81,74 @@ class OrganizationWorkflowIndexGetTest(OrganizationWorkflowDetailsBaseTest):
 
 
 @cell_silo_test
+class OrganizationWorkflowProjectScopeTest(APITestCase):
+    endpoint = "sentry-api-0-organization-workflow-project-scope"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+
+    def test_project_scope(self) -> None:
+        workflow = self.create_workflow(organization_id=self.organization.id)
+        other_project = self.create_project(organization=self.organization)
+        for _ in range(2):
+            detector = self.create_detector(project=self.project, type=MetricIssue.slug)
+            self.create_detector_workflow(workflow=workflow, detector=detector)
+        other_detector = self.create_detector(project=other_project)
+        self.create_detector_workflow(workflow=workflow, detector=other_detector)
+
+        response = self.get_success_response(self.organization.slug, workflow.id)
+
+        assert response.data == {
+            "projectIds": [
+                str(project_id) for project_id in sorted([self.project.id, other_project.id])
+            ],
+            "includesAllProjects": False,
+        }
+
+    def test_unattached_workflow(self) -> None:
+        workflow = self.create_workflow(organization_id=self.organization.id)
+
+        response = self.get_success_response(self.organization.slug, workflow.id)
+
+        assert response.data == {
+            "projectIds": [],
+            "includesAllProjects": False,
+        }
+
+    def test_workflow_in_another_organization_is_not_found(self) -> None:
+        other_organization = self.create_organization()
+        workflow = self.create_workflow(organization_id=other_organization.id)
+
+        self.get_error_response(self.organization.slug, workflow.id, status_code=404)
+
+    @with_feature("organizations:workflow-engine-all-projects-detector")
+    def test_all_projects_workflow(self) -> None:
+        workflow = self.create_workflow(organization_id=self.organization.id)
+        detector = ensure_default_all_projects_detector(self.organization.id)
+        self.create_detector_workflow(workflow=workflow, detector=detector)
+
+        response = self.get_success_response(self.organization.slug, workflow.id)
+
+        assert response.data == {
+            "projectIds": [],
+            "includesAllProjects": True,
+        }
+
+    def test_all_projects_workflow_without_feature(self) -> None:
+        workflow = self.create_workflow(organization_id=self.organization.id)
+        detector = ensure_default_all_projects_detector(self.organization.id)
+        self.create_detector_workflow(workflow=workflow, detector=detector)
+
+        self.get_error_response(self.organization.slug, workflow.id, status_code=403)
+
+    def test_only_get_is_supported(self) -> None:
+        workflow = self.create_workflow(organization_id=self.organization.id)
+
+        self.get_error_response(self.organization.slug, workflow.id, method="post", status_code=405)
+
+
+@cell_silo_test
 class OrganizationUpdateWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWorkflowTest):
     method = "PUT"
 
@@ -1667,6 +1735,46 @@ class OrganizationDeleteWorkflowTest(OrganizationWorkflowDetailsBaseTest, BaseWo
         assert not Workflow.objects_for_deletion.filter(id=self.workflow.id).exists()
         assert not Rule.objects.filter(id=rule.id).exists()
         assert not AlertRuleWorkflow.objects.filter(rule_id=rule.id).exists()
+
+
+@cell_silo_test
+class OrganizationWorkflowProjectScopeProjectAccessTest(APITestCase, ProjectAccessTestMixin):
+    endpoint = "sentry-api-0-organization-workflow-project-scope"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.setup_project_access_test_data()
+        self.login_as(self.limited_user)
+
+    def test_cannot_access_workflow_from_inaccessible_project(self) -> None:
+        self.get_error_response(
+            self.organization.slug,
+            self.other_workflow.id,
+            status_code=403,
+        )
+
+    def test_can_access_workflow_from_accessible_project(self) -> None:
+        response = self.get_success_response(self.organization.slug, self.user_workflow.id)
+
+        assert response.data == {
+            "projectIds": [str(self.user_project.id)],
+            "includesAllProjects": False,
+        }
+
+    def test_scope_includes_all_projects_for_accessible_workflow(self) -> None:
+        mixed_workflow = self.create_workflow(organization_id=self.organization.id)
+        self.create_detector_workflow(workflow=mixed_workflow, detector=self.user_detector)
+        self.create_detector_workflow(workflow=mixed_workflow, detector=self.other_detector)
+
+        response = self.get_success_response(self.organization.slug, mixed_workflow.id)
+
+        assert response.data == {
+            "projectIds": [
+                str(project_id)
+                for project_id in sorted([self.user_project.id, self.other_project.id])
+            ],
+            "includesAllProjects": False,
+        }
 
 
 @cell_silo_test


### PR DESCRIPTION
Ref ISWF-3404

For most users the permissions structure stays the same for workflows, but team admins (without `alerts:write`) have a special case which allows them to create/edit workflows connected exclusively to projects they own. The workflows endpoint was recently modified to check those permissions: https://github.com/getsentry/sentry/pull/123033

The next step is to enable workflow editing on the UI side, but there isn't a great way right now for the UI to know which projects a workflow touches. This PR adds a new endpoint `GET /workflows/<id>/project-scope/` which returns the set of projects that a workflow is connected to through it's WorkflowDetector connections.

This isn't the most elegant solution, but I couldn't find a better one with the way our current permission structure works. If you have any ideas for a better way around this lmk.
