### PR TITLE
docs(breadcrumbList): Rework the story around item types and props

### DIFF
--- a/static/app/components/core/breadcrumbList/breadcrumbList.mdx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.mdx
@@ -231,8 +231,121 @@ demo below mirrors that heading and flex layout.
 </TopBar.Slot>
 ```
 
-#### Pagination
+### `'editable-title'` — rename in place
 
+The `editable-title` item renders the current page as a click-to-edit field for
+pages that let users rename in place. Pass the editable field props directly on
+the `editable-title` item passed to `BreadcrumbList.Title`. Unlike
+`page-title`, it has no `trailingActions` slot; `EditableText` provides its own
+edit affordance.
+
+<Storybook.Demo>
+  <BreadcrumbListDemo
+    items={[
+      {
+        type: 'link',
+        label: 'Dashboards',
+        to: '/organizations/org-slug/dashboards/',
+      },
+    ]}
+    title={
+      <BreadcrumbList.Title
+        item={{
+          type: 'editable-title',
+          value: 'Frontend Overview',
+          onChange: () => null,
+          'aria-label': 'Edit dashboard name',
+        }}
+      />
+    }
+  />
+</Storybook.Demo>
+```tsx
+<TopBar.Slot name="breadcrumbs">
+  <BreadcrumbList
+    items={[
+      {type: 'link', label: 'Dashboards', to: '/organizations/org-slug/dashboards/'},
+    ]}
+  />
+</TopBar.Slot>
+<TopBar.Slot name="title">
+  <BreadcrumbList.Title
+    item={{
+      type: 'editable-title',
+      value: dashboard.title,
+      onChange: handleRename,
+      'aria-label': 'Edit dashboard name',
+    }}
+  />
+</TopBar.Slot>
+```
+
+## Props
+
+Beyond `label`, the optional props are not shared evenly across the item types.
+
+| Prop              | `'link'` | `'page-title'` | `'editable-title'` |
+| ----------------- | :------: | :------------: | :----------------: |
+| `leadingGraphic`  |    ✓     |       ✓        |         ✓          |
+| `labelTooltip`    |          |       ✓        |                    |
+| `pagination`      |          |       ✓        |                    |
+| `trailingActions` |          |       ✓        |                    |
+
+### Leading graphics
+
+**Available on** `'link'`, `'page-title'`, and `'editable-title'`.
+An optional `React.ReactNode` — a `ProjectsBadge`, an avatar, or a Sentry icon.
+It is rendered as decorative content in a fixed 16×16 slot, so the label carries
+the meaning.
+
+<Storybook.Demo>
+  <BreadcrumbListDemo
+    items={[
+      {
+        type: 'link',
+        label: 'My Projects',
+        to: '/settings/org-slug/projects/',
+        leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
+      },
+    ]}
+    title={
+      <BreadcrumbList.Title
+        item={{
+          type: 'page-title',
+          label: 'Client Keys (DSN)',
+          leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
+        }}
+      />
+    }
+  />
+</Storybook.Demo>
+```tsx
+<TopBar.Slot name="breadcrumbs">
+  <BreadcrumbList
+    items={[
+      {
+        type: 'link',
+        label: 'My Projects',
+        to: '/settings/org-slug/projects/',
+        leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
+      },
+    ]}
+  />
+</TopBar.Slot>
+<TopBar.Slot name="title">
+  <BreadcrumbList.Title
+    item={{
+      type: 'page-title',
+      label: 'Client Keys (DSN)',
+      leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
+    }}
+  />
+</TopBar.Slot>
+```
+
+### Pagination
+
+**Available on** `'page-title'` only.
 The `page-title` item accepts an optional `pagination` prop for pages where the
 user can step through a list of items, such as issues, replays, or traces. Each
 direction has an `ariaLabel`, an optional `to` URL, an optional `disabled` flag,
@@ -343,8 +456,9 @@ a chevron below and move onto the tooltip to reach the link.
 />
 ```
 
-#### Trailing actions
+### Trailing actions
 
