### PR TITLE
fix(explore): Add function type badges to aggregate dropdowns

### DIFF
--- a/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
+++ b/static/app/views/explore/components/toolbar/toolbarVisualize/index.tsx
@@ -14,7 +14,11 @@ import {IconAdd} from 'sentry/icons';
 import {IconDelete} from 'sentry/icons/iconDelete';
 import {t} from 'sentry/locale';
 import type {ParsedFunction} from 'sentry/utils/discover/fields';
-import {getFieldDefinition, type GetFieldDefinitionType} from 'sentry/utils/fields';
+import {
+  FieldKind,
+  getFieldDefinition,
+  type GetFieldDefinitionType,
+} from 'sentry/utils/fields';
 import {
   ToolbarFooterButton,
   ToolbarHeader,
@@ -22,6 +26,7 @@ import {
   ToolbarRow,
 } from 'sentry/views/explore/components/toolbar/styles';
 import {ExpandableFilterSearchBar} from 'sentry/views/explore/components/toolbar/toolbarVisualize/expandableFilterSearchBar';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {sortSearchedAttributes} from 'sentry/views/explore/utils/sortSearchedAttributes';
 
 export function ToolbarVisualizeHeader() {
@@ -111,7 +116,10 @@ export function ToolbarVisualizeDropdown({
         <Flex gap="md" align="center" width="100%">
           <AggregateCompactSelect
             search
-            options={aggregateOptions}
+            options={aggregateOptions.map(option => ({
+              ...option,
+              trailingItems: <TypeBadge kind={FieldKind.FUNCTION} />,
+            }))}
             value={parsedFunction?.name ?? ''}
             onChange={onChangeAggregate}
           />

--- a/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
+++ b/static/app/views/explore/metrics/metricToolbar/aggregateDropdown.tsx
@@ -9,6 +9,8 @@ import {
 import {OverlayTrigger} from '@sentry/scraps/overlayTrigger';
 
 import {t} from 'sentry/locale';
+import {FieldKind} from 'sentry/utils/fields';
+import {TypeBadge} from 'sentry/views/explore/components/typeBadge';
 import {
   DEFAULT_YAXIS_BY_TYPE,
   GROUPED_OPTIONS_BY_TYPE,
@@ -123,6 +125,17 @@ export function AggregateDropdown({
       {groups.map(group => {
         const groupKey = String(group.key);
         const isMulti = !singleSelect && MULTI_SELECT_GROUP_KEYS.has(groupKey);
+        const options = group.options.map<SelectOption<string>>(option => ({
+          ...option,
+          trailingItems: state => (
+            <Fragment>
+              {typeof option.trailingItems === 'function'
+                ? option.trailingItems(state)
+                : option.trailingItems}
+              <TypeBadge kind={FieldKind.FUNCTION} />
+            </Fragment>
+          ),
+        }));
         const activeValues = group.options
           .map(opt => String(opt.value))
           .filter(v => selectedNames.has(v));
@@ -133,7 +146,7 @@ export function AggregateDropdown({
               key={groupKey}
               label={group.label}
               multiple
-              options={group.options}
+              options={options}
               value={activeValues}
               onChange={handleChange}
             />
@@ -144,7 +157,7 @@ export function AggregateDropdown({
           <CompositeSelect.Region
             key={groupKey}
             label={group.label}
-            options={group.options}
+            options={options}
             value={activeValues[0]}
             onChange={opt => handleChange([opt])}
           />


### PR DESCRIPTION
Add the green `f(x)` type badge beside function options in Explore's visualize dropdowns for spans, logs, and errors, and in the Metrics aggregate dropdown. Both reuse the shared `TypeBadge` component to match dashboards. Metrics keeps its existing “Default” labels alongside the badge.

Closes EXP-1180

|Traces|Logs|Metrics|
|-|-|-|
|<img width="322" height="597" alt="Screenshot 2026-09-11 at 07 33 00" src="https://github.com/user-attachments/assets/6b2d136c-a34c-48d5-899c-a5bb38d2591a" />|<img width="327" height="524" alt="Screenshot 2026-09-11 at 07 33 34" src="https://github.com/user-attachments/assets/712007eb-8340-47a9-b95c-f680eed7b994" />|<img width="174" height="569" alt="Screenshot 2026-09-11 at 07 33 48" src="https://github.com/user-attachments/assets/c5d49d43-97f0-41f7-bb4b-fc524e4cb020" />|
