### PR TITLE
chore(workflow-engine): Schedule repair tasks for all projects detector

### DIFF
--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1041,6 +1041,10 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "workflow_engine:sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         "schedule": timedelta(seconds=15),
     },
+    "health_check_organization_detectors": {
+        "task": "workflow_engine:sentry.workflow_engine.tasks.health_check.health_check_organization_detectors",
+        "schedule": crontab("*/30", "*", "*", "*", "*"),
+    },
     "resolve-stale-sourcemap-detectors": {
         "task": "workflow_engine:sentry.processing_errors.tasks.resolve_stale_sourcemap_detectors",
         "schedule": crontab("*/5", "*", "*", "*", "*"),

--- a/src/sentry/conf/server.py
+++ b/src/sentry/conf/server.py
@@ -1041,7 +1041,7 @@ TASKWORKER_REGION_SCHEDULES: ScheduleConfigMap = {
         "task": "workflow_engine:sentry.workflow_engine.tasks.workflows.schedule_delayed_workflows",
         "schedule": timedelta(seconds=15),
     },
-    "health_check_organization_detectors": {
+    "health-check-organization-detectors": {
         "task": "workflow_engine:sentry.workflow_engine.tasks.health_check.health_check_organization_detectors",
         "schedule": crontab("*/30", "*", "*", "*", "*"),
     },

--- a/tests/sentry/workflow_engine/tasks/test_health_check.py
+++ b/tests/sentry/workflow_engine/tasks/test_health_check.py
@@ -13,10 +13,11 @@ HEALTH_CHECK_OPTIONS = {
 
 
 class TestHealthCheckOrganizationDetectors(TestCase):
+    @override_options(HEALTH_CHECK_OPTIONS)
     def test_no_missing_detectors(self) -> None:
         detector = self.create_all_projects_detector(self.organization)
 
-        with override_options(HEALTH_CHECK_OPTIONS), self.tasks():
+        with self.tasks():
             health_check_organization_detectors()
 
         assert Detector.objects.filter(
@@ -32,13 +33,14 @@ class TestHealthCheckOrganizationDetectors(TestCase):
             == 1
         )
 
+    @override_options(HEALTH_CHECK_OPTIONS)
     def test_missing_org_detector(self) -> None:
         assert not Detector.objects.filter(
             project__isnull=True,
             config__organization_id=self.organization.id,
         ).exists()
 
-        with override_options(HEALTH_CHECK_OPTIONS), self.tasks():
+        with self.tasks():
             health_check_organization_detectors()
 
         assert Detector.objects.filter(
@@ -46,19 +48,26 @@ class TestHealthCheckOrganizationDetectors(TestCase):
             config__organization_id=self.organization.id,
         ).exists()
 
+    @override_options(HEALTH_CHECK_OPTIONS)
+    @mock.patch(
+        "sentry.workflow_engine.tasks.health_check.ensure_default_detectors_for_organization"
+    )
+    def test_org_with_existing_detector_not_dispatched(self, mock_task: mock.Mock) -> None:
+        self.create_all_projects_detector(self.organization)
+        org_without_detector = self.create_organization()
+
+        health_check_organization_detectors()
+
+        mock_task.delay.assert_called_with(organization_id=org_without_detector.id)
+        assert mock.call(organization_id=self.organization.id) not in mock_task.delay.call_args_list
+
+    @override_options(HEALTH_CHECK_OPTIONS)
+    @mock.patch("sentry.workflow_engine.tasks.health_check.HEALTH_CHECK_BUFFER_SIZE", 2)
     def test_buffer_size_limit(self) -> None:
-        organizations = [
-            self.organization,
-            self.create_organization(),
-            self.create_organization(),
-        ]
+        organizations = [self.organization, self.create_organization(), self.create_organization()]
         organization_ids = [organization.id for organization in organizations]
 
-        with (
-            override_options(HEALTH_CHECK_OPTIONS),
-            mock.patch("sentry.workflow_engine.tasks.health_check.HEALTH_CHECK_BUFFER_SIZE", 2),
-            self.tasks(),
-        ):
+        with self.tasks():
             health_check_organization_detectors()
 
         assert (
@@ -69,11 +78,9 @@ class TestHealthCheckOrganizationDetectors(TestCase):
             == 2
         )
 
+    @override_options({"workflow_engine.tasks.health_check_organization.enabled": True})
     def test_all_projects_detector_option_disabled(self) -> None:
-        with (
-            override_options({"workflow_engine.tasks.health_check_organization.enabled": True}),
-            self.tasks(),
-        ):
+        with self.tasks():
             health_check_organization_detectors()
 
         assert not Detector.objects.filter(
@@ -81,11 +88,9 @@ class TestHealthCheckOrganizationDetectors(TestCase):
             config__organization_id=self.organization.id,
         ).exists()
 
+    @override_options({"workflow_engine.auto_creation.all_projects_detector": True})
     def test_health_check_disabled(self) -> None:
-        with (
-            override_options({"workflow_engine.auto_creation.all_projects_detector": True}),
-            self.tasks(),
-        ):
+        with self.tasks():
             health_check_organization_detectors()
 
         assert not Detector.objects.filter(
@@ -93,10 +98,11 @@ class TestHealthCheckOrganizationDetectors(TestCase):
             config__organization_id=self.organization.id,
         ).exists()
 
+    @override_options(HEALTH_CHECK_OPTIONS)
     def test_inactive_organization_ignored(self) -> None:
         self.organization.update(status=OrganizationStatus.PENDING_DELETION)
 
-        with override_options(HEALTH_CHECK_OPTIONS), self.tasks():
+        with self.tasks():
             health_check_organization_detectors()
 
         assert not Detector.objects.filter(


### PR DESCRIPTION
Schedules the task registered in the previous PR. Every 30m, in batches of 1000 with a max runtime of 5m per scheduling. The tasks is just to query missing rows and schedule separate tasks for each, so even the 5m is probably generous.




---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>