+**Available on** `'page-title'` only.
 The `page-title` item accepts a `trailingActions` slot rendered after the label,
 for example a copy action or page-level menu. The slot is bounded to
 typed `copy`, `menu`, or `button` objects. Falsy entries are dropped so
@@ -410,107 +524,6 @@ a row of icons competing for the same space.
             : null,
         ].filter(item => item !== null),
       },
-    }}
-  />
-</TopBar.Slot>
-```
-
-### `'editable-title'` — rename in place
-
-The `editable-title` item renders the current page as a click-to-edit field for
-pages that let users rename in place. Pass the editable field props directly on
-the `editable-title` item passed to `BreadcrumbList.Title`. Unlike
-`page-title`, it has no `trailingActions` slot; `EditableText` provides its own
-edit affordance.
-
-<Storybook.Demo>
-  <BreadcrumbListDemo
-    items={[
-      {
-        type: 'link',
-        label: 'Dashboards',
-        to: '/organizations/org-slug/dashboards/',
-      },
-    ]}
-    title={
-      <BreadcrumbList.Title
-        item={{
-          type: 'editable-title',
-          value: 'Frontend Overview',
-          onChange: () => null,
-          'aria-label': 'Edit dashboard name',
-        }}
-      />
-    }
-  />
-</Storybook.Demo>
-```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {type: 'link', label: 'Dashboards', to: '/organizations/org-slug/dashboards/'},
-    ]}
-  />
-</TopBar.Slot>
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title
-    item={{
-      type: 'editable-title',
-      value: dashboard.title,
-      onChange: handleRename,
-      'aria-label': 'Edit dashboard name',
-    }}
-  />
-</TopBar.Slot>
-```
-
-## Leading graphics
-
-All parent and title items that display text accept an optional `leadingGraphic`
-typed as `React.ReactNode` — for example, a `ProjectsBadge`, avatar, or
-Sentry icon. It is rendered as decorative content in a fixed 16×16 slot, so the
-label carries the meaning.
-
-<Storybook.Demo>
-  <BreadcrumbListDemo
-    items={[
-      {
-        type: 'link',
-        label: 'My Projects',
-        to: '/settings/org-slug/projects/',
-        leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
-      },
-    ]}
-    title={
-      <BreadcrumbList.Title
-        item={{
-          type: 'page-title',
-          label: 'Client Keys (DSN)',
-          leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
-        }}
-      />
-    }
-  />
-</Storybook.Demo>
-```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {
-        type: 'link',
-        label: 'My Projects',
-        to: '/settings/org-slug/projects/',
-        leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
-      },
-    ]}
-  />
-</TopBar.Slot>
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title
-    item={{
-      type: 'page-title',
-      label: 'Client Keys (DSN)',
-      leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
     }}
   />
 </TopBar.Slot>

--- a/static/app/components/core/breadcrumbList/breadcrumbList.mdx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.mdx
@@ -104,10 +104,7 @@ leading graphics, trailing actions, or an editable control.
 A clickable, muted-weight crumb that navigates to a parent page. It takes a
 string `label`, a `to` destination, and an optional `leadingGraphic`.
 
