### PR TITLE
test(onboarding): Cover the SCM messaging treatment end to end

### DIFF
--- a/static/app/components/onboarding/scm/scmMessagingProviderRow/index.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow/index.spec.tsx
@@ -5,6 +5,7 @@ import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
 
 import {
+  cleanup,
   render,
   renderGlobalModal,
   screen,
@@ -89,6 +90,14 @@ const connectedSlack: ScmMessagingResolvedProvider = {
   provider: slackProvider,
   status: 'connected',
   eligibleIntegrations: [slackIntegration],
+  permissionLimitedIntegration: undefined,
+};
+
+const installableMsteams: ScmMessagingResolvedProvider = {
+  providerKey: 'msteams',
+  provider: msteamsProvider,
+  status: 'installable',
+  eligibleIntegrations: [],
   permissionLimitedIntegration: undefined,
 };
 
@@ -196,6 +205,8 @@ function renderRow(
 
 describe('ScmMessagingProviderRow', () => {
   afterEach(() => {
+    // Unmount active queries before restoring focus to avoid triggering another refetch.
+    cleanup();
     jest.restoreAllMocks();
     focusManager.setFocused(undefined);
   });
@@ -232,45 +243,11 @@ describe('ScmMessagingProviderRow', () => {
       );
     });
 
-    it('opens the marketplace modal for MS Teams', async () => {
+    it('opens the marketplace modal for MS Teams and completes the install on return', async () => {
       mockPipeline();
-      const installableMsteams: ScmMessagingResolvedProvider = {
-        providerKey: 'msteams',
-        provider: msteamsProvider,
-        status: 'installable',
-        eligibleIntegrations: [],
-        permissionLimitedIntegration: undefined,
-      };
-      MockApiClient.addMockResponse({
-        url: '/organizations/org-slug/integrations/',
-        body: [],
-      });
-      renderGlobalModal({organization});
-      renderRow(installableMsteams);
-
-      const connect = screen.getByRole('button', {name: /Connect/});
-      expect(connect).toBeEnabled();
-
-      await userEvent.click(connect);
-
-      expect(
-        await screen.findByText('Installing Microsoft Teams Integration')
-      ).toBeInTheDocument();
-      expect(screen.getByRole('button', {name: 'Teams Marketplace'})).toBeInTheDocument();
-      expect(pipelineModal.openPipelineModal).not.toHaveBeenCalled();
-    });
-
-    it('closes the marketplace modal and completes the install once MS Teams appears', async () => {
       // Start unfocused so the later focus transition deterministically refetches.
       focusManager.setFocused(false);
       jest.spyOn(window, 'open').mockImplementation(() => null);
-      const installableMsteams: ScmMessagingResolvedProvider = {
-        providerKey: 'msteams',
-        provider: msteamsProvider,
-        status: 'installable',
-        eligibleIntegrations: [],
-        permissionLimitedIntegration: undefined,
-      };
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/',
         body: [],
@@ -281,18 +258,24 @@ describe('ScmMessagingProviderRow', () => {
         onInstallComplete,
       });
 
-      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
-      await userEvent.click(
-        await screen.findByRole('button', {name: 'Teams Marketplace'})
-      );
+      const connect = screen.getByRole('button', {name: /Connect/});
+      expect(connect).toBeEnabled();
 
+      await userEvent.click(connect);
+
+      expect(
+        await screen.findByText('Installing Microsoft Teams Integration')
+      ).toBeInTheDocument();
+      expect(pipelineModal.openPipelineModal).not.toHaveBeenCalled();
+
+      await userEvent.click(screen.getByRole('button', {name: 'Teams Marketplace'}));
       expect(onInstallComplete).not.toHaveBeenCalled();
 
       // The user finishes in the Marketplace and returns to the tab: the focus
-      // refetch surfaces the new team installation.
+      // refetch surfaces the new installation.
       MockApiClient.addMockResponse({
         url: '/organizations/org-slug/integrations/',
-        body: [{...msteamsIntegration, configData: {installationType: 'team'}}],
+        body: [msteamsIntegration],
       });
       act(() => focusManager.setFocused(true));
 

--- a/static/app/components/onboarding/scm/scmMessagingProviderRow/index.spec.tsx
+++ b/static/app/components/onboarding/scm/scmMessagingProviderRow/index.spec.tsx
@@ -1,4 +1,5 @@
 import {act, useState} from 'react';
+import {focusManager} from '@tanstack/react-query';
 import {GitHubIntegrationProviderFixture} from 'sentry-fixture/githubIntegrationProvider';
 import {OrganizationFixture} from 'sentry-fixture/organization';
 import {OrganizationIntegrationsFixture} from 'sentry-fixture/organizationIntegrations';
@@ -194,7 +195,10 @@ function renderRow(
 }
 
 describe('ScmMessagingProviderRow', () => {
-  afterEach(() => jest.restoreAllMocks());
+  afterEach(() => {
+    jest.restoreAllMocks();
+    focusManager.setFocused(undefined);
+  });
 
   describe('installable state', () => {
     it('opens the install flow when Connect is clicked', async () => {
@@ -254,6 +258,46 @@ describe('ScmMessagingProviderRow', () => {
       ).toBeInTheDocument();
       expect(screen.getByRole('button', {name: 'Teams Marketplace'})).toBeInTheDocument();
       expect(pipelineModal.openPipelineModal).not.toHaveBeenCalled();
+    });
+
+    it('closes the marketplace modal and completes the install once MS Teams appears', async () => {
+      // Start unfocused so the later focus transition deterministically refetches.
+      focusManager.setFocused(false);
+      jest.spyOn(window, 'open').mockImplementation(() => null);
+      const installableMsteams: ScmMessagingResolvedProvider = {
+        providerKey: 'msteams',
+        provider: msteamsProvider,
+        status: 'installable',
+        eligibleIntegrations: [],
+        permissionLimitedIntegration: undefined,
+      };
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/',
+        body: [],
+      });
+      const onInstallComplete = jest.fn();
+      const {waitForModalToHide} = renderGlobalModal({organization});
+      renderRow(installableMsteams, UNCONFIGURED_SCM_MESSAGING_SETUP, {
+        onInstallComplete,
+      });
+
+      await userEvent.click(screen.getByRole('button', {name: /Connect/}));
+      await userEvent.click(
+        await screen.findByRole('button', {name: 'Teams Marketplace'})
+      );
+
+      expect(onInstallComplete).not.toHaveBeenCalled();
+
+      // The user finishes in the Marketplace and returns to the tab: the focus
+      // refetch surfaces the new team installation.
+      MockApiClient.addMockResponse({
+        url: '/organizations/org-slug/integrations/',
+        body: [{...msteamsIntegration, configData: {installationType: 'team'}}],
+      });
+      act(() => focusManager.setFocused(true));
+
+      await waitForModalToHide();
+      expect(onInstallComplete).toHaveBeenCalledWith('msteams');
     });
   });
 

--- a/tests/acceptance/test_scm_onboarding.py
+++ b/tests/acceptance/test_scm_onboarding.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 
 from sentry.integrations.github.integration import GitHubOAuthLoginResult
 from sentry.integrations.models.integration import Integration
+from sentry.integrations.slack.utils.channel import SlackChannelIdData
 from sentry.models.project import Project
 from sentry.models.rule import Rule
 from sentry.shared_integrations.exceptions import ApiError
@@ -15,9 +16,22 @@ from sentry.testutils.cases import AcceptanceTestCase
 from sentry.testutils.helpers.features import with_feature
 from sentry.testutils.silo import no_silo_test
 from sentry.workflow_engine.defaults.workflows import DEFAULT_WORKFLOW_LABEL
-from sentry.workflow_engine.models import Workflow
+from sentry.workflow_engine.models import Action, Workflow
 
 pytestmark = pytest.mark.sentry_metrics
+
+SCM_MESSAGING_TREATMENT = {
+    "organizations:onboarding-scm-experiment": True,
+    "organizations:onboarding-scm-messaging-experiment": True,
+}
+
+
+def workflow_action_types(workflow: Workflow) -> list[str]:
+    return sorted(
+        Action.objects.filter(
+            dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow=workflow
+        ).values_list("type", flat=True)
+    )
 
 
 @no_silo_test
@@ -80,8 +94,40 @@ class ScmOnboardingTest(AcceptanceTestCase):
         with mock.patch.object(Project.objects, "create", side_effect=create_active):
             yield
 
-    def skip_to_setup_docs(self, platform_search: str, platform_label: str) -> None:
-        """Skip connect → pick platform → Continue auto-creates the project."""
+    @contextmanager
+    def slack_resolves_alerts_channel(self) -> Generator[None]:
+        """Answer every Slack lookup in the flow with one channel, #alerts.
+
+        The picker lists channels through conversations_list. Workflow creation
+        and channel-validate (which runs when a saved destination is restored)
+        both resolve the channel name with get_channel_id.
+        """
+        channel = SlackChannelIdData(prefix="#", channel_id="C125", timed_out=False)
+        with (
+            mock.patch(
+                "sentry.integrations.slack.sdk_client.SlackSdkClient.conversations_list"
+            ) as conversations_list,
+            mock.patch(
+                "sentry.integrations.slack.actions.form.get_channel_id",
+                return_value=channel,
+            ),
+            mock.patch(
+                "sentry.integrations.api.endpoints.organization_integration_channel_validate.get_channel_id",
+                return_value=channel,
+            ),
+        ):
+            conversations_list.return_value.data = {
+                "ok": True,
+                "channels": [{"id": "C125", "name": "alerts", "is_private": False}],
+            }
+            yield
+
+    def continue_past_platform_features(self, platform_search: str, platform_label: str) -> None:
+        """Skip connect → pick platform → Continue.
+
+        Control auto-creates the project and lands on setup-docs; treatment
+        lands on the messaging step with no project yet.
+        """
         self.browser.click(xpath='//button[contains(., "Continue without a repo")]')
 
         self.browser.wait_until('[data-test-id="onboarding-step-scm-platform-features"]')
@@ -96,6 +142,18 @@ class ScmOnboardingTest(AcceptanceTestCase):
         )
         self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
         self.browser.click(xpath='//button[contains(., "Continue")]')
+
+    def confirm_slack_destination(self) -> None:
+        """On the messaging step, pick #alerts in the connected Slack row and
+        Confirm and continue, which creates the project."""
+        self.browser.wait_until('[data-test-id="onboarding-step-scm-messaging"]')
+        self.browser.click(xpath='//button[contains(., "Choose destination")]')
+        input_el = self.browser.element('input[aria-autocomplete="list"]')
+        input_el.send_keys("alerts")
+        self.browser.wait_until(xpath='//*[@data-test-id="menu-list-item-label"][text()="#alerts"]')
+        self.browser.click(xpath='//*[@data-test-id="menu-list-item-label"][text()="#alerts"]')
+        self.browser.wait_until_clickable(xpath='//button[contains(., "Confirm and continue")]')
+        self.browser.click(xpath='//button[contains(., "Confirm and continue")]')
 
     def test_scm_onboarding_reload_restores_connected_repo(self) -> None:
         """Reloading the platform-features step restores the connected repo from
@@ -546,7 +604,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             }
         ):
             self.start_onboarding()
-            self.skip_to_setup_docs("React", "React")
+            self.continue_past_platform_features("React", "React")
 
             # Skips scm-project-details entirely and lands on setup-docs.
             self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
@@ -649,7 +707,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             }
         ):
             self.start_onboarding()
-            self.skip_to_setup_docs("React", "React")
+            self.continue_past_platform_features("React", "React")
 
             self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
             project1 = Project.objects.get(organization=self.org)
@@ -682,7 +740,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.projects_born_active(),
         ):
             self.start_onboarding()
-            self.skip_to_setup_docs("React", "React")
+            self.continue_past_platform_features("React", "React")
 
             self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
             project = Project.objects.get(organization=self.org)
@@ -709,7 +767,7 @@ class ScmOnboardingTest(AcceptanceTestCase):
             self.projects_born_active(),
         ):
             self.start_onboarding()
-            self.skip_to_setup_docs("React", "React")
+            self.continue_past_platform_features("React", "React")
 
             self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
             project1 = Project.objects.get(organization=self.org)
@@ -731,4 +789,88 @@ class ScmOnboardingTest(AcceptanceTestCase):
                 self.org,
                 active_project_ids=[project1.id, project2.id],
                 deleted_project_ids=[],
+            )
+
+    def test_scm_treatment_set_up_later_creates_email_only_project(self) -> None:
+        """Treatment defers creation to the messaging step: no project exists on
+        arrival, and Set up later creates one with only the default email workflow."""
+        with self.feature(SCM_MESSAGING_TREATMENT):
+            self.start_onboarding()
+            self.continue_past_platform_features("React", "React")
+
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-messaging"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Set up later")]')
+            assert not Project.objects.filter(organization=self.org).exists()
+
+            self.browser.click(xpath='//button[contains(., "Set up later")]')
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+
+            project = Project.objects.get(organization=self.org)
+            assert project.platform == "javascript-react"
+            workflow = Workflow.objects.get(organization=self.org)
+            assert workflow.name == DEFAULT_WORKFLOW_LABEL
+            assert workflow_action_types(workflow) == [Action.Type.EMAIL]
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
+
+    def test_scm_treatment_slack_destination_creates_messaging_workflow(self) -> None:
+        """Treatment happy path: Confirm and continue with a Slack channel creates
+        the project and one workflow that notifies both email and the channel."""
+        integration = self.create_slack_integration(self.org, user=self.user)
+
+        with self.feature(SCM_MESSAGING_TREATMENT), self.slack_resolves_alerts_channel():
+            self.start_onboarding()
+            self.continue_past_platform_features("React", "React")
+            self.confirm_slack_destination()
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+
+            project = Project.objects.get(organization=self.org)
+            assert project.platform == "javascript-react"
+            workflow = Workflow.objects.get(organization=self.org)
+            assert workflow_action_types(workflow) == [Action.Type.EMAIL, Action.Type.SLACK]
+            slack_action = Action.objects.get(
+                dataconditiongroupaction__condition_group__workflowdataconditiongroup__workflow=workflow,
+                type=Action.Type.SLACK,
+            )
+            assert slack_action.integration_id == integration.id
+            assert slack_action.config["target_display"] == "#alerts"
+            assert slack_action.config["target_identifier"] == "C125"
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
+            )
+
+    def test_scm_treatment_back_from_setup_docs_restores_destination_and_reuses_project(
+        self,
+    ) -> None:
+        """Back from setup-docs returns to the messaging step with the saved
+        destination revalidated; Continue reuses the active project instead of
+        creating a second one."""
+        self.create_slack_integration(self.org, user=self.user)
+
+        with (
+            self.feature(SCM_MESSAGING_TREATMENT),
+            self.slack_resolves_alerts_channel(),
+            self.projects_born_active(),
+        ):
+            self.start_onboarding()
+            self.continue_past_platform_features("React", "React")
+            self.confirm_slack_destination()
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            project = Project.objects.get(organization=self.org)
+
+            self.browser.click('[aria-label="Back"]')
+            self.browser.wait_until('[data-test-id="onboarding-step-scm-messaging"]')
+            # Continue enables only once the restored destination is revalidated.
+            self.browser.wait_until(xpath='//*[text()="#alerts"]')
+            self.browser.wait_until_clickable(xpath='//button[contains(., "Continue")]')
+            self.browser.click(xpath='//button[contains(., "Continue")]')
+
+            self.browser.wait_until(xpath='//h2[text()="Configure React SDK"]')
+            assert Project.objects.filter(organization=self.org, status=0).count() == 1
+            assert Workflow.objects.filter(organization=self.org).count() == 1
+            assert_existing_projects_status(
+                self.org, active_project_ids=[project.id], deleted_project_ids=[]
             )


### PR DESCRIPTION
Acceptance coverage for the SCM messaging treatment, plus one jest test for the MS Teams return path. Refs VDY-147.

Acceptance, in `tests/acceptance/test_scm_onboarding.py`:
- Set up later: no project exists on arrival at the messaging step. Set up later creates it with only the default email workflow.
- Slack destination: Confirm and continue creates the project and one workflow carrying email and Slack actions, with the channel resolved by the backend lookup.
- Back from setup-docs: the saved destination is restored and revalidated on the messaging step, and Continue reuses the active project instead of creating a second one.

Slack is answered by three mocks: the channel list, the lookup the workflow validator runs, and the lookup channel-validate runs when a destination is restored. `skip_to_setup_docs` is renamed to `continue_past_platform_features` because treatment lands on the messaging step instead of setup-docs.

Jest: the existing MS Teams marketplace modal test now continues through the return path. The modal closes and the row reports the install complete once an installation appears on the focus refetch. The row and the global modal render with separate query clients in this spec, so the focus manager is how the spec reaches the modal's refetch.

