### PR TITLE
fix(alerts): Advertise required scope for monitor updates

### DIFF
--- a/src/sentry/workflow_engine/endpoints/organization_detector_details.py
+++ b/src/sentry/workflow_engine/endpoints/organization_detector_details.py
@@ -14,6 +14,7 @@ from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import cell_silo_endpoint
 from sentry.api.bases import OrganizationDetectorPermission, OrganizationEndpoint
 from sentry.api.exceptions import ResourceDoesNotExist
+from sentry.api.permissions import enforce_scope
 from sentry.api.serializers import serialize
 from sentry.api.utils import to_valid_int_id
 from sentry.apidocs.constants import (
@@ -44,6 +45,7 @@ from sentry.workflow_engine.endpoints.validators.utils import (
     can_delete_detector,
     can_edit_detector,
     get_unknown_detector_type_error,
+    is_system_created_detector,
     should_include_all_projects_detector,
 )
 from sentry.workflow_engine.models import DataSource, Detector
@@ -224,6 +226,8 @@ class OrganizationDetectorDetailsEndpoint(OrganizationEndpoint):
         _check_metric_detector_allowed(detector, organization)
 
         if not can_edit_detector(detector, request):
+            if not is_system_created_detector(detector):
+                enforce_scope(request, "alerts:write")
             raise PermissionDenied
 
         group_type = request.data.get("type") or detector.group_type.slug

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -2,10 +2,8 @@ from datetime import timedelta
 from unittest import mock
 
 import pytest
-from django.test import override_settings
 from django.utils import timezone
 from rest_framework.exceptions import ErrorDetail
-from rest_framework.test import APIClient
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
@@ -17,7 +15,6 @@ from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.incidents.utils.subscription_limits import METRIC_SUBSCRIPTION_FEATURE_FLAGS
 from sentry.models.auditlogentry import AuditLogEntry
-from sentry.seer import agent_token
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
@@ -46,8 +43,6 @@ from sentry.workflow_engine.types import DetectorPriorityLevel
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba, requires_kafka]
-
-AGENT_TOKEN_SECRET = "test-seer-api-shared-secret-thirty-two-bytes!"
 
 
 @pytest.mark.snuba_ci
@@ -349,30 +344,6 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 
         self.detector.refresh_from_db()
         assert self.detector.description == "New description for the detector"
-
-    @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
-    def test_agent_token_missing_alerts_write_advertises_scope(self) -> None:
-        token, _ = agent_token.encode_agent_token(
-            user_id=self.user.id,
-            organization_id=self.organization.id,
-            scopes=["org:read"],
-            session_id="detector-update",
-        )
-        client = APIClient()
-
-        with self.feature(agent_token.FEATURE_FLAG):
-            response = client.put(
-                f"/api/0/organizations/{self.organization.slug}/detectors/{self.detector.id}/",
-                data={"name": "Updated Detector"},
-                format="json",
-                HTTP_AUTHORIZATION=f"Bearer {token}",
-            )
-
-        assert response.status_code == 403, response.content
-        assert (
-            response["WWW-Authenticate"]
-            == 'Bearer error="insufficient_scope", scope="alerts:write"'
-        )
 
     def test_update_eap_invalid_time_window_rejected(self) -> None:
         data = {**self.valid_data}

--- a/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
+++ b/tests/sentry/workflow_engine/endpoints/test_organization_detector_details.py
@@ -2,8 +2,10 @@ from datetime import timedelta
 from unittest import mock
 
 import pytest
+from django.test import override_settings
 from django.utils import timezone
 from rest_framework.exceptions import ErrorDetail
+from rest_framework.test import APIClient
 
 from sentry import audit_log
 from sentry.api.serializers import serialize
@@ -15,6 +17,7 @@ from sentry.incidents.models.alert_rule import AlertRuleDetectionType
 from sentry.incidents.utils.constants import INCIDENTS_SNUBA_SUBSCRIPTION_TYPE
 from sentry.incidents.utils.subscription_limits import METRIC_SUBSCRIPTION_FEATURE_FLAGS
 from sentry.models.auditlogentry import AuditLogEntry
+from sentry.seer import agent_token
 from sentry.silo.base import SiloMode
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.models import QuerySubscription, SnubaQuery, SnubaQueryEventType
@@ -43,6 +46,8 @@ from sentry.workflow_engine.types import DetectorPriorityLevel
 from sentry.workflow_engine.typings.grouptype import IssueStreamGroupType
 
 pytestmark = [pytest.mark.sentry_metrics, requires_snuba, requires_kafka]
+
+AGENT_TOKEN_SECRET = "test-seer-api-shared-secret-thirty-two-bytes!"
 
 
 @pytest.mark.snuba_ci
@@ -344,6 +349,30 @@ class OrganizationDetectorDetailsPutTest(OrganizationDetectorDetailsBaseTest):
 
         self.detector.refresh_from_db()
         assert self.detector.description == "New description for the detector"
+
+    @override_settings(SEER_API_SHARED_SECRET=AGENT_TOKEN_SECRET)
+    def test_agent_token_missing_alerts_write_advertises_scope(self) -> None:
+        token, _ = agent_token.encode_agent_token(
+            user_id=self.user.id,
+            organization_id=self.organization.id,
+            scopes=["org:read"],
+            session_id="detector-update",
+        )
+        client = APIClient()
+
+        with self.feature(agent_token.FEATURE_FLAG):
+            response = client.put(
+                f"/api/0/organizations/{self.organization.slug}/detectors/{self.detector.id}/",
+                data={"name": "Updated Detector"},
+                format="json",
+                HTTP_AUTHORIZATION=f"Bearer {token}",
+            )
+
+        assert response.status_code == 403, response.content
+        assert (
+            response["WWW-Authenticate"]
+            == 'Bearer error="insufficient_scope", scope="alerts:write"'
+        )
 
     def test_update_eap_invalid_time_window_rejected(self) -> None:
         data = {**self.valid_data}


### PR DESCRIPTION
Advertise `alerts:write` when an agent attempts to update a user-created monitor without enough scope.

The detector endpoint allows read-scoped requests through its outer permission class so project and team permissions can be checked later. That later check currently returns a generic 403, preventing Seer from recognizing that it can ask the user to approve a write scope.

This preserves the existing authorization decision and invokes the shared scope enforcement only after authorization fails for a user-created detector. System-created and otherwise ungrantable denials remain generic.