-Page filters are not carried automatically. To keep the project, environment, and
-date selection across the navigation, build the query into `to` yourself with
-`extractSelectionParameters` from `sentry/components/pageFilters/parse`,
-overriding any parameter the destination needs different.
+Page filters are not carried automatically — see [Page filters](#page-filters).
 
 <Storybook.Demo>
   <BreadcrumbListDemo
@@ -181,6 +178,52 @@ props.
   />
 </TopBar.Slot>
 ```
+
+## Page filters
+
+A crumb that links to a bare pathname does not leave the page-filter selection
+alone — it **clears** it. `PageFiltersContainer` reconciles its store against the
+URL on navigation, and an absent `project` reads as an empty selection rather
+than "unchanged". So a trail that links back to a filtered list drops the user's
+project, environment, and date range unless the crumb carries them.
+
+To carry the whole selection, build the query with `extractSelectionParameters`
+from `sentry/components/pageFilters/parse`:
+
+```tsx
+<TopBar.Slot name="breadcrumbs">
+  <BreadcrumbList
+    items={[
+      {
+        type: 'link',
+        label: 'Releases',
+        to: {
+          pathname: makeReleasesPathname({organization, path: '/'}),
+          query: extractSelectionParameters(location.query),
+        },
+      },
+    ]}
+  />
+</TopBar.Slot>
+```
+
+To carry part of it, spread and override. Clearing `start` and `end` is required
+whenever you set `statsPeriod` — otherwise an absolute range and a relative
+period both travel, and the destination picks one:
+
+```tsx
+const query = {
+  ...extractSelectionParameters(location.query),
+  statsPeriod: '24h',
+  start: undefined,
+  end: undefined,
+};
+```
+
+> [!NOTE]
+> Leaving the bare pathname is a valid choice, not an oversight — a settings or
+> configuration destination has no use for a stale `statsPeriod`. Decide per
+> crumb based on whether the destination is filtered.
 
 ## Page titles
 

--- a/static/app/components/core/breadcrumbList/breadcrumbList.mdx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.mdx
@@ -33,9 +33,42 @@ import {BreadcrumbList} from '@sentry/scraps/breadcrumbList';
 import {TopBar} from 'sentry/views/navigation/topBar';
 ```
 
-Pass parent crumbs in a typed `items` array. Each entry is a discriminated union:
-a `type` key plus that type's own props, flattened onto the same object. The
-current page is a separate `BreadcrumbList.Title` item.
+The `title` slot is always the page's single `<h1>`. `BreadcrumbList.Title`
+renders title content _without_ a heading of its own, so the slot supplies the
+heading and the item supplies everything else — a leading graphic, a tooltip,
+pagination, trailing actions, or an editable field. Never change the title
+slot's element.
+
+Use `BreadcrumbList.Title` on every page, whether or not it has parents. A plain
+string in the title slot renders, but it forfeits every one of those props.
+
+### Index pages
+
+An index page has no parents, so it renders the title slot alone — no `items`
+array and no `breadcrumbs` slot. Reaching for `BreadcrumbList.Title` here rather
+than a bare string is what keeps a leading graphic or a trailing action
+available if the page needs one later.
+
+<Storybook.Demo>
+  <BreadcrumbListDemo
+    items={[]}
+    title={<BreadcrumbList.Title item={{type: 'page-title', label: 'Dashboards'}} />}
+  />
+</Storybook.Demo>
+```tsx
+<TopBar.Slot name="title">
+  <BreadcrumbList.Title item={{type: 'page-title', label: 'Dashboards'}} />
+</TopBar.Slot>
+```
+
+### Pages with parents
+
+Add the `breadcrumbs` slot, which renders to the left of the title. Pass parent
+crumbs in a typed `items` array: each entry is a discriminated union, a `type`
+key plus that type's own props flattened onto the same object.
+
+Keep the current page out of `items`. It is the title, not a crumb — leaving it
+in renders the page name twice.
 
 <Storybook.Demo>
   <BreadcrumbListDemo
@@ -72,30 +105,9 @@ current page is a separate `BreadcrumbList.Title` item.
 </TopBar.Slot>
 ```
 
-## TopBar composition
-
-Use two `TopBar.Slot`s when the breadcrumb trail belongs in the page header. The
-`breadcrumbs` slot is placed to the left of the `title` slot. Keep the title item
-out of `BreadcrumbList.items`, and do not change the title slot's element: it is
-always the page's `<h1>`.
-
-```tsx
-import {TopBar} from 'sentry/views/navigation/topBar';
-import {BreadcrumbList} from '@sentry/scraps/breadcrumbList';
-
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[{type: 'link', label: 'Issues', to: '/organizations/org-slug/issues/'}]}
-  />
-</TopBar.Slot>
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title item={{type: 'page-title', label: 'Current Issue'}} />
-</TopBar.Slot>
-```
-
-`BreadcrumbList.Title` renders title content without a heading, so this
-composition produces one heading even when the title includes pagination,
-leading graphics, trailing actions, or an editable control.
+Because `BreadcrumbList.Title` carries no heading, this composition still
+produces exactly one `<h1>` even when the title includes pagination, a leading
+graphic, trailing actions, or an editable control.
 
 ## Item types
 

--- a/static/app/components/core/breadcrumbList/breadcrumbList.mdx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.mdx
@@ -325,6 +325,61 @@ the meaning.
 />
 ```
 
