### PR TITLE
ref(events): Migrate responsive layouts to container queries

### DIFF
--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -148,7 +148,7 @@ const SectionHeader = styled('div')`
     font-weight: ${p => p.theme.font.weight.sans.regular};
   }
 
-  @media (min-width: ${p => p.theme.breakpoints.lg}) {
+  @container (min-width: ${p => p.theme.container['4xl']}) {
     & > small {
       margin-left: ${p => p.theme.space.md};
       display: inline-block;

--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -62,7 +62,13 @@ export function EventDataSection({
   const titleNode = <h3>{title}</h3>;
 
   return (
-    <DataSection ref={scrollToSection} className={className || ''} {...props}>
+    <DataSection
+      ref={scrollToSection}
+      className={className || ''}
+      data-event-data-section
+      padding={{zero: 'md xl', '3xl': 'lg 3xl'}}
+      {...props}
+    >
       <SectionHeader id={type} data-test-id={`event-section-${type}`}>
         {title && (
           <Title>

--- a/static/app/components/events/eventDataSection.tsx
+++ b/static/app/components/events/eventDataSection.tsx
@@ -1,9 +1,8 @@
 import styled from '@emotion/styled';
 
-import {Container} from '@sentry/scraps/layout';
+import {Container, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 
-import {DataSection} from 'sentry/components/events/styles';
 import {IconLink} from 'sentry/icons';
 
 interface EventDataSectionProps {
@@ -62,10 +61,9 @@ export function EventDataSection({
   const titleNode = <h3>{title}</h3>;
 
   return (
-    <DataSection
+    <Stack
       ref={scrollToSection}
       className={className || ''}
-      data-event-data-section
       padding={{zero: 'md xl', '3xl': 'lg 3xl'}}
       {...props}
     >
@@ -91,7 +89,7 @@ export function EventDataSection({
         )}
       </SectionHeader>
       <Container position="relative">{children}</Container>
-    </DataSection>
+    </Stack>
   );
 }
 

--- a/static/app/components/events/eventDrawer.tsx
+++ b/static/app/components/events/eventDrawer.tsx
@@ -62,7 +62,7 @@ export const EventDrawerContainer = styled('div')`
   --event-navigator-box-shadow: none;
   --event-navigator-border-bottom: 1px solid ${p => p.theme.tokens.border.primary};
 
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
+  @container (min-width: ${p => p.theme.container['3xl']}) {
     --event-drawer-header-height: ${PRIMARY_HEADER_HEIGHT}px;
   }
 `;

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -113,7 +113,7 @@ export function ReplayClipPreviewPlayer({
 const PlayerContainer = styled(FluidHeight)`
   position: relative;
   max-height: ${REPLAY_LOADING_HEIGHT + 16}px;
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
+  @container (min-width: ${p => p.theme.container.xl}) {
     min-height: ${REPLAY_LOADING_HEIGHT + 16}px;
   }
   overflow: unset;

--- a/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
+++ b/static/app/components/events/eventReplay/replayClipPreviewPlayer.tsx
@@ -89,7 +89,13 @@ export function ReplayClipPreviewPlayer({
         }
 
         return (
-          <PlayerContainer data-test-id="player-container">
+          <FluidHeight
+            data-test-id="player-container"
+            position="relative"
+            maxHeight={`${REPLAY_LOADING_HEIGHT + 16}px`}
+            minHeight={{xl: `${REPLAY_LOADING_HEIGHT + 16}px`}}
+            overflow="visible"
+          >
             <ReplayPlayerPluginsContextProvider>
               <ReplayReaderProvider replay={replay}>
                 <ReplayPlayerStateContextProvider>
@@ -103,21 +109,12 @@ export function ReplayClipPreviewPlayer({
                 </ReplayPlayerStateContextProvider>
               </ReplayReaderProvider>
             </ReplayPlayerPluginsContextProvider>
-          </PlayerContainer>
+          </FluidHeight>
         );
       }}
     </ReplayLoadingState>
   );
 }
