### PR TITLE
ref(forms): Migrate five admin forms to Scraps

### DIFF
--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.spec.tsx
@@ -72,6 +72,31 @@ describe('BackendJsonSubmitForm', () => {
       );
     });
 
+    it('passes native input constraints to text fields', () => {
+      render(
+        <BackendJsonSubmitForm
+          fields={[
+            {
+              name: 'expires_at',
+              type: 'string',
+              label: 'Expires At',
+              inputType: 'datetime-local',
+              maxLength: 64,
+            },
+          ]}
+          onSubmit={onSubmit}
+          submitLabel="Save"
+        />,
+        {organization: org}
+      );
+
+      expect(screen.getByLabelText('Expires At')).toHaveAttribute(
+        'type',
+        'datetime-local'
+      );
+      expect(screen.getByLabelText('Expires At')).toHaveAttribute('maxlength', '64');
+    });
+
     it('renders textarea field', () => {
       render(
         <BackendJsonSubmitForm

--- a/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
+++ b/static/app/components/backendJsonFormAdapter/backendJsonSubmitForm.tsx
@@ -581,10 +581,12 @@ export function BackendJsonSubmitForm({
                             onChange={handleChange}
                             placeholder={field.placeholder}
                             disabled={disabledProp}
+                            maxLength={field.maxLength}
                             type={
-                              field.type === 'string' || field.type === 'text'
+                              field.inputType ??
+                              (field.type === 'string' || field.type === 'text'
                                 ? 'text'
-                                : field.type
+                                : field.type)
                             }
                           />
                         </fieldApi.Layout.Stack>

--- a/static/app/components/backendJsonFormAdapter/types.ts
+++ b/static/app/components/backendJsonFormAdapter/types.ts
@@ -36,6 +36,8 @@ interface JsonFormAdapterBoolean extends JsonFormAdapterBase {
 interface JsonFormAdapterString extends JsonFormAdapterBase {
   type: 'string' | 'text' | 'textarea' | 'url' | 'email';
   autosize?: boolean;
+  inputType?: 'datetime-local';
+  maxLength?: number;
   maxRows?: number;
 }
 
@@ -76,7 +78,10 @@ interface JsonFormAdapterNumber extends JsonFormAdapterBase {
   default?: number;
 }
 
-type ChoiceMapperSelector = {choices: Array<[string, string]>; placeholder?: string};
+type ChoiceMapperSelector = {
+  choices: Array<[string, string]>;
+  placeholder?: string;
+};
 
 interface JsonFormAdapterChoiceMapperBase extends JsonFormAdapterBase {
   type: 'choice_mapper';

--- a/static/app/utils/api/knownGetsentryApiUrls.ts
+++ b/static/app/utils/api/knownGetsentryApiUrls.ts
@@ -13,6 +13,7 @@ export type KnownGetsentryApiUrls =
   | '/_admin/customers/$organizationIdOrSlug/balance-changes/'
   | '/_admin/customers/$organizationIdOrSlug/queue-spike-projection/'
   | '/_admin/instance-level-oauth/'
+  | '/_admin/instance-level-oauth/$clientId/'
   | '/_admin/users/$userId/suspend/'
   | '/audit-logs/'
   | '/auth/sso-locate/'

--- a/static/gsAdmin/components/addGiftBudgetAction.tsx
+++ b/static/gsAdmin/components/addGiftBudgetAction.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useMemo, useState} from 'react';
-import styled from '@emotion/styled';
 import {useMutation} from '@tanstack/react-query';
 import {z} from 'zod';
 
@@ -13,6 +12,7 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
 import type {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApi} from 'sentry/utils/useApi';
 
 import type {Subscription} from 'getsentry/types';
@@ -59,18 +59,23 @@ function AddGiftBudgetModal({
         budget => budget.id === activeBudgetId
       );
 
-      return api.requestPromise(`/customers/${organization.slug}/`, {
-        method: 'PUT',
-        data: {
-          freeReservedBudget: {
-            id: activeBudgetId,
-            freeBudget: value.giftAmount * 100,
-            categories: Object.keys(selectedBudget?.categories ?? []),
+      return api.requestPromise(
+        getApiUrl('/customers/$organizationIdOrSlug/', {
+          path: {organizationIdOrSlug: organization.slug},
+        }),
+        {
+          method: 'PUT',
+          data: {
+            freeReservedBudget: {
+              id: activeBudgetId,
+              freeBudget: value.giftAmount * 100,
+              categories: Object.keys(selectedBudget?.categories ?? []),
+            },
+            ticketUrl: value.ticketUrl || null,
+            notes: value.notes,
           },
-          ticketUrl: value.ticketUrl || null,
-          notes: value.notes,
-        },
-      });
+        }
+      );
     },
     onSuccess: () => {
       addSuccessMessage('Added gifted budget amount.');
@@ -102,9 +107,14 @@ function AddGiftBudgetModal({
         )}
         <form.AppForm form={form}>
           {reservedBudgetOptions.map(budget => (
-            <BudgetCard
+            <Container
               key={budget.id}
-              isSelected={activeBudgetId === budget.id}
+              padding="xl"
+              margin="md 0"
+              border="primary"
+              radius="md"
+              background={activeBudgetId === budget.id ? 'secondary' : undefined}
+              cursor="pointer"
               onClick={() => setSelectedBudgetId(budget.id)}
             >
               <Flex justify="between" marginBottom="md">
@@ -150,7 +160,7 @@ function AddGiftBudgetModal({
                   )}
                 </form.AppField>
               )}
-            </BudgetCard>
+            </Container>
           ))}
           {reservedBudgetOptions.length === 0 && (
             <div>No reserved budgets available.</div>
@@ -180,7 +190,9 @@ function AddGiftBudgetModal({
             </form.AppField>
             <Flex gap="md" justify="end">
               <Button onClick={closeModal}>Cancel</Button>
-              <form.SubmitButton>Confirm</form.SubmitButton>
+              <Button type="submit" variant="primary">
+                Confirm
+              </Button>
             </Flex>
           </Stack>
         </form.AppForm>
@@ -196,12 +208,3 @@ export const addGiftBudgetAction = (opts: Options) => {
     closeEvents: 'escape-key',
   });
 };
-
-const BudgetCard = styled('div')<{isSelected: boolean}>`
-  padding: ${p => p.theme.space.xl};
-  margin: ${p => p.theme.space.md} 0;
-  border: 1px solid ${p => p.theme.tokens.border.primary};
-  border-radius: ${p => p.theme.radius.md};
-  background-color: ${p => (p.isSelected ? p.theme.colors.surface200 : 'transparent')};
-  cursor: pointer;
-`;

--- a/static/gsAdmin/components/addGiftBudgetAction.tsx
+++ b/static/gsAdmin/components/addGiftBudgetAction.tsx
@@ -1,15 +1,16 @@
-import {Fragment, useEffect, useMemo, useState} from 'react';
+import {Fragment, useMemo, useState} from 'react';
 import styled from '@emotion/styled';
+import {useMutation} from '@tanstack/react-query';
+import {z} from 'zod';
 
-import {Flex, Container} from '@sentry/scraps/layout';
+import {Button} from '@sentry/scraps/button';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {addErrorMessage, addSuccessMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {openModal} from 'sentry/actionCreators/modal';
-import {InputField} from 'sentry/components/forms/fields/inputField';
-import {NumberField} from 'sentry/components/forms/fields/numberField';
-import {TextField} from 'sentry/components/forms/fields/textField';
-import {Form} from 'sentry/components/forms/form';
 import type {DataCategory} from 'sentry/types/core';
 import type {Organization} from 'sentry/types/organization';
 import {useApi} from 'sentry/utils/useApi';
@@ -25,6 +26,12 @@ type Props = {
 
 type ModalProps = Props & ModalRenderProps;
 
+const schema = z.object({
+  giftAmount: z.number().positive().max(10000),
+  ticketUrl: z.string(),
+  notes: z.string().min(1).max(500),
+});
+
 function AddGiftBudgetModal({
   onSuccess,
   organization,
@@ -35,58 +42,49 @@ function AddGiftBudgetModal({
 }: ModalProps) {
   const api = useApi();
   const [selectedBudgetId, setSelectedBudgetId] = useState<string | null>(null);
-  const [giftAmount, setGiftAmount] = useState(0);
-  const [ticketUrl, setTicketUrl] = useState<string | null>(null);
-  const [notes, setNotes] = useState<string | null>(null);
 
   const reservedBudgetOptions = useMemo(
     () => subscription.reservedBudgets?.filter(b => b.reservedBudget > 0) ?? [],
     [subscription.reservedBudgets]
   );
 
-  useEffect(() => {
-    if (reservedBudgetOptions.length > 0 && !selectedBudgetId) {
-      // oxlint-disable-next-line react/set-state-in-effect
-      setSelectedBudgetId(reservedBudgetOptions[0]?.id ?? null);
-    }
-  }, [reservedBudgetOptions, selectedBudgetId]);
+  const activeBudgetId = selectedBudgetId ?? reservedBudgetOptions[0]?.id ?? null;
+  const mutation = useMutation({
+    mutationFn: (value: z.infer<typeof schema>) => {
+      if (!activeBudgetId) {
+        throw new Error('A reserved budget is required');
+      }
 
-  const onSubmit = () => {
-    if (!selectedBudgetId || giftAmount <= 0) {
-      return;
-    }
+      const selectedBudget = reservedBudgetOptions.find(
+        budget => budget.id === activeBudgetId
+      );
 
-    const selectedBudget = reservedBudgetOptions.find(
-      budget => budget.id === selectedBudgetId
-    );
-
-    const data = {
-      freeReservedBudget: {
-        id: selectedBudgetId,
-        freeBudget: giftAmount * 100, // convert to cents
-        categories: Object.keys(selectedBudget?.categories ?? []),
-      },
-      ticketUrl,
-      notes,
-    };
-
-    api.request(`/customers/${organization.slug}/`, {
-      method: 'PUT',
-      data,
-      success: () => {
-        addSuccessMessage('Added gifted budget amount.');
-        closeModal();
-        onSuccess();
-      },
-      error: () => {
-        addErrorMessage('Unable to add gifted budget amount for org.');
-      },
-    });
-  };
-
-  function getHelp() {
-    return `Total Gift: $${giftAmount.toLocaleString()}`;
-  }
+      return api.requestPromise(`/customers/${organization.slug}/`, {
+        method: 'PUT',
+        data: {
+          freeReservedBudget: {
+            id: activeBudgetId,
+            freeBudget: value.giftAmount * 100,
+            categories: Object.keys(selectedBudget?.categories ?? []),
+          },
+          ticketUrl: value.ticketUrl || null,
+          notes: value.notes,
+        },
+      });
+    },
+    onSuccess: () => {
+      addSuccessMessage('Added gifted budget amount.');
+      closeModal();
+      onSuccess();
+    },
+    onError: () => addErrorMessage('Unable to add gifted budget amount for org.'),
+  });
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {giftAmount: 0, ticketUrl: '', notes: ''},
+    validators: {onDynamic: schema},
+    onSubmit: ({value}) => mutation.mutateAsync(value).catch(() => {}),
+  });
 
   return (
     <Fragment>
@@ -102,11 +100,11 @@ function AddGiftBudgetModal({
         ) : (
           <div />
         )}
-        <Form onSubmit={onSubmit} submitLabel="Confirm" onCancel={closeModal}>
+        <form.AppForm form={form}>
           {reservedBudgetOptions.map(budget => (
             <BudgetCard
               key={budget.id}
-              isSelected={selectedBudgetId === budget.id}
+              isSelected={activeBudgetId === budget.id}
               onClick={() => setSelectedBudgetId(budget.id)}
             >
               <Flex justify="between" marginBottom="md">
@@ -132,59 +130,60 @@ function AddGiftBudgetModal({
                   )
                   .join(', ') || 'None'}
               </Container>
-              {selectedBudgetId === budget.id && (
-                <NumberField
-                  inline={false}
-                  stacked
-                  flexibleControlStateSize
-                  label="Gift Amount ($)"
-                  help={
-                    <Fragment>
-                      <Fragment>Enter gift amount in dollars (max $10,000).</Fragment>
-                      <br />
-                      <Fragment>{getHelp()}</Fragment>
-                    </Fragment>
-                  }
-                  name="giftAmount"
-                  value={giftAmount}
-                  defaultValue={0}
-                  onChange={(value: number) => {
-                    const clampedValue = Math.min(10000, Math.max(0, value));
-                    setGiftAmount(clampedValue);
-                  }}
-                  required
-                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                />
+              {activeBudgetId === budget.id && (
+                <form.AppField name="giftAmount">
+                  {field => (
+                    <field.Layout.Stack
+                      label="Gift Amount ($)"
+                      hintText="Enter gift amount in dollars (max $10,000)."
+                      required
+                    >
+                      <field.Number
+                        min={0}
+                        max={10000}
+                        value={field.state.value}
+                        onChange={value => field.handleChange(value ?? 0)}
+                        onClick={(event: React.MouseEvent) => event.stopPropagation()}
+                      />
+                      <Text>Total Gift: ${field.state.value.toLocaleString()}</Text>
+                    </field.Layout.Stack>
+                  )}
+                </form.AppField>
               )}
             </BudgetCard>
           ))}
           {reservedBudgetOptions.length === 0 && (
             <div>No reserved budgets available.</div>
           )}
-          <Container marginTop="xl">
-            <InputField
-              data-test-id="url-field"
-              name="ticket-url"
-              type="url"
-              label="TicketUrl"
-              inline={false}
-              stacked
-              flexibleControlStateSize
-              onChange={(ticketUrlInput: any) => setTicketUrl(ticketUrlInput)}
-            />
-            <TextField
-              data-test-id="notes-field"
-              name="notes"
-              label="Notes"
-              inline={false}
-              stacked
-              flexibleControlStateSize
-              maxLength={500}
-              required // serializer requires this to be present
-              onChange={(notesInput: any) => setNotes(notesInput)}
-            />
-          </Container>
-        </Form>
+          <Stack gap="lg" marginTop="xl">
+            <form.AppField name="ticketUrl">
+              {field => (
+                <field.Layout.Stack label="Ticket URL">
+                  <field.Input
+                    type="url"
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                </field.Layout.Stack>
+              )}
+            </form.AppField>
+            <form.AppField name="notes">
+              {field => (
+                <field.Layout.Stack label="Notes" required>
+                  <field.Input
+                    value={field.state.value}
+                    onChange={field.handleChange}
+                    maxLength={500}
+                  />
+                </field.Layout.Stack>
+              )}
+            </form.AppField>
+            <Flex gap="md" justify="end">
+              <Button onClick={closeModal}>Cancel</Button>
+              <form.SubmitButton>Confirm</form.SubmitButton>
+            </Flex>
+          </Stack>
+        </form.AppForm>
       </Body>
     </Fragment>
   );

--- a/static/gsAdmin/components/createBroadcastModal.tsx
+++ b/static/gsAdmin/components/createBroadcastModal.tsx
@@ -1,37 +1,40 @@
-import {useCallback} from 'react';
+import {Fragment} from 'react';
 import {useMutation} from '@tanstack/react-query';
 import moment from 'moment-timezone';
 
-import {addErrorMessage, addLoadingMessage} from 'sentry/actionCreators/indicator';
+import {Button} from '@sentry/scraps/button';
+import {Flex} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
+
+import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {FieldFromConfig} from 'sentry/components/forms/fieldFromConfig';
-import {Form} from 'sentry/components/forms/form';
-import type {Field, OnSubmitCallback} from 'sentry/components/forms/types';
+import {BackendJsonSubmitForm} from 'sentry/components/backendJsonFormAdapter/backendJsonSubmitForm';
+import type {JsonFormAdapterFieldConfig} from 'sentry/components/backendJsonFormAdapter/types';
 import type {Broadcast} from 'sentry/types/system';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import {safeURL} from 'sentry/utils/url/safeURL';
-import {useApi} from 'sentry/utils/useApi';
 import {useNavigate} from 'sentry/utils/useNavigate';
 interface CreateBroadcastModal extends ModalRenderProps {
-  fields: Field[];
+  fields: JsonFormAdapterFieldConfig[];
 }
 
 export function CreateBroadcastModal({
   Header,
   Body,
+  Footer,
   closeModal,
   fields,
 }: CreateBroadcastModal) {
   const navigate = useNavigate();
-  const api = useApi();
-
-  const {mutate: updateBroadcast} = useMutation({
-    mutationFn: (data: Broadcast) => {
-      return api.requestPromise('/broadcasts/', {
+  const updateBroadcast = useMutation({
+    mutationFn: (data: Record<string, unknown>) => {
+      return fetchMutation<Broadcast>({
+        url: '/broadcasts/',
         method: 'POST',
         data,
       });
     },
-    onSuccess: (data: Broadcast) => {
+    onSuccess: data => {
       navigate(`/_admin/broadcasts/${data.id}/`);
     },
     onError: () => {
@@ -39,68 +42,61 @@ export function CreateBroadcastModal({
     },
   });
 
-  const handleSubmit: OnSubmitCallback = useCallback(
-    (data, _onSubmitSuccess, onSubmitError) => {
-      addLoadingMessage('Saving form\u2026');
-      const errors: Partial<Record<keyof Broadcast, [string]>> = {};
+  const handleSubmit = (data: Record<string, unknown>) => {
+    const link = typeof data.link === 'string' ? data.link : '';
+    const mediaUrl = typeof data.mediaUrl === 'string' ? data.mediaUrl : '';
+    if (!safeURL(link)) {
+      addErrorMessage('Enter a valid URL.');
+      return Promise.reject(new Error('Invalid URL'));
+    }
 
-      if (!safeURL(data.link)) {
-        errors.link = ['Invalid URL'];
-      }
+    if (mediaUrl && !safeURL(mediaUrl)) {
+      addErrorMessage('Enter a valid image URL.');
+      return Promise.reject(new Error('Invalid image URL'));
+    }
 
-      if (data.mediaUrl && !safeURL(data.mediaUrl)) {
-        errors.mediaUrl = ['Invalid image URL'];
-      }
-
-      if (Object.keys(errors).length) {
-        onSubmitError({responseJSON: errors});
-        return;
-      }
-
-      const newData = {
-        ...(data as Broadcast),
-        category: data.category || undefined,
-        mediaUrl: data.mediaUrl || undefined,
-        region: data.region || undefined,
-        organizations: data.organizations
-          ? String(data.organizations)
+    const newData: Record<string, unknown> = {
+      ...data,
+      link,
+      category: data.category || undefined,
+      mediaUrl: mediaUrl || undefined,
+      region: data.region || undefined,
+      organizations:
+        typeof data.organizations === 'string'
+          ? data.organizations
               .split(',')
               .map(s => Number(s.trim()))
               .filter(n => n > 0)
           : undefined,
-      };
+    };
 
-      updateBroadcast(newData);
-    },
-
-    [updateBroadcast]
-  );
+    return updateBroadcast.mutateAsync(newData);
+  };
 
   return (
-    <Form
-      onSubmit={handleSubmit}
-      onCancel={closeModal}
-      saveOnBlur={false}
-      initialData={{
-        isActive: true,
-        dateExpires: moment().add(7, 'days').format('YYYY-MM-DDTHH:mm'),
-      }}
-      submitLabel="Save"
-    >
-      <Header>
-        <h4>Add Broadcast</h4>
+    <Fragment>
+      <Header closeButton>
+        <Heading as="h3">Add Broadcast</Heading>
       </Header>
       <Body>
-        {fields.map(field => (
-          <FieldFromConfig
-            key={field.name}
-            field={field}
-            flexibleControlStateSize
-            inline={false}
-            stacked
-          />
-        ))}
+        <BackendJsonSubmitForm
+          fields={fields}
+          onSubmit={handleSubmit}
+          initialValues={{
+            isActive: true,
+            dateExpires: moment().add(7, 'days').format('YYYY-MM-DDTHH:mm'),
+          }}
+          submitLabel="Save"
+          footer={({SubmitButton, disabled}) => (
+            <Footer>
+              <Flex gap="md" justify="end">
+                <Button onClick={closeModal}>Cancel</Button>
+                <SubmitButton disabled={disabled}>Save</SubmitButton>
+              </Flex>
+            </Footer>
+          )}
+        />
       </Body>
-    </Form>
+    </Fragment>
   );
 }

--- a/static/gsAdmin/components/createBroadcastModal.tsx
+++ b/static/gsAdmin/components/createBroadcastModal.tsx
@@ -11,6 +11,7 @@ import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {BackendJsonSubmitForm} from 'sentry/components/backendJsonFormAdapter/backendJsonSubmitForm';
 import type {JsonFormAdapterFieldConfig} from 'sentry/components/backendJsonFormAdapter/types';
 import type {Broadcast} from 'sentry/types/system';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {fetchMutation} from 'sentry/utils/queryClient';
 import {safeURL} from 'sentry/utils/url/safeURL';
 import {useNavigate} from 'sentry/utils/useNavigate';
@@ -29,7 +30,7 @@ export function CreateBroadcastModal({
   const updateBroadcast = useMutation({
     mutationFn: (data: Record<string, unknown>) => {
       return fetchMutation<Broadcast>({
-        url: '/broadcasts/',
+        url: getApiUrl('/broadcasts/'),
         method: 'POST',
         data,
       });
@@ -87,11 +88,13 @@ export function CreateBroadcastModal({
             dateExpires: moment().add(7, 'days').format('YYYY-MM-DDTHH:mm'),
           }}
           submitLabel="Save"
-          footer={({SubmitButton, disabled}) => (
+          footer={() => (
             <Footer>
               <Flex gap="md" justify="end">
                 <Button onClick={closeModal}>Cancel</Button>
-                <SubmitButton disabled={disabled}>Save</SubmitButton>
+                <Button type="submit" variant="primary">
+                  Save
+                </Button>
               </Flex>
             </Footer>
           )}

--- a/static/gsAdmin/components/mergeAccounts.tsx
+++ b/static/gsAdmin/components/mergeAccounts.tsx
@@ -48,7 +48,7 @@ export function MergeAccountsModal(props: Props) {
     try {
       const encodedUsername = encodeURIComponent(username);
       const data = await api.requestPromise(
-        `/users/${userId}/merge-accounts/?username=${encodedUsername}`
+        `${getApiUrl('/users/$userId/merge-accounts/', {path: {userId}})}?username=${encodedUsername}`
       );
       setApiQueryData(
         queryClient,
@@ -70,10 +70,13 @@ export function MergeAccountsModal(props: Props) {
     mutationFn: async () => {
       const userIds = selectedUserIds;
       addLoadingMessage();
-      await api.requestPromise(`/users/${userId}/merge-accounts/`, {
-        method: 'POST',
-        data: {users: userIds},
-      });
+      await api.requestPromise(
+        getApiUrl('/users/$userId/merge-accounts/', {path: {userId}}),
+        {
+          method: 'POST',
+          data: {users: userIds},
+        }
+      );
     },
     onSuccess: () => {
       clearIndicators();

--- a/static/gsAdmin/components/mergeAccounts.tsx
+++ b/static/gsAdmin/components/mergeAccounts.tsx
@@ -3,12 +3,10 @@ import {useMutation, useQueryClient} from '@tanstack/react-query';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button} from '@sentry/scraps/button';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
 
 import {addLoadingMessage, clearIndicators} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {TextField} from 'sentry/components/forms/fields/textField';
-import type {FormProps} from 'sentry/components/forms/form';
-import {Form} from 'sentry/components/forms/form';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {User} from 'sentry/types/user';
@@ -40,7 +38,9 @@ export function MergeAccountsModal(props: Props) {
     isPending,
     isError,
     refetch,
-  } = useApiQuery<{users: User[]}>(makeMergeAccountsQueryKey(), {staleTime: 0});
+  } = useApiQuery<{users: User[]}>(makeMergeAccountsQueryKey(), {
+    staleTime: 0,
+  });
 
   const mergeAccounts = fetchedMergeAccounts ?? {users: []};
 
@@ -86,6 +86,12 @@ export function MergeAccountsModal(props: Props) {
     },
   });
 
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {username: ''},
+    onSubmit: ({value}) => fetchUserByUsername(value.username),
+  });
+
   if (isPending) {
     return <LoadingIndicator />;
   }
@@ -93,10 +99,6 @@ export function MergeAccountsModal(props: Props) {
   if (isError) {
     return <LoadingError onRetry={refetch} />;
   }
-
-  const addUsername: FormProps['onSubmit'] = data => {
-    fetchUserByUsername(data.username);
-  };
 
   const selectUser = (newUserId: string) =>
     setSelectedUserIds(prevSelectedUserIds =>
@@ -126,7 +128,7 @@ export function MergeAccountsModal(props: Props) {
       <Body>
         <h5>Listed accounts will be merged into this user.</h5>
         <div>{renderUsernames()}</div>
-        <Form onSubmit={addUsername} hideFooter>
+        <form.AppForm form={form}>
           {error && (
             <Alert.Container>
               <Alert variant="danger" showIcon={false}>
@@ -134,12 +136,18 @@ export function MergeAccountsModal(props: Props) {
               </Alert>
             </Alert.Container>
           )}
-          <TextField
-            label="Add another username:"
-            name="username"
-            placeholder="username"
-          />
-        </Form>
+          <form.AppField name="username">
+            {field => (
+              <field.Layout.Stack label="Add another username:">
+                <field.Input
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  placeholder="username"
+                />
+              </field.Layout.Stack>
+            )}
+          </form.AppField>
+        </form.AppForm>
       </Body>
       <Footer>
         <Button onClick={() => doMergeMutation.mutate()} variant="primary">

--- a/static/gsAdmin/components/users/userPermissionsModal.tsx
+++ b/static/gsAdmin/components/users/userPermissionsModal.tsx
@@ -1,18 +1,22 @@
 import {Fragment, useEffect} from 'react';
 import {useMutation} from '@tanstack/react-query';
 
+import {Button} from '@sentry/scraps/button';
 import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
 import {Stack} from '@sentry/scraps/layout';
 import {Heading} from '@sentry/scraps/text';
 
-import {addLoadingMessage, clearIndicators} from 'sentry/actionCreators/indicator';
+import {
+  addErrorMessage,
+  addLoadingMessage,
+  clearIndicators,
+} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {User} from 'sentry/types/user';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
-import {useApiQuery} from 'sentry/utils/queryClient';
-import {useApi} from 'sentry/utils/useApi';
+import {fetchMutation, useApiQuery} from 'sentry/utils/queryClient';
 
 type Props = ModalRenderProps & {
   onSubmit: (user: User) => void;
@@ -20,8 +24,6 @@ type Props = ModalRenderProps & {
 };
 
 export function UserPermissionsModal({Body, Header, user, onSubmit, closeModal}: Props) {
-  const api = useApi({persistInFlight: true});
-
   const {
     data: availablePermissions,
     isPending: availablePermissionsLoading,
@@ -59,17 +61,24 @@ export function UserPermissionsModal({Body, Header, user, onSubmit, closeModal}:
       const removedPerms = permissions.filter(perm => !data[perm]);
 
       await Promise.all([
-        api.requestPromise(`/users/${user.id}/`, {
+        fetchMutation({
+          url: getApiUrl('/users/$userId/', {path: {userId: user.id}}),
           method: 'PUT',
           data: {isSuperuser: data.isSuperuser, isStaff: data.isStaff},
         }),
         ...addedPerms.map(perm =>
-          api.requestPromise(`/users/${user.id}/permissions/${perm}/`, {
+          fetchMutation({
+            url: getApiUrl('/users/$userId/permissions/$permissionName/', {
+              path: {userId: user.id, permissionName: perm},
+            }),
             method: 'POST',
           })
         ),
         ...removedPerms.map(perm =>
-          api.requestPromise(`/users/${user.id}/permissions/${perm}/`, {
+          fetchMutation({
+            url: getApiUrl('/users/$userId/permissions/$permissionName/', {
+              path: {userId: user.id, permissionName: perm},
+            }),
             method: 'DELETE',
           })
         ),
@@ -86,6 +95,7 @@ export function UserPermissionsModal({Body, Header, user, onSubmit, closeModal}:
       onSubmit(newUser);
       closeModal();
     },
+    onError: () => addErrorMessage('Unable to update user permissions.'),
     onSettled: clearIndicators,
   });
 
@@ -159,7 +169,9 @@ export function UserPermissionsModal({Body, Header, user, onSubmit, closeModal}:
                 )}
               </form.AppField>
             ))}
-            <form.SubmitButton>Save Changes</form.SubmitButton>
+            <Button type="submit" variant="primary">
+              Save Changes
+            </Button>
           </Stack>
         </form.AppForm>
       </Body>

--- a/static/gsAdmin/components/users/userPermissionsModal.tsx
+++ b/static/gsAdmin/components/users/userPermissionsModal.tsx
@@ -1,21 +1,18 @@
-import {Fragment} from 'react';
+import {Fragment, useEffect} from 'react';
+import {useMutation} from '@tanstack/react-query';
+
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {Stack} from '@sentry/scraps/layout';
+import {Heading} from '@sentry/scraps/text';
 
 import {addLoadingMessage, clearIndicators} from 'sentry/actionCreators/indicator';
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
-import {BooleanField} from 'sentry/components/forms/fields/booleanField';
-import {Form} from 'sentry/components/forms/form';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import type {User} from 'sentry/types/user';
 import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useApiQuery} from 'sentry/utils/queryClient';
 import {useApi} from 'sentry/utils/useApi';
-
-const fieldProps = {
-  stacked: true,
-  inline: false,
-  flexibleControlStateSize: true,
-} as const;
 
 type Props = ModalRenderProps & {
   onSubmit: (user: User) => void;
@@ -50,6 +47,71 @@ export function UserPermissionsModal({Body, Header, user, onSubmit, closeModal}:
     {staleTime: 0}
   );
 
+  const permissions = permissionList ?? [];
+  const available = availablePermissions ?? [];
+
+  const mutation = useMutation({
+    mutationFn: async (data: Record<string, boolean>) => {
+      addLoadingMessage('Saving changes\u2026');
+      const currentPerms = new Set(permissions);
+      const newPerms = available.filter(k => data[k]);
+      const addedPerms = newPerms.filter(perm => !currentPerms.has(perm));
+      const removedPerms = permissions.filter(perm => !data[perm]);
+
+      await Promise.all([
+        api.requestPromise(`/users/${user.id}/`, {
+          method: 'PUT',
+          data: {isSuperuser: data.isSuperuser, isStaff: data.isStaff},
+        }),
+        ...addedPerms.map(perm =>
+          api.requestPromise(`/users/${user.id}/permissions/${perm}/`, {
+            method: 'POST',
+          })
+        ),
+        ...removedPerms.map(perm =>
+          api.requestPromise(`/users/${user.id}/permissions/${perm}/`, {
+            method: 'DELETE',
+          })
+        ),
+      ]);
+
+      return {
+        ...user,
+        isSuperuser: Boolean(data.isSuperuser),
+        isStaff: Boolean(data.isStaff),
+        permissions: new Set(newPerms),
+      };
+    },
+    onSuccess: newUser => {
+      onSubmit(newUser);
+      closeModal();
+    },
+    onSettled: clearIndicators,
+  });
+
+  const defaultValues: Record<string, boolean> = {
+    isSuperuser: user.isSuperuser,
+    isStaff: user.isStaff,
+    ...Object.fromEntries(available.map(k => [k, permissions.includes(k)])),
+  };
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues,
+    onSubmit: ({value}) => mutation.mutateAsync(value).catch(() => {}),
+  });
+
+  useEffect(() => {
+    if (availablePermissions && permissionList) {
+      form.reset({
+        isSuperuser: user.isSuperuser,
+        isStaff: user.isStaff,
+        ...Object.fromEntries(
+          availablePermissions.map(k => [k, permissionList.includes(k)])
+        ),
+      });
+    }
+  }, [availablePermissions, permissionList, form, user.isStaff, user.isSuperuser]);
+
   if (permissionListError || availablePermissionsError) {
     return <LoadingError />;
   }
@@ -62,85 +124,44 @@ export function UserPermissionsModal({Body, Header, user, onSubmit, closeModal}:
     <Fragment>
       <Header closeButton>Edit Permissions</Header>
       <Body>
-        <Form
-          onSubmit={(data, onSuccess, onError) => {
-            addLoadingMessage('Saving changes\u2026');
-
-            // XXX(dcramer): why did i optimize the api for individual idempotent perm changes..
-
-            // existing users permissions
-            const currentPerms = new Set(permissionList);
-
-            // permissions as defined by form submission
-            const newPerms: string[] = availablePermissions.filter(k => data[k]);
-            const addedPerms = newPerms.filter(perm => !currentPerms.has(perm));
-            const removedPerms = permissionList.filter(perm => !data[perm]);
-
-            const requests = [
-              api.requestPromise(`/users/${user.id}/`, {
-                method: 'PUT',
-                data: {isSuperuser: data.isSuperuser, isStaff: data.isStaff},
-              }),
-              ...addedPerms.map(perm =>
-                api.requestPromise(`/users/${user.id}/permissions/${perm}/`, {
-                  method: 'POST',
-                })
-              ),
-              ...removedPerms.map(perm =>
-                api.requestPromise(`/users/${user.id}/permissions/${perm}/`, {
-                  method: 'DELETE',
-                })
-              ),
-            ];
-
-            Promise.all(requests)
-              .then(() => {
-                onSuccess({
-                  // TODO(dcramer): we could technically pull latest user state from the isSuperuser submission and
-                  // merge it here
-                  ...user,
-                  isSuperuser: data.isSuperuser,
-                  isStaff: data.isStaff,
-                  permissions: newPerms,
-                });
-              })
-              .catch(error => {
-                // TODO(dcramer): technically this is wrong and should probably reload the initial form data as
-                // some of the API changes might have been successful whereas others were not. Probably ok though
-                // just click some buttons again.
-                onError(error);
-              })
-              .finally(() => {
-                clearIndicators();
-              });
-          }}
-          onSubmitSuccess={newUser => {
-            onSubmit(newUser);
-            closeModal();
-          }}
-          initialData={{
-            isSuperuser: user.isSuperuser,
-            isStaff: user.isStaff,
-            ...Object.fromEntries(
-              availablePermissions.map(k => [k, permissionList.includes(k)])
-            ),
-          }}
-        >
-          <BooleanField
-            {...fieldProps}
-            name="isSuperuser"
-            label="Grant superuser permission (required for admin access)."
-          />
-          <BooleanField
-            {...fieldProps}
-            name="isStaff"
-            label="Grant staff permission (WIP, will be required for admin access in the future)."
-          />
-          <h4>Additional Permissions</h4>
-          {availablePermissions.map(perm => (
-            <BooleanField {...fieldProps} key={perm} name={perm} label={perm} />
-          ))}
-        </Form>
+        <form.AppForm form={form}>
+          <Stack gap="lg">
+            <form.AppField name="isSuperuser">
+              {field => (
+                <field.Layout.Stack label="Grant superuser permission (required for admin access).">
+                  <field.Switch
+                    checked={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                </field.Layout.Stack>
+              )}
+            </form.AppField>
+            <form.AppField name="isStaff">
+              {field => (
+                <field.Layout.Stack label="Grant staff permission (WIP, will be required for admin access in the future).">
+                  <field.Switch
+                    checked={field.state.value}
+                    onChange={field.handleChange}
+                  />
+                </field.Layout.Stack>
+              )}
+            </form.AppField>
+            <Heading as="h4">Additional Permissions</Heading>
+            {available.map(perm => (
+              <form.AppField key={perm} name={perm}>
+                {field => (
+                  <field.Layout.Stack label={perm}>
+                    <field.Switch
+                      checked={field.state.value}
+                      onChange={field.handleChange}
+                    />
+                  </field.Layout.Stack>
+                )}
+              </form.AppField>
+            ))}
+            <form.SubmitButton>Save Changes</form.SubmitButton>
+          </Stack>
+        </form.AppForm>
       </Body>
     </Fragment>
   );

--- a/static/gsAdmin/schemas/broadcasts.tsx
+++ b/static/gsAdmin/schemas/broadcasts.tsx
@@ -1,4 +1,4 @@
-import type {Field} from 'sentry/components/forms/types';
+import type {JsonFormAdapterFieldConfig} from 'sentry/components/backendJsonFormAdapter/types';
 
 import {
   AVAILABLE_PLANCHOICES,
@@ -10,10 +10,7 @@ import {
   TRIALCHOICES,
 } from 'getsentry/utils/broadcasts';
 
-const mapChoices = (choices: ReadonlyArray<readonly [string, string]>) =>
-  choices.map(([value, label]) => ({value, label}));
-
-export function getBroadcastSchema(): Field[] {
+export function getBroadcastSchema(): JsonFormAdapterFieldConfig[] {
   return [
     {
       name: 'title',
@@ -59,16 +56,14 @@ export function getBroadcastSchema(): Field[] {
       type: 'choice',
       required: false,
       label: 'Category',
-      options: mapChoices(CATEGORYCHOICES),
-      allowClear: true,
+      choices: CATEGORYCHOICES,
     },
     {
       name: 'region',
       type: 'choice',
       required: false,
       label: 'Region',
-      options: mapChoices(REGIONCHOICES),
-      allowClear: true,
+      choices: REGIONCHOICES,
     },
     {
       name: 'platform',
@@ -76,7 +71,9 @@ export function getBroadcastSchema(): Field[] {
       required: false,
       multiple: true,
       label: 'Platform',
-      options: platformOptions,
+      choices: platformOptions.flatMap(group =>
+        group.options.map(({value, label}) => [value, label] as const)
+      ),
     },
     {
       name: 'product',
@@ -84,7 +81,7 @@ export function getBroadcastSchema(): Field[] {
       required: false,
       multiple: true,
       label: 'Product',
-      options: mapChoices(PRODUCTCHOICES),
+      choices: PRODUCTCHOICES,
     },
     {
       name: 'roles',
@@ -92,7 +89,7 @@ export function getBroadcastSchema(): Field[] {
       required: false,
       multiple: true,
       label: 'Roles',
-      options: mapChoices(ROLECHOICES),
+      choices: ROLECHOICES,
     },
     {
       name: 'plans',
@@ -100,7 +97,7 @@ export function getBroadcastSchema(): Field[] {
       required: false,
       multiple: true,
       label: 'Plans',
-      options: mapChoices(AVAILABLE_PLANCHOICES),
+      choices: AVAILABLE_PLANCHOICES,
     },
     {
       name: 'trialStatus',
@@ -108,7 +105,7 @@ export function getBroadcastSchema(): Field[] {
       required: false,
       multiple: true,
       label: 'Trial Status',
-      options: mapChoices(TRIALCHOICES),
+      choices: TRIALCHOICES,
     },
     {
       name: 'earlyAdopter',
@@ -118,7 +115,8 @@ export function getBroadcastSchema(): Field[] {
     },
     {
       name: 'dateExpires',
-      type: 'datetime',
+      type: 'string',
+      inputType: 'datetime-local',
       required: false,
       label: 'Expires At',
       help: 'The broadcast will automatically deactivate upon expiration.',
@@ -126,8 +124,9 @@ export function getBroadcastSchema(): Field[] {
     {
       name: 'isActive',
       type: 'boolean',
+      label: 'Active',
       required: false,
       help: 'Activate this broadcast immediately.',
     },
-  ] as Field[];
+  ];
 }

--- a/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
@@ -1,5 +1,4 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
-import styled from '@emotion/styled';
 import {useMutation} from '@tanstack/react-query';
 import {z} from 'zod';
 
@@ -10,8 +9,10 @@ import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {getFormattedDate} from 'sentry/utils/dates';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
+import {fetchMutation} from 'sentry/utils/queryClient';
 import type {RequestError} from 'sentry/utils/requestError/requestError';
 import {testableWindowLocation} from 'sentry/utils/testableWindowLocation';
 import {useApi} from 'sentry/utils/useApi';
@@ -44,14 +45,17 @@ const clientSchema = z.object({
 });
 
 function ClientDetailsForm({clientDetails}: {clientDetails: ClientDetails}) {
-  const api = useApi();
   const mutation = useMutation({
     mutationFn: (data: z.infer<typeof clientSchema>) =>
-      api.requestPromise(`/_admin/instance-level-oauth/${clientDetails.clientID}/`, {
+      fetchMutation({
+        url: getApiUrl('/_admin/instance-level-oauth/$clientId/', {
+          path: {clientId: clientDetails.clientID ?? ''},
+        }),
         method: 'PUT',
         data,
       }),
     onSuccess: () => testableWindowLocation.reload(),
+    onError: () => addErrorMessage('Unable to update client settings.'),
   });
   const form = useScrapsForm({
     ...defaultFormOptions,
@@ -137,7 +141,9 @@ function ClientDetailsForm({clientDetails}: {clientDetails: ClientDetails}) {
         <p>
           <b>Date added:</b> {clientDetails.createdAt}
         </p>
-        <form.SubmitButton>Save Client Settings</form.SubmitButton>
+        <Button type="submit" variant="primary">
+          Save Client Settings
+        </Button>
       </Stack>
     </form.AppForm>
   );
@@ -156,7 +162,9 @@ export function InstanceLevelOAuthDetails() {
   const fetchClientData = useCallback(async () => {
     try {
       const response = await api.requestPromise(
-        `/_admin/instance-level-oauth/${params.clientID}/`,
+        getApiUrl('/_admin/instance-level-oauth/$clientId/', {
+          path: {clientId: params.clientID},
+        }),
         {}
       );
 
@@ -195,8 +203,8 @@ export function InstanceLevelOAuthDetails() {
             title={`Details For Instance Level OAuth Client: ${clientDetails.name}`}
           />
           <ClientDetailsForm clientDetails={clientDetails} />
-          <Flex justify="right">
-            <StyledButton
+          <Flex justify="right" padding="lg 0">
+            <Button
               size="sm"
               variant="danger"
               onClick={() =>
@@ -210,7 +218,7 @@ export function InstanceLevelOAuthDetails() {
               }
             >
               Delete client
-            </StyledButton>
+            </Button>
           </Flex>
         </Fragment>
       )}
@@ -218,8 +226,3 @@ export function InstanceLevelOAuthDetails() {
     </div>
   );
 }
-
-const StyledButton = styled(Button)`
-  margin-top: 20px;
-  margin-bottom: 15px;
-`;

--- a/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
+++ b/static/gsAdmin/views/instanceLevelOAuth/instanceLevelOAuthDetails.tsx
@@ -1,13 +1,14 @@
 import {Fragment, useCallback, useEffect, useState} from 'react';
 import styled from '@emotion/styled';
+import {useMutation} from '@tanstack/react-query';
+import {z} from 'zod';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex} from '@sentry/scraps/layout';
+import {defaultFormOptions, useScrapsForm} from '@sentry/scraps/form';
+import {Flex, Stack} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
 
 import {addErrorMessage} from 'sentry/actionCreators/indicator';
-import {ApiForm} from 'sentry/components/forms/apiForm';
-import {TextField} from 'sentry/components/forms/fields/textField';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
 import {getFormattedDate} from 'sentry/utils/dates';
 import {handleXhrErrorResponse} from 'sentry/utils/handleXhrErrorResponse';
@@ -32,11 +33,115 @@ type ClientDetails = {
   termsUrl: string | null;
 };
 
-const fieldProps = {
-  stacked: true,
-  inline: false,
-  flexibleControlStateSize: true,
-} as const;
+const clientSchema = z.object({
+  clientID: z.string(),
+  name: z.string().min(1),
+  redirectUris: z.string().min(1),
+  allowedOrigins: z.string(),
+  homepageUrl: z.string(),
+  privacyUrl: z.string(),
+  termsUrl: z.string(),
+});
+
+function ClientDetailsForm({clientDetails}: {clientDetails: ClientDetails}) {
+  const api = useApi();
+  const mutation = useMutation({
+    mutationFn: (data: z.infer<typeof clientSchema>) =>
+      api.requestPromise(`/_admin/instance-level-oauth/${clientDetails.clientID}/`, {
+        method: 'PUT',
+        data,
+      }),
+    onSuccess: () => testableWindowLocation.reload(),
+  });
+  const form = useScrapsForm({
+    ...defaultFormOptions,
+    defaultValues: {
+      clientID: clientDetails.clientID ?? '',
+      name: clientDetails.name ?? '',
+      redirectUris: clientDetails.redirectUris ?? '',
+      allowedOrigins: clientDetails.allowedOrigins ?? '',
+      homepageUrl: clientDetails.homepageUrl ?? '',
+      privacyUrl: clientDetails.privacyUrl ?? '',
+      termsUrl: clientDetails.termsUrl ?? '',
+    },
+    validators: {onDynamic: clientSchema},
+    onSubmit: ({value}) => mutation.mutateAsync(value).catch(() => {}),
+  });
+  const fields = [
+    {
+      name: 'clientID' as const,
+      label: 'Client ID',
+      hintText: 'ID of the selected client (not modifiable)',
+      disabled: true,
+    },
+    {
+      name: 'name' as const,
+      label: 'Client Name',
+      hintText: 'Human readable name for the client',
+      placeholder: 'e.g. CodeCov',
+      required: true,
+    },
+    {
+      name: 'redirectUris' as const,
+      label: 'Redirect URIs (space separated)',
+      hintText: 'The URL that users will redirect to after login/signup',
+      placeholder: 'e.g. https://notsentry.io/redirect',
+      required: true,
+    },
+    {
+      name: 'allowedOrigins' as const,
+      label: 'Allowed Origins (space separated)',
+      hintText: 'Allowed origins for the client',
+      placeholder: 'e.g. https://notsentry.io/origin',
+    },
+    {
+      name: 'homepageUrl' as const,
+      label: 'Homepage URL',
+      hintText: "Client's homepage",
+      placeholder: 'e.g. https://notsentry.io/home',
+    },
+    {
+      name: 'privacyUrl' as const,
+      label: 'Privacy Policy URL',
+      hintText: "URL to client's privacy policy",
+      placeholder: 'e.g. https://notsentry.io/privacy',
+    },
+    {
+      name: 'termsUrl' as const,
+      label: 'Terms and Conditions URL',
+      hintText: "URL to client's terms and conditions",
+      placeholder: 'e.g. https://notsentry.io/terms',
+    },
+  ];
+  return (
+    <form.AppForm form={form}>
+      <Stack gap="lg">
+        {fields.map(fieldConfig => (
+          <form.AppField key={fieldConfig.name} name={fieldConfig.name}>
+            {field => (
+              <field.Layout.Stack
+                label={fieldConfig.label}
+                hintText={fieldConfig.hintText}
+                required={fieldConfig.required}
+              >
+                <field.Input
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  placeholder={fieldConfig.placeholder}
+                  disabled={fieldConfig.disabled || mutation.isPending}
+                />
+              </field.Layout.Stack>
+            )}
+          </form.AppField>
+        ))}
+        <p>
+          <b>Date added:</b> {clientDetails.createdAt}
+        </p>
+        <form.SubmitButton>Save Client Settings</form.SubmitButton>
+      </Stack>
+    </form.AppForm>
+  );
+}
 
 export function InstanceLevelOAuthDetails() {
   const {openModal} = useModal();
@@ -89,74 +194,7 @@ export function InstanceLevelOAuthDetails() {
           <PageHeader
             title={`Details For Instance Level OAuth Client: ${clientDetails.name}`}
           />
-          <ApiForm
-            apiMethod="PUT"
-            apiEndpoint={`/_admin/instance-level-oauth/${clientDetails.clientID}/`}
-            onSubmitSuccess={() => testableWindowLocation.reload()}
-            submitLabel="Save Client Settings"
-          >
-            <TextField
-              {...fieldProps}
-              name="clientID"
-              label="Client ID"
-              defaultValue={clientDetails.clientID}
-              help="ID of the selected client (not modifiable)"
-              disabled
-            />
-            <TextField
-              {...fieldProps}
-              name="name"
-              label="Client Name"
-              defaultValue={clientDetails.name}
-              help="Human readable name for the client"
-              placeholder="e.g. CodeCov"
-              required
-            />
-            <TextField
-              {...fieldProps}
-              name="redirectUris"
-              label="Redirect URIs (space separated)"
-              defaultValue={clientDetails.redirectUris}
-              help="The URL that users will redirect to after login/signup"
-              placeholder="e.g. https://notsentry.io/redirect"
-              required
-            />
-            <TextField
-              {...fieldProps}
-              name="allowedOrigins"
-              label="Allowed Origins (space separated)"
-              placeholder="e.g. https://notsentry.io/origin"
-              defaultValue={clientDetails.allowedOrigins}
-              help="Allowed origins for the client"
-            />
-            <TextField
-              {...fieldProps}
-              name="homepageUrl"
-              label="Homepage URL"
-              placeholder="e.g. https://notsentry.io/home"
-              defaultValue={clientDetails.homepageUrl}
-              help="Client's homepage"
-            />
-            <TextField
-              {...fieldProps}
-              name="privacyUrl"
-              label="Privacy Policy URL"
-              placeholder="e.g. https://notsentry.io/privacy"
-              defaultValue={clientDetails.privacyUrl}
-              help="URL to client's privacy policy"
-            />
-            <TextField
-              {...fieldProps}
-              name="termsUrl"
-              label="Terms and Conditions URL"
-              placeholder="e.g. https://notsentry.io/terms"
-              defaultValue={clientDetails.termsUrl}
-              help="URL to client's terms and conditions"
-            />
-            <p>
-              <b>Date added:</b> {clientDetails.createdAt}
-            </p>
-          </ApiForm>
+          <ClientDetailsForm clientDetails={clientDetails} />
           <Flex justify="right">
             <StyledButton
               size="sm"


### PR DESCRIPTION
Migrates five admin forms—account merging, user permissions, gift budgets, broadcast creation, and instance-level OAuth client details—from the legacy form model to Scraps forms while preserving their existing submission flows and validation.

Broadcast creation continues to use its config-driven schema through `BackendJsonSubmitForm`. The adapter now forwards `maxLength` and `datetime-local` constraints to native inputs, with focused coverage for both attributes.

The migrated forms use Scraps layout primitives and typed `getApiUrl` paths. Mutation failures are handled in `onError`; primary and cancel actions remain available while requests are pending, and fieldless actions invoke their mutation directly.
