### PR TITLE
feat(apidocs): Add internal OpenAPI build for frontend contract generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ node_modules
 /tests/apidocs/openapi-deprecated.json
 /tests/sentry/utils/appleconnect/*.json
 /tests/apidocs/openapi-spectacular.json
+/tests/apidocs/openapi-internal.json
 /fixtures/integrations/*/data/**
 /wheelhouse
 /test_cli/

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,14 @@ build-deprecated-docs:
 	@echo "--> Building deprecated openapi spec from json files"
 	pnpm run build-deprecated-docs
 
+# Like build-spectacular-docs, but also includes every private/experimental
+# endpoint method that declares a schema, stamps operations with
+# x-sentry-publish-status, and describes TypedDict responses as closed objects.
+# This is the input for frontend contract generation; it is never published.
+build-internal-api-docs: build-deprecated-docs
+	@echo "--> Building internal drf-spectacular openapi spec (public + schema-declaring private endpoints)"
+	@SENTRY_OPENAPI_INTERNAL=1 OPENAPIGENERATE=1 sentry django spectacular --file tests/apidocs/openapi-internal.json --format openapi-json --validate
+
 build-api-docs: build-deprecated-docs build-spectacular-docs
 	@echo "--> Dereference the json schema for ease of use"
 	pnpm run deref-api-docs

--- a/src/sentry/apidocs/extensions.py
+++ b/src/sentry/apidocs/extensions.py
@@ -10,7 +10,7 @@ from drf_spectacular.plumbing import build_basic_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import Direction
 
-from sentry.apidocs.spectacular_ports import resolve_type_hint
+from sentry.apidocs.spectacular_ports import resolve_type_hint, resolve_type_hint_lenient
 
 
 class TokenAuthExtension(OpenApiAuthenticationExtension):
@@ -74,7 +74,7 @@ class SentryInlineResponseSerializerExtension(OpenApiSerializerExtension):
         return self.target.__name__
 
     def map_serializer(self, auto_schema: AutoSchema, direction: Direction) -> Any:
-        return resolve_type_hint(self.target.typeSchema)
+        return resolve_type_hint_lenient(self.target.typeSchema, self.target.__name__)
 
 
 class RestrictedJsonFieldExtension(OpenApiSerializerFieldExtension):

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -11,7 +11,7 @@ from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.apidocs.api_ownership_allowlist_dont_modify import API_OWNERSHIP_ALLOWLIST_DONT_MODIFY
 from sentry.apidocs.build import OPENAPI_TAGS
-from sentry.apidocs.utils import SentryApiBuildError
+from sentry.apidocs.utils import SentryApiBuildError, is_internal_build
 
 HTTP_METHOD_NAME = Literal[
     "GET", "POST", "PUT", "OPTIONS", "HEAD", "DELETE", "TRACE", "CONNECT", "PATCH"
@@ -104,9 +104,38 @@ class CustomGenerator(SchemaGenerator):
 # Collected during preprocessing, used in postprocessing
 _ENDPOINT_SERVERS: dict[str, list[dict[str, Any]]] = {}
 
+# Non-public operations admitted to an internal build, keyed by (path, lowercase
+# method). Postprocessing stamps these with ``x-sentry-publish-status`` and skips
+# the checks that only make sense for the published reference (tags, docstrings,
+# unique summaries, body parameter descriptions).
+_INTERNAL_OPERATIONS: dict[tuple[str, str], ApiPublishStatus] = {}
+
+PUBLISH_STATUS_EXTENSION = "x-sentry-publish-status"
+
+
+def _declares_schema(view_class: type, method: str) -> bool:
+    """
+    True when ``method`` on ``view_class`` carries an ``@extend_schema`` override,
+    either directly on the handler or on the endpoint class.
+
+    drf-spectacular records a method-level decorator as ``handler.kwargs["schema"]``
+    and a class-level decorator as a ``schema`` attribute set on the decorated class
+    itself (``APIView`` only provides one through a descriptor on its own class).
+    """
+    handler = getattr(view_class, method.lower(), None)
+    if handler is not None and "schema" in getattr(handler, "kwargs", {}):
+        return True
+    return any(
+        "schema" in vars(cls)
+        for cls in view_class.__mro__
+        if cls.__module__.startswith(("sentry", "getsentry"))
+    )
+
 
 def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, rename
     _ENDPOINT_SERVERS.clear()
+    _INTERNAL_OPERATIONS.clear()
+    internal_build = is_internal_build()
 
     filtered = []
     ownership_data: dict[ApiOwner, dict] = {}
@@ -138,26 +167,24 @@ def custom_preprocessing_hook(endpoints: Any) -> Any:  # TODO: organize method, 
                 f"All methods must declare a publish_status. Please add a valid publish status for Endpoint {callback.view_class} {method} method.",
             )
 
+        status = callback.view_class.publish_status[method]
+
         if any(path.startswith(p) for p in EXCLUSION_PATH_PREFIXES):
             pass
 
-        elif callback.view_class.publish_status:
-            # endpoints that are documented via tooling
-            if (
-                method in callback.view_class.publish_status
-                and callback.view_class.publish_status[method] is ApiPublishStatus.PUBLIC
-            ):
-                # only pass declared public methods of the endpoint
-                # to the rest of the OpenAPI build pipeline
-                filtered.append((path, path_regex, method, callback))
+        elif status is ApiPublishStatus.PUBLIC:
+            # only pass declared public methods of the endpoint
+            # to the rest of the OpenAPI build pipeline
+            filtered.append((path, path_regex, method, callback))
 
-        else:
-            # if an endpoint doesn't have any registered public methods, don't check it.
-            pass
+        elif internal_build and _declares_schema(callback.view_class, method):
+            # Internal builds also admit private/experimental methods, but only
+            # those that already declare a schema: an undocumented method would
+            # produce an empty operation that says nothing about its response.
+            filtered.append((path, path_regex, method, callback))
+            _INTERNAL_OPERATIONS[(path, method.lower())] = status
 
-        ownership_data[owner_team][callback.view_class.publish_status[method]].add(
-            f"{callback.view_class.__name__}::{method}"
-        )
+        ownership_data[owner_team][status].add(f"{callback.view_class.__name__}::{method}")
 
     __write_ownership_data(ownership_data)
     return filtered
@@ -224,6 +251,28 @@ def _validate_request_body(
         )
 
 
+def _stamp_publish_status(result: Any) -> None:
+    """
+    Record each operation's publish status as ``x-sentry-publish-status``.
+
+    Only internal builds carry the extension, so the published spec is unchanged.
+    This runs before ``_fix_issue_paths`` moves operations between paths, and the
+    later checks read the stamp off the operation rather than re-deriving it.
+    """
+    if not is_internal_build():
+        return
+    for path, endpoints in result["paths"].items():
+        for method, method_info in endpoints.items():
+            status = _INTERNAL_OPERATIONS.get((path, method), ApiPublishStatus.PUBLIC)
+            method_info[PUBLISH_STATUS_EXTENSION] = status.value
+
+
+def _is_internal_operation(method_info: Mapping[str, Any]) -> bool:
+    return method_info.get(PUBLISH_STATUS_EXTENSION, ApiPublishStatus.PUBLIC.value) != (
+        ApiPublishStatus.PUBLIC.value
+    )
+
+
 def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> Any:
     # Add servers override from endpoint class definitions
     for path, servers in _ENDPOINT_SERVERS.items():
@@ -231,6 +280,7 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
             for method_info in result["paths"][path].values():
                 method_info["servers"] = servers
 
+    _stamp_publish_status(result)
     _fix_issue_paths(result)
     _fix_nullable_enums(result)
 
@@ -244,6 +294,11 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
     for path, endpoints in result["paths"].items():
         for method_info in endpoints.values():
             endpoint_name = f"'{method_info['operationId']}'"
+
+            if _is_internal_operation(method_info):
+                # Private/experimental operations are only in the spec for their
+                # response shapes; the reference-quality checks below do not apply.
+                continue
 
             summary = method_info.get("summary")
             if summary is not None:

--- a/src/sentry/apidocs/spectacular_ports.py
+++ b/src/sentry/apidocs/spectacular_ports.py
@@ -225,7 +225,13 @@ def resolve_type_hint(hint) -> Any:
             #   - https://github.com/tfranzel/drf-spectacular/issues/925
             #   - https://github.com/OAI/OpenAPI-Specification/issues/1368.
             if len(args) > 2:
-                schema["anyOf"].append({"type": "object", "nullable": True})
+                null_schema: dict[str, Any] = {"type": "object", "nullable": True}
+                if is_internal_build():
+                    # Nullable objects also accept arbitrary dictionaries. Limit
+                    # this branch to null so it cannot bypass the other members'
+                    # contracts. Preserve the existing published schema.
+                    null_schema["enum"] = [None]
+                schema["anyOf"].append(null_schema)
             else:
                 schema["nullable"] = True
         return schema

--- a/src/sentry/apidocs/spectacular_ports.py
+++ b/src/sentry/apidocs/spectacular_ports.py
@@ -38,7 +38,7 @@ from typing import Any, Literal, Union, is_typeddict
 from typing import get_type_hints as _get_type_hints
 
 import drf_spectacular
-from drf_spectacular.drainage import get_override
+from drf_spectacular.drainage import get_override, warn
 from drf_spectacular.plumbing import (
     UnableToProceedError,
     build_basic_type,
@@ -49,7 +49,7 @@ from drf_spectacular.plumbing import build_array_type as drf_build_array_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import _SchemaType
 
-from sentry.apidocs.utils import reload_module_with_type_checking_enabled
+from sentry.apidocs.utils import is_internal_build, reload_module_with_type_checking_enabled
 
 # This function is ported from the drf-spectacular library method here:
 # https://github.com/tfranzel/drf-spectacular/blob/03d315ced245db71cef1e45fd05a082b7dedc7aa/drf_spectacular/plumbing.py#L1100
@@ -109,6 +109,28 @@ def build_array_type(
     return drf_build_array_type(schema=schema, min_length=min_length, max_length=max_length)
 
 
+UNRESOLVED_EXTENSION = "x-sentry-unresolved"
+
+
+def resolve_type_hint_lenient(hint, context: str) -> Any:
+    """
+    Resolve ``hint`` like ``resolve_type_hint``, but in internal builds replace an
+    unresolvable hint with an untyped placeholder instead of failing the build.
+
+    The placeholder carries the offending hint under ``x-sentry-unresolved`` so
+    generated types show ``unknown`` exactly where the backend contract is not
+    expressible yet (a plain class used as a response, an unsupported generic).
+    The published spec keeps failing hard: an unresolvable public type is a bug.
+    """
+    try:
+        return resolve_type_hint(hint)
+    except UnableToProceedError:
+        if not is_internal_build():
+            raise
+        warn(f"could not resolve {hint!r} for {context}; emitting an untyped placeholder")
+        return {UNRESOLVED_EXTENSION: repr(hint)}
+
+
 def resolve_type_hint(hint) -> Any:
     """drf-spectacular library method modified as described above"""
     origin, args = _get_type_hint_origin(hint)
@@ -133,7 +155,12 @@ def resolve_type_hint(hint) -> Any:
             max_length=len(args),
             min_length=len(args),
         )
-    elif origin is dict or origin is defaultdict:
+    elif origin in (
+        dict,
+        defaultdict,
+        collections.abc.Mapping,
+        collections.abc.MutableMapping,
+    ):
         schema = build_basic_type(OpenApiTypes.OBJECT)
         if args and args[1] is not typing.Any and schema is not None:
             schema["additionalProperties"] = resolve_type_hint(args[1])
@@ -162,14 +189,20 @@ def resolve_type_hint(hint) -> Any:
             schema.update(basic_type)
         return schema
     elif is_typeddict(hint):
+        # A TypedDict enumerates every key it can carry, so internal builds describe
+        # it as a closed object: a serializer emitting an undeclared key is drift,
+        # not an extension. The published spec keeps objects open until existing
+        # drift on public endpoints has been measured and fixed.
+        closed: dict[str, Any] = {"additionalProperties": False} if is_internal_build() else {}
         return build_object_type(
             properties={
-                k: resolve_type_hint(v)
+                k: resolve_type_hint_lenient(v, f"{hint.__name__}.{k}")
                 for k, v in get_type_hints(hint).items()
                 if k not in excluded_fields
             },
             description=inspect.cleandoc(hint.__doc__ or ""),
             required=[h for h in hint.__required_keys__ if h not in excluded_fields],
+            **closed,
         )
     elif origin is Union or origin is UnionType:
         type_args = [arg for arg in args if arg is not type(None)]
@@ -196,7 +229,12 @@ def resolve_type_hint(hint) -> Any:
             else:
                 schema["nullable"] = True
         return schema
-    elif origin is collections.abc.Iterable:
+    elif origin in (
+        collections.abc.Iterable,
+        collections.abc.Collection,
+        collections.abc.Sequence,
+        collections.abc.MutableSequence,
+    ):
         return build_array_type(resolve_type_hint(args[0]))
     else:
         raise UnableToProceedError(hint)

--- a/src/sentry/apidocs/utils.py
+++ b/src/sentry/apidocs/utils.py
@@ -60,6 +60,18 @@ def inline_sentry_response_serializer(name: str, t: ResponseTypeHint) -> type:
     return serializer_class
 
 
+def is_internal_build() -> bool:
+    """
+    True when the OpenAPI spec is being built for internal consumers (frontend
+    type generation) rather than for the published public API reference.
+
+    Internal builds include every endpoint method that declares a schema, not just
+    the ones marked ``ApiPublishStatus.PUBLIC``, and describe TypedDict responses
+    as closed objects. See ``make build-internal-api-docs``.
+    """
+    return bool(os.environ.get("SENTRY_OPENAPI_INTERNAL"))
+
+
 class SentryApiBuildError(UnableToProceedError):
     def __init__(self, msg: str = "", *args: Any, **kwargs: Any) -> None:
         super().__init__(

--- a/src/sentry/auth_v2/endpoints/csrf.py
+++ b/src/sentry/auth_v2/endpoints/csrf.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, TypedDict
 
 from django.middleware.csrf import rotate_token
 from django.utils.decorators import method_decorator
@@ -13,9 +13,15 @@ from sentry.analytics.events.auth_v2 import AuthV2CsrfTokenRotated
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.api.base import Endpoint, control_silo_endpoint
-from sentry.auth_v2.utils.session import SessionSerializer
+from sentry.apidocs.utils import inline_sentry_response_serializer
+from sentry.auth_v2.utils.session import SessionSerializer, SessionSerializerResponse
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
+
+
+class CsrfTokenResponse(TypedDict):
+    detail: str
+    session: SessionSerializerResponse
 
 
 @control_silo_endpoint
@@ -48,13 +54,10 @@ class CsrfTokenEndpoint(Endpoint):
     @extend_schema(
         operation_id="Retrieve the CSRF token in your session",
         parameters=[],
-        responses={
-            "detail": "string",
-            "session": SessionSerializer,
-        },
+        responses={200: inline_sentry_response_serializer("CsrfTokenResponse", CsrfTokenResponse)},
     )
     @method_decorator(ensure_csrf_cookie)
-    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+    def get(self, request: Request, *args: Any, **kwargs: Any) -> Response[CsrfTokenResponse]:
         return self.respond(
             {
                 "detail": "Set CSRF cookie",
@@ -66,13 +69,10 @@ class CsrfTokenEndpoint(Endpoint):
     @extend_schema(
         operation_id="Rotate the CSRF token in your session",
         parameters=[],
-        responses={
-            "detail": "string",
-            "session": SessionSerializer,
-        },
+        responses={200: inline_sentry_response_serializer("CsrfTokenResponse", CsrfTokenResponse)},
     )
     @method_decorator(ensure_csrf_cookie)
-    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+    def put(self, request: Request, *args: Any, **kwargs: Any) -> Response[CsrfTokenResponse]:
         rotate_token(request)
         if referrer := request.GET.get("referrer"):
             analytics.record(

--- a/tests/apidocs/test_hooks.py
+++ b/tests/apidocs/test_hooks.py
@@ -1,12 +1,17 @@
+import os
 from typing import Any
-from unittest import TestCase
+from unittest import TestCase, mock
 
 import pytest
 
+from sentry.api.api_publish_status import ApiPublishStatus
 from sentry.apidocs.hooks import (
     _ENDPOINT_SERVERS,
+    _INTERNAL_OPERATIONS,
+    PUBLISH_STATUS_EXTENSION,
     _fix_nullable_enums,
     custom_postprocessing_hook,
+    custom_preprocessing_hook,
 )
 from sentry.apidocs.utils import SentryApiBuildError
 
@@ -241,3 +246,119 @@ class FixNullableEnumsTest(TestCase):
                 {"type": "object", "nullable": True},
             ],
         }
+
+
+def _fake_endpoint(publish_status: dict[str, Any], **handlers: Any) -> Any:
+    """A callback whose ``view_class`` carries only what the preprocessing hook reads."""
+    from sentry.api.api_owners import ApiOwner
+
+    namespace: dict[str, Any] = {
+        "owner": ApiOwner.ISSUES,
+        "publish_status": publish_status,
+        "__module__": "sentry.api.endpoints.fake",
+    }
+    namespace.update(handlers)
+    view_class = type("FakeEndpoint", (), namespace)
+
+    class Callback:
+        pass
+
+    callback = Callback()
+    callback.view_class = view_class  # type: ignore[attr-defined]
+    return callback
+
+
+def _public_operation(operation_id: str) -> dict[str, Any]:
+    return {
+        "tags": ["Events"],
+        "description": "Documented",
+        "operationId": operation_id,
+        "parameters": [],
+    }
+
+
+class InternalBuildTest(TestCase):
+    def setUp(self) -> None:
+        _INTERNAL_OPERATIONS.clear()
+
+    def tearDown(self) -> None:
+        _INTERNAL_OPERATIONS.clear()
+
+    def _endpoints(self) -> list[tuple[str, str, str, Any]]:
+        def documented(self: Any, request: Any) -> None:
+            pass
+
+        setattr(documented, "kwargs", {"schema": object()})  # left behind by @extend_schema
+
+        def undocumented(self: Any, request: Any) -> None:
+            pass
+
+        public = _fake_endpoint({"GET": ApiPublishStatus.PUBLIC}, get=documented)
+        private_documented = _fake_endpoint({"GET": ApiPublishStatus.PRIVATE}, get=documented)
+        private_undocumented = _fake_endpoint(
+            {"GET": ApiPublishStatus.EXPERIMENTAL}, get=undocumented
+        )
+        return [
+            ("/api/0/public/", "^api/0/public/$", "GET", public),
+            ("/api/0/private/", "^api/0/private/$", "GET", private_documented),
+            ("/api/0/undocumented/", "^api/0/undocumented/$", "GET", private_undocumented),
+        ]
+
+    @mock.patch("sentry.apidocs.hooks.__write_ownership_data")
+    def test_public_build_only_keeps_public_methods(self, _write: mock.Mock) -> None:
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SENTRY_OPENAPI_INTERNAL", None)
+            filtered = custom_preprocessing_hook(self._endpoints())
+
+        assert [path for path, *_ in filtered] == ["/api/0/public/"]
+        assert _INTERNAL_OPERATIONS == {}
+
+    @mock.patch("sentry.apidocs.hooks.__write_ownership_data")
+    def test_internal_build_admits_private_methods_that_declare_a_schema(
+        self, _write: mock.Mock
+    ) -> None:
+        with mock.patch.dict(os.environ, {"SENTRY_OPENAPI_INTERNAL": "1"}):
+            filtered = custom_preprocessing_hook(self._endpoints())
+
+        assert [path for path, *_ in filtered] == ["/api/0/public/", "/api/0/private/"]
+        assert _INTERNAL_OPERATIONS == {("/api/0/private/", "get"): ApiPublishStatus.PRIVATE}
+
+    def test_internal_postprocessing_stamps_status_and_skips_reference_checks(self) -> None:
+        _INTERNAL_OPERATIONS[("/api/0/private/", "get")] = ApiPublishStatus.PRIVATE
+        result = {
+            "components": {"schemas": {}},
+            "paths": {
+                "/api/0/public/": {"get": _public_operation("public")},
+                # No tag and no description would fail the public checks;
+                # internal operations are exempt from them.
+                "/api/0/private/": {"get": {"operationId": "private", "parameters": []}},
+            },
+        }
+
+        with mock.patch.dict(os.environ, {"SENTRY_OPENAPI_INTERNAL": "1"}):
+            processed = custom_postprocessing_hook(result, None)
+
+        assert processed["paths"]["/api/0/public/"]["get"][PUBLISH_STATUS_EXTENSION] == "public"
+        assert processed["paths"]["/api/0/private/"]["get"][PUBLISH_STATUS_EXTENSION] == "private"
+
+    def test_internal_postprocessing_still_checks_public_operations(self) -> None:
+        result = {
+            "components": {"schemas": {}},
+            "paths": {"/api/0/public/": {"get": {"operationId": "public", "parameters": []}}},
+        }
+        with (
+            mock.patch.dict(os.environ, {"SENTRY_OPENAPI_INTERNAL": "1"}),
+            pytest.raises(SentryApiBuildError),
+        ):
+            custom_postprocessing_hook(result, None)
+
+    def test_public_build_does_not_stamp_status(self) -> None:
+        result = {
+            "components": {"schemas": {}},
+            "paths": {"/api/0/public/": {"get": _public_operation("public")}},
+        }
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("SENTRY_OPENAPI_INTERNAL", None)
+            processed = custom_postprocessing_hook(result, None)
+
+        assert PUBLISH_STATUS_EXTENSION not in processed["paths"]["/api/0/public/"]["get"]

--- a/tests/sentry/apidocs/test_extensions.py
+++ b/tests/sentry/apidocs/test_extensions.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import os
 from collections.abc import Mapping
 from typing import Any, Literal, TypedDict
+from unittest import mock
 
 import pytest
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.utils import extend_schema_serializer
+from openapi_schema_validator import OAS30Validator
 from rest_framework import serializers
 
 from sentry.api.serializers import Serializer
@@ -19,6 +22,16 @@ from sentry.apidocs.utils import inline_sentry_response_serializer
 
 class NestedDict(TypedDict):
     zz: str
+
+
+class UnionSuccess(TypedDict):
+    status: Literal["success"]
+    url: str
+
+
+class UnionFailure(TypedDict):
+    status: Literal["failure"]
+    reason: str
 
 
 class BasicSerializerOptional(TypedDict, total=False):
@@ -133,3 +146,58 @@ def test_sentry_restricted_json_field_extension() -> None:
     seralizer_extension = RestrictedJsonFieldExtension(serializers.JSONField)
     schema = seralizer_extension.map_serializer_field(AutoSchema(), "response")
     assert schema == {"type": "object", "additionalProperties": {}}
+
+
+@pytest.mark.parametrize(
+    "value, valid",
+    [
+        (None, True),
+        ({"status": "success", "url": "https://example.com"}, True),
+        ({"status": "failure", "reason": "unavailable"}, True),
+        ({}, False),
+        ({"unexpected": True}, False),
+        ({"status": "success", "reason": "unavailable"}, False),
+        ({"status": "failure", "reason": "unavailable", "extra": True}, False),
+        ("success", False),
+    ],
+)
+@mock.patch.dict(os.environ, SENTRY_OPENAPI_INTERNAL="1")
+def test_internal_nullable_union(value: Any, valid: bool) -> None:
+    serializer = inline_sentry_response_serializer(
+        "NullableUnion", UnionSuccess | UnionFailure | None
+    )
+    schema = SentryInlineResponseSerializerExtension(serializer).map_serializer(
+        AutoSchema(), "response"
+    )
+
+    assert schema["anyOf"][-1] == {"type": "object", "nullable": True, "enum": [None]}
+    OAS30Validator.check_schema(schema)
+    assert OAS30Validator(schema).is_valid(value) is valid
+
+
+@mock.patch.dict(os.environ, SENTRY_OPENAPI_INTERNAL="1")
+def test_internal_nullable_numeric_union() -> None:
+    serializer = inline_sentry_response_serializer("NullableNumber", int | float | None)
+    schema = SentryInlineResponseSerializerExtension(serializer).map_serializer(
+        AutoSchema(), "response"
+    )
+
+    OAS30Validator.check_schema(schema)
+    validator = OAS30Validator(schema)
+    assert validator.is_valid(None)
+    assert validator.is_valid(1)
+    assert validator.is_valid(1.5)
+    assert not validator.is_valid({})
+
+
+@mock.patch.dict(os.environ, SENTRY_OPENAPI_INTERNAL="1")
+def test_internal_nullable_dictionary() -> None:
+    serializer = inline_sentry_response_serializer("NullableDictionary", dict[str, Any] | None)
+    schema = SentryInlineResponseSerializerExtension(serializer).map_serializer(
+        AutoSchema(), "response"
+    )
+
+    validator = OAS30Validator(schema)
+    assert validator.is_valid(None)
+    assert validator.is_valid({"arbitrary": True})
+    assert "enum" not in schema

--- a/tests/tools/test_api_contract_report.py
+++ b/tests/tools/test_api_contract_report.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import pytest
+
+from tools.api_contract_report import (
+    build_rows,
+    canonical_route,
+    classify_return_annotation,
+    collect_frontend_routes,
+    describe_method,
+)
+
+
+@pytest.mark.parametrize(
+    ("route", "expected"),
+    (
+        ("/organizations/${org.slug}/projects/", "/organizations/*/projects/"),
+        ("/organizations/$organizationIdOrSlug/projects/", "/organizations/*/projects/"),
+        (
+            "/organizations/$organizationIdOrSlug/events/$projectIdOrSlug:$eventId/",
+            "/organizations/*/events/*:*/",
+        ),
+        ("/projects/${orgSlug}/${projectSlug}/?expand=1", "/projects/*/*/"),
+        ("/organizations/", "/organizations/"),
+    ),
+)
+def test_canonical_route(route: str, expected: str) -> None:
+    assert canonical_route(route) == expected
+
+
+@pytest.mark.parametrize(
+    ("annotation", "expected"),
+    (
+        ("Response[ProjectSerializerResponse]", ("typed", "ProjectSerializerResponse")),
+        ("Response[list[ProjectSerializerResponse]]", ("typed", "list[ProjectSerializerResponse]")),
+        ("Response[dict[str, Any]]", ("loose", "dict[str, Any]")),
+        ("Response[Any]", ("loose", "Any")),
+        (
+            "Response[OrgResponse] | Response[DetailResponse]",
+            ("typed", "OrgResponse | DetailResponse"),
+        ),
+        ("Response[dict[str, Any]] | Response[Any]", ("loose", "dict[str, Any] | Any")),
+        ("Response[Foo] | HttpResponse", ("none", "")),
+        ("Response", ("none", "")),
+        ("HttpResponse", ("none", "")),
+        (None, ("none", "")),
+    ),
+)
+def test_classify_return_annotation(annotation: Any, expected: tuple[str, str]) -> None:
+    assert classify_return_annotation(annotation) == expected
+
+
+def test_collect_frontend_routes_only_counts_api_contexts(tmp_path) -> None:
+    app = tmp_path / "static" / "app"
+    app.mkdir(parents=True)
+    (app / "useProjects.tsx").write_text(
+        "\n".join(
+            [
+                "const query = useQuery(",
+                "  apiOptions.as<Project[]>()(",
+                "    '/organizations/$organizationIdOrSlug/projects/',",
+                "    {path: {organizationIdOrSlug: slug}, staleTime: 0}",
+                "  )",
+                ");",
+                "const legacy = useApiQuery<Team[]>([`/organizations/${slug}/teams/`], {});",
+                "",
+                "",
+                "",
+                "// a router link far from any API helper, not an API call:",
+                "const href = `/organizations/${slug}/issues/`;",
+            ]
+        )
+    )
+    (app / "useProjects.spec.tsx").write_text(
+        "MockApiClient.addMockResponse({url: '/organizations/org-slug/members/'});"
+    )
+    (tmp_path / "static" / "gsApp").mkdir()
+    (tmp_path / "static" / "gsAdmin").mkdir()
+
+    routes = collect_frontend_routes(os.fspath(tmp_path))
+
+    assert routes == {
+        "/organizations/*/projects/": ["static/app/useProjects.tsx:3"],
+        "/organizations/*/teams/": ["static/app/useProjects.tsx:7"],
+    }
+
+
+class _Status:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+class _Owner:
+    value = "owners-team"
+
+
+def _endpoint(**handlers: Any) -> type:
+    namespace: dict[str, Any] = {
+        "owner": _Owner(),
+        "publish_status": {name.upper(): _Status("private") for name in handlers},
+        "__module__": "sentry.api.endpoints.fake",
+    }
+    namespace.update(handlers)
+    return type("FakeEndpoint", (), namespace)
+
+
+def test_describe_method_prefers_extend_schema_and_annotation() -> None:
+    def get(self, request):
+        pass
+
+    get.__annotations__["return"] = "Response[FooResponse]"
+    setattr(get, "kwargs", {"schema": object()})  # what @extend_schema leaves behind
+
+    def post(self, request):
+        pass
+
+    post.__annotations__["return"] = "Response[dict[str, Any]]"
+
+    def delete(self, request):
+        pass
+
+    endpoint = _endpoint(get=get, post=post, delete=delete)
+
+    assert describe_method(endpoint, "GET") == ("extend_schema+annotation", "FooResponse")
+    assert describe_method(endpoint, "POST") == ("loose", "dict[str, Any]")
+    assert describe_method(endpoint, "DELETE") == ("none", "")
+
+
+def test_build_rows_joins_frontend_calls_to_endpoint_methods() -> None:
+    def get(self, request):
+        pass
+
+    get.__annotations__["return"] = "Response[list[FooResponse]]"
+    endpoint = _endpoint(get=get)
+    unused = _endpoint(get=get)
+
+    rows = build_rows(
+        [
+            ("/organizations/$organizationIdOrSlug/foos/", endpoint),
+            ("/organizations/$organizationIdOrSlug/bars/", unused),
+        ],
+        {"/organizations/*/foos/": ["static/app/a.tsx:1", "static/app/b.tsx:9"]},
+    )
+
+    assert [(r.route, r.method, r.contract, r.detail, len(r.call_sites)) for r in rows] == [
+        ("/organizations/$organizationIdOrSlug/foos/", "GET", "annotation", "list[FooResponse]", 2)
+    ]
+    assert rows[0].owner == "owners-team"
+    assert rows[0].publish_status == "private"
+    assert rows[0].has_contract

