### PR TITLE
feat(autofix): Generalize autofix feature payload

### DIFF
--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -433,7 +433,7 @@ def _build_repo_pins(group: Group, referrer: AutofixReferrer) -> RepoPins | None
     # import back into sentry.seer.autofix.
     from sentry.scm import factory as scm_factory
 
-    repo_pins: RepoPins | None = None
+    repo_pins: RepoPins = {}
     for repo in preference.repositories:
         if repo.repository_id is None:
             continue
@@ -454,10 +454,6 @@ def _build_repo_pins(group: Group, referrer: AutofixReferrer) -> RepoPins | None
             sha = scm.get_branch(branch)["data"]["sha"]
         except Exception:
             logger.exception(
-                "autofix.base_shas.resolve_failed",
-                extra={"repo": full_name, "group_id": group.id},
-            )
-            logger.exception(
                 "autofix.repo_pins.resolve_failed",
                 extra={"repo": full_name, "group_id": group.id},
             )
@@ -466,7 +462,7 @@ def _build_repo_pins(group: Group, referrer: AutofixReferrer) -> RepoPins | None
         if sha:
             repo_pins[full_name] = RepoPin(sha=sha, branch=branch, base_sha=sha, base_branch=branch)
 
-    return repo_pins
+    return repo_pins or None
 
 
 def trigger_autofix_agent(
@@ -613,7 +609,9 @@ def trigger_autofix_agent(
     if step == AutofixStep.ROOT_CAUSE:
         repo_pins = _build_repo_pins(group, referrer)
         if repo_pins:
-            repo_pins_str = json.dumps(repo_pins)
+            repo_pins_str = json.dumps(
+                {repository: repo_pin.dict() for repository, repo_pin in repo_pins.items()}
+            )
             # Backwards compatibility, use repo_pins in future usages
             prompt_metadata["base_shas"] = repo_pins_str
             prompt_metadata["repo_pins"] = repo_pins_str

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -38,7 +38,7 @@ from sentry.seer.autofix.commit_author import SeerCommitAuthor
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.exceptions import NoSeerQuotaException
 from sentry.seer.autofix.feature.dispatch import (
-    AutofixFeatureTriggerArgs,
+    AutofixFeatureArgs,
     trigger_autofix_feature,
 )
 from sentry.seer.autofix.feature.models import RCAStepArgs, RepoPin, RepoPins
@@ -426,14 +426,14 @@ def _resolve_default_branch(
     return None
 
 
-def _build_base_shas_metadata(group: Group, referrer: AutofixReferrer) -> str | None:
+def _build_repo_pins(group: Group, referrer: AutofixReferrer) -> RepoPins | None:
     preference = read_preference_from_sentry_db(group.project)
     # Imported lazily to avoid a circular import: sentry.scm pulls in the
     # github/slack integrations, which import notifications templates that
     # import back into sentry.seer.autofix.
     from sentry.scm import factory as scm_factory
 
-    base_shas: dict[str, dict[str, str]] = {}
+    repo_pins: RepoPins | None = None
     for repo in preference.repositories:
         if repo.repository_id is None:
             continue
@@ -442,39 +442,31 @@ def _build_base_shas_metadata(group: Group, referrer: AutofixReferrer) -> str | 
         try:
             scm = scm_factory.new(group.organization.id, repo.repository_id, referrer.value)
             if repo.branch_name:
-                base_branch: str | None = repo.branch_name
+                branch: str | None = repo.branch_name
             elif isinstance(scm, GetRepositoryProtocol):
-                base_branch = scm.get_repository()["data"]["default_branch"]
+                branch = scm.get_repository()["data"]["default_branch"]
             else:
                 continue
-            if not base_branch:
+            if not branch:
                 continue
             if not isinstance(scm, GetBranchProtocol):
                 continue
-            base_sha = scm.get_branch(base_branch)["data"]["sha"]
+            sha = scm.get_branch(branch)["data"]["sha"]
         except Exception:
             logger.exception(
                 "autofix.base_shas.resolve_failed",
                 extra={"repo": full_name, "group_id": group.id},
             )
+            logger.exception(
+                "autofix.repo_pins.resolve_failed",
+                extra={"repo": full_name, "group_id": group.id},
+            )
             continue
 
-        if base_sha:
-            base_shas[full_name] = {"base_sha": base_sha, "base_branch": base_branch}
+        if sha:
+            repo_pins[full_name] = RepoPin(sha=sha, branch=branch, base_sha=sha, base_branch=branch)
 
-    if not base_shas:
-        return None
-    return json.dumps(base_shas)
-
-
-def _parse_repo_pins(repo_pins: str | None) -> RepoPins | None:
-    if repo_pins is None:
-        return None
-
-    return {
-        repo_name: RepoPin.parse_obj(repo_pin)
-        for repo_name, repo_pin in json.loads(repo_pins).items()
-    }
+    return repo_pins
 
 
 def trigger_autofix_agent(
@@ -529,17 +521,15 @@ def trigger_autofix_agent(
         "organizations:autofix-rca-in-seer", group.organization, actor=user
     )
     if step == AutofixStep.ROOT_CAUSE and run_id is None and use_seer_rca_feature:
-        args = AutofixFeatureTriggerArgs(
+        args = AutofixFeatureArgs(
             step=step,
             referrer=referrer,
+            step_args=RCAStepArgs(repo_pins=_build_repo_pins(group, referrer)),
             user_context=user_context,
             stopping_point=stopping_point,
             allow_free_cohort=allow_free_cohort,
             user=user,
             enable_bash_tools=enable_bash_tools,
-            step_args=RCAStepArgs(
-                repo_pins=_parse_repo_pins(_build_base_shas_metadata(group, referrer))
-            ),
         )
         feature_run = trigger_autofix_feature(group, args)
         feature_run_id = feature_run.seer_run_state_id
@@ -621,9 +611,12 @@ def trigger_autofix_agent(
         prompt_metadata["iteration_id"] = str(iteration_id)
 
     if step == AutofixStep.ROOT_CAUSE:
-        base_shas = _build_base_shas_metadata(group, referrer)
-        if base_shas:
-            prompt_metadata["base_shas"] = base_shas
+        repo_pins = _build_repo_pins(group, referrer)
+        if repo_pins:
+            repo_pins_str = json.dumps(repo_pins)
+            # Backwards compatibility, use repo_pins in future usages
+            prompt_metadata["base_shas"] = repo_pins_str
+            prompt_metadata["repo_pins"] = repo_pins_str
 
     artifact_key = step.value if config.artifact_schema else None
     artifact_schema = config.artifact_schema

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -465,55 +465,6 @@ def _build_base_shas_metadata(group: Group, referrer: AutofixReferrer) -> str | 
     return json.dumps(base_shas)
 
 
-def trigger_autofix_rca_in_seer(
-    group: Group,
-    *,
-    referrer: AutofixReferrer,
-    user_context: str | None,
-    stopping_point: AutofixStoppingPoint | None,
-    allow_free_cohort: bool,
-    user: User | RpcUser | AnonymousUser | None,
-    enable_bash_tools: bool,
-) -> SeerRun:
-    """Start the RCA-in-Seer feature run and emit the legacy start events."""
-    # Local import avoids a circular import (dispatch imports this module).
-    from sentry.seer.autofix.feature.dispatch import trigger_autofix_feature
-
-    feature_run = trigger_autofix_feature(
-        group,
-        referrer=referrer,
-        user_context=user_context,
-        stopping_point=stopping_point,
-        allow_free_cohort=allow_free_cohort,
-        user=user,
-        enable_bash_tools=enable_bash_tools,
-        repo_pins=_build_base_shas_metadata(group, referrer),
-    )
-    feature_run_id = feature_run.seer_run_state_id
-    if feature_run_id is None:
-        # flush=True populates this on success; guard defensively.
-        raise SeerApiError("autofix feature run has no run id", 500)
-
-    logger.info(
-        "autofix.trigger.routed_to_feature",
-        extra={
-            "group_id": group.id,
-            "organization_id": group.organization.id,
-            "run_id": feature_run_id,
-            "referrer": referrer.value,
-        },
-    )
-
-    _handle_step_started_events(
-        group,
-        AutofixStep.ROOT_CAUSE,
-        feature_run_id,
-        str(feature_run.uuid),
-        referrer,
-    )
-    return feature_run
-
-
 def trigger_autofix_agent(
     group: Group,
     step: AutofixStep,
@@ -566,15 +517,53 @@ def trigger_autofix_agent(
         "organizations:autofix-rca-in-seer", group.organization, actor=user
     )
     if step == AutofixStep.ROOT_CAUSE and run_id is None and use_seer_rca_feature:
-        return trigger_autofix_rca_in_seer(
-            group,
+        # Local import avoids a circular import (dispatch imports this module).
+        from sentry.seer.autofix.feature.dispatch import (
+            AutofixFeatureTrigger,
+            parse_repo_pins,
+            trigger_autofix_feature,
+        )
+        from sentry.seer.autofix.feature.models import RCAStepArgs
+
+        feature_trigger = AutofixFeatureTrigger(
+            step=step,
             referrer=referrer,
             user_context=user_context,
             stopping_point=stopping_point,
             allow_free_cohort=allow_free_cohort,
             user=user,
             enable_bash_tools=enable_bash_tools,
+            step_args=RCAStepArgs(
+                repo_pins=parse_repo_pins(_build_base_shas_metadata(group, referrer))
+            ),
         )
+        feature_run = trigger_autofix_feature(
+            group,
+            feature_trigger,
+        )
+        feature_run_id = feature_run.seer_run_state_id
+        if feature_run_id is None:
+            # flush=True populates this on success; guard defensively.
+            raise SeerApiError("autofix feature run has no run id", 500)
+
+        logger.info(
+            "autofix.trigger.routed_to_feature",
+            extra={
+                "group_id": group.id,
+                "organization_id": group.organization.id,
+                "run_id": feature_run_id,
+                "referrer": referrer.value,
+            },
+        )
+
+        _handle_step_started_events(
+            group,
+            step,
+            feature_run_id,
+            str(feature_run.uuid),
+            referrer,
+        )
+        return feature_run
 
     config = STEP_CONFIGS[step]
 

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -36,6 +36,12 @@ from sentry.seer.autofix.artifact_schemas import (
 )
 from sentry.seer.autofix.commit_author import SeerCommitAuthor
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.exceptions import NoSeerQuotaException
+from sentry.seer.autofix.feature.dispatch import (
+    AutofixFeatureTriggerArgs,
+    trigger_autofix_feature,
+)
+from sentry.seer.autofix.feature.models import RCAStepArgs, RepoPin, RepoPins
 from sentry.seer.autofix.pr_iteration.constants import (
     MANUAL_FLAG,
     REVIEW_REQUEST_FLAG,
@@ -80,10 +86,6 @@ if TYPE_CHECKING:
     from sentry.users.services.user import RpcUser
 
 logger = logging.getLogger(__name__)
-
-
-class NoSeerQuotaException(Exception):
-    pass
 
 
 class PrIterationNoPullRequestException(Exception):
@@ -465,6 +467,16 @@ def _build_base_shas_metadata(group: Group, referrer: AutofixReferrer) -> str | 
     return json.dumps(base_shas)
 
 
+def _parse_repo_pins(repo_pins: str | None) -> RepoPins | None:
+    if repo_pins is None:
+        return None
+
+    return {
+        repo_name: RepoPin.parse_obj(repo_pin)
+        for repo_name, repo_pin in json.loads(repo_pins).items()
+    }
+
+
 def trigger_autofix_agent(
     group: Group,
     step: AutofixStep,
@@ -517,15 +529,7 @@ def trigger_autofix_agent(
         "organizations:autofix-rca-in-seer", group.organization, actor=user
     )
     if step == AutofixStep.ROOT_CAUSE and run_id is None and use_seer_rca_feature:
-        # Local import avoids a circular import (dispatch imports this module).
-        from sentry.seer.autofix.feature.dispatch import (
-            AutofixFeatureTrigger,
-            parse_repo_pins,
-            trigger_autofix_feature,
-        )
-        from sentry.seer.autofix.feature.models import RCAStepArgs
-
-        feature_trigger = AutofixFeatureTrigger(
+        args = AutofixFeatureTriggerArgs(
             step=step,
             referrer=referrer,
             user_context=user_context,
@@ -534,14 +538,12 @@ def trigger_autofix_agent(
             user=user,
             enable_bash_tools=enable_bash_tools,
             step_args=RCAStepArgs(
-                repo_pins=parse_repo_pins(_build_base_shas_metadata(group, referrer))
+                repo_pins=_parse_repo_pins(_build_base_shas_metadata(group, referrer))
             ),
         )
-        feature_run = trigger_autofix_feature(
-            group,
-            feature_trigger,
-        )
+        feature_run = trigger_autofix_feature(group, args)
         feature_run_id = feature_run.seer_run_state_id
+
         if feature_run_id is None:
             # flush=True populates this on success; guard defensively.
             raise SeerApiError("autofix feature run has no run id", 500)

--- a/src/sentry/seer/autofix/exceptions.py
+++ b/src/sentry/seer/autofix/exceptions.py
@@ -1,0 +1,2 @@
+class NoSeerQuotaException(Exception):
+    """Raised when an Autofix run cannot consume Seer quota."""

--- a/src/sentry/seer/autofix/feature/dispatch.py
+++ b/src/sentry/seer/autofix/feature/dispatch.py
@@ -24,7 +24,6 @@ from sentry.seer.autofix.feature.models import (
     AutofixRCATweaks,
     RCAStepArgs,
 )
-from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
 from sentry.seer.autofix.steps import AutofixStep
 from sentry.seer.autofix.utils import AutofixStoppingPoint, is_free_cohort_org
 from sentry.seer.models.run import SeerRun
@@ -52,6 +51,9 @@ def trigger_autofix_feature(
     group: Group,
     args: AutofixFeatureArgs,
 ) -> SeerRun:
+    # Avoid a circular import through the legacy Autofix dispatcher.
+    from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
+
     # Free cohort orgs bypass quota only when called from night shift
     # (allow_free_cohort=True). Not exposed via the API.
     skip_quota = args.allow_free_cohort and is_free_cohort_org(group.organization)
@@ -71,7 +73,7 @@ def trigger_autofix_feature(
             )
             raise NoSeerQuotaException()
 
-    rca_step_args = args.step_args or RCAStepArgs()
+    rca_step_args = args.step_args
     payload = AutofixFeaturePayload(
         group_id=group.id,
         project_id=group.project_id,

--- a/src/sentry/seer/autofix/feature/dispatch.py
+++ b/src/sentry/seer/autofix/feature/dispatch.py
@@ -36,10 +36,10 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class AutofixFeatureTriggerArgs:
+class AutofixFeatureArgs:
     step: AutofixStep
     referrer: AutofixReferrer
-    step_args: RCAStepArgs | None = None
+    step_args: RCAStepArgs
     user_context: str | None = None
     stopping_point: AutofixStoppingPoint | None = None
     allow_free_cohort: bool = False
@@ -50,11 +50,11 @@ class AutofixFeatureTriggerArgs:
 
 def trigger_autofix_feature(
     group: Group,
-    trigger: AutofixFeatureTriggerArgs,
+    args: AutofixFeatureArgs,
 ) -> SeerRun:
     # Free cohort orgs bypass quota only when called from night shift
     # (allow_free_cohort=True). Not exposed via the API.
-    skip_quota = trigger.allow_free_cohort and is_free_cohort_org(group.organization)
+    skip_quota = args.allow_free_cohort and is_free_cohort_org(group.organization)
     if not skip_quota:
         has_budget: bool = quotas.backend.check_seer_quota(
             org_id=group.organization.id,
@@ -66,12 +66,12 @@ def trigger_autofix_feature(
                 extra={
                     "group_id": group.id,
                     "organization_id": group.organization.id,
-                    "referrer": trigger.referrer.value,
+                    "referrer": args.referrer.value,
                 },
             )
             raise NoSeerQuotaException()
 
-    rca_step_args = trigger.step_args or RCAStepArgs()
+    rca_step_args = args.step_args or RCAStepArgs()
     payload = AutofixFeaturePayload(
         group_id=group.id,
         project_id=group.project_id,
@@ -83,39 +83,37 @@ def trigger_autofix_feature(
         tweaks=AutofixRCATweaks(
             intelligence_level=rca_step_args.intelligence_level,
             reasoning_effort=rca_step_args.reasoning_effort,
-            user_context=trigger.user_context,
+            user_context=args.user_context,
         ),
-        step=trigger.step,
-        user_context=trigger.user_context,
-        stopping_point=(
-            trigger.stopping_point.value if trigger.stopping_point is not None else None
-        ),
-        step_args=trigger.step_args,
+        step=args.step,
+        user_context=args.user_context,
+        stopping_point=(args.stopping_point.value if args.stopping_point is not None else None),
+        step_args=args.step_args,
     )
 
     client = SeerAgentClient(
         organization=group.organization,
         project=group.project,
         group=group,
-        user=trigger.user,
-        enable_bash_tools=trigger.enable_bash_tools,
+        user=args.user,
+        enable_bash_tools=args.enable_bash_tools,
     )
 
     extras: dict[str, Any] = {
-        "referrer": trigger.referrer.value,
+        "referrer": args.referrer.value,
     }
     # Store the stopping point here for delivery to use when advancing steps.
-    if trigger.stopping_point is not None:
-        extras["stopping_point"] = trigger.stopping_point.value
+    if args.stopping_point is not None:
+        extras["stopping_point"] = args.stopping_point.value
 
     run = client.start_feature_run(
         feature_id=FEATURE_ID,
         payload=payload.dict(),
         title=f"Autofix RCA — {payload.short_id}",
-        flush=trigger.flush,
+        flush=args.flush,
         extras=extras,
-        referrer=trigger.referrer.value,
-        user_org_context=collect_user_org_context(trigger.user, group.organization),
+        referrer=args.referrer.value,
+        user_org_context=collect_user_org_context(args.user, group.organization),
         proxy_headers=get_proxy_headers(),
         agent_run_options=AgentRunOptions(
             is_context_engine_enabled=False,
@@ -128,7 +126,7 @@ def trigger_autofix_feature(
             group.organization.id, group.project.id, DataCategory.SEER_AUTOFIX
         )
 
-    metrics.incr("autofix_feature.trigger", tags={"referrer": trigger.referrer.value})
+    metrics.incr("autofix_feature.trigger", tags={"referrer": args.referrer.value})
 
     logger.info(
         "autofix_feature.dispatch.started",
@@ -136,12 +134,12 @@ def trigger_autofix_feature(
             "group_id": group.id,
             "organization_id": group.organization.id,
             "run_id": run.seer_run_state_id,
-            "referrer": trigger.referrer.value,
-            "stopping_point": trigger.stopping_point,
-            "flush": trigger.flush,
-            "allow_free_cohort": trigger.allow_free_cohort,
-            "user_context": trigger.user_context,
-            "enable_bash_tools": trigger.enable_bash_tools,
+            "referrer": args.referrer.value,
+            "stopping_point": args.stopping_point,
+            "flush": args.flush,
+            "allow_free_cohort": args.allow_free_cohort,
+            "user_context": args.user_context,
+            "enable_bash_tools": args.enable_bash_tools,
         },
     )
 

--- a/src/sentry/seer/autofix/feature/dispatch.py
+++ b/src/sentry/seer/autofix/feature/dispatch.py
@@ -16,15 +16,13 @@ from sentry.seer.agent.client_utils import (
     get_proxy_headers,
 )
 from sentry.seer.agent.on_completion_hook import extract_hook_definition
-from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.exceptions import NoSeerQuotaException
 from sentry.seer.autofix.feature.models import (
     FEATURE_ID,
     AutofixFeaturePayload,
     AutofixRCATweaks,
     RCAStepArgs,
-    RepoPin,
-    RepoPins,
 )
 from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
 from sentry.seer.autofix.steps import AutofixStep
@@ -32,15 +30,13 @@ from sentry.seer.autofix.utils import AutofixStoppingPoint, is_free_cohort_org
 from sentry.seer.models.run import SeerRun
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
-from sentry.utils import json, metrics
+from sentry.utils import metrics
 
 logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
-class AutofixFeatureTrigger:
-    """Inputs used to start or continue an Autofix feature run."""
-
+class AutofixFeatureTriggerArgs:
     step: AutofixStep
     referrer: AutofixReferrer
     step_args: RCAStepArgs | None = None
@@ -52,19 +48,9 @@ class AutofixFeatureTrigger:
     flush: bool = True
 
 
-def parse_repo_pins(repo_pins: str | None) -> RepoPins | None:
-    if repo_pins is None:
-        return None
-
-    return {
-        repo_name: RepoPin.parse_obj(repo_pin)
-        for repo_name, repo_pin in json.loads(repo_pins).items()
-    }
-
-
 def trigger_autofix_feature(
     group: Group,
-    trigger: AutofixFeatureTrigger,
+    trigger: AutofixFeatureTriggerArgs,
 ) -> SeerRun:
     # Free cohort orgs bypass quota only when called from night shift
     # (allow_free_cohort=True). Not exposed via the API.

--- a/src/sentry/seer/autofix/feature/dispatch.py
+++ b/src/sentry/seer/autofix/feature/dispatch.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import logging
-from typing import Any, Literal
+from dataclasses import dataclass
+from typing import Any
 
 from django.contrib.auth.models import AnonymousUser
 
@@ -19,12 +20,13 @@ from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.feature.models import (
     FEATURE_ID,
-    AutofixRCAPayload,
-    AutofixRCATweaks,
+    AutofixFeaturePayload,
+    RCAStepArgs,
     RepoPin,
     RepoPins,
 )
 from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
+from sentry.seer.autofix.steps import AutofixStep
 from sentry.seer.autofix.utils import AutofixStoppingPoint, is_free_cohort_org
 from sentry.seer.models.run import SeerRun
 from sentry.users.models.user import User
@@ -34,7 +36,22 @@ from sentry.utils import json, metrics
 logger = logging.getLogger(__name__)
 
 
-def _parse_repo_pins(repo_pins: str | None) -> RepoPins | None:
+@dataclass(frozen=True)
+class AutofixFeatureTrigger:
+    """Inputs used to start or continue an Autofix feature run."""
+
+    step: AutofixStep
+    referrer: AutofixReferrer
+    user_context: str | None = None
+    stopping_point: AutofixStoppingPoint | None = None
+    allow_free_cohort: bool = False
+    user: User | RpcUser | AnonymousUser | None = None
+    enable_bash_tools: bool = False
+    step_args: RCAStepArgs | None = None
+    flush: bool = True
+
+
+def parse_repo_pins(repo_pins: str | None) -> RepoPins | None:
     if repo_pins is None:
         return None
 
@@ -46,22 +63,11 @@ def _parse_repo_pins(repo_pins: str | None) -> RepoPins | None:
 
 def trigger_autofix_feature(
     group: Group,
-    *,
-    referrer: AutofixReferrer,
-    # Not to be confused with user_org_context, this is free-form context added by the user to the rca run.
-    user_context: str | None = None,
-    stopping_point: AutofixStoppingPoint | None = None,
-    intelligence_level: Literal["low", "medium", "high"] = "medium",
-    reasoning_effort: Literal["low", "medium", "high"] | None = "medium",
-    flush: bool = True,
-    allow_free_cohort: bool = False,
-    user: User | RpcUser | AnonymousUser | None = None,
-    enable_bash_tools: bool = False,
-    repo_pins: str | None = None,
+    trigger: AutofixFeatureTrigger,
 ) -> SeerRun:
     # Free cohort orgs bypass quota only when called from night shift
     # (allow_free_cohort=True). Not exposed via the API.
-    skip_quota = allow_free_cohort and is_free_cohort_org(group.organization)
+    skip_quota = trigger.allow_free_cohort and is_free_cohort_org(group.organization)
     if not skip_quota:
         has_budget: bool = quotas.backend.check_seer_quota(
             org_id=group.organization.id,
@@ -73,49 +79,49 @@ def trigger_autofix_feature(
                 extra={
                     "group_id": group.id,
                     "organization_id": group.organization.id,
-                    "referrer": referrer.value,
+                    "referrer": trigger.referrer.value,
                 },
             )
             raise NoSeerQuotaException()
 
-    payload = AutofixRCAPayload(
+    payload = AutofixFeaturePayload(
         group_id=group.id,
         project_id=group.project_id,
         short_id=group.qualified_short_id or str(group.id),
         title=group.title or "Unknown error",
         culprit=group.culprit or "unknown",
         on_completion_hook=extract_hook_definition(AutofixOnCompletionHook, call_on_failure=True),
-        repo_pins=_parse_repo_pins(repo_pins),
-        tweaks=AutofixRCATweaks(
-            intelligence_level=intelligence_level,
-            reasoning_effort=reasoning_effort,
-            user_context=user_context,
+        step=trigger.step,
+        user_context=trigger.user_context,
+        stopping_point=(
+            trigger.stopping_point.value if trigger.stopping_point is not None else None
         ),
+        step_args=trigger.step_args,
     )
 
     client = SeerAgentClient(
         organization=group.organization,
         project=group.project,
         group=group,
-        user=user,
-        enable_bash_tools=enable_bash_tools,
+        user=trigger.user,
+        enable_bash_tools=trigger.enable_bash_tools,
     )
 
     extras: dict[str, Any] = {
-        "referrer": referrer.value,
+        "referrer": trigger.referrer.value,
     }
     # Store the stopping point here for delivery to use when advancing steps.
-    if stopping_point is not None:
-        extras["stopping_point"] = stopping_point.value
+    if trigger.stopping_point is not None:
+        extras["stopping_point"] = trigger.stopping_point.value
 
     run = client.start_feature_run(
         feature_id=FEATURE_ID,
         payload=payload.dict(),
         title=f"Autofix RCA — {payload.short_id}",
-        flush=flush,
+        flush=trigger.flush,
         extras=extras,
-        referrer=referrer.value,
-        user_org_context=collect_user_org_context(user, group.organization),
+        referrer=trigger.referrer.value,
+        user_org_context=collect_user_org_context(trigger.user, group.organization),
         proxy_headers=get_proxy_headers(),
         agent_run_options=AgentRunOptions(
             is_context_engine_enabled=False,
@@ -128,7 +134,7 @@ def trigger_autofix_feature(
             group.organization.id, group.project.id, DataCategory.SEER_AUTOFIX
         )
 
-    metrics.incr("autofix_feature.trigger", tags={"referrer": referrer.value})
+    metrics.incr("autofix_feature.trigger", tags={"referrer": trigger.referrer.value})
 
     logger.info(
         "autofix_feature.dispatch.started",
@@ -136,14 +142,12 @@ def trigger_autofix_feature(
             "group_id": group.id,
             "organization_id": group.organization.id,
             "run_id": run.seer_run_state_id,
-            "referrer": referrer.value,
-            "stopping_point": stopping_point,
-            "intelligence_level": intelligence_level,
-            "reasoning_effort": reasoning_effort,
-            "flush": flush,
-            "allow_free_cohort": allow_free_cohort,
-            "user_context": user_context,
-            "enable_bash_tools": enable_bash_tools,
+            "referrer": trigger.referrer.value,
+            "stopping_point": trigger.stopping_point,
+            "flush": trigger.flush,
+            "allow_free_cohort": trigger.allow_free_cohort,
+            "user_context": trigger.user_context,
+            "enable_bash_tools": trigger.enable_bash_tools,
         },
     )
 

--- a/src/sentry/seer/autofix/feature/dispatch.py
+++ b/src/sentry/seer/autofix/feature/dispatch.py
@@ -21,6 +21,7 @@ from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.feature.models import (
     FEATURE_ID,
     AutofixFeaturePayload,
+    AutofixRCATweaks,
     RCAStepArgs,
     RepoPin,
     RepoPins,
@@ -42,12 +43,12 @@ class AutofixFeatureTrigger:
 
     step: AutofixStep
     referrer: AutofixReferrer
+    step_args: RCAStepArgs | None = None
     user_context: str | None = None
     stopping_point: AutofixStoppingPoint | None = None
     allow_free_cohort: bool = False
     user: User | RpcUser | AnonymousUser | None = None
     enable_bash_tools: bool = False
-    step_args: RCAStepArgs | None = None
     flush: bool = True
 
 
@@ -84,6 +85,7 @@ def trigger_autofix_feature(
             )
             raise NoSeerQuotaException()
 
+    rca_step_args = trigger.step_args or RCAStepArgs()
     payload = AutofixFeaturePayload(
         group_id=group.id,
         project_id=group.project_id,
@@ -91,6 +93,12 @@ def trigger_autofix_feature(
         title=group.title or "Unknown error",
         culprit=group.culprit or "unknown",
         on_completion_hook=extract_hook_definition(AutofixOnCompletionHook, call_on_failure=True),
+        repo_pins=rca_step_args.repo_pins,
+        tweaks=AutofixRCATweaks(
+            intelligence_level=rca_step_args.intelligence_level,
+            reasoning_effort=rca_step_args.reasoning_effort,
+            user_context=trigger.user_context,
+        ),
         step=trigger.step,
         user_context=trigger.user_context,
         stopping_point=(

--- a/src/sentry/seer/autofix/feature/models.py
+++ b/src/sentry/seer/autofix/feature/models.py
@@ -2,25 +2,16 @@ from __future__ import annotations
 
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel
 
 from sentry.seer.agent.on_completion_hook import OnCompletionHookDefinition
+from sentry.seer.autofix.steps import AutofixStep
 
 # Keep models in sync with src/seer/automation/features/autofix/models.py in Seer
 
 FEATURE_ID = "autofix"
 # In-flight runs started before the rename still deliver and persist this id.
 LEGACY_FEATURE_ID = "autofix_rca"
-
-
-class AutofixRCATweaks(BaseModel):
-    class Config:
-        extra = "ignore"
-
-    intelligence_level: Literal["low", "medium", "high"] = "medium"
-    reasoning_effort: Literal["low", "medium", "high"] | None = "medium"
-    # Not to be confused with user_org_context, this is free-form context added by the user to the rca run.
-    user_context: str | None = None
 
 
 class RepoPin(BaseModel):
@@ -45,15 +36,28 @@ class RepoPin(BaseModel):
 RepoPins = dict[str, RepoPin]
 
 
-class AutofixRCAPayload(BaseModel):
+class RCAStepArgs(BaseModel):
     class Config:
         extra = "ignore"
 
+    intelligence_level: Literal["low", "medium", "high"] = "medium"
+    reasoning_effort: Literal["low", "medium", "high"] | None = "medium"
+    repo_pins: RepoPins | None = None
+
+
+class AutofixFeaturePayload(BaseModel):
+    class Config:
+        extra = "ignore"
+
+    # Universal params across all steps
     group_id: int
     project_id: int
     short_id: str
     title: str
     culprit: str
     on_completion_hook: OnCompletionHookDefinition
-    repo_pins: RepoPins | None = None
-    tweaks: AutofixRCATweaks = Field(default_factory=AutofixRCATweaks)
+    step: AutofixStep = AutofixStep.ROOT_CAUSE
+    # Not to be confused with user_org_context, this is free-form context added by the user.
+    user_context: str | None = None
+    stopping_point: str | None = None
+    step_args: RCAStepArgs | None = None

--- a/src/sentry/seer/autofix/feature/models.py
+++ b/src/sentry/seer/autofix/feature/models.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Literal, Self
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -31,18 +31,11 @@ class RepoPin(BaseModel):
         extra = "forbid"
 
     sha: str
-    branch: str
-
-    @classmethod
-    def parse_obj(cls, obj: Any) -> Self:
-        # Allow "base_sha" as alias for "sha" and "base_branch" as alias for "branch"
-        if "base_sha" in obj and "sha" not in obj:
-            obj = dict(obj)
-            obj["sha"] = obj.pop("base_sha")
-        if "base_branch" in obj and "branch" not in obj:
-            obj = dict(obj)
-            obj["branch"] = obj.pop("base_branch")
-        return super().parse_obj(obj)
+    branch: str | None = None
+    # Deprecated: this is the same as sha, but poorly named.
+    base_sha: str
+    # Deprecated: this is the same as branch, but poorly named.
+    base_branch: str | None = None
 
 
 RepoPins = dict[str, RepoPin]
@@ -77,7 +70,7 @@ class AutofixFeaturePayload(BaseModel):
     tweaks: AutofixRCATweaks = Field(default_factory=AutofixRCATweaks)
 
     step: AutofixStep = AutofixStep.ROOT_CAUSE
+    step_args: RCAStepArgs
     # Not to be confused with user_org_context, this is free-form context added by the user.
     user_context: str | None = None
     stopping_point: str | None = None
-    step_args: RCAStepArgs | None = None

--- a/src/sentry/seer/autofix/feature/models.py
+++ b/src/sentry/seer/autofix/feature/models.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from sentry.seer.agent.on_completion_hook import OnCompletionHookDefinition
 from sentry.seer.autofix.steps import AutofixStep
@@ -12,6 +12,18 @@ from sentry.seer.autofix.steps import AutofixStep
 FEATURE_ID = "autofix"
 # In-flight runs started before the rename still deliver and persist this id.
 LEGACY_FEATURE_ID = "autofix_rca"
+
+
+class AutofixRCATweaks(BaseModel):
+    """Deprecated RCA arguments retained until Seer reads step_args."""
+
+    class Config:
+        extra = "ignore"
+
+    intelligence_level: Literal["low", "medium", "high"] = "medium"
+    reasoning_effort: Literal["low", "medium", "high"] | None = "medium"
+    # Not to be confused with user_org_context, this is free-form context added by the user.
+    user_context: str | None = None
 
 
 class RepoPin(BaseModel):
@@ -37,6 +49,8 @@ RepoPins = dict[str, RepoPin]
 
 
 class RCAStepArgs(BaseModel):
+    """RCA-specific arguments for the generic Autofix feature payload."""
+
     class Config:
         extra = "ignore"
 
@@ -56,6 +70,12 @@ class AutofixFeaturePayload(BaseModel):
     title: str
     culprit: str
     on_completion_hook: OnCompletionHookDefinition
+
+    # Deprecated: the current Seer feature still reads these RCA-only fields.
+    # Keep them in sync with step_args until Seer accepts the step_args.
+    repo_pins: RepoPins | None = None
+    tweaks: AutofixRCATweaks = Field(default_factory=AutofixRCATweaks)
+
     step: AutofixStep = AutofixStep.ROOT_CAUSE
     # Not to be confused with user_org_context, this is free-form context added by the user.
     user_context: str | None = None

--- a/src/sentry/seer/autofix/issue_summary.py
+++ b/src/sentry/seer/autofix/issue_summary.py
@@ -22,16 +22,14 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.net.http import connection_from_url
 from sentry.seer.autofix.autofix import get_trace_tree_for_event
-from sentry.seer.autofix.autofix_agent import (
-    NoSeerQuotaException,
-    trigger_autofix_agent,
-)
+from sentry.seer.autofix.autofix_agent import trigger_autofix_agent
 from sentry.seer.autofix.constants import (
     AutofixAutomationTuningSettings,
     AutofixReferrer,
     FixabilityScoreThresholds,
     SeerAutomationSource,
 )
+from sentry.seer.autofix.exceptions import NoSeerQuotaException
 from sentry.seer.autofix.steps import AutofixStep
 from sentry.seer.autofix.utils import (
     AutofixStoppingPoint,

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -43,7 +43,6 @@ from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.seer.autofix.autofix_agent import (
-    NoSeerQuotaException,
     get_autofix_agent_state,
     get_autofix_run_state,
     trigger_autofix_agent,
@@ -56,6 +55,7 @@ from sentry.seer.autofix.coding_agent import (
 )
 from sentry.seer.autofix.commit_author import commit_author_for_user
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.exceptions import NoSeerQuotaException
 from sentry.seer.autofix.github_perms import (
     get_blocked_pr_iteration_permissions,
 )

--- a/src/sentry/seer/entrypoints/operator.py
+++ b/src/sentry/seer/entrypoints/operator.py
@@ -180,11 +180,11 @@ class SeerAutofixOperator[CachePayloadT]:
         run_id: int | None = None,
     ) -> None:
         from sentry.seer.autofix.autofix_agent import (
-            NoSeerQuotaException,
             get_autofix_agent_state,
             trigger_autofix_agent,
             trigger_push_changes,
         )
+        from sentry.seer.autofix.exceptions import NoSeerQuotaException
         from sentry.seer.autofix.steps import AutofixStep
 
         event_lifecyle = SeerOperatorEventLifecycleMetric(

--- a/tests/sentry/seer/autofix/feature/test_dispatch.py
+++ b/tests/sentry/seer/autofix/feature/test_dispatch.py
@@ -2,9 +2,9 @@ from unittest.mock import patch
 
 import pytest
 
-from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
-from sentry.seer.autofix.feature.dispatch import AutofixFeatureTrigger, trigger_autofix_feature
+from sentry.seer.autofix.exceptions import NoSeerQuotaException
+from sentry.seer.autofix.feature.dispatch import AutofixFeatureTriggerArgs, trigger_autofix_feature
 from sentry.seer.autofix.feature.models import RCAStepArgs
 from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
 from sentry.seer.autofix.steps import AutofixStep
@@ -41,7 +41,7 @@ class TestTriggerAutofixFeature(TestCase):
 
             run = trigger_autofix_feature(
                 self.group,
-                AutofixFeatureTrigger(
+                AutofixFeatureTriggerArgs(
                     referrer=AutofixReferrer.NIGHT_SHIFT,
                     step=AutofixStep.ROOT_CAUSE,
                     user_context="an upstream triage summary",
@@ -116,7 +116,7 @@ class TestTriggerAutofixFeature(TestCase):
             with pytest.raises(NoSeerQuotaException):
                 trigger_autofix_feature(
                     self.group,
-                    AutofixFeatureTrigger(
+                    AutofixFeatureTriggerArgs(
                         referrer=AutofixReferrer.NIGHT_SHIFT,
                         step=AutofixStep.ROOT_CAUSE,
                     ),
@@ -137,7 +137,7 @@ class TestTriggerAutofixFeature(TestCase):
 
             run = trigger_autofix_feature(
                 self.group,
-                AutofixFeatureTrigger(
+                AutofixFeatureTriggerArgs(
                     referrer=AutofixReferrer.NIGHT_SHIFT,
                     step=AutofixStep.ROOT_CAUSE,
                     allow_free_cohort=True,
@@ -160,7 +160,7 @@ class TestTriggerAutofixFeature(TestCase):
 
             trigger_autofix_feature(
                 self.group,
-                AutofixFeatureTrigger(
+                AutofixFeatureTriggerArgs(
                     referrer=AutofixReferrer.NIGHT_SHIFT,
                     step=AutofixStep.ROOT_CAUSE,
                     flush=False,
@@ -182,7 +182,7 @@ class TestTriggerAutofixFeature(TestCase):
 
             trigger_autofix_feature(
                 self.group,
-                AutofixFeatureTrigger(
+                AutofixFeatureTriggerArgs(
                     referrer=AutofixReferrer.NIGHT_SHIFT,
                     step=AutofixStep.ROOT_CAUSE,
                     user=user,

--- a/tests/sentry/seer/autofix/feature/test_dispatch.py
+++ b/tests/sentry/seer/autofix/feature/test_dispatch.py
@@ -4,8 +4,10 @@ import pytest
 
 from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
-from sentry.seer.autofix.feature.dispatch import trigger_autofix_feature
+from sentry.seer.autofix.feature.dispatch import AutofixFeatureTrigger, trigger_autofix_feature
+from sentry.seer.autofix.feature.models import RCAStepArgs
 from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
+from sentry.seer.autofix.steps import AutofixStep
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.testutils.cases import TestCase
 from sentry.testutils.pytest.fixtures import django_db_all
@@ -39,10 +41,15 @@ class TestTriggerAutofixFeature(TestCase):
 
             run = trigger_autofix_feature(
                 self.group,
-                referrer=AutofixReferrer.NIGHT_SHIFT,
-                user_context="an upstream triage summary",
-                stopping_point=AutofixStoppingPoint.OPEN_PR,
-                repo_pins='{"owner/repo":{"base_sha":"abc123","base_branch":"main"}}',
+                AutofixFeatureTrigger(
+                    referrer=AutofixReferrer.NIGHT_SHIFT,
+                    step=AutofixStep.ROOT_CAUSE,
+                    user_context="an upstream triage summary",
+                    stopping_point=AutofixStoppingPoint.OPEN_PR,
+                    step_args=RCAStepArgs(
+                        repo_pins={"owner/repo": {"sha": "abc123", "branch": "main"}}
+                    ),
+                ),
             )
 
         assert run is fake_run
@@ -61,10 +68,16 @@ class TestTriggerAutofixFeature(TestCase):
         payload = run_kwargs["payload"]
         assert payload["group_id"] == self.group.id
         assert payload["project_id"] == self.group.project_id
+        assert payload["step"] == AutofixStep.ROOT_CAUSE
         assert payload["short_id"] == (self.group.qualified_short_id or str(self.group.id))
         assert payload["title"] == self.group.title
-        assert payload["repo_pins"] == {"owner/repo": {"sha": "abc123", "branch": "main"}}
-        assert payload["tweaks"]["user_context"] == "an upstream triage summary"
+        assert payload["user_context"] == "an upstream triage summary"
+        assert payload["stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
+        assert payload["step_args"] == {
+            "intelligence_level": "medium",
+            "reasoning_effort": "medium",
+            "repo_pins": {"owner/repo": {"sha": "abc123", "branch": "main"}},
+        }
         # Seer persists this hook on the Explorer run so later PR iteration
         # completions continue through the Autofix completion flow.
         assert payload["on_completion_hook"] == {
@@ -94,7 +107,10 @@ class TestTriggerAutofixFeature(TestCase):
             with pytest.raises(NoSeerQuotaException):
                 trigger_autofix_feature(
                     self.group,
-                    referrer=AutofixReferrer.NIGHT_SHIFT,
+                    AutofixFeatureTrigger(
+                        referrer=AutofixReferrer.NIGHT_SHIFT,
+                        step=AutofixStep.ROOT_CAUSE,
+                    ),
                 )
 
         MockClient.return_value.start_feature_run.assert_not_called()
@@ -112,8 +128,11 @@ class TestTriggerAutofixFeature(TestCase):
 
             run = trigger_autofix_feature(
                 self.group,
-                referrer=AutofixReferrer.NIGHT_SHIFT,
-                allow_free_cohort=True,
+                AutofixFeatureTrigger(
+                    referrer=AutofixReferrer.NIGHT_SHIFT,
+                    step=AutofixStep.ROOT_CAUSE,
+                    allow_free_cohort=True,
+                ),
             )
 
         assert run is fake_run
@@ -132,8 +151,11 @@ class TestTriggerAutofixFeature(TestCase):
 
             trigger_autofix_feature(
                 self.group,
-                referrer=AutofixReferrer.NIGHT_SHIFT,
-                flush=False,
+                AutofixFeatureTrigger(
+                    referrer=AutofixReferrer.NIGHT_SHIFT,
+                    step=AutofixStep.ROOT_CAUSE,
+                    flush=False,
+                ),
             )
 
         assert mock_client_cls.return_value.start_feature_run.call_args.kwargs["flush"] is False
@@ -151,9 +173,12 @@ class TestTriggerAutofixFeature(TestCase):
 
             trigger_autofix_feature(
                 self.group,
-                referrer=AutofixReferrer.NIGHT_SHIFT,
-                user=user,
-                enable_bash_tools=True,
+                AutofixFeatureTrigger(
+                    referrer=AutofixReferrer.NIGHT_SHIFT,
+                    step=AutofixStep.ROOT_CAUSE,
+                    user=user,
+                    enable_bash_tools=True,
+                ),
             )
 
         client_kwargs = mock_client_cls.call_args.kwargs

--- a/tests/sentry/seer/autofix/feature/test_dispatch.py
+++ b/tests/sentry/seer/autofix/feature/test_dispatch.py
@@ -47,7 +47,9 @@ class TestTriggerAutofixFeature(TestCase):
                     user_context="an upstream triage summary",
                     stopping_point=AutofixStoppingPoint.OPEN_PR,
                     step_args=RCAStepArgs(
-                        repo_pins={"owner/repo": {"sha": "abc123", "branch": "main"}}
+                        intelligence_level="high",
+                        reasoning_effort="low",
+                        repo_pins={"owner/repo": {"sha": "abc123", "branch": "main"}},
                     ),
                 ),
             )
@@ -73,9 +75,16 @@ class TestTriggerAutofixFeature(TestCase):
         assert payload["title"] == self.group.title
         assert payload["user_context"] == "an upstream triage summary"
         assert payload["stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
+        # Retained while Seer continues to consume the legacy RCA payload shape.
+        assert payload["repo_pins"] == {"owner/repo": {"sha": "abc123", "branch": "main"}}
+        assert payload["tweaks"] == {
+            "intelligence_level": "high",
+            "reasoning_effort": "low",
+            "user_context": "an upstream triage summary",
+        }
         assert payload["step_args"] == {
-            "intelligence_level": "medium",
-            "reasoning_effort": "medium",
+            "intelligence_level": "high",
+            "reasoning_effort": "low",
             "repo_pins": {"owner/repo": {"sha": "abc123", "branch": "main"}},
         }
         # Seer persists this hook on the Explorer run so later PR iteration

--- a/tests/sentry/seer/autofix/feature/test_dispatch.py
+++ b/tests/sentry/seer/autofix/feature/test_dispatch.py
@@ -4,7 +4,7 @@ import pytest
 
 from sentry.seer.autofix.constants import AutofixReferrer
 from sentry.seer.autofix.exceptions import NoSeerQuotaException
-from sentry.seer.autofix.feature.dispatch import AutofixFeatureTriggerArgs, trigger_autofix_feature
+from sentry.seer.autofix.feature.dispatch import AutofixFeatureArgs, trigger_autofix_feature
 from sentry.seer.autofix.feature.models import RCAStepArgs
 from sentry.seer.autofix.on_completion_hook import AutofixOnCompletionHook
 from sentry.seer.autofix.steps import AutofixStep
@@ -41,7 +41,7 @@ class TestTriggerAutofixFeature(TestCase):
 
             run = trigger_autofix_feature(
                 self.group,
-                AutofixFeatureTriggerArgs(
+                AutofixFeatureArgs(
                     referrer=AutofixReferrer.NIGHT_SHIFT,
                     step=AutofixStep.ROOT_CAUSE,
                     user_context="an upstream triage summary",
@@ -49,7 +49,14 @@ class TestTriggerAutofixFeature(TestCase):
                     step_args=RCAStepArgs(
                         intelligence_level="high",
                         reasoning_effort="low",
-                        repo_pins={"owner/repo": {"sha": "abc123", "branch": "main"}},
+                        repo_pins={
+                            "owner/repo": {
+                                "sha": "abc123",
+                                "branch": "main",
+                                "base_sha": "abc123",
+                                "base_branch": "main",
+                            }
+                        },
                     ),
                 ),
             )
@@ -76,7 +83,14 @@ class TestTriggerAutofixFeature(TestCase):
         assert payload["user_context"] == "an upstream triage summary"
         assert payload["stopping_point"] == AutofixStoppingPoint.OPEN_PR.value
         # Retained while Seer continues to consume the legacy RCA payload shape.
-        assert payload["repo_pins"] == {"owner/repo": {"sha": "abc123", "branch": "main"}}
+        assert payload["repo_pins"] == {
+            "owner/repo": {
+                "sha": "abc123",
+                "branch": "main",
+                "base_sha": "abc123",
+                "base_branch": "main",
+            }
+        }
         assert payload["tweaks"] == {
             "intelligence_level": "high",
             "reasoning_effort": "low",
@@ -85,7 +99,14 @@ class TestTriggerAutofixFeature(TestCase):
         assert payload["step_args"] == {
             "intelligence_level": "high",
             "reasoning_effort": "low",
-            "repo_pins": {"owner/repo": {"sha": "abc123", "branch": "main"}},
+            "repo_pins": {
+                "owner/repo": {
+                    "sha": "abc123",
+                    "branch": "main",
+                    "base_sha": "abc123",
+                    "base_branch": "main",
+                }
+            },
         }
         # Seer persists this hook on the Explorer run so later PR iteration
         # completions continue through the Autofix completion flow.
@@ -116,9 +137,10 @@ class TestTriggerAutofixFeature(TestCase):
             with pytest.raises(NoSeerQuotaException):
                 trigger_autofix_feature(
                     self.group,
-                    AutofixFeatureTriggerArgs(
+                    AutofixFeatureArgs(
                         referrer=AutofixReferrer.NIGHT_SHIFT,
                         step=AutofixStep.ROOT_CAUSE,
+                        step_args=RCAStepArgs(),
                     ),
                 )
 
@@ -137,9 +159,10 @@ class TestTriggerAutofixFeature(TestCase):
 
             run = trigger_autofix_feature(
                 self.group,
-                AutofixFeatureTriggerArgs(
+                AutofixFeatureArgs(
                     referrer=AutofixReferrer.NIGHT_SHIFT,
                     step=AutofixStep.ROOT_CAUSE,
+                    step_args=RCAStepArgs(),
                     allow_free_cohort=True,
                 ),
             )
@@ -160,9 +183,10 @@ class TestTriggerAutofixFeature(TestCase):
 
             trigger_autofix_feature(
                 self.group,
-                AutofixFeatureTriggerArgs(
+                AutofixFeatureArgs(
                     referrer=AutofixReferrer.NIGHT_SHIFT,
                     step=AutofixStep.ROOT_CAUSE,
+                    step_args=RCAStepArgs(),
                     flush=False,
                 ),
             )
@@ -182,9 +206,10 @@ class TestTriggerAutofixFeature(TestCase):
 
             trigger_autofix_feature(
                 self.group,
-                AutofixFeatureTriggerArgs(
+                AutofixFeatureArgs(
                     referrer=AutofixReferrer.NIGHT_SHIFT,
                     step=AutofixStep.ROOT_CAUSE,
+                    step_args=RCAStepArgs(),
                     user=user,
                     enable_bash_tools=True,
                 ),

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -1209,9 +1209,16 @@ class TestTriggerAutofixAgent(TestCase):
             )
 
         prompt_metadata = mock_client.start_run.call_args.kwargs["prompt_metadata"]
-        assert json.loads(prompt_metadata["base_shas"]) == {
-            "owner/repo": {"base_sha": "abc123", "base_branch": "main"}
+        expected_repo_pins = {
+            "owner/repo": {
+                "sha": "abc123",
+                "branch": "main",
+                "base_sha": "abc123",
+                "base_branch": "main",
+            }
         }
+        assert json.loads(prompt_metadata["base_shas"]) == expected_repo_pins
+        assert json.loads(prompt_metadata["repo_pins"]) == expected_repo_pins
 
     @patch("sentry.scm.factory.new")
     @patch("sentry.quotas.backend.record_seer_run")

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -16,7 +16,6 @@ from sentry.seer.agent.client_models import (
 from sentry.seer.autofix.analytics import record_autofix_event
 from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
-    NoSeerQuotaException,
     PrIterationNoPullRequestException,
     _build_base_shas_metadata,
     build_step_prompt,
@@ -30,6 +29,7 @@ from sentry.seer.autofix.autofix_agent import (
 )
 from sentry.seer.autofix.commit_author import SeerCommitAuthor
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.exceptions import NoSeerQuotaException
 from sentry.seer.autofix.steps import AutofixStep
 from sentry.seer.autofix.utils import AutofixStoppingPoint
 from sentry.seer.models import SeerPermissionError

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -17,7 +17,7 @@ from sentry.seer.autofix.analytics import record_autofix_event
 from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
     PrIterationNoPullRequestException,
-    _build_base_shas_metadata,
+    _build_repo_pins,
     build_step_prompt,
     generate_autofix_handoff_prompt,
     get_iteration_for_insert_index,
@@ -568,7 +568,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
     @patch("sentry.scm.factory.new")
-    @patch("sentry.seer.autofix.feature.dispatch.trigger_autofix_feature")
+    @patch("sentry.seer.autofix.autofix_agent.trigger_autofix_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_root_cause_routes_repo_pins_to_feature_when_flagged(
         self,
@@ -606,7 +606,12 @@ class TestTriggerAutofixAgent(TestCase):
         feature_trigger = mock_feature.call_args.args[1]
         assert feature_trigger.step_args is not None
         assert feature_trigger.step_args.repo_pins == {
-            "owner/repo": {"sha": "abc123", "branch": "main"}
+            "owner/repo": {
+                "sha": "abc123",
+                "branch": "main",
+                "base_sha": "abc123",
+                "base_branch": "main",
+            }
         }
         # legacy explorer run is not started for a flagged root-cause kickoff
         mock_client_class.return_value.start_run.assert_not_called()
@@ -622,7 +627,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.feature.dispatch.trigger_autofix_feature")
+    @patch("sentry.seer.autofix.autofix_agent.trigger_autofix_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_feature_receives_stopping_point(
         self, mock_client_class, mock_feature, mock_broadcast, mock_check_quota, mock_record_run
@@ -648,7 +653,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.feature.dispatch.trigger_autofix_feature")
+    @patch("sentry.seer.autofix.autofix_agent.trigger_autofix_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_feature_receives_run_options(
         self, mock_client_class, mock_feature, mock_broadcast, mock_check_quota, mock_record_run
@@ -675,7 +680,7 @@ class TestTriggerAutofixAgent(TestCase):
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
     @patch("sentry.seer.autofix.autofix_agent.broadcast_webhooks_for_organization.delay")
-    @patch("sentry.seer.autofix.feature.dispatch.trigger_autofix_feature")
+    @patch("sentry.seer.autofix.autofix_agent.trigger_autofix_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_night_shift_repo_checks_force_bash_tools_on_the_feature(
         self, mock_client_class, mock_feature, mock_broadcast, mock_check_quota, mock_record_run
@@ -696,7 +701,7 @@ class TestTriggerAutofixAgent(TestCase):
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix.feature.dispatch.trigger_autofix_feature")
+    @patch("sentry.seer.autofix.autofix_agent.trigger_autofix_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_solution_step_does_not_route_to_feature(
         self, mock_client_class, mock_feature, mock_check_quota, mock_record_run
@@ -721,7 +726,7 @@ class TestTriggerAutofixAgent(TestCase):
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
-    @patch("sentry.seer.autofix.feature.dispatch.trigger_autofix_feature")
+    @patch("sentry.seer.autofix.autofix_agent.trigger_autofix_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_root_cause_uses_legacy_flow_without_flag(
         self, mock_client_class, mock_feature, mock_check_quota, mock_record_run
@@ -744,7 +749,7 @@ class TestTriggerAutofixAgent(TestCase):
         mock_client.start_run.assert_called_once()
 
     @patch("sentry.quotas.backend.check_seer_quota", return_value=False)
-    @patch("sentry.seer.autofix.feature.dispatch.trigger_autofix_feature")
+    @patch("sentry.seer.autofix.autofix_agent.trigger_autofix_feature")
     @patch("sentry.seer.autofix.autofix_agent.SeerAgentClient")
     def test_flagged_root_cause_still_enforces_quota(
         self, mock_client_class, mock_feature, mock_check_quota
@@ -1258,7 +1263,7 @@ class TestTriggerAutofixAgent(TestCase):
         mock_scm_new.assert_not_called()
 
 
-class TestBuildBaseShasMetadata(TestCase):
+class TestBuildRepoPins(TestCase):
     def setUp(self) -> None:
         super().setUp()
         self.group = self.create_group(project=self.project)
@@ -1284,7 +1289,7 @@ class TestBuildBaseShasMetadata(TestCase):
         )
 
     def test_returns_none_without_repos(self) -> None:
-        assert _build_base_shas_metadata(self.group, AutofixReferrer.UNKNOWN) is None
+        assert _build_repo_pins(self.group, AutofixReferrer.UNKNOWN) is None
 
     @patch("sentry.scm.factory.new")
     def test_builds_base_shas_using_default_branch(self, mock_scm_new):
@@ -1295,10 +1300,17 @@ class TestBuildBaseShasMetadata(TestCase):
         )
         mock_scm_new.return_value = mock_scm
 
-        result = _build_base_shas_metadata(self.group, AutofixReferrer.UNKNOWN)
+        result = _build_repo_pins(self.group, AutofixReferrer.UNKNOWN)
 
         assert result is not None
-        assert json.loads(result) == {"owner/repo": {"base_sha": "deadbeef", "base_branch": "main"}}
+        assert result == {
+            "owner/repo": {
+                "sha": "deadbeef",
+                "branch": "main",
+                "base_sha": "deadbeef",
+                "base_branch": "main",
+            }
+        }
         mock_scm.get_branch.assert_called_once_with("main")
 
     @patch("sentry.scm.factory.new")
@@ -1307,11 +1319,16 @@ class TestBuildBaseShasMetadata(TestCase):
         mock_scm = _make_scm_mock(get_branch={"data": {"sha": "abc"}})
         mock_scm_new.return_value = mock_scm
 
-        result = _build_base_shas_metadata(self.group, AutofixReferrer.UNKNOWN)
+        result = _build_repo_pins(self.group, AutofixReferrer.UNKNOWN)
 
         assert result is not None
-        assert json.loads(result) == {
-            "owner/repo": {"base_sha": "abc", "base_branch": "release/v2"}
+        assert result == {
+            "owner/repo": {
+                "sha": "abc",
+                "branch": "release/v2",
+                "base_sha": "abc",
+                "base_branch": "release/v2",
+            }
         }
         mock_scm.get_repository.assert_not_called()
         mock_scm.get_branch.assert_called_once_with("release/v2")
@@ -1322,7 +1339,7 @@ class TestBuildBaseShasMetadata(TestCase):
         self._make_repo_and_projectrepo()
         mock_scm_new.side_effect = Exception("boom")
 
-        assert _build_base_shas_metadata(self.group, AutofixReferrer.UNKNOWN) is None
+        assert _build_repo_pins(self.group, AutofixReferrer.UNKNOWN) is None
         mock_logger.exception.assert_called_once()
 
     @patch("sentry.scm.factory.new")
@@ -1331,7 +1348,7 @@ class TestBuildBaseShasMetadata(TestCase):
         mock_scm = _make_scm_mock(get_repository={"data": {"default_branch": None}})
         mock_scm_new.return_value = mock_scm
 
-        assert _build_base_shas_metadata(self.group, AutofixReferrer.UNKNOWN) is None
+        assert _build_repo_pins(self.group, AutofixReferrer.UNKNOWN) is None
         mock_scm.get_branch.assert_not_called()
 
     @patch("sentry.scm.factory.new")
@@ -1349,11 +1366,16 @@ class TestBuildBaseShasMetadata(TestCase):
         )
         mock_scm_new.side_effect = [ok_scm, bad_scm]
 
-        result = _build_base_shas_metadata(self.group, AutofixReferrer.UNKNOWN)
+        result = _build_repo_pins(self.group, AutofixReferrer.UNKNOWN)
 
         assert result is not None
-        assert json.loads(result) == {
-            "owner/repo-ok": {"base_sha": "sha-ok", "base_branch": "main"}
+        assert result == {
+            "owner/repo-ok": {
+                "sha": "sha-ok",
+                "branch": "main",
+                "base_sha": "sha-ok",
+                "base_branch": "main",
+            }
         }
 
 

--- a/tests/sentry/seer/autofix/test_autofix_agent.py
+++ b/tests/sentry/seer/autofix/test_autofix_agent.py
@@ -603,8 +603,10 @@ class TestTriggerAutofixAgent(TestCase):
         assert result == feature_run
         mock_feature.assert_called_once()
         assert mock_feature.call_args.args[0] == self.group
-        assert json.loads(mock_feature.call_args.kwargs["repo_pins"]) == {
-            "owner/repo": {"base_sha": "abc123", "base_branch": "main"}
+        feature_trigger = mock_feature.call_args.args[1]
+        assert feature_trigger.step_args is not None
+        assert feature_trigger.step_args.repo_pins == {
+            "owner/repo": {"sha": "abc123", "branch": "main"}
         }
         # legacy explorer run is not started for a flagged root-cause kickoff
         mock_client_class.return_value.start_run.assert_not_called()
@@ -640,7 +642,8 @@ class TestTriggerAutofixAgent(TestCase):
                 stopping_point=AutofixStoppingPoint.CODE_CHANGES,
             )
 
-        assert mock_feature.call_args.kwargs["stopping_point"] == AutofixStoppingPoint.CODE_CHANGES
+        feature_trigger = mock_feature.call_args.args[1]
+        assert feature_trigger.stopping_point == AutofixStoppingPoint.CODE_CHANGES
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
@@ -665,8 +668,9 @@ class TestTriggerAutofixAgent(TestCase):
                 enable_bash_tools=True,
             )
 
-        assert mock_feature.call_args.kwargs["user"] == user
-        assert mock_feature.call_args.kwargs["enable_bash_tools"] is True
+        feature_trigger = mock_feature.call_args.args[1]
+        assert feature_trigger.user == user
+        assert feature_trigger.enable_bash_tools is True
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)
@@ -687,7 +691,8 @@ class TestTriggerAutofixAgent(TestCase):
                 run_id=None,
             )
 
-        assert mock_feature.call_args.kwargs["enable_bash_tools"] is True
+        feature_trigger = mock_feature.call_args.args[1]
+        assert feature_trigger.enable_bash_tools is True
 
     @patch("sentry.quotas.backend.record_seer_run")
     @patch("sentry.quotas.backend.check_seer_quota", return_value=True)

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -15,8 +15,8 @@ from sentry.seer.agent.client_models import (
     RepoPRState,
     SeerRunState,
 )
-from sentry.seer.autofix.autofix_agent import NoSeerQuotaException
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.exceptions import NoSeerQuotaException
 from sentry.seer.autofix.github_perms import MissingGithubPermissions
 from sentry.seer.autofix.pr_iteration.feedback import Feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.base import Decision


### PR DESCRIPTION
Cleans up triggering of autofix features and preps for future steps added to run in seer by adding new args types.

Also updates some repo_pin logic while I was at it. 

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>