+### Label tooltip
+
+**Available on** `'page-title'` only.
+
+`labelTooltip` explains a label that cannot explain itself — an opaque
+identifier, or a value the label shows in shortened form. It is always on, not
+overflow-only: the title already ellipsizes without it, so reach for it when
+there is _more_ to say, not to reveal text that was truncated.
+
+Setting it changes the title's appearance and behaviour. The label picks up a
+dotted underline and becomes keyboard focusable, so the tooltip is reachable
+without a pointer. A title with no `labelTooltip` renders as plain text with
+neither.
+
+<Storybook.Demo>
+  <BreadcrumbListDemo
+    items={[{type: 'link', label: 'Issues', to: '/organizations/org-slug/issues/'}]}
+    title={
+      <BreadcrumbList.Title
+        item={{
+          type: 'page-title',
+          label: 'JAVASCRIPT-2X9',
+          labelTooltip:
+            'This identifier is unique across your organization, and can be used to reference an issue in various places, like commit messages.',
+        }}
+      />
+    }
+  />
+</Storybook.Demo>
+```tsx
+<BreadcrumbList.Title
+  item={{
+    type: 'page-title',
+    label: group.shortId,
+    labelTooltip: t(
+      'This identifier is unique across your organization, and can be used to reference an issue in various places, like commit messages.'
+    ),
+  }}
+/>
+```
+
+When the label is a shortened form of a longer value, pass the full value —
+and pass `undefined` when the label is already complete, so the underline and
+tab stop only appear where there is something to read:
+
+```tsx
+<BreadcrumbList.Title
+  item={{
+    type: 'page-title',
+    label: getDisplayId(conversationId),
+    labelTooltip: isUUID(conversationId) ? conversationId : undefined,
+  }}
+/>
+```
+
 ### Pagination
 
 **Available on** `'page-title'` only.

--- a/static/app/components/core/breadcrumbList/breadcrumbList.mdx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.mdx
@@ -121,20 +121,18 @@ To carry the whole selection, build the query with `extractSelectionParameters`
 from `sentry/components/pageFilters/parse`:
 
 ```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {
-        type: 'link',
-        label: 'Releases',
-        to: {
-          pathname: makeReleasesPathname({organization, path: '/'}),
-          query: extractSelectionParameters(location.query),
-        },
+<BreadcrumbList
+  items={[
+    {
+      type: 'link',
+      label: 'Releases',
+      to: {
+        pathname: makeReleasesPathname({organization, path: '/'}),
+        query: extractSelectionParameters(location.query),
       },
-    ]}
-  />
-</TopBar.Slot>
+    },
+  ]}
+/>
 ```
 
 To carry part of it, spread and override. Clearing `start` and `end` is required