-
-const PlayerContainer = styled(FluidHeight)`
-  position: relative;
-  max-height: ${REPLAY_LOADING_HEIGHT + 16}px;
-  @container (min-width: ${p => p.theme.container.xl}) {
-    min-height: ${REPLAY_LOADING_HEIGHT + 16}px;
-  }
-  overflow: unset;
-`;
 
 const StyledNegativeSpaceContainer = styled(NegativeSpaceContainer)`
   height: ${REPLAY_LOADING_HEIGHT}px;

--- a/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
+++ b/static/app/components/events/eventReplay/replayInlineOnboardingPanel.tsx
@@ -1,10 +1,9 @@
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import replayInlineOnboarding from 'sentry-images/spot/replay-inline-onboarding-v2.svg';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Container} from '@sentry/scraps/layout';
+import {Flex, Container, useResponsivePropValue} from '@sentry/scraps/layout';
 
 import {usePrompt} from 'sentry/actionCreators/prompts';
 import {DropdownMenu} from 'sentry/components/dropdownMenu';
@@ -14,7 +13,6 @@ import {t, tct} from 'sentry/locale';
 import type {PlatformKey} from 'sentry/types/platform';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {useReplayOnboardingSidebarPanel} from 'sentry/utils/replays/hooks/useReplayOnboarding';
-import {useMedia} from 'sentry/utils/useMedia';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
@@ -28,13 +26,12 @@ export default function ReplayInlineOnboardingPanel({
   platform,
   projectId,
 }: OnboardingCTAProps) {
-  const theme = useTheme();
   const organization = useOrganization();
   const {activateSidebar} = useReplayOnboardingSidebarPanel();
 
   const platformKey = platforms.find(p => p.id === platform) ?? otherPlatform;
   const platformName = platformKey === otherPlatform ? '' : platformKey.name;
-  const isScreenSmall = useMedia(`(max-width: ${theme.breakpoints.sm})`);
+  const isContainerSmall = useResponsivePropValue({zero: true, xl: false});
 
   const {isLoading, isError, isPromptDismissed, dismissPrompt, snoozePrompt} = usePrompt({
     feature: 'issue_replay_inline_onboarding',
@@ -70,7 +67,7 @@ export default function ReplayInlineOnboardingPanel({
             </Button>
           </Flex>
         </div>
-        {!isScreenSmall && <Background image={replayInlineOnboarding} />}
+        {!isContainerSmall && <Background image={replayInlineOnboarding} />}
         <CloseDropdownMenu
           position="bottom-end"
           triggerProps={{

--- a/static/app/components/events/eventTags/eventTagCustomBanner.tsx
+++ b/static/app/components/events/eventTags/eventTagCustomBanner.tsx
@@ -69,7 +69,7 @@ const SentaurIllustration = styled('img')`
   margin: 20px 20px 10px 10px;
   pointer-events: none;
   justify-self: end;
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+  @container (max-width: ${p => p.theme.container.xl}) {
     display: none;
   }
 `;

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -1,10 +1,10 @@
-import type {ReactEventHandler} from 'react';
+import type {ReactEventHandler, ReactNode} from 'react';
 import {useState} from 'react';
 import {css} from '@emotion/react';
 import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
-import {Flex, Grid} from '@sentry/scraps/layout';
+import {Flex, Grid, Stack} from '@sentry/scraps/layout';
 
 import {useRole} from 'sentry/components/acl/useRole';
 import {openConfirmModal} from 'sentry/components/confirm';
@@ -76,7 +76,7 @@ export function Screenshot({
   const downloadUrl = `/api/0/projects/${organization.slug}/${projectSlug}/events/${eventId}/attachments/${screenshot.id}/`;
 
   return (
-    <StyledPanel>
+    <ScreenshotPanel>
       {totalScreenshots > 1 && (
         <StyledPanelHeader lightText>
           <Button
@@ -166,23 +166,28 @@ export function Screenshot({
           />
         </Grid>
       </StyledPanelFooter>
-    </StyledPanel>
+    </ScreenshotPanel>
   );
 }
 
-const StyledPanel = styled(Panel)`
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  margin-bottom: 0;
-  max-width: 100%;
-  height: 100%;
-  border: 0;
+function ScreenshotPanel({children}: {children: ReactNode}) {
+  return (
+    <Stack
+      justify="center"
+      align="center"
+      marginBottom="0"
+      maxWidth={{zero: '100%', xl: '175px'}}
+      height="100%"
+    >
+      {({className}) => (
+        <BorderlessPanel className={className}>{children}</BorderlessPanel>
+      )}
+    </Stack>
+  );
+}
 
-  @container (min-width: ${p => p.theme.container.xl}) {
-    max-width: 175px;
-  }
+const BorderlessPanel = styled(Panel)`
+  border: 0;
 `;
 
 const StyledPanelHeader = styled(PanelHeader)`

--- a/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
+++ b/static/app/components/events/eventTagsAndScreenshot/screenshot/index.tsx
@@ -180,7 +180,7 @@ const StyledPanel = styled(Panel)`
   height: 100%;
   border: 0;
 
