### PR TITLE
feat(api): Infer apiOptions response types from the backend contract

### DIFF
--- a/static/app/types/apiContracts.spec.ts
+++ b/static/app/types/apiContracts.spec.ts
@@ -1,0 +1,401 @@
+import {expectTypeOf} from 'expect-type';
+
+import type {Group, Tag} from 'sentry/types/group';
+import type {OrganizationIntegration, Repository} from 'sentry/types/integrations';
+import type {
+  DetailedTeam,
+  Member,
+  Organization,
+  OrganizationSummary,
+  Team,
+} from 'sentry/types/organization';
+import type {
+  DetailedProject,
+  Environment,
+  Project,
+  ProjectKey,
+} from 'sentry/types/project';
+import type {Release} from 'sentry/types/release';
+import type {Detector} from 'sentry/types/workflowEngine/detectors';
+import type {ContractResponse} from 'sentry/utils/api/apiOptions';
+import type {DashboardListItem} from 'sentry/views/dashboards/types';
+import type {Monitor} from 'sentry/views/insights/crons/types';
+
+/**
+ * The response type the backend declares for `GET <route>`.
+ */
+type Get<TRoute extends string> = ContractResponse<TRoute>;
+
+/**
+ * The element type of a list response.
+ */
+type Item<T> = T extends Array<infer TItem> ? TItem : T;
+
+/**
+ * The keys of `TFrontend` that `TBackend` does not satisfy: required on the
+ * frontend but absent from the backend contract, or declared with an
+ * incompatible type. Each key maps to the two sides' types (or a note that the
+ * backend contract lacks the key), so hovering a `Drift<...>` alias shows the
+ * exact disagreement.
+ */
+type Drift<TBackend, TFrontend> = {
+  [
+    K in keyof TFrontend as K extends keyof TBackend
+      ? TBackend[K] extends TFrontend[K]
+        ? never
+        : K
+      : undefined extends TFrontend[K]
+        ? never
+        : K
+  ]: K extends keyof TBackend
+    ? {backend: TBackend[K]; frontend: TFrontend[K]}
+    : 'missing from the backend contract';
+};
+
+type OrganizationList = Drift<Item<Get<'/organizations/'>>, OrganizationSummary>;
+type OrganizationDetails = Drift<
+  Get<'/organizations/$organizationIdOrSlug/'>,
+  Organization
+>;
+type OrganizationProjects = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/projects/'>>,
+  Project
+>;
+type OrganizationTeams = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/teams/'>>,
+  Team
+>;
+type OrganizationMembers = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/members/'>>,
+  Member
+>;
+type OrganizationMemberDetails = Drift<
+  Get<'/organizations/$organizationIdOrSlug/members/$memberId/'>,
+  Member
+>;
+type OrganizationReleases = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/releases/'>>,
+  Release
+>;
+type OrganizationEnvironments = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/environments/'>>,
+  Environment
+>;
+type OrganizationRepositories = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/repos/'>>,
+  Repository
+>;
+type OrganizationIntegrations = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/integrations/'>>,
+  OrganizationIntegration
+>;
+type OrganizationDashboards = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/dashboards/'>>,
+  DashboardListItem
+>;
+type OrganizationIssues = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/issues/'>>,
+  Group
+>;
+type IssueDetails = Drift<
+  Get<'/organizations/$organizationIdOrSlug/issues/$issueId/'>,
+  Group
+>;
+type OrganizationMonitors = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/monitors/'>>,
+  Monitor
+>;
+type OrganizationTags = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/tags/'>>,
+  Tag
+>;
+type OrganizationDetectors = Drift<
+  Item<Get<'/organizations/$organizationIdOrSlug/detectors/'>>,
+  Detector
+>;
+type ProjectDetails = Drift<
+  Get<'/projects/$organizationIdOrSlug/$projectIdOrSlug/'>,
+  DetailedProject
+>;
+type ProjectKeys = Drift<
+  Item<Get<'/projects/$organizationIdOrSlug/$projectIdOrSlug/keys/'>>,
+  ProjectKey
+>;
+type ProjectEnvironments = Drift<
+  Item<Get<'/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/'>>,
+  Environment
+>;
+type ProjectTeams = Drift<
+  Item<Get<'/projects/$organizationIdOrSlug/$projectIdOrSlug/teams/'>>,
+  Team
+>;
+type TeamDetails = Drift<
+  Get<'/teams/$organizationIdOrSlug/$teamIdOrSlug/'>,
+  DetailedTeam
+>;
+type TeamProjects = Drift<
+  Item<Get<'/teams/$organizationIdOrSlug/$teamIdOrSlug/projects/'>>,
+  Project
+>;
+
+/**
+ * Backend response contracts should be assignable to the hand-written frontend
+ * types that consume them. Each assertion pins the keys that drift today, so
+ * both a new disagreement and a fix change the expected union and fail
+ * typecheck until the list is updated. The goal is `never` everywhere.
+ *
+ * A drifting key means one of: the backend TypedDict lacks a field the
+ * serializer really sends (add it on the backend), the backend declares a
+ * looser type than the frontend relies on (`str` where the frontend expects a
+ * literal union, `dict[str, Any]` where it expects a shape), or the frontend
+ * type claims something the API never returns (fix the frontend type). Hover
+ * the `Drift<...>` alias for the two sides of each key.
+ */
+describe('API contracts', () => {
+  it('organization endpoints', () => {
+    expectTypeOf<keyof OrganizationList>().toEqualTypeOf<
+      | 'avatar'
+      | 'hideAiFeatures'
+      | 'issueAlertsThreadFlag'
+      | 'metricAlertsThreadFlag'
+      | 'status'
+    >();
+    expectTypeOf<keyof OrganizationDetails>().toEqualTypeOf<
+      | 'access'
+      | 'aggregatedDataConsent'
+      | 'alertsMemberWrite'
+      | 'allowJoinRequests'
+      | 'allowSharedIssues'
+      | 'attachmentsRole'
+      | 'autoEnableCodeReview'
+      | 'autoOpenPrs'
+      | 'availableRoles'
+      | 'avatar'
+      | 'dataScrubber'
+      | 'dataScrubberDefaults'
+      | 'debugFilesRole'
+      | 'defaultAutomatedRunStoppingPoint'
+      | 'defaultCodeReviewTriggers'
+      | 'defaultCodingAgent'
+      | 'defaultCodingAgentIntegrationId'
+      | 'defaultRole'
+      | 'enhancedPrivacy'
+      | 'eventsMemberAdmin'
+      | 'extraOptions'
+      | 'features'
+      | 'hasGranularReplayPermissions'
+      | 'hideAiFeatures'
+      | 'isDefault'
+      | 'isDynamicallySampled'
+      | 'issueAlertsThreadFlag'
+      | 'metricAlertsThreadFlag'
+      | 'onboardingTasks'
+      | 'openMembership'
+      | 'orgRoleList'
+      | 'pendingAccessRequests'
+      | 'quota'
+      | 'relayPiiConfig'
+      | 'replayAccessMembers'
+      | 'requiresSso'
+      | 'safeFields'
+      | 'samplingMode'
+      | 'scrapeJavaScript'
+      | 'scrubIPAddresses'
+      | 'sensitiveFields'
+      | 'status'
+      | 'storeCrashReports'
+      | 'streamlineOnly'
+      | 'targetSampleRate'
+      | 'teamRoleList'
+    >();
+    expectTypeOf<keyof OrganizationProjects>().toEqualTypeOf<
+      | 'access'
+      | 'latestDeploys'
+      | 'platform'
+      | 'platforms'
+      | 'sessionStats'
+      | 'stats'
+      | 'team'
+      | 'teams'
+      | 'transactionStats'
+    >();
+    expectTypeOf<keyof OrganizationTeams>().toEqualTypeOf<
+      'access' | 'avatar' | 'externalTeams' | 'flags'
+    >();
+    expectTypeOf<keyof OrganizationMembers>().toEqualTypeOf<
+      | 'inviteStatus'
+      | 'invite_link'
+      | 'isOnlyOwner'
+      | 'orgRoleList'
+      | 'projects'
+      | 'role'
+      | 'roleName'
+      | 'roles'
+      | 'teamRoleList'
+      | 'teamRoles'
+      | 'teams'
+      | 'user'
+    >();
+    expectTypeOf<keyof OrganizationMemberDetails>().toEqualTypeOf<
+      | 'inviteStatus'
+      | 'projects'
+      | 'role'
+      | 'roleName'
+      | 'roles'
+      | 'teamRoleList'
+      | 'user'
+    >();
+    expectTypeOf<keyof OrganizationReleases>().toEqualTypeOf<
+      | 'adoptionStages'
+      | 'authors'
+      | 'currentProjectMeta'
+      | 'dateCreated'
+      | 'dateReleased'
+      | 'fileCount'
+      | 'firstEvent'
+      | 'id'
+      | 'lastCommit'
+      | 'lastDeploy'
+      | 'lastEvent'
+      | 'projects'
+      | 'ref'
+      | 'status'
+      | 'url'
+      | 'userAgent'
+      | 'versionInfo'
+    >();
+    expectTypeOf<keyof OrganizationEnvironments>().toEqualTypeOf<'displayName'>();
+    expectTypeOf<keyof OrganizationRepositories>().toEqualTypeOf<
+      'externalId' | 'externalSlug' | 'integrationId' | 'provider' | 'status' | 'url'
+    >();
+    expectTypeOf<keyof OrganizationIntegrations>().toEqualTypeOf<
+      | 'configData'
+      | 'configOrganization'
+      | 'organizationIntegrationStatus'
+      | 'provider'
+      | 'status'
+    >();
+    expectTypeOf<keyof OrganizationDashboards>().toEqualTypeOf<
+      | 'createdBy'
+      | 'filters'
+      | 'lastVisited'
+      | 'permissions'
+      | 'prebuiltId'
+      | 'widgetDisplay'
+      | 'widgetPreview'
+    >();
+    expectTypeOf<keyof OrganizationIssues>().toEqualTypeOf<
+      | 'activity'
+      | 'culprit'
+      | 'derivedData'
+      | 'filtered'
+      | 'firstSeen'
+      | 'integrationIssues'
+      | 'issueCategory'
+      | 'issueType'
+      | 'lastSeen'
+      | 'level'
+      | 'lifetime'
+      | 'owners'
+      | 'participants'
+      | 'platform'
+      | 'priority'
+      | 'project'
+      | 'seenBy'
+      | 'sentryAppIssues'
+      | 'sessionCount'
+      | 'shareId'
+      | 'stats'
+      | 'status'
+      | 'substatus'
+      | 'type'
+      | 'userReportCount'
+    >();
+    expectTypeOf<keyof IssueDetails>().toEqualTypeOf<
+      | 'activity'
+      | 'count'
+      | 'culprit'
+      | 'derivedData'
+      | 'filtered'
+      | 'firstSeen'
+      | 'integrationIssues'
+      | 'issueCategory'
+      | 'issueType'
+      | 'lastSeen'
+      | 'level'
+      | 'owners'
+      | 'participants'
+      | 'platform'
+      | 'priority'
+      | 'project'
+      | 'seenBy'
+      | 'shareId'
+      | 'stats'
+      | 'status'
+      | 'substatus'
+      | 'type'
+      | 'userCount'
+    >();
+    expectTypeOf<keyof OrganizationMonitors>().toEqualTypeOf<
+      'alertRule' | 'config' | 'environments' | 'project' | 'status'
+    >();
+    expectTypeOf<keyof OrganizationTags>().toEqualTypeOf<
+      'totalValues' | 'uniqueValues'
+    >();
+    expectTypeOf<keyof OrganizationDetectors>().toEqualTypeOf<
+      | 'createdBy'
+      | 'description'
+      | 'lastTriggered'
+      | 'latestGroup'
+      | 'owner'
+      | 'projectId'
+      | 'type'
+      | 'workflowIds'
+    >();
+  });
+
+  it('project endpoints', () => {
+    expectTypeOf<keyof ProjectDetails>().toEqualTypeOf<
+      | 'access'
+      | 'autofixAutomationTuning'
+      | 'defaultEnvironment'
+      | 'dynamicSamplingBiases'
+      | 'environments'
+      | 'highlightContext'
+      | 'options'
+      | 'platform'
+      | 'platforms'
+      | 'relayPiiConfig'
+      | 'securityTokenHeader'
+      | 'sessionStats'
+      | 'stats'
+      | 'team'
+      | 'teams'
+      | 'transactionStats'
+    >();
+    expectTypeOf<keyof ProjectKeys>().toEqualTypeOf<
+      'browserSdk' | 'dateCreated' | 'public' | 'secret'
+    >();
+    expectTypeOf<keyof ProjectEnvironments>().toEqualTypeOf<'displayName'>();
+    expectTypeOf<keyof ProjectTeams>().toEqualTypeOf<
+      'access' | 'avatar' | 'externalTeams' | 'flags'
+    >();
+  });
+
+  it('team endpoints', () => {
+    expectTypeOf<keyof TeamDetails>().toEqualTypeOf<
+      'access' | 'avatar' | 'externalTeams' | 'flags' | 'projects'
+    >();
+    expectTypeOf<keyof TeamProjects>().toEqualTypeOf<
+      | 'access'
+      | 'latestDeploys'
+      | 'platform'
+      | 'platforms'
+      | 'sessionStats'
+      | 'stats'
+      | 'team'
+      | 'teams'
+      | 'transactionStats'
+    >();
+  });
+});

