### PR TITLE
fix(spans): Reject malformed segment IDs before buffering

### DIFF
--- a/src/sentry/spans/consumers/process/factory.py
+++ b/src/sentry/spans/consumers/process/factory.py
@@ -2,6 +2,7 @@ import logging
 import time
 from collections.abc import Mapping
 from functools import partial
+from typing import Annotated
 
 import msgspec
 import sentry_sdk
@@ -227,7 +228,7 @@ def process_batch(
 
 
 class SpanAttributeValue(msgspec.Struct, gc=False):
-    value: str | None = None
+    value: Annotated[str, msgspec.Meta(pattern=r"\A[0-9a-fA-F]{16}\Z")] | None = None
 
 
 class SpanAttributes(msgspec.Struct, gc=False):

--- a/tests/sentry/spans/consumers/process/test_factory.py
+++ b/tests/sentry/spans/consumers/process/test_factory.py
@@ -57,7 +57,7 @@ def test_decode_extracts_segment_id() -> None:
     assert event.segment_id == "a" * 16
 
 
-@pytest.mark.parametrize("segment_id", ["aa:bb", "aa:bb:cc", "not-a-span-id"])
+@pytest.mark.parametrize("segment_id", ["aa:bb", "aa:bb:cc", "not-a-span-id", "aa:bb:cc:dd:ee:f"])
 def test_decode_rejects_invalid_segment_id(segment_id: str) -> None:
     payload = _valid_span(attributes={"sentry.segment.id": {"type": "string", "value": segment_id}})
 

--- a/tests/sentry/spans/consumers/process/test_factory.py
+++ b/tests/sentry/spans/consumers/process/test_factory.py
@@ -57,6 +57,14 @@ def test_decode_extracts_segment_id() -> None:
     assert event.segment_id == "a" * 16
 
 
+@pytest.mark.parametrize("segment_id", ["aa:bb", "aa:bb:cc", "not-a-span-id"])
+def test_decode_rejects_invalid_segment_id(segment_id: str) -> None:
+    payload = _valid_span(attributes={"sentry.segment.id": {"type": "string", "value": segment_id}})
+
+    with pytest.raises(msgspec.ValidationError):
+        decode_process_span_event(orjson.dumps(payload))
+
+
 def test_decode_without_segment_id_attribute() -> None:
     event = decode_process_span_event(
         orjson.dumps(_valid_span(attributes={"some.other.attr": {"type": "integer", "value": 1}}))


### PR DESCRIPTION
Validate `sentry.segment.id` as a 16-character hexadecimal string during decoding.

Malformed values such as `aa:bb:cc` will follow the existing invalid-message path before reaching Redis, preventing segment-key parsing errors from aborting a flush.