-  @media (min-width: ${p => p.theme.breakpoints.sm}) {
+  @container (min-width: ${p => p.theme.container.xl}) {
     max-width: 175px;
   }
 `;

--- a/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
+++ b/static/app/components/events/featureFlags/eventFeatureFlagSection.tsx
@@ -1,11 +1,10 @@
 import {Fragment, useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {useTheme} from '@emotion/react';
 import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {Button} from '@sentry/scraps/button';
 import {useDrawer} from '@sentry/scraps/drawer';
-import {Grid} from '@sentry/scraps/layout';
+import {Grid, useResponsivePropValue} from '@sentry/scraps/layout';
 
 import {AnalyticsArea} from 'sentry/components/analyticsArea';
 import {EmptyStateWarning} from 'sentry/components/emptyStateWarning';
@@ -34,7 +33,6 @@ import type {Project} from 'sentry/types/project';
 import {trackAnalytics} from 'sentry/utils/analytics';
 import {MutableSearch} from 'sentry/utils/tokenizeSearch';
 import {useLocation} from 'sentry/utils/useLocation';
-import {useMedia} from 'sentry/utils/useMedia';
 import {useOrganization} from 'sentry/utils/useOrganization';
 import {SectionKey} from 'sentry/views/issueDetails/context';
 import {FoldSection} from 'sentry/views/issueDetails/foldSection';
@@ -57,10 +55,9 @@ type EventFeatureFlagSectionProps = {
 
 function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagSectionProps) {
   const organization = useOrganization();
-  const theme = useTheme();
-  const isXsScreen = useMedia(`(max-width: ${theme.breakpoints.xs})`);
+  const isXsContainer = useResponsivePropValue({zero: true, sm: false});
 
-  const feedbackButton = isXsScreen ? null : (
+  const feedbackButton = isXsContainer ? null : (
     <FeedbackButton
       variant="secondary"
       aria-label={t('Give feedback on the feature flag section')}
@@ -263,7 +260,7 @@ function BaseEventFeatureFlagList({event, group, project}: EventFeatureFlagSecti
   );
 
   const shouldUseTwoColumns =
-    !isXsScreen && truncatedItems.length > NUM_PREVIEW_FLAGS / 2;
+    !isXsContainer && truncatedItems.length > NUM_PREVIEW_FLAGS / 2;
   const columnOne = shouldUseTwoColumns
     ? truncatedItems.slice(0, NUM_PREVIEW_FLAGS / 2)
     : truncatedItems;
@@ -323,7 +320,7 @@ const ValueWrapper = styled('div')`
   grid-template-columns: 1fr 1fr 0.5fr;
   justify-items: start;
 
-  @media (max-width: ${p => p.theme.breakpoints.xs}) {
+  @container (max-width: ${p => p.theme.container.sm}) {
     grid-template-columns: 1fr 0.5fr;
     grid-template-rows: auto auto;
 

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -204,7 +204,7 @@ const Header = styled('div')`
   align-items: center;
   justify-content: space-between;
   margin-bottom: ${p => p.theme.space.xl};
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+  @container (max-width: ${p => p.theme.container.xl}) {
     display: block;
   }
 `;
@@ -245,7 +245,7 @@ const TextWithQuestionTooltip = styled('div')`
 `;
 
 const Hash = styled('span')`
-  @media (max-width: ${p => p.theme.breakpoints.sm}) {
+  @container (max-width: ${p => p.theme.container.xl}) {
     display: block;
     white-space: nowrap;
     overflow: hidden;

--- a/static/app/components/events/groupingInfo/groupingVariant.tsx
+++ b/static/app/components/events/groupingInfo/groupingVariant.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import {InfoTip} from '@sentry/scraps/info';
+import {Container} from '@sentry/scraps/layout';
 
 import {getSpanHash} from 'sentry/components/events/interfaces/performance/utils';
 import type {RawSpanType} from 'sentry/components/events/interfaces/spans/types';
@@ -179,7 +180,9 @@ export function GroupingVariant({
   const [data] = getVariantData();
   return (
     <VariantWrapper>
-      <Header>{renderTitle()}</Header>
+      <Container display={{zero: 'block', xl: 'flex'}} marginBottom="xl">
+        {renderTitle()}
+      </Container>
 
       <KeyValueTableDataList
         margin
@@ -197,16 +200,6 @@ export function GroupingVariant({
 
 const VariantWrapper = styled('div')`
   margin-bottom: ${p => p.theme.space['3xl']};
-`;
-
-const Header = styled('div')`
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: ${p => p.theme.space.xl};
-  @container (max-width: ${p => p.theme.container.xl}) {
-    display: block;
-  }
 `;
 
 const VariantTitle = styled('h5')`

--- a/static/app/components/events/highlights/highlightsDataSection.tsx
+++ b/static/app/components/events/highlights/highlightsDataSection.tsx
@@ -386,7 +386,7 @@ const highlightModalCss = (theme: Theme) => css`
   padding: 0 ${theme.space.xl};
   margin: ${theme.space.xl} 0;
   /* Disable overriding margins with breakpoint on default modal */
-  @media (min-width: ${theme.breakpoints.md}) {
+  @container (min-width: ${theme.container['3xl']}) {
     margin: ${theme.space.xl} 0;
     padding: 0 ${theme.space.xl};
   }

--- a/static/app/components/events/styles.tsx
+++ b/static/app/components/events/styles.tsx
@@ -1,14 +1,3 @@
-import styled from '@emotion/styled';
+import {Stack} from '@sentry/scraps/layout';
 
-export const DataSection = styled('div')`
-  display: flex;
-  flex-direction: column;
-  margin: 0;
-
-  /* Padding aligns with Layout.Body */
-  padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
-
-  @container (min-width: ${p => p.theme.container['3xl']}) {
-    padding: ${p => p.theme.space.lg} ${p => p.theme.space['3xl']};
-  }
-`;
+export const DataSection = Stack;

--- a/static/app/components/events/styles.tsx
+++ b/static/app/components/events/styles.tsx
@@ -8,7 +8,7 @@ export const DataSection = styled('div')`
   /* Padding aligns with Layout.Body */
   padding: ${p => p.theme.space.md} ${p => p.theme.space.xl};
 
-  @media (min-width: ${p => p.theme.breakpoints.md}) {
+  @container (min-width: ${p => p.theme.container['3xl']}) {
     padding: ${p => p.theme.space.lg} ${p => p.theme.space['3xl']};
   }
 `;

--- a/static/app/components/events/styles.tsx
+++ b/static/app/components/events/styles.tsx
@@ -1,3 +1,0 @@
-import {Stack} from '@sentry/scraps/layout';
-
-export const DataSection = Stack;

--- a/static/app/components/events/suspectCommitFeedback.tsx
+++ b/static/app/components/events/suspectCommitFeedback.tsx
@@ -1,8 +1,8 @@
 import {useState} from 'react';
-import styled from '@emotion/styled';
 
 import {Button} from '@sentry/scraps/button';
 import {Flex} from '@sentry/scraps/layout';
+import {Text} from '@sentry/scraps/text';
 
 import {IconThumb} from 'sentry/icons';
 import {t} from 'sentry/locale';
@@ -38,14 +38,18 @@ export function SuspectCommitFeedback({
   if (feedbackSubmitted) {
     return (
       <Flex display={{zero: 'none', sm: 'flex'}} align="center" gap="xs">
-        <ThankYouText>{t('Thanks!')}</ThankYouText>
+        <Text variant="muted" density="comfortable" wrap="nowrap">
+          {t('Thanks!')}
+        </Text>
       </Flex>
     );
   }
 
   return (
     <Flex display={{zero: 'none', sm: 'flex'}} align="center" gap="xs">
-      <FeedbackText>{t('Is this correct?')}</FeedbackText>
+      <Text variant="muted" density="comfortable" wrap="nowrap">
+        {t('Is this correct?')}
+      </Text>
       <Flex gap="2xs">
         <Button
           size="zero"
@@ -63,17 +67,3 @@ export function SuspectCommitFeedback({
     </Flex>
   );
 }
-
-const FeedbackText = styled('span')`
-  font-size: ${p => p.theme.font.size.md};
-  line-height: 1.5;
-  color: ${p => p.theme.tokens.content.secondary};
-  white-space: nowrap;
-`;
-
-const ThankYouText = styled('span')`
-  font-size: ${p => p.theme.font.size.md};
-  line-height: 1.5;
-  color: ${p => p.theme.tokens.content.secondary};
-  white-space: nowrap;
-`;

--- a/static/app/components/events/suspectCommitFeedback.tsx
+++ b/static/app/components/events/suspectCommitFeedback.tsx
@@ -37,14 +37,14 @@ export function SuspectCommitFeedback({
 
   if (feedbackSubmitted) {
     return (
-      <FeedbackContainer>
+      <Flex display={{zero: 'none', sm: 'flex'}} align="center" gap="xs">
         <ThankYouText>{t('Thanks!')}</ThankYouText>
-      </FeedbackContainer>
+      </Flex>
     );
   }
 
   return (
-    <FeedbackContainer>
+    <Flex display={{zero: 'none', sm: 'flex'}} align="center" gap="xs">
       <FeedbackText>{t('Is this correct?')}</FeedbackText>
       <Flex gap="2xs">
         <Button
@@ -60,20 +60,9 @@ export function SuspectCommitFeedback({
           aria-label={t('No, this suspect commit is incorrect')}
         />
       </Flex>
-    </FeedbackContainer>
+    </Flex>
   );
 }
-
-const FeedbackContainer = styled('div')`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  gap: ${p => p.theme.space.xs};
-
-  @media (max-width: ${p => p.theme.breakpoints.xs}) {
-    display: none;
-  }
-`;
 
 const FeedbackText = styled('span')`
   font-size: ${p => p.theme.font.size.md};

--- a/static/app/views/discover/table/quickContext/releaseContext.tsx
+++ b/static/app/views/discover/table/quickContext/releaseContext.tsx
@@ -198,7 +198,7 @@ const ReleaseContextContainer = styled(ContextContainer)`
     border: none;
     box-shadow: none;
   }
-  ${DataSection} {
+  [data-event-data-section] {
     padding: 0;
   }
   & + & {

--- a/static/app/views/discover/table/quickContext/releaseContext.tsx
+++ b/static/app/views/discover/table/quickContext/releaseContext.tsx
@@ -3,9 +3,9 @@ import styled from '@emotion/styled';
 import {useQuery} from '@tanstack/react-query';
 
 import {AvatarList} from '@sentry/scraps/avatar';
+import {Stack} from '@sentry/scraps/layout';
 
 import {QuickContextCommitRow} from 'sentry/components/discover/quickContextCommitRow';
-import {DataSection} from 'sentry/components/events/styles';
 import {Panel} from 'sentry/components/panels/panel';
 import {TimeSince} from 'sentry/components/timeSince';
 import {IconNot} from 'sentry/icons';
@@ -137,11 +137,11 @@ export function ReleaseContext(props: BaseContextProps) {
         <ContextHeader>
           <ContextTitle>{t('Last Commit')}</ContextTitle>
         </ContextHeader>
-        <DataSection>
+        <Stack>
           <Panel>
             <QuickContextCommitRow commit={data.lastCommit} />
           </Panel>
-        </DataSection>
+        </Stack>
       </ReleaseContextContainer>
     );
 
@@ -197,9 +197,6 @@ const ReleaseContextContainer = styled(ContextContainer)`
     margin: 0;
     border: none;
     box-shadow: none;
-  }
-  [data-event-data-section] {
-    padding: 0;
   }
   & + & {
     margin-top: ${p => p.theme.space.xl};

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -96,10 +96,6 @@ const BodyContainer = styled('div')`
   height: calc(100% - 52px);
   overflow-y: auto;
   overflow-x: hidden;
-
-  [data-event-data-section] {
-    padding: 0;
-  }
 `;
 
 const DetailContainer = styled('div')`

--- a/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
+++ b/static/app/views/performance/newTraceDetails/traceDrawer/details/styles.tsx
@@ -20,7 +20,6 @@ import {
 } from 'sentry/components/dropdownMenu';
 import {EventTagsDataSection} from 'sentry/components/events/eventTagsAndScreenshot/tags';
 import {generateStats} from 'sentry/components/events/opsBreakdown';
-import {DataSection} from 'sentry/components/events/styles';
 import ProjectBadge from 'sentry/components/idBadge/projectBadge';
 import {type LazyRenderProps} from 'sentry/components/lazyRender';
 import {Panel} from 'sentry/components/panels/panel';
@@ -98,7 +97,7 @@ const BodyContainer = styled('div')`
   overflow-y: auto;
   overflow-x: hidden;
 
-  ${DataSection} {
+  [data-event-data-section] {
     padding: 0;
   }
 `;


### PR DESCRIPTION
Top-level event detail sections now respond to their available container width instead of the viewport. This covers grouping info, replay, highlights, event tags, feature flags, tags and screenshot, and the shared top-level event layouts while keeping the existing narrow and wide presentations.

Pure layout and visibility changes use responsive layout primitives, render-time width branches use container-scoped responsive values, and CSS-only cases use pixel-mapped container breakpoints. Interface components remain out of scope.

Refs #120315
