### PR TITLE
Revert "ref(agents): update Explore Agents onboarding arcade"

### DIFF
--- a/static/app/views/insights/pages/agents/onboarding.tsx
+++ b/static/app/views/insights/pages/agents/onboarding.tsx
@@ -216,7 +216,7 @@ function OnboardingPanel({
                 <Preview>
                   <BodyTitle>{t('Preview Agent Insights')}</BodyTitle>
                   <Arcade
-                    src="https://demo.arcade.software/aEDAYP7ebTJvWKABSBdc?embed"
+                    src="https://demo.arcade.software/0NzB6M1Wn8sDsFDAj4sE?embed"
                     loading="lazy"
                     allowFullScreen
                   />


### PR DESCRIPTION
Reverts getsentry/sentry#123563
This mistakenly updated the arcade for the empty state of the Agents Overview dashboard instead of conversations.