--- a/static/app/utils/api/apiOptions.spec.tsx
+++ b/static/app/utils/api/apiOptions.spec.tsx
@@ -4,6 +4,7 @@ import {expectTypeOf} from 'expect-type';
 
 import {renderHookWithProviders, waitFor} from 'sentry-test/reactTestingLibrary';
 
+import type {ApiMapping} from 'sentry/utils/api/apiContracts.generated';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import {apiOptions} from 'sentry/utils/api/apiOptions';
 import {parseQueryKey} from 'sentry/utils/api/apiQueryKey';
@@ -12,6 +13,27 @@ type Promisable<T> = T | Promise<T>;
 type QueryFunctionResult<T> = Promisable<ApiResponse<T>>;
 
 describe('apiOptions', () => {
+  it('infers the response type from the backend contract', () => {
+    const options = apiOptions.contract('/organizations/$organizationIdOrSlug/teams/', {
+      staleTime: 0,
+      path: {organizationIdOrSlug: 'org-slug'},
+    });
+
+    type Expected =
+      ApiMapping['/organizations/$organizationIdOrSlug/teams/']['GET']['response'];
+    expectTypeOf(options.queryFn).returns.toEqualTypeOf<QueryFunctionResult<Expected>>();
+    expect(options.queryKey).toEqual([
+      '/organizations/org-slug/teams/',
+      {},
+      {infinite: false},
+    ]);
+  });
+
+  it('rejects routes without a GET contract', () => {
+    // @ts-expect-error `/api-tokens/` declares no response type on the backend
+    apiOptions.contract('/api-tokens/', {staleTime: 0});
+  });
+
   it('should encode path parameters correctly', () => {
     const options = apiOptions.as<unknown>()(
       '/organizations/$organizationIdOrSlug/releases/$version/',

--- a/static/app/utils/api/apiOptions.ts
+++ b/static/app/utils/api/apiOptions.ts
@@ -1,6 +1,7 @@
 import type {SkipToken} from '@tanstack/react-query';
 import {infiniteQueryOptions, queryOptions, skipToken} from '@tanstack/react-query';
 
+import type {ApiMapping} from 'sentry/utils/api/apiContracts.generated';
 import {apiFetch, apiFetchInfinite} from 'sentry/utils/api/apiFetch';
 import type {ApiResponse} from 'sentry/utils/api/apiFetch';
 import type {QueryKeyEndpointOptions} from 'sentry/utils/api/apiQueryKey';
@@ -11,6 +12,27 @@ import type {KnownSentryApiUrls} from 'sentry/utils/api/knownSentryApiUrls.gener
 import {parseLinkHeader} from 'sentry/utils/parseLinkHeader';
 
 type KnownApiUrls = KnownGetsentryApiUrls | KnownSentryApiUrls;
+
+/**
+ * Routes whose GET response type is known from the backend contract.
+ */
+export type ContractApiUrls = {
+  [TApiPath in keyof ApiMapping]: 'GET' extends keyof ApiMapping[TApiPath]
+    ? TApiPath
+    : never;
+}[keyof ApiMapping];
+
+/**
+ * The response type the backend declares for `GET <path>`, from the generated
+ * `ApiMapping`. `unknown` for routes without a contract.
+ */
+export type ContractResponse<TApiPath extends string> = TApiPath extends keyof ApiMapping
+  ? 'GET' extends keyof ApiMapping[TApiPath]
+    ? ApiMapping[TApiPath]['GET'] extends {response: infer TResponse}
+      ? TResponse
+      : unknown
+    : unknown
+  : unknown;
 
 type Options = QueryKeyEndpointOptions & {staleTime: number | 'static'};
 
@@ -51,7 +73,8 @@ function _apiOptions<
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   TManualData = never,
   TApiPath extends KnownApiUrls = KnownApiUrls,
-  // todo: infer the actual data type from the ApiMapping
+  // `apiOptions.as<T>()` passes T explicitly; `apiOptions.contract()` passes
+  // the response type the backend declares for the route.
   TActualData = TManualData,
 >(
   path: TApiPath,
@@ -85,7 +108,6 @@ function _apiOptionsInfinite<
   // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-parameters
   TManualData = never,
   TApiPath extends KnownApiUrls = KnownApiUrls,
-  // todo: infer the actual data type from the ApiMapping
   TActualData = TManualData,
 >(
   path: TApiPath,
@@ -152,6 +174,19 @@ function _apiOptionsInfinite<
  * const items = data?.json ?? [];
  * const pageLinks = data?.headers.Link;
  * ```
+ *
+ * @example Inferring the response type from the backend contract
+ * ```ts
+ * const query = useQuery(
+ *   apiOptions.contract('/organizations/$organizationIdOrSlug/teams/', {
+ *     path: {organizationIdOrSlug: organization.slug},
+ *     staleTime: 30_000,
+ *   })
+ * );
+ * // query.data is the response type the backend declares for GET on this
+ * // route (see apiContracts.generated.ts). Only routes with a GET contract
+ * // are accepted; use `as<T>()` for the rest.
+ * ```
  */
 export const apiOptions = {
   as:
@@ -169,4 +204,14 @@ export const apiOptions = {
       options: Options & PathParamOptions<TApiPath>
     ) =>
       _apiOptionsInfinite<TManualData>(path, options as never),
+
+  contract: <TApiPath extends ContractApiUrls>(
+    path: TApiPath,
+    options: Options & PathParamOptions<TApiPath>
+  ) => _apiOptions<ContractResponse<TApiPath>, TApiPath>(path, options as never),
+
+  contractInfinite: <TApiPath extends ContractApiUrls>(
+    path: TApiPath,
+    options: Options & PathParamOptions<TApiPath>
+  ) => _apiOptionsInfinite<ContractResponse<TApiPath>, TApiPath>(path, options as never),
 };


### PR DESCRIPTION
## Why

Step 3 of 3. Step 1 (#124177) builds an internal OpenAPI spec that covers private endpoints; step 2 (#124178) generates `ApiMapping` from it. This PR makes the generated contract usable from `apiOptions` and turns the gap between backend contracts and hand-written frontend types into something typecheck enforces.

## What

**`apiOptions.contract(path, options)`** (and `contractInfinite`) infer the response type from `ApiMapping['<path>']['GET']['response']`. Only routes with a GET contract are accepted, so `apiOptions.contract('/api-tokens/', ...)` is a type error. `apiOptions.as<T>()` is unchanged and remains the escape hatch. The `ContractApiUrls` and `ContractResponse<TPath>` types are exported for reuse. The old `todo: infer the actual data type from the ApiMapping` is resolved.

**`static/app/types/apiContracts.spec.ts`** pins, for 22 core GET routes, the exact set of keys on which the backend contract and the frontend type disagree. A `Drift<Backend, Frontend>` helper computes the keys the frontend requires that the backend contract lacks or types incompatibly, and each assertion is `expectTypeOf<keyof Drift<...>>().toEqualTypeOf<'key' | ...>()`. Both a newly drifting key and a fixed one change the union and fail `pnpm typecheck` until the list is updated; the target is `never` everywhere. Hovering a `Drift<...>` alias shows the two sides of each key.

## What the drift looks like today

Every one of the 22 routes drifts. Three patterns account for nearly all of it:

| Pattern | Example | Where to fix |
|---|---|---|
| Backend TypedDict lacks a field the serializer sends | `hideAiFeatures`, `issueAlertsThreadFlag`, `metricAlertsThreadFlag` on the organization list; `displayName` on environments; `invite_link`, `isOnlyOwner`, `role`, `roleName` on members | Backend TypedDict |
| Backend declares a looser type than the frontend relies on | `access: str` list vs `Scope[]`; `status.id: str` vs `ObjectStatus`; `avatar` with every key optional; `flags: dict[str, Any]`; `stats: Any` | Backend TypedDict (`Literal`, required keys, real shapes) |
| Frontend type claims something the API does not return | `Project.team: Team` where the API sends `{id, name, slug}`; `Environment.displayName` | Frontend type |

Full per-route lists are in the spec. The organization details route alone has 46 drifting keys, mostly the first pattern.

## What was tried and deferred

`satisfies ContractResponse<...>` on `ProjectFixture` and `TeamFixture` fails today for the same reasons the spec records (the backend `Team` contract requires `dateCreated`, which the frontend `Team` type does not declare; the project contract requires keys the fixture lacks). Fixture checks are the natural next step once a route's drift reaches `never`. Likewise no call site was migrated to `apiOptions.contract`, since on every checked route the inferred type would differ from the `as<T>()` type in use.

## Verification

- `pnpm typecheck` passes.
- `apiOptions.spec.tsx` (2 new tests) and `apiContracts.spec.ts` pass under jest.
- `prek` passes on the changed files.

https://claude.ai/code/session_018d6yv4s3FR9D4iEmKPtvef
