### PR TITLE
feat(ai-monitoring): Support conversation messages alias

### DIFF
--- a/src/sentry/ai_monitoring/constants.py
+++ b/src/sentry/ai_monitoring/constants.py
@@ -39,6 +39,10 @@ AI_CONVERSATIONS_FIELDS = {
     ),
 }
 
+AI_CONVERSATIONS_LEGACY_ALIASES = {
+    "conversation.messages": "conversation.llmCalls",
+}
+
 # Keep old spellings while frontend and backend deploy independently.
 for _field, (_expression, _alias) in tuple(AI_CONVERSATIONS_FIELDS.items()):
     for _legacy_name in (
@@ -47,3 +51,6 @@ for _field, (_expression, _alias) in tuple(AI_CONVERSATIONS_FIELDS.items()):
         get_function_alias(_expression),
     ):
         AI_CONVERSATIONS_FIELDS[_legacy_name] = (_expression, _alias)
+
+for _legacy_name, _canonical_name in AI_CONVERSATIONS_LEGACY_ALIASES.items():
+    AI_CONVERSATIONS_FIELDS[_legacy_name] = AI_CONVERSATIONS_FIELDS[_canonical_name]

--- a/tests/sentry/api/endpoints/test_organization_ai_conversations.py
+++ b/tests/sentry/api/endpoints/test_organization_ai_conversations.py
@@ -143,6 +143,7 @@ class TestConversationSortSerializer:
             "conversation.generationDuration",
             "conversation.errors",
             "conversation.llmCalls",
+            "conversation.messages",
             "conversation.toolCalls",
             "conversation.totalTokens",
             "conversation.inputTokens",
@@ -331,6 +332,13 @@ def test_alias_filter(alias: str) -> None:
     compiled = compile_conversation_query(f"{alias}:>0", resolver)
     _, having, _ = resolver.resolve_query(compiled)
     assert having is not None
+
+
+def test_messages_alias_matches_llm_calls() -> None:
+    resolver = Spans.get_resolver(SnubaParams(), SearchResolverConfig())
+    assert compile_conversation_query(
+        "conversation.messages:>0", resolver
+    ) == compile_conversation_query("conversation.llmCalls:>0", resolver)
 
 
 def test_group_filter_accepts_long_text() -> None:


### PR DESCRIPTION
Conversation queries can now use `conversation.messages` for filters and sorting. It behaves like `conversation.llmCalls`, so UI terminology also works for direct API, CLI, and MCP clients while preserving existing queries and response fields.

Why do this?

Because our API response contains `llmCalls` field, so it makes sense to support both `conversation.messages` (which is visible in UI table) and `conversation.llmCalls` which is visible in API response, and in the future offers us flexibility when changing table
