### PR TITLE
feat(explore): Expose automatic JSON expansion flag to Relay

### DIFF
--- a/src/sentry/features/temporary.py
+++ b/src/sentry/features/temporary.py
@@ -466,6 +466,8 @@ def register_temporary_features(manager: FeatureManager) -> None:
     manager.add("organizations:tracemetrics-enabled", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics product to be ingested via Relay
     manager.add("organizations:tracemetrics-ingestion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
+    # Enable Relay to expand incoming JSON strings on EAP items into KVList attributes
+    manager.add("organizations:relay-automatic-json-expansion", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics multi-metric selection in dashboards
     manager.add("organizations:tracemetrics-multi-metric-selection-in-dashboards", OrganizationFeature, FeatureHandlerStrategy.FLAGPOLE, api_expose=True)
     # Enable trace metrics units in trace view UI

--- a/src/sentry/relay/config/__init__.py
+++ b/src/sentry/relay/config/__init__.py
@@ -58,6 +58,7 @@ EXPOSABLE_FEATURES = [
     "organizations:indexed-spans-extraction",
     "organizations:ourlogs-ingestion",
     "organizations:tracemetrics-ingestion",
+    "organizations:relay-automatic-json-expansion",
     "organizations:view-hierarchy-scrubbing",
     "organizations:performance-issues-spans",
     "organizations:relay-playstation-ingestion",


### PR DESCRIPTION
### Summary
Register organizations:relay-automatic-json-expansion so Relay can later choose KVList vs string for incoming json-like strings to forward to EAP. EAP will be handling everything related to expansion, we're just using the project config mechanism to pass the 'feature' along to EAP via proto types.

For [information about 'why'](https://app.notion.com/p/sentry/Object-Expansion-Into-Attributes-3d78b10e4b5d80fe81a2c44a02580ff1) 

Closes EXP-1188