### PR TITLE
ref(autofix): Accept all autofix metrics, remove explicit Sentry metric

### DIFF
--- a/src/sentry/seer/autofix/analytics.py
+++ b/src/sentry/seer/autofix/analytics.py
@@ -1,5 +1,3 @@
-from sentry_sdk import metrics as sentry_metrics
-
 from sentry import analytics
 from sentry.analytics.events.autofix_events import AiAutofixPhaseEvent
 from sentry.utils import metrics
@@ -9,5 +7,4 @@ def record_autofix_event(event: AiAutofixPhaseEvent) -> None:
     """Record an Autofix funnel event in BigQuery, Datadog, and Sentry Metrics."""
     analytics.record(event)
     if event.type is not None:
-        metrics.incr(event.type)
-        sentry_metrics.count(event.type, 1)
+        metrics.incr(event.type, sample_rate=1.0)

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -507,7 +507,7 @@ class TestTriggerAutofixAgent(TestCase):
                 mock_process_autofix_updates.call_args.kwargs["kwargs"]["activity_already_recorded"]
                 is True
             )
-            mock_metrics_incr.assert_any_call(f"ai.autofix.{step.value}.started")
+            mock_metrics_incr.assert_any_call(f"ai.autofix.{step.value}.started", sample_rate=1.0)
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
@@ -1950,12 +1950,9 @@ class TestTriggerPushChanges(TestCase):
 
 
 class TestAutofixFunnelAnalytics:
-    @patch("sentry_sdk.metrics.count")
     @patch("sentry.seer.autofix.analytics.metrics.incr")
     @patch("sentry.seer.autofix.analytics.analytics.record")
-    def test_records_solution_completion_in_all_destinations(
-        self, mock_record, mock_metrics_incr, mock_sentry_count
-    ) -> None:
+    def test_records_solution_completion(self, mock_record, mock_metrics_incr) -> None:
         event = AiAutofixSolutionCompletedEvent(
             organization_id=1,
             project_id=1,
@@ -1966,5 +1963,4 @@ class TestAutofixFunnelAnalytics:
         record_autofix_event(event)
 
         mock_record.assert_called_once_with(event)
-        mock_metrics_incr.assert_called_once_with("ai.autofix.solution.completed")
-        mock_sentry_count.assert_called_once_with("ai.autofix.solution.completed", 1)
+        mock_metrics_incr.assert_called_once_with("ai.autofix.solution.completed", sample_rate=1.0)

--- a/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
+++ b/tests/sentry/seer/autofix/test_autofix_on_completion_hook.py
@@ -1071,7 +1071,7 @@ class TestAutofixOnCompletionHookWebhooks(TestCase):
             mock_analytics.call_args.args[0].referrer
             == AutofixReferrer.GROUP_AUTOFIX_ENDPOINT.value
         )
-        mock_metrics_incr.assert_any_call("ai.autofix.pr_iteration.completed")
+        mock_metrics_incr.assert_any_call("ai.autofix.pr_iteration.completed", sample_rate=1.0)
 
     @patch("sentry.seer.autofix.on_completion_hook.analytics.record")
     @patch("sentry.seer.autofix.on_completion_hook.broadcast_webhooks_for_organization.delay")


### PR DESCRIPTION
Increase sample rate to accept all metrics fired by our autofix event logging. Also remove explicit sentry metric emission as I realized our metric helpers are already sending to Sentry.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>