@@ -181,18 +179,16 @@ Page filters are not carried automatically — see [Page filters](#page-filters)
   />
 </Storybook.Demo>
 ```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {type: 'link', label: 'Projects', to: '/organizations/org-slug/projects/'},
-      {
-        type: 'link',
-        label: 'Issues',
-        to: {pathname: '/issues/', query: extractSelectionParameters(location.query)},
-      },
-    ]}
-  />
-</TopBar.Slot>
+<BreadcrumbList
+  items={[
+    {type: 'link', label: 'Projects', to: '/organizations/org-slug/projects/'},
+    {
+      type: 'link',
+      label: 'Issues',
+      to: {pathname: '/issues/', query: extractSelectionParameters(location.query)},
+    },
+  ]}
+/>
 ```
 
 ### `'page-title'` — the current page
@@ -216,19 +212,15 @@ demo below mirrors that heading and flex layout.
   />
 </Storybook.Demo>
 ```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[{type: 'link', label: 'Issues', to: '/organizations/org-slug/issues/'}]}
-  />
-</TopBar.Slot>
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title
-    item={{
-      type: 'page-title',
-      label: 'Issue details',
-    }}
-  />
-</TopBar.Slot>
+<BreadcrumbList
+  items={[{type: 'link', label: 'Issues', to: '/organizations/org-slug/issues/'}]}
+/>
+<BreadcrumbList.Title
+  item={{
+    type: 'page-title',
+    label: 'Issue details',
+  }}
+/>
 ```
 
 ### `'editable-title'` — rename in place
@@ -261,23 +253,17 @@ edit affordance.
   />
 </Storybook.Demo>
 ```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {type: 'link', label: 'Dashboards', to: '/organizations/org-slug/dashboards/'},
-    ]}
-  />
-</TopBar.Slot>
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title
-    item={{
-      type: 'editable-title',
-      value: dashboard.title,
-      onChange: handleRename,
-      'aria-label': 'Edit dashboard name',
-    }}
-  />
-</TopBar.Slot>
+<BreadcrumbList
+  items={[{type: 'link', label: 'Dashboards', to: '/organizations/org-slug/dashboards/'}]}
+/>
+<BreadcrumbList.Title
+  item={{
+    type: 'editable-title',
+    value: dashboard.title,
+    onChange: handleRename,
+    'aria-label': 'Edit dashboard name',
+  }}
+/>
 ```
 
 ## Props
@@ -320,27 +306,23 @@ the meaning.
   />
 </Storybook.Demo>
 ```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {
-        type: 'link',
-        label: 'My Projects',
-        to: '/settings/org-slug/projects/',
-        leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
-      },
-    ]}
-  />
-</TopBar.Slot>
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title
-    item={{
-      type: 'page-title',
-      label: 'Client Keys (DSN)',
+<BreadcrumbList
+  items={[
+    {
+      type: 'link',
+      label: 'My Projects',
+      to: '/settings/org-slug/projects/',
       leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
-    }}
-  />
-</TopBar.Slot>
+    },
+  ]}
+/>
+<BreadcrumbList.Title
+  item={{
+    type: 'page-title',
+    label: 'Client Keys (DSN)',
+    leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
+  }}
+/>
 ```
 
 ### Pagination
@@ -375,23 +357,19 @@ item happens to have no neighbours.
   />
 </Storybook.Demo>
 ```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[{type: 'link', label: 'Issues', to: '/organizations/org-slug/issues/'}]}
-  />
-</TopBar.Slot>
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title
-    item={{
-      type: 'page-title',
-      label: group.shortId,
-      pagination: {
-        previous: {ariaLabel: 'Previous issue', to: previousIssueUrl},
-        next: {ariaLabel: 'Next issue', to: nextIssueUrl},
-      },
-    }}
-  />
-</TopBar.Slot>
+<BreadcrumbList
+  items={[{type: 'link', label: 'Issues', to: '/organizations/org-slug/issues/'}]}
+/>
+<BreadcrumbList.Title
+  item={{
+    type: 'page-title',
+    label: group.shortId,
+    pagination: {
+      previous: {ariaLabel: 'Previous issue', to: previousIssueUrl},
+      next: {ariaLabel: 'Next issue', to: nextIssueUrl},
+    },
+  }}
+/>
 ```
 
 The `tooltip` accepts rich content, not just a string. Pagination tooltips are
@@ -498,35 +476,33 @@ a row of icons competing for the same space.
   />
 </Storybook.Demo>
 ```tsx
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title
-    item={{
-      type: 'page-title',
-      label: group.shortId,
-      trailingActions: {
-        type: 'menu',
-        triggerLabel: 'More actions',
-        triggerIcon: <IconEllipsis />,
-        items: [
-          {
-            key: 'copy-short-id',
-            label: 'Copy Short-ID',
-            leadingItems: <IconCopyId variant="muted" />,
-            onAction: () => copy(group.shortId),
-          },
-          isPublic && shareUrl
-            ? {
-                key: 'share',
-                label: 'Share',
-                leadingItems: <IconGlobe />,
-                onAction: openShareModal,
-              }
-            : null,
-        ].filter(item => item !== null),
-      },
-    }}
-  />
-</TopBar.Slot>
+<BreadcrumbList.Title
+  item={{
+    type: 'page-title',
+    label: group.shortId,
+    trailingActions: {
+      type: 'menu',
+      triggerLabel: 'More actions',
+      triggerIcon: <IconEllipsis />,
+      items: [
+        {
+          key: 'copy-short-id',
+          label: 'Copy Short-ID',
+          leadingItems: <IconCopyId variant="muted" />,
+          onAction: () => copy(group.shortId),
+        },
+        isPublic && shareUrl
+          ? {
+              key: 'share',
+              label: 'Share',
+              leadingItems: <IconGlobe />,
+              onAction: openShareModal,
+            }
+          : null,
+      ].filter(item => item !== null),
+    },
+  }}
+/>
 ```
 
 ## Overflow (container query)

--- a/static/app/components/core/breadcrumbList/breadcrumbList.mdx
+++ b/static/app/components/core/breadcrumbList/breadcrumbList.mdx
@@ -109,89 +109,7 @@ Because `BreadcrumbList.Title` carries no heading, this composition still
 produces exactly one `<h1>` even when the title includes pagination, a leading
 graphic, trailing actions, or an editable control.
 
-## Item types
-
-### `'link'` — parent page
-
-A clickable, muted-weight crumb that navigates to a parent page. It takes a
-string `label`, a `to` destination, and an optional `leadingGraphic`.
-
-Page filters are not carried automatically — see [Page filters](#page-filters).
-
-<Storybook.Demo>
-  <BreadcrumbListDemo
-    items={[
-      {
-        type: 'link',
-        label: 'A very long project name that will be truncated',
-        to: '/organizations/org-slug/projects/',
-      },
-      {
-        type: 'link',
-        label: 'Issues',
-        to: '/organizations/org-slug/issues/',
-      },
-    ]}
-  />
-</Storybook.Demo>
-```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {type: 'link', label: 'Projects', to: '/organizations/org-slug/projects/'},
-      {
-        type: 'link',
-        label: 'Issues',
-        to: {pathname: '/issues/', query: extractSelectionParameters(location.query)},
-      },
-    ]}
-  />
-</TopBar.Slot>
-```
-
-### `'select-projects'` — project picker
-
-A `CompactSelect` trigger used in settings pages where the user can switch
-between projects inline. It accepts standard `options`, `value`, and `onChange`
-props.
-
-<Storybook.Demo>
-  <BreadcrumbListDemo
-    items={[
-      {type: 'link', label: 'Settings', to: '/settings/'},
-      {
-        type: 'select-projects',
-        value: 'javascript',
-        options: [
-          {value: 'javascript', label: 'javascript'},
-          {value: 'python', label: 'python'},
-          {value: 'ruby', label: 'ruby'},
-        ],
-        onChange: () => {},
-      },
-    ]}
-  />
-</Storybook.Demo>
-```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {type: 'link', label: 'Settings', to: '/settings/'},
-      {
-        type: 'select-projects',
-        value: 'javascript',
-        options: [
-          {value: 'javascript', label: 'javascript'},
-          {value: 'python', label: 'python'},
-        ],
-        onChange: option => navigate(`/settings/${org.slug}/projects/${option.value}/`),
-      },
-    ]}
-  />
-</TopBar.Slot>
-```
-
-## Page filters
+### Page filters
 
 A crumb that links to a bare pathname does not leave the page-filter selection
 alone — it **clears** it. `PageFiltersContainer` reconciles its store against the
@@ -237,7 +155,47 @@ const query = {
 > configuration destination has no use for a stale `statsPeriod`. Decide per
 > crumb based on whether the destination is filtered.
 
-## Page titles
+## Item types
+
+### `'link'` — parent page
+
+A clickable, muted-weight crumb that navigates to a parent page. It takes a
+string `label`, a `to` destination, and an optional `leadingGraphic`.
+
+Page filters are not carried automatically — see [Page filters](#page-filters).
+
+<Storybook.Demo>
+  <BreadcrumbListDemo
+    items={[
+      {
+        type: 'link',
+        label: 'A very long project name that will be truncated',
+        to: '/organizations/org-slug/projects/',
+      },
+      {
+        type: 'link',
+        label: 'Issues',
+        to: '/organizations/org-slug/issues/',
+      },
+    ]}
+  />
+</Storybook.Demo>
+```tsx
+<TopBar.Slot name="breadcrumbs">
+  <BreadcrumbList
+    items={[
+      {type: 'link', label: 'Projects', to: '/organizations/org-slug/projects/'},
+      {
+        type: 'link',
+        label: 'Issues',
+        to: {pathname: '/issues/', query: extractSelectionParameters(location.query)},
+      },
+    ]}
+  />
+</TopBar.Slot>
+```
+
+### `'page-title'` — the current page
 
 The `page-title` item is rendered with `BreadcrumbList.Title`, not in the
 `BreadcrumbList.items` array. It is bold, non-interactive, and renders as inline
@@ -273,108 +231,7 @@ demo below mirrors that heading and flex layout.
 </TopBar.Slot>
 ```
 
-## Leading graphics
-
-All parent and title items that display text accept an optional `leadingGraphic`
-typed as `React.ReactNode` — for example, a `ProjectsBadge`, avatar, or
-Sentry icon. It is rendered as decorative content in a fixed 16×16 slot, so the
-label carries the meaning.
-
-<Storybook.Demo>
-  <BreadcrumbListDemo
-    items={[
-      {
-        type: 'link',
-        label: 'My Projects',
-        to: '/settings/org-slug/projects/',
-        leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
-      },
-    ]}
-    title={
-      <BreadcrumbList.Title
-        item={{
-          type: 'page-title',
-          label: 'Client Keys (DSN)',
-          leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
-        }}
-      />
-    }
-  />
-</Storybook.Demo>
-```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {
-        type: 'link',
-        label: 'My Projects',
-        to: '/settings/org-slug/projects/',
-        leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
-      },
-    ]}
-  />
-</TopBar.Slot>
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title
-    item={{
-      type: 'page-title',
-      label: 'Client Keys (DSN)',
-      leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
-    }}
-  />
-</TopBar.Slot>
-```
-
-## Editable titles
-
-The `editable-title` item renders the current page as a click-to-edit field for
-pages that let users rename in place. Pass the editable field props directly on
-the `editable-title` item passed to `BreadcrumbList.Title`. Unlike
-`page-title`, it has no `trailingActions` slot; `EditableText` provides its own
-edit affordance.
-
-<Storybook.Demo>
-  <BreadcrumbListDemo
-    items={[
-      {
-        type: 'link',
-        label: 'Dashboards',
-        to: '/organizations/org-slug/dashboards/',
-      },
-    ]}
-    title={
-      <BreadcrumbList.Title
-        item={{
-          type: 'editable-title',
-          value: 'Frontend Overview',
-          onChange: () => null,
-          'aria-label': 'Edit dashboard name',
-        }}
-      />
-    }
-  />
-</Storybook.Demo>
-```tsx
-<TopBar.Slot name="breadcrumbs">
-  <BreadcrumbList
-    items={[
-      {type: 'link', label: 'Dashboards', to: '/organizations/org-slug/dashboards/'},
-    ]}
-  />
-</TopBar.Slot>
-<TopBar.Slot name="title">
-  <BreadcrumbList.Title
-    item={{
-      type: 'editable-title',
-      value: dashboard.title,
-      onChange: handleRename,
-      'aria-label': 'Edit dashboard name',
-    }}
-  />
-</TopBar.Slot>
-```
-
-## Pagination
+#### Pagination
 
 The `page-title` item accepts an optional `pagination` prop for pages where the
 user can step through a list of items, such as issues, replays, or traces. Each
@@ -486,7 +343,7 @@ a chevron below and move onto the tooltip to reach the link.
 />
 ```
 
-## Trailing actions
+#### Trailing actions
 
 The `page-title` item accepts a `trailingActions` slot rendered after the label,
 for example a copy action or page-level menu. The slot is bounded to
@@ -558,15 +415,116 @@ a row of icons competing for the same space.
 </TopBar.Slot>
 ```
 
+### `'editable-title'` — rename in place
+
+The `editable-title` item renders the current page as a click-to-edit field for
+pages that let users rename in place. Pass the editable field props directly on
+the `editable-title` item passed to `BreadcrumbList.Title`. Unlike
+`page-title`, it has no `trailingActions` slot; `EditableText` provides its own
+edit affordance.
+
+<Storybook.Demo>
+  <BreadcrumbListDemo
+    items={[
+      {
+        type: 'link',
+        label: 'Dashboards',
+        to: '/organizations/org-slug/dashboards/',
+      },
+    ]}
+    title={
+      <BreadcrumbList.Title
+        item={{
+          type: 'editable-title',
+          value: 'Frontend Overview',
+          onChange: () => null,
+          'aria-label': 'Edit dashboard name',
+        }}
+      />
+    }
+  />
+</Storybook.Demo>
+```tsx
+<TopBar.Slot name="breadcrumbs">
+  <BreadcrumbList
+    items={[
+      {type: 'link', label: 'Dashboards', to: '/organizations/org-slug/dashboards/'},
+    ]}
+  />
+</TopBar.Slot>
+<TopBar.Slot name="title">
+  <BreadcrumbList.Title
+    item={{
+      type: 'editable-title',
+      value: dashboard.title,
+      onChange: handleRename,
+      'aria-label': 'Edit dashboard name',
+    }}
+  />
+</TopBar.Slot>
+```
+
+## Leading graphics
+
+All parent and title items that display text accept an optional `leadingGraphic`
+typed as `React.ReactNode` — for example, a `ProjectsBadge`, avatar, or
+Sentry icon. It is rendered as decorative content in a fixed 16×16 slot, so the
+label carries the meaning.
+
+<Storybook.Demo>
+  <BreadcrumbListDemo
+    items={[
+      {
+        type: 'link',
+        label: 'My Projects',
+        to: '/settings/org-slug/projects/',
+        leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
+      },
+    ]}
+    title={
+      <BreadcrumbList.Title
+        item={{
+          type: 'page-title',
+          label: 'Client Keys (DSN)',
+          leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
+        }}
+      />
+    }
+  />
+</Storybook.Demo>
+```tsx
+<TopBar.Slot name="breadcrumbs">
+  <BreadcrumbList
+    items={[
+      {
+        type: 'link',
+        label: 'My Projects',
+        to: '/settings/org-slug/projects/',
+        leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
+      },
+    ]}
+  />
+</TopBar.Slot>
+<TopBar.Slot name="title">
+  <BreadcrumbList.Title
+    item={{
+      type: 'page-title',
+      label: 'Client Keys (DSN)',
+      leadingGraphic: <ProjectsBadge projectPlatforms={['python', 'javascript']} />,
+    }}
+  />
+</TopBar.Slot>
+```
+
 ## Overflow (container query)
 
 `BreadcrumbList` uses the nearest inline-size query container. Standalone lists
 establish their own container; lists rendered in the TopBar `breadcrumbs` slot
 reuse the TopBar's flexible content region so the slot remains content-sized.
-Below 512px, parent items hide and link parents collapse into a single `…`
-overflow button. Other parent types, such as `select-projects`, simply collapse
-out of view. The page title is rendered separately in the title slot and remains
-visible there.
+Below 512px, parent items hide and `'link'` parents collapse into a single `…`
+overflow button. Any other parent type simply collapses out of view — only links
+survive in the overflow menu. The page title is rendered separately in the title
+slot and remains visible there.
 
 Drag the resize handle to see the transition:
 


### PR DESCRIPTION
This is a small PR to just improve the story for `BreadcrumbList` component/usage.

### Whats changed?
- **Structure:** Three top level sections which better communicate how you can use the component, what each item type is, and what props are available.
- **Added Content:** Specifically
  - How to persist page filters.
  - How to use `BreadcrumbList.Title` for index pages
  - How to utilise `labelTooltip` for `BreadcrumbList.Title`
- **Improved Code Snippets:** Clearly I vibed too hard on the first iteration of this doc, because the code snippets were just plain wrong.
