### PR TITLE
chore(sdk): Decrease `SAMPLED_DEFAULT_RATE` to 0.035

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -2907,7 +2907,7 @@ SENTRY_PROJECT_COUNTER_STATEMENT_TIMEOUT = 1000
 # Implemented in getsentry to run additional devserver workers.
 SENTRY_EXTRA_WORKERS: MutableSequence[str] = []
 
-SAMPLED_DEFAULT_RATE = 0.07
+SAMPLED_DEFAULT_RATE = 0.035
 
 # A set of extra URLs to sample
 ADDITIONAL_SAMPLED_URLS: dict[str, float] = {}


### PR DESCRIPTION
Further reduce sample rates that the SDK's traces sampler references, following up on https://github.com/getsentry/sentry/pull/124039

We intend to turn off dynamic sampling for the monolith and are moving the average server-side sampling rate to the client.

See corresponding `getsentry` PR: https://github.com/getsentry/getsentry/pull/21951