### PR TITLE
feat(metrics): Option to disable generic metrics

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -668,6 +668,13 @@ register(
     flags=FLAG_AUTOMATOR_MODIFIABLE,
 )
 
+register(
+    "relay.generic-metrics.disabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_AUTOMATOR_MODIFIABLE,
+)
+
 # Slack Integration
 register("slack.client-id", flags=FLAG_PRIORITIZE_DISK | FLAG_AUTOMATOR_MODIFIABLE)
 register("slack.client-secret", flags=FLAG_CREDENTIAL | FLAG_PRIORITIZE_DISK)

--- a/src/sentry/relay/globalconfig.py
+++ b/src/sentry/relay/globalconfig.py
@@ -20,6 +20,7 @@ RELAY_OPTIONS: list[str] = [
     "relay.objectstore-attachments.sample-rate",
     "relay.endpoint-fetch-config.enabled",
     "relay.attachment-inline.limit",
+    "relay.generic-metrics.disabled",
 ]
 
 


### PR DESCRIPTION
Register an option to killswitch generic metrics , and forward its value to relay.

See also https://github.com/getsentry/relay/pull/6365.

ref: TET-2981