--- a/tools/api_contract_report.py
+++ b/tools/api_contract_report.py
@@ -1,0 +1,340 @@
+#!/usr/bin/env python3
+# flake8: noqa: S002
+"""
+Report which API routes the frontend calls and whether each one declares a
+response contract on the backend.
+
+The frontend side is a heuristic scan of ``static/`` for API route literals that
+sit next to an API helper (``apiOptions``, ``useApiQuery``, ``getApiUrl``, ...).
+The backend side walks the Django URL patterns to the endpoint class and inspects
+each HTTP method for an ``@extend_schema`` override or a ``Response[T]`` return
+annotation.
+
+Usage:
+    python3 -m tools.api_contract_report             # markdown table, all rows
+    python3 -m tools.api_contract_report --missing   # only rows without a contract
+    python3 -m tools.api_contract_report --json      # machine readable
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import typing
+from collections import defaultdict
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from django.urls import URLPattern, URLResolver
+
+from tools.api_urls_to_typescript import EXCLUDED_ROUTE_PREFIXES, regexp_to_routes
+
+FRONTEND_ROOTS = ("static/app", "static/gsApp", "static/gsAdmin")
+FRONTEND_EXTENSIONS = (".ts", ".tsx")
+FRONTEND_EXCLUDED_PARTS = (".spec.", ".stories.", ".snapshots.", "/__mocks__/", "/__fixtures__/")
+
+# A route literal only counts as an API call when one of these appears on the
+# same line or the few lines above it. Router links use the same shapes as API
+# routes, so a bare literal is ambiguous.
+API_CALL_MARKERS = (
+    "apiOptions",
+    "useApiQuery",
+    "useInfiniteApiQuery",
+    "useApiQueries",
+    "fetchDataQuery",
+    "fetchMutation",
+    "getApiUrl",
+    "requestPromise",
+    "api.request",
+    "queryKey",
+    "ApiQueryKey",
+    "makeQueryKey",
+    "endpoint",
+    "url:",
+    "url =",
+)
+API_CALL_WINDOW = 3
+
+ROUTE_LITERAL = re.compile(r"""(?P<quote>['`"])(?P<route>/[^'`"\n]*?/)(?P=quote)""")
+TEMPLATE_EXPRESSION = re.compile(r"\$\{[^}]*\}")
+ROUTE_PARAM = re.compile(r"\$[A-Za-z0-9_]+")
+QUERY_STRING = re.compile(r"\?.*$")
+
+HTTP_METHODS = ("GET", "POST", "PUT", "PATCH", "DELETE")
+
+# Return annotations that declare a Response but say nothing about its shape.
+LOOSE_RESPONSE_TYPES = frozenset({"Any", "dict[str, Any]", "list[Any]", "object", "dict", "list"})
+
+
+@dataclass
+class ContractRow:
+    route: str
+    method: str
+    endpoint: str
+    owner: str
+    publish_status: str
+    contract: str
+    detail: str
+    call_sites: list[str] = field(default_factory=list)
+
+    @property
+    def has_contract(self) -> bool:
+        return self.contract in ("extend_schema", "annotation", "extend_schema+annotation")
+
+
+def canonical_route(route: str) -> str:
+    """
+    Reduce a route literal to a comparable shape: every path parameter, whether
+    written as ``$param`` (known API urls) or ``${expr}`` (template literals),
+    becomes ``*`` and any query string is dropped.
+
+    >>> canonical_route("/organizations/${org.slug}/projects/")
+    '/organizations/*/projects/'
+    >>> canonical_route("/organizations/$organizationIdOrSlug/events/$projectIdOrSlug:$eventId/")
+    '/organizations/*/events/*:*/'
+    """
+    route = QUERY_STRING.sub("", route)
+    route = TEMPLATE_EXPRESSION.sub("*", route)
+    route = ROUTE_PARAM.sub("*", route)
+    return route
+
+
+def _is_api_call_context(lines: list[str], index: int) -> bool:
+    window = lines[max(0, index - API_CALL_WINDOW) : index + 1]
+    return any(marker in line for line in window for marker in API_CALL_MARKERS)
+
+
+def collect_frontend_routes(root: str) -> dict[str, list[str]]:
+    """
+    Map each canonical route literal found next to an API helper to the
+    ``path:line`` locations it appears at.
+    """
+    routes: dict[str, list[str]] = defaultdict(list)
+    for frontend_root in FRONTEND_ROOTS:
+        base = os.path.join(root, frontend_root)
+        for dirpath, _dirnames, filenames in os.walk(base):
+            for filename in filenames:
+                if not filename.endswith(FRONTEND_EXTENSIONS):
+                    continue
+                path = os.path.join(dirpath, filename)
+                relative = os.path.relpath(path, root)
+                if any(part in f"/{relative}" for part in FRONTEND_EXCLUDED_PARTS):
+                    continue
+                with open(path, encoding="utf-8") as f:
+                    lines = f.read().split("\n")
+                for index, line in enumerate(lines):
+                    for match in ROUTE_LITERAL.finditer(line):
+                        route = match.group("route")
+                        if route.startswith("//") or "/api/0/" in route:
+                            continue
+                        if not _is_api_call_context(lines, index):
+                            continue
+                        routes[canonical_route(route)].append(f"{relative}:{index + 1}")
+    return dict(routes)
+
+
+def urls_to_route_views(prefix: str, urlpatterns: list[Any]) -> list[tuple[str, Any]]:
+    """Like ``api_urls_to_typescript.urls_to_routes`` but keeps the endpoint class."""
+    routes: list[tuple[str, Any]] = []
+    for urlpattern in urlpatterns:
+        if isinstance(urlpattern, URLResolver):
+            for child in regexp_to_routes(urlpattern.pattern.regex.pattern):
+                routes += urls_to_route_views(prefix + child, urlpattern.url_patterns)
+        elif isinstance(urlpattern, URLPattern):
+            view_class = getattr(urlpattern.callback, "view_class", None)
+            if view_class is None:
+                continue
+            for variant in regexp_to_routes(urlpattern.pattern.regex.pattern):
+                routes.append((prefix + variant, view_class))
+        else:
+            raise ValueError(f"Unknown pattern type: {type(urlpattern)}")
+    return routes
+
+
+def classify_return_annotation(annotation: Any) -> tuple[str, str]:
+    """
+    Classify a handler's return annotation.
+
+    Returns ``(kind, detail)`` where ``kind`` is ``"typed"`` for ``Response[T]``
+    with a real ``T``, ``"loose"`` for ``Response[Any]``-like escape hatches, and
+    ``"none"`` for a bare ``Response`` or no annotation. ``detail`` is the ``T``
+    text, if any.
+
+    >>> classify_return_annotation("Response[ProjectSerializerResponse]")
+    ('typed', 'ProjectSerializerResponse')
+    >>> classify_return_annotation("Response[dict[str, Any]]")
+    ('loose', 'dict[str, Any]')
+    >>> classify_return_annotation("Response")
+    ('none', '')
+    """
+    if annotation is None:
+        return "none", ""
+    if isinstance(annotation, str):
+        text = annotation.strip()
+    else:
+        origin = typing.get_origin(annotation)
+        args = typing.get_args(annotation)
+        if origin is not None and args:
+            text = f"{origin.__name__}[{', '.join(_hint_text(a) for a in args)}]"
+        else:
+            text = _hint_text(annotation)
+    inners: list[str] = []
+    for part in _split_top_level_union(text):
+        match = re.fullmatch(r"Response\[(.+)\]", part)
+        if match is None:
+            return "none", ""
+        inners.append(match.group(1).strip())
+    inner = " | ".join(inners)
+    if all(i in LOOSE_RESPONSE_TYPES for i in inners):
+        return "loose", inner
+    return "typed", inner
+
+
+def _split_top_level_union(text: str) -> list[str]:
+    """Split ``A[x | y] | B`` on the pipes outside brackets: ``["A[x | y]", "B"]``."""
+    parts: list[str] = []
+    depth = 0
+    current: list[str] = []
+    for char in text:
+        if char == "[":
+            depth += 1
+        elif char == "]":
+            depth -= 1
+        if char == "|" and depth == 0:
+            parts.append("".join(current).strip())
+            current = []
+            continue
+        current.append(char)
+    parts.append("".join(current).strip())
+    return [part for part in parts if part]
+
+
+def _hint_text(hint: Any) -> str:
+    if isinstance(hint, str):
+        return hint
+    if hint is type(None):
+        return "None"
+    if hasattr(hint, "__name__") and typing.get_origin(hint) is None:
+        return hint.__name__
+    return repr(hint).replace("typing.", "")
+
+
+def _declares_extend_schema(view_class: type, method: str) -> bool:
+    handler = getattr(view_class, method.lower(), None)
+    if handler is not None and "schema" in getattr(handler, "kwargs", {}):
+        return True
+    return any(
+        "schema" in vars(cls)
+        for cls in view_class.__mro__
+        if cls.__module__.startswith(("sentry", "getsentry"))
+    )
+
+
+def describe_method(view_class: type, method: str) -> tuple[str, str]:
+    """``(contract, detail)`` for one HTTP method of an endpoint class."""
+    handler = getattr(view_class, method.lower(), None)
+    annotation = None
+    if handler is not None:
+        annotation = getattr(handler, "__annotations__", {}).get("return")
+    kind, detail = classify_return_annotation(annotation)
+    has_schema = _declares_extend_schema(view_class, method)
+
+    if has_schema and kind == "typed":
+        return "extend_schema+annotation", detail
+    if has_schema:
+        return "extend_schema", detail
+    if kind == "typed":
+        return "annotation", detail
+    if kind == "loose":
+        return "loose", detail
+    return "none", ""
+
+
+def build_rows(
+    route_views: list[tuple[str, Any]], frontend_routes: dict[str, list[str]]
+) -> list[ContractRow]:
+    rows: list[ContractRow] = []
+    seen: set[tuple[str, str]] = set()
+    for route, view_class in route_views:
+        if route.startswith(EXCLUDED_ROUTE_PREFIXES):
+            continue
+        call_sites = frontend_routes.get(canonical_route(route))
+        if not call_sites:
+            continue
+        publish_status = getattr(view_class, "publish_status", {}) or {}
+        owner = getattr(view_class, "owner", None)
+        for method in HTTP_METHODS:
+            if method not in publish_status:
+                continue
+            key = (route, method)
+            if key in seen:
+                continue
+            seen.add(key)
+            contract, detail = describe_method(view_class, method)
+            rows.append(
+                ContractRow(
+                    route=route,
+                    method=method,
+                    endpoint=view_class.__name__,
+                    owner=getattr(owner, "value", str(owner)),
+                    publish_status=publish_status[method].value,
+                    contract=contract,
+                    detail=detail,
+                    call_sites=sorted(set(call_sites)),
+                )
+            )
+    rows.sort(key=lambda r: (-len(r.call_sites), r.route, r.method))
+    return rows
+
+
+def render_markdown(rows: list[ContractRow]) -> str:
+    lines = [
+        "| Route | Method | Endpoint | Owner | Status | Contract | Call sites |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        contract = row.contract if not row.detail else f"{row.contract} (`{row.detail}`)"
+        lines.append(
+            f"| `{row.route}` | {row.method} | {row.endpoint} | {row.owner} | "
+            f"{row.publish_status} | {contract} | {len(row.call_sites)} |"
+        )
+    total = len(rows)
+    covered = sum(1 for r in rows if r.has_contract)
+    lines.append("")
+    lines.append(f"{covered}/{total} frontend-called endpoint methods declare a response contract.")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of markdown")
+    parser.add_argument(
+        "--missing", action="store_true", help="only list methods without a response contract"
+    )
+    parser.add_argument("--root", default=".", help="repository root (default: cwd)")
+    args = parser.parse_args(argv)
+
+    from sentry.runner import configure
+
+    configure()
+
+    from sentry.api.urls import urlpatterns
+
+    frontend_routes = collect_frontend_routes(args.root)
+    rows = build_rows(urls_to_route_views("/", urlpatterns), frontend_routes)
+    if args.missing:
+        rows = [row for row in rows if not row.has_contract]
+
+    if args.json:
+        json.dump([asdict(row) for row in rows], sys.stdout, indent=2)
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(render_markdown(rows) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Why

The frontend needs a machine-readable contract for the endpoints it actually calls, so drift between serializer output and frontend types can be caught at typecheck time. The published OpenAPI spec cannot serve that role: it only describes `ApiPublishStatus.PUBLIC` methods (218 operations), while most of what the UI calls is private or experimental.

This is step 1 of 3. Step 2 generates TypeScript types from this spec; step 3 wires them into `apiOptions` and the test fixtures.

## What

**Internal build mode** (`SENTRY_OPENAPI_INTERNAL=1`, `make build-internal-api-docs`, output gitignored at `tests/apidocs/openapi-internal.json`):

- `custom_preprocessing_hook` also admits private/experimental methods that declare a schema via `@extend_schema`. Undocumented methods stay out, since they would produce empty operations.
- Every operation is stamped with `x-sentry-publish-status`. The reference-quality checks (tags, docstrings, unique summaries, body parameter descriptions) are skipped for non-public operations.
- TypedDict responses are emitted with `additionalProperties: false`, since a TypedDict enumerates every key it can carry. The published spec keeps objects open until drift on public endpoints has been measured.
- An unresolvable field becomes an `x-sentry-unresolved` placeholder with a build warning instead of failing the whole build. The published build still fails hard.

**Resolver:** `collections.abc.Sequence`, `MutableSequence`, `Collection`, `Mapping` and `MutableMapping` now resolve. 68 response TypedDicts use them and the internal build could not complete without this.

**Report tool:** `python3 -m tools.api_contract_report [--missing] [--json]` joins the API routes the frontend calls (heuristic scan of `static/`) to the endpoint class and reports, per HTTP method, whether a response contract exists (`extend_schema`, `Response[T]`, both, a loose `Response[dict[str, Any]]`, or nothing), with owner, publish status and call-site count. This is the annotation backlog for step 3.

**Fix:** `CsrfTokenEndpoint` declared `responses={"detail": ..., "session": ...}` (a field mapping where a status-code mapping is expected), which the internal build's validation rejected. It now uses a `CsrfTokenResponse` TypedDict.

## Numbers from a local build

| | Public build | Internal build |
|---|---|---|
| Operations | 218 | 387 (221 public, 111 private, 55 experimental) |
| Operations with a 2xx schema | | 278 |
| Operations with examples | 124 | 166 |
| Unresolved fields | 0 | 1 (`MonitorBulkEditResponse` is a plain class, not a TypedDict) |

Frontend-called endpoint methods with a response contract: 280 of 652.

## Verification

- `tests/apidocs/test_hooks.py` (14 tests, 5 new) and `tests/tools/test_api_contract_report.py` (18 tests) pass locally.
- `make build-spectacular-docs` (public) and the internal build both complete with `--validate`.
- `prek` passes on all changed files. mypy could not be run reliably from the worktree; relying on CI for that.

https://claude.ai/code/session_018d6yv4s3FR9D4iEmKPtvef
