### PR TITLE
ref(stories): Render stories from fixtures instead of the live API

### DIFF
--- a/oxlint.config.ts
+++ b/oxlint.config.ts
@@ -24,6 +24,15 @@ const enableTypeAwareLinting = (() => {
 const CHARTCUTERIE_MESSAGE =
   'Chartcuterie runs server-side in Node.js. This import is not available.';
 
+const STORY_API_MESSAGE =
+  'Stories must not call the API. Render from fixture data (sentry-fixture/*) instead, so the page is deterministic and safe to screenshot.';
+const storyRestrictedApiImports = [
+  'sentry/api',
+  'sentry/utils/api/apiOptions',
+  'sentry/utils/api/apiFetch',
+  'sentry/utils/queryClient',
+].map(name => ({name, message: STORY_API_MESSAGE}));
+
 const restrictedThemeImportPattern = {
   group: ['sentry/utils/theme*', 'sentry/utils/theme'],
   importNames: ['lightTheme', 'darkTheme', 'default'],
@@ -1757,6 +1766,16 @@ const config = defineConfig({
         'import/no-webpack-loader-syntax': 'off',
         // Stories sometimes contain intentionally unusual hard-coded numbers.
         'no-loss-of-precision': 'off',
+        // Stories render from fixtures, never from the live API: a story that
+        // fetches shows whatever the proxied org happens to contain, which is
+        // neither deterministic nor safe to screenshot.
+        'no-restricted-imports': [
+          'error',
+          {
+            patterns: [restrictedThemeImportPattern],
+            paths: [...restrictedImportPaths, ...storyRestrictedApiImports],
+          },
+        ],
       },
     },
     // Keep lint-disable comments out of this SDK source because users consume

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -27,7 +27,6 @@ const {env} = process;
 // Environment configuration
 env.NODE_ENV = env.NODE_ENV ?? 'development';
 const IS_PRODUCTION = env.NODE_ENV === 'production';
-const IS_TEST = env.NODE_ENV === 'test' || !!env.TEST_SUITE;
 
 // This is used to stop rendering dynamic content for tests/snapshots
 // We want it in the case where we are running tests and it is in CI,
@@ -644,13 +643,15 @@ const workerConfig: Configuration = {
   devtool: appConfig.devtool,
 };
 
-if (IS_TEST) {
-  (appConfig.resolve!.alias! as Record<string, string>)['sentry-fixture'] = path.join(
-    import.meta.dirname,
-    'fixtures',
-    'js-stubs'
-  );
-}
+// Stories render from the same fixture factories the tests use, so the alias
+// has to resolve in the app bundle too (tsconfig.json and jest.config.ts map it
+// the same way).
+(appConfig.resolve!.alias! as Record<string, string>)['sentry-fixture'] = path.join(
+  import.meta.dirname,
+  'tests',
+  'js',
+  'fixtures'
+);
 
 if (IS_ACCEPTANCE_TEST) {
   appConfig.plugins?.push(new LastBuiltPlugin({basePath: import.meta.dirname}));

--- a/static/app/components/replays/list/__stories__/replayList.stories.tsx
+++ b/static/app/components/replays/list/__stories__/replayList.stories.tsx
@@ -1,51 +1,82 @@
 import {useState} from 'react';
 import {ClassNames} from '@emotion/react';
 import {useInfiniteQuery} from '@tanstack/react-query';
-import {parseAsString, useQueryState} from 'nuqs';
+import {duration} from 'moment-timezone';
+import {ReplayListFixture} from 'sentry-fixture/replayList';
 
 import {Flex, Stack} from '@sentry/scraps/layout';
 
 import {Hovercard} from 'sentry/components/hovercard';
 import {ReplayList} from 'sentry/components/replays/list/__stories__/replayList';
-import {EnvironmentPicker} from 'sentry/components/replays/player/__stories__/environmentPicker';
 import * as Storybook from 'sentry/stories';
-import {replayListInfiniteApiOptions} from 'sentry/utils/replays/replayListApiOptions';
-import {useOrganization} from 'sentry/utils/useOrganization';
+import type {ReplayListRecord} from 'sentry/views/explore/replays/types';
+
+const PAGE_SIZE = 10;
+const PAGE_COUNT = 3;
+const NEWEST_STARTED_AT = new Date('2022-09-15T06:50:03+00:00');
+const USERS = ['alice', 'bob', 'carol', 'dmitri', 'erin'];
+const BROWSERS = ['Firefox', 'Chrome', 'Safari', 'Edge'];
+
+/**
+ * Several pages of replays derived from the fixture record, varied
+ * deterministically so the list has some texture (different users, browsers,
+ * durations, activity) without depending on any org's real data.
+ */
+function replayPage(page: number): ReplayListRecord[] {
+  const [template] = ReplayListFixture();
+  return Array.from({length: PAGE_SIZE}, (_, index) => {
+    const n = page * PAGE_SIZE + index;
+    const startedAt = new Date(NEWEST_STARTED_AT.getTime() - n * 17 * 60 * 1000);
+    const seconds = 30 + n * 11;
+    return {
+      ...template!,
+      id: `${n.toString(16).padStart(4, '0')}${template!.id.slice(4)}`,
+      activity: (n * 7) % 10,
+      count_errors: n % 4 === 0 ? (n % 3) + 1 : 0,
+      count_rage_clicks: n % 5 === 0 ? 1 : 0,
+      browser: {name: BROWSERS[n % BROWSERS.length]!, version: '111.0'},
+      duration: duration(seconds, 'seconds'),
+      started_at: startedAt,
+      finished_at: new Date(startedAt.getTime() + seconds * 1000),
+      has_viewed: n % 3 === 0,
+      user: {
+        ...template!.user,
+        id: String(147086 + n),
+        display_name: USERS[n % USERS.length]!,
+        username: USERS[n % USERS.length]!,
+      },
+    };
+  });
+}
+
+/**
+ * Serves the fixture pages through the same infinite query shape the real
+ * replay list endpoint produces, so `ReplayList` renders exactly as in the app.
+ */
+function useFixtureReplayList() {
+  return useInfiniteQuery({
+    queryKey: ['stories', 'replay-list'],
+    queryFn: async ({
+      pageParam,
+    }): Promise<{headers: {Link?: string}; json: {data: ReplayListRecord[]}}> => {
+      await new Promise(resolve => setTimeout(resolve, 300));
+      return {headers: {}, json: {data: replayPage(pageParam)}};
+    },
+    initialPageParam: 0,
+    getNextPageParam: (_lastPage, _pages, lastPageParam) =>
+      lastPageParam + 1 < PAGE_COUNT ? lastPageParam + 1 : undefined,
+    staleTime: Infinity,
+  });
+}
 
 export default Storybook.story('ReplayList', story => {
   story('Rendered', () => {
-    const organization = useOrganization();
-    const [project, setProject] = useQueryState('project', parseAsString);
-    const [environment, setEnvironment] = useQueryState('environment', parseAsString);
     const [replayId, setReplayId] = useState<string | undefined>();
-
-    const query = {
-      environment: environment ? [environment] : undefined,
-      project: project ? [project] : undefined,
-      sort: '-started_at',
-      statsPeriod: '90d',
-    };
-
-    const queryResult = useInfiniteQuery(
-      replayListInfiniteApiOptions({
-        options: {query},
-        organization,
-        queryReferrer: 'replayList',
-      })
-    );
+    const queryResult = useFixtureReplayList();
 
     return (
       <Stack gap="md">
         Selected Replay: {replayId}
-        <Flex gap="sm">
-          <Storybook.SelectProject projectSlug={project} setProjectSlug={setProject} />
-
-          <EnvironmentPicker
-            project={project}
-            environment={environment}
-            onChange={setEnvironment}
-          />
-        </Flex>
         <Flex height="500px">
           <Stack gap="md" flex="1">
             <ReplayList onSelect={setReplayId} queryResult={queryResult} />
@@ -56,49 +87,19 @@ export default Storybook.story('ReplayList', story => {
   });
 
   story('Hovercard', () => {
-    const organization = useOrganization();
-    const [project, setProject] = useQueryState('project', parseAsString);
-    const [environment, setEnvironment] = useQueryState('environment', parseAsString);
     const [replayId, setReplayId] = useState<string | undefined>();
-
-    const query = {
-      environment: environment ? [environment] : undefined,
-      project: project ? [project] : undefined,
-      sort: '-started_at',
-      statsPeriod: '90d',
-    };
-
-    const queryResult = useInfiniteQuery(
-      replayListInfiniteApiOptions({
-        options: {query},
-        organization,
-        queryReferrer: 'replayList',
-      })
-    );
+    const queryResult = useFixtureReplayList();
 
     return (
       <ClassNames>
         {({css}) => (
           <Hovercard
             body={
-              <Stack gap="md">
-                <Flex gap="sm">
-                  <Storybook.SelectProject
-                    projectSlug={project}
-                    setProjectSlug={setProject}
-                  />
-                  <EnvironmentPicker
-                    project={project}
-                    environment={environment}
-                    onChange={setEnvironment}
-                  />
-                </Flex>
-                <Flex height="500px">
-                  <Stack gap="md" flex="1">
-                    <ReplayList onSelect={setReplayId} queryResult={queryResult} />
-                  </Stack>
-                </Flex>
-              </Stack>
+              <Flex height="500px">
+                <Stack gap="md" flex="1">
+                  <ReplayList onSelect={setReplayId} queryResult={queryResult} />
+                </Stack>
+              </Flex>
             }
             containerClassName={css`
               width: max-content;

--- a/static/app/components/seer/markdown/embeds/components/autofix.stories.tsx
+++ b/static/app/components/seer/markdown/embeds/components/autofix.stories.tsx
@@ -1,37 +1,15 @@
-import {useMemo, useState, type ReactNode} from 'react';
-import {useQuery} from '@tanstack/react-query';
+import type {ReactNode} from 'react';
 
 import {Button} from '@sentry/scraps/button';
 import {AssistantMessage, MessageRow, UserMessage} from '@sentry/scraps/chat';
-import {CompactSelect} from '@sentry/scraps/compactSelect';
 import {InputGroup} from '@sentry/scraps/input';
-import {Container, Flex, Stack} from '@sentry/scraps/layout';
-import {Text} from '@sentry/scraps/text';
+import {Container, Stack} from '@sentry/scraps/layout';
 
-import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
-import {
-  getOrderedAutofixSections,
-  isPullRequestsSection,
-  useExplorerAutofix,
-  type AutofixExplorerStep,
-} from 'sentry/components/events/autofix/useExplorerAutofix';
+import type {AutofixExplorerStep} from 'sentry/components/events/autofix/useExplorerAutofix';
 import {SeerMarkdown} from 'sentry/components/seer/markdown';
-import {
-  NEXT_STEP,
-  STEP_LABELS,
-} from 'sentry/components/seer/markdown/embeds/components/autofix';
 import type {EmbedOutput} from 'sentry/components/seer/markdown/embeds/utils';
 import {IconArrow} from 'sentry/icons';
 import * as Storybook from 'sentry/stories';
-import type {Group} from 'sentry/types/group';
-import {apiOptions} from 'sentry/utils/api/apiOptions';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import type {SeerExplorerRunId} from 'sentry/views/seerExplorer/types';
-import type {
-  AutofixOverviewResponse,
-  MilestoneKey,
-  OverviewRun,
-} from 'sentry/views/seerWorkflows/overview/types';
 
 const ISSUE = {id: '6789012345', shortId: 'CHECKOUT-42'};
 
@@ -50,14 +28,6 @@ function autofix(
   details: AutofixDetails = {}
 ): string {
   return `{% autofix %}${JSON.stringify({...ISSUE, step, result, ...details})}{% /autofix %}`;
-}
-
-function autofixRefTag(
-  group: Pick<Group, 'id' | 'shortId'>,
-  step: AutofixExplorerStep,
-  runId: SeerExplorerRunId
-): string {
-  return `{% autofixRef %}${JSON.stringify({id: group.id, shortId: group.shortId, runId, step})}{% /autofixRef %}`;
 }
 
 const ROOT_CAUSE = autofix(
@@ -190,214 +160,6 @@ function ChatShell({children}: {children: ReactNode}) {
   );
 }
 
-interface AutofixOverviewIssue extends Pick<Group, 'id' | 'shortId'> {
-  milestone: MilestoneKey;
-  title: string;
-}
-
-const MILESTONE_LABELS: Record<MilestoneKey, string> = {
-  autofix_root_cause: 'Root cause',
-  autofix_solution: 'Plan',
-  autofix_code_changes: 'Code changes',
-  has_pull_request: 'Pull request',
-  pull_requests_merged: 'Merged',
-};
-
-function flattenOverviewIssues(data: AutofixOverviewResponse): AutofixOverviewIssue[] {
-  const seen = new Set<string>();
-  const issues: AutofixOverviewIssue[] = [];
-  for (const [milestone, runs] of Object.entries(data.runsByMilestone) as Array<
-    [MilestoneKey, OverviewRun[]]
-  >) {
-    for (const run of runs) {
-      if (seen.has(run.groupId)) {
-        continue;
-      }
-      seen.add(run.groupId);
-      issues.push({id: run.groupId, shortId: run.shortId, title: run.title, milestone});
-    }
-  }
-  return issues;
-}
-
-/**
- * A stable pool of issues to pick from: ones Seer has already run Autofix on,
- * rather than a live `is:unresolved` search that churns as issues resolve.
- */
-function useAutofixOverviewIssues() {
-  const organization = useOrganization();
-  return useQuery({
-    ...apiOptions.as<AutofixOverviewResponse>()(
-      '/organizations/$organizationIdOrSlug/seer/autofix-overview/',
-      {
-        path: {organizationIdOrSlug: organization.slug},
-        query: {project: [-1], statsPeriod: '90d', expand: ['status']},
-        staleTime: 30_000,
-      }
-    ),
-    select: data => flattenOverviewIssues(data.json),
-  });
-}
-
-function IssuePicker({
-  onChange,
-  value,
-}: {
-  onChange: (issue: AutofixOverviewIssue) => void;
-  value: AutofixOverviewIssue | null;
-}) {
-  const {data: issues, isPending} = useAutofixOverviewIssues();
-
-  return (
-    <CompactSelect
-      search
-      disabled={isPending}
-      options={(issues ?? []).map(issue => ({
-        value: issue.id,
-        label: `${issue.shortId} — ${issue.title} (${MILESTONE_LABELS[issue.milestone]})`,
-      }))}
-      value={value?.id}
-      onChange={opt => {
-        const issue = issues?.find(candidate => candidate.id === opt.value);
-        if (issue) {
-          onChange(issue);
-        }
-      }}
-    />
-  );
-}
-
-const AUTOFIX_STEP_ORDER: AutofixExplorerStep[] = [
-  'root_cause',
-  'solution',
-  'code_changes',
-];
-
-function isAutofixStep(step: string): step is AutofixExplorerStep {
-  return step === 'pr_iteration' || (AUTOFIX_STEP_ORDER as string[]).includes(step);
-}
-
-/**
- * Renders every step already on the issue's real Autofix run state — reusing
- * `NEXT_STEP`/`STEP_LABELS` from the embed itself rather than tracking a
- * locally clicked-steps list, so what's shown always matches the backend.
- */
-function AutofixIssueDemo({group}: {group: Pick<Group, 'id' | 'shortId'>}) {
-  const explorerAutofix = useExplorerAutofix(group, {pollPR: true});
-  const {runState, isLoading, isPolling, startStep, createPR} = explorerAutofix;
-  const runId = getAutofixRunId(runState);
-
-  const steps = useMemo(() => {
-    const sections = getOrderedAutofixSections(runState);
-    const explorerSteps = sections.map(section => section.step).filter(isAutofixStep);
-    if (sections.some(isPullRequestsSection) && !explorerSteps.includes('pr_iteration')) {
-      return [...explorerSteps, 'pr_iteration' as const];
-    }
-    return explorerSteps;
-  }, [runState]);
-
-  const lastStep = steps.at(-1);
-  const nextStep = lastStep ? NEXT_STEP[lastStep] : AUTOFIX_STEP_ORDER[0];
-
-  function handleTriggerNext() {
-    if (nextStep) {
-      startStep(nextStep, runId ? {runId} : undefined);
-    }
-  }
-
-  function handleCreatePR() {
-    if (runId) {
-      createPR(runId);
-    }
-  }
-
-  // Exactly one of these renders at a time, so a state we did not anticipate
-  // (e.g. sections exist but no run id came back) is still visible instead of
-  // silently rendering nothing.
-  let body: ReactNode;
-  if (isLoading) {
-    body = <Text variant="muted">Loading Autofix state…</Text>;
-  } else if (runId && steps.length > 0) {
-    body = (
-      <Storybook.SizingWindow display="block">
-        {steps.map(step => (
-          <MessageRow key={step} from="assistant">
-            <AssistantMessage>
-              <SeerMarkdown raw={autofixRefTag(group, step, runId)} />
-            </AssistantMessage>
-          </MessageRow>
-        ))}
-      </Storybook.SizingWindow>
-    );
-  } else if (isPolling) {
-    body = <Text variant="muted">Starting the run…</Text>;
-  } else if (steps.length > 0) {
-    body = (
-      <Text variant="danger">
-        Autofix has {steps.length} step(s) recorded, but no run id came back — can't
-        render step cards.
-      </Text>
-    );
-  } else {
-    body = <Text variant="muted">No Autofix run yet for this issue.</Text>;
-  }
-
-  return (
-    <Stack gap="xl">
-      <Flex gap="md" align="center" justify="between" wrap="wrap">
-        <Text bold>{group.shortId}</Text>
-        <Flex gap="sm">
-          {lastStep === 'code_changes' && (
-            <Button size="sm" disabled={isPolling} onClick={handleCreatePR}>
-              Draft a pull request
-            </Button>
-          )}
-          {nextStep && (
-            <Button size="sm" disabled={isPolling} onClick={handleTriggerNext}>
-              {steps.length
-                ? `Continue: ${STEP_LABELS[nextStep]}`
-                : `Run: ${STEP_LABELS[nextStep]}`}
-            </Button>
-          )}
-        </Flex>
-      </Flex>
-
-      {body}
-    </Stack>
-  );
-}
-
-function AutofixRefStory() {
-  const [issue, setIssue] = useState<AutofixOverviewIssue | null>(null);
-
-  return (
-    <Stack
-      width="100%"
-      minWidth="640px"
-      background="primary"
-      border="primary"
-      radius="md"
-      padding="xl"
-      gap="xl"
-    >
-      <Stack gap="md">
-        <Text bold>Pick an issue with existing Autofix activity</Text>
-        <IssuePicker value={issue} onChange={setIssue} />
-      </Stack>
-
-      {issue && <Text>{issue.title}</Text>}
-
-      <Container borderTop="primary" paddingTop="xl">
-        {issue ? (
-          <AutofixIssueDemo key={issue.id} group={issue} />
-        ) : (
-          <Text variant="muted">No issue selected yet.</Text>
-        )}
-      </Container>
-    </Stack>
-  );
-}
-
 export default Storybook.story('Autofix', story => {
   story('Fix it end to end', () => (
     <ChatShell>
@@ -446,6 +208,4 @@ export default Storybook.story('Autofix', story => {
       <Seer raw={`Here's the plan:\n\n${PLANNED_SOLUTION}`} />
     </ChatShell>
   ));
-
-  story('Live Autofix run (autofixRef)', () => <AutofixRefStory />);
 });

--- a/static/app/utils/api/useAggregatedQueryKeys.stories.tsx
+++ b/static/app/utils/api/useAggregatedQueryKeys.stories.tsx
@@ -1,38 +1,57 @@
 import {Fragment, useCallback, useEffect} from 'react';
+import {queryOptions} from '@tanstack/react-query';
+import {TeamFixture} from 'sentry-fixture/team';
 
 import {StructuredEventData} from 'sentry/components/structuredEventData';
 import * as Storybook from 'sentry/stories';
-import {apiOptions} from 'sentry/utils/api/apiOptions';
+import type {ApiQueryKey} from 'sentry/utils/api/apiQueryKey';
+import {getApiUrl} from 'sentry/utils/api/getApiUrl';
 import {useAggregatedQueryKeys} from 'sentry/utils/api/useAggregatedQueryKeys';
-import {useOrganization} from 'sentry/utils/useOrganization';
-import {useUserTeams} from 'sentry/utils/useUserTeams';
 
 type CountState = Record<string, undefined | number>;
 
+const TEAMS = [
+  TeamFixture({id: '1', slug: 'backend'}),
+  TeamFixture({id: '2', slug: 'frontend'}),
+  TeamFixture({id: '3', slug: 'mobile'}),
+];
+
+/**
+ * Stands in for the replay-count endpoint: resolves after a short delay with a
+ * deterministic count per requested id, so the batching is observable without
+ * a network request. Watch the console to see one call for all three ids.
+ */
+async function fetchCounts(ids: readonly string[]): Promise<{
+  headers: {Link?: string};
+  json: CountState;
+}> {
+  // eslint-disable-next-line no-console
+  console.log('useAggregatedQueryKeys story: one request for ids', ids);
+  await new Promise(resolve => setTimeout(resolve, 300));
+  return {
+    headers: {},
+    json: Object.fromEntries(ids.map(id => [id, Number(id) * 7])),
+  };
+}
+
 export default Storybook.story('useAggregatedQueryKeys', story => {
   story('useAggregatedQueryKeys', () => {
-    const organization = useOrganization();
-
-    // Get a list of valid teamIds to use as demo aggregation keys.
-    const {teams: userTeams} = useUserTeams();
-
     const cache = useAggregatedQueryKeys<string, CountState>({
       getQueryOptions: useCallback(
         ids =>
-          apiOptions.as<CountState>()(
-            '/organizations/$organizationIdOrSlug/replay-count/',
-            {
-              path: {organizationIdOrSlug: organization.slug},
-              query: {
-                data_source: 'discover',
-                project: -1,
-                statsPeriod: '14d',
-                query: `issue.id:[${ids.join(',')}]`,
-              },
-              staleTime: 0,
-            }
-          ),
-        [organization.slug]
+          queryOptions({
+            queryKey: [
+              getApiUrl('/organizations/$organizationIdOrSlug/replay-count/', {
+                path: {organizationIdOrSlug: 'org-slug'},
+              }),
+              {query: {data_source: 'discover', query: `issue.id:[${ids.join(',')}]`}},
+              {infinite: false},
+            ] as ApiQueryKey,
+            queryFn: () => fetchCounts(ids),
+            staleTime: 0,
+            select: data => data.json,
+          }),
+        []
       ),
       onError: useCallback(() => {}, []),
       responseReducer: useCallback((prevState, response, aggregates) => {
@@ -43,25 +62,19 @@ export default Storybook.story('useAggregatedQueryKeys', story => {
 
     useEffect(() => {
       // Request only the first team's id as a demo aggregate key
-      const firstTeam = userTeams[0];
-      if (firstTeam) {
-        cache.buffer([firstTeam.id]);
-      }
-    }, [cache, userTeams]);
+      cache.buffer([TEAMS[0]!.id]);
+    }, [cache]);
     useEffect(() => {
       // Request some more ids separately
-      const moreTeams = userTeams.slice(1, 3);
-      if (moreTeams.length) {
-        cache.buffer(moreTeams.map(team => team.id));
-      }
-    }, [cache, userTeams]);
+      cache.buffer(TEAMS.slice(1).map(team => team.id));
+    }, [cache]);
 
     return (
       <Fragment>
         <p>
-          Checkout the network traffic to really understand how this works. We've called{' '}
+          Check the console to really understand how this works. We've called{' '}
           <code>cache.buffer()</code> in two independent places, but those 3 ids were
-          grouped together into one request on the network.
+          grouped together into one request.
         </p>
         <StructuredEventData data={cache.data} />
       </Fragment>

--- a/static/app/utils/seer/seerProjectSettings.stories.tsx
+++ b/static/app/utils/seer/seerProjectSettings.stories.tsx
@@ -1,12 +1,14 @@
 import {Fragment, useState} from 'react';
 import {
-  useMutation,
-  useQuery,
-  useQueryClient,
-  infiniteQueryOptions,
+  mutationOptions,
   useInfiniteQuery,
+  useMutation,
+  useQueryClient,
 } from '@tanstack/react-query';
-import {parseAsArrayOf, parseAsString, useQueryState} from 'nuqs';
+import {
+  SeerProjectSettingFixture,
+  SeerProjectSettingsListFixture,
+} from 'sentry-fixture/seerProjectSetting';
 
 import {Checkbox} from '@sentry/scraps/checkbox';
 import {AutoSaveForm, FieldGroup} from '@sentry/scraps/form';
@@ -14,45 +16,32 @@ import {Flex, Stack} from '@sentry/scraps/layout';
 import type {TableColumnConfig} from '@sentry/scraps/table';
 import {Text} from '@sentry/scraps/text';
 
+import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
 import {InfiniteTable} from 'sentry/components/infiniteTable/infiniteTable';
 import {LoadingError} from 'sentry/components/loadingError';
 import {LoadingIndicator} from 'sentry/components/loadingIndicator';
-import {MutableSearch} from 'sentry/components/searchSyntax/mutableSearch';
 import {PreferredAgentDropdownMenu} from 'sentry/components/seer/preferredAgentDropdownMenu';
 import {StoppingPointDropdownMenu} from 'sentry/components/seer/stoppingPointDropdownMenu';
 import {SimpleTable} from 'sentry/components/tables/simpleTable';
 import {t} from 'sentry/locale';
 import * as Storybook from 'sentry/stories';
-import {useFetchAllPages} from 'sentry/utils/api/apiFetch';
-import {safeParseQueryKey} from 'sentry/utils/api/apiQueryKey';
-import {defined} from 'sentry/utils/defined';
 import {ListItemSelectCheckbox} from 'sentry/utils/list/listItemSelectCheckbox';
 import {ListItemCheckboxProvider} from 'sentry/utils/list/useListItemCheckboxState';
-import {useProjectsById} from 'sentry/utils/project/useProjectsById';
-import {
-  seerAgentIntegrationsSelectQueryOptions,
-  knownAgentIntegrationsQueryOptions,
-  coalesePreferredAgent,
-} from 'sentry/utils/seer/preferredAgent';
-import {
-  getMutateSeerProjectSettingsOptions,
-  getSeerProjectSettingsQueryOptions,
-  getInfiniteSeerProjectsSettingsQueryOptions,
-  getMutateSeerProjectsSettingsOptions,
-  seerProjectSettingsSchema,
-} from 'sentry/utils/seer/seerProjectSettings';
+import {coalesePreferredAgent, parseAgentOption} from 'sentry/utils/seer/preferredAgent';
+import {seerProjectSettingsSchema} from 'sentry/utils/seer/seerProjectSettings';
 import {
   coaleseStoppingPoint,
   useStoppingPointSelectOptions,
 } from 'sentry/utils/seer/stoppingPoint';
 import type {
+  AgentIntegration,
   AutofixAgentSelectOption,
   InternalAutomationTuning,
   SeerAutofixStoppingPoint,
   SeerProjectSettingResponse,
+  SeerProjectSettingUpdatePayload,
 } from 'sentry/utils/seer/types';
 import {useOrganization} from 'sentry/utils/useOrganization';
-import {useProjects} from 'sentry/utils/useProjects';
 
 const STORY_COLUMNS: TableColumnConfig[] = [
   {key: 'select', width: 'max-content'},
@@ -62,237 +51,201 @@ const STORY_COLUMNS: TableColumnConfig[] = [
   {key: 'stoppingPoint', width: '1fr'},
 ];
 
+/**
+ * Stands in for the coding-agent integrations the org has installed.
+ */
+const KNOWN_AGENTS: AgentIntegration[] = [
+  {
+    id: '1001',
+    name: 'Claude Code Agent',
+    provider: CodingAgentProvider.CLAUDE_CODE_AGENT,
+  },
+  {
+    id: '1002',
+    name: 'Cursor Cloud Agent - dev@example.com',
+    provider: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
+  },
+];
+
+const AGENT_SELECT_OPTIONS: Array<{label: string; value: AutofixAgentSelectOption}> = [
+  {value: 'seer', label: t('Seer')},
+  ...KNOWN_AGENTS.map(agent => ({
+    value: `${agent.provider}::${agent.id}` as const,
+    label: agent.name,
+  })),
+];
+
+const PAGE_SIZE = 3;
+
+function sleep(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Applies a single-field update to a settings row the way the backend would,
+ * so the stories can show the new value after a fake save.
+ */
+function applyUpdate(
+  settings: SeerProjectSettingResponse,
+  data: SeerProjectSettingUpdatePayload
+): SeerProjectSettingResponse {
+  const {agentOption, stoppingPoint, ...rest} = data;
+  const agent: Partial<Pick<SeerProjectSettingResponse, 'agent' | 'integrationId'>> =
+    agentOption ? parseAgentOption(agentOption, KNOWN_AGENTS) : {};
+  const tuning: Partial<Pick<SeerProjectSettingResponse, 'automationTuning'>> =
+    stoppingPoint === undefined
+      ? {}
+      : {automationTuning: stoppingPoint === 'off' ? 'off' : 'medium'};
+  return {
+    ...settings,
+    ...rest,
+    ...agent,
+    ...(agent.agent === 'seer' ? {integrationId: null} : {}),
+    ...(stoppingPoint === undefined ? {} : {stoppingPoint}),
+    ...tuning,
+  };
+}
+
+/**
+ * Mutation options that resolve locally after a short delay instead of
+ * PUT-ing to the project settings endpoint.
+ */
+function getFakeMutateOptions(
+  onSaved: (update: SeerProjectSettingUpdatePayload) => void
+) {
+  return mutationOptions({
+    mutationFn: async (data: SeerProjectSettingUpdatePayload) => {
+      await sleep(400);
+      onSaved(data);
+      return data;
+    },
+  });
+}
+
 export default Storybook.story('SeerProjectSettings', story => {
   story('Autofix Project Settings', () => {
-    function Example({projectSlug}: {projectSlug: string}) {
-      const [showFormatted, setShowFormatted] = useState(false);
-
-      const organization = useOrganization();
-
-      const {data, isPending, isError, error} = useQuery({
-        ...getSeerProjectSettingsQueryOptions({
-          organization,
-          project: {slug: projectSlug ?? ''},
-        }),
-        enabled: !!projectSlug,
-      });
-
-      if (isPending) {
-        return (
-          <Flex justify="center" padding="xl">
-            <LoadingIndicator />
-          </Flex>
-        );
-      }
-      if (isError) {
-        return (
-          <Flex justify="center" padding="xl">
-            <Text variant="muted">{t('Error: %s', error?.message)}</Text>
-          </Flex>
-        );
-      }
-
-      if (!data) {
-        return (
-          <Flex justify="center" padding="xl">
-            <Text variant="muted">{t('No data found')}</Text>
-          </Flex>
-        );
-      }
-
-      return (
-        <Stack gap="xl">
-          <Flex as="label" gap="md" htmlFor="showFormatted">
-            <Text>{t('Format Column Values')}</Text>
-            <Checkbox
-              id="showFormatted"
-              checked={showFormatted}
-              onChange={() => setShowFormatted(!showFormatted)}
-            />
-          </Flex>
-
-          <SimpleTable
-            style={{gridTemplateColumns: '2fr max-content repeat(2, 1fr)'}}
-            header={
-              <SimpleTable.HeaderRow>
-                <SimpleTable.HeaderCell>{t('Project')}</SimpleTable.HeaderCell>
-                <SimpleTable.HeaderCell>{t('Repos')}</SimpleTable.HeaderCell>
-                <SimpleTable.HeaderCell>{t('Agent')}</SimpleTable.HeaderCell>
-                <SimpleTable.HeaderCell>{t('Stopping Point')}</SimpleTable.HeaderCell>
-              </SimpleTable.HeaderRow>
-            }
-          >
-            <SimpleTable.Row>
-              <SimpleTable.RowCell>
-                <Text bold>{data.projectSlug}</Text>
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell>
-                <Text>{data.reposCount}</Text>
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell>
-                <Text>
-                  {showFormatted ? <PreferredAgentLabel settings={data} /> : data.agent}
-                </Text>
-              </SimpleTable.RowCell>
-              <SimpleTable.RowCell>
-                <Text>
-                  {showFormatted ? (
-                    <StoppingPointLabel
-                      stoppingPoint={data.stoppingPoint}
-                      automationTuning={data.automationTuning}
-                    />
-                  ) : (
-                    data.stoppingPoint
-                  )}
-                </Text>
-              </SimpleTable.RowCell>
-            </SimpleTable.Row>
-          </SimpleTable>
-        </Stack>
-      );
-    }
-
-    const [projectSlug, setProjectSlug] = useQueryState('project', parseAsString);
+    const [showFormatted, setShowFormatted] = useState(false);
+    const data = SeerProjectSettingFixture();
 
     return (
-      <Stack gap="lg">
-        <Storybook.SelectProject
-          projectSlug={projectSlug}
-          setProjectSlug={setProjectSlug}
-        />
-        {projectSlug ? (
-          <Example projectSlug={projectSlug} />
-        ) : (
-          <Flex justify="center" padding="xl">
-            <Text variant="muted">Select a project to view the story</Text>
-          </Flex>
-        )}
+      <Stack gap="xl">
+        <Flex as="label" gap="md" htmlFor="showFormatted">
+          <Text>{t('Format Column Values')}</Text>
+          <Checkbox
+            id="showFormatted"
+            checked={showFormatted}
+            onChange={() => setShowFormatted(!showFormatted)}
+          />
+        </Flex>
+
+        <SimpleTable
+          style={{gridTemplateColumns: '2fr max-content repeat(2, 1fr)'}}
+          header={
+            <SimpleTable.HeaderRow>
+              <SimpleTable.HeaderCell>{t('Project')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell>{t('Repos')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell>{t('Agent')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell>{t('Stopping Point')}</SimpleTable.HeaderCell>
+            </SimpleTable.HeaderRow>
+          }
+        >
+          <SimpleTable.Row>
+            <SimpleTable.RowCell>
+              <Text bold>{data.projectSlug}</Text>
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              <Text>{data.reposCount}</Text>
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              <Text>
+                {showFormatted ? (
+                  <PreferredAgentLabel settings={data} knownAgents={KNOWN_AGENTS} />
+                ) : (
+                  data.agent
+                )}
+              </Text>
+            </SimpleTable.RowCell>
+            <SimpleTable.RowCell>
+              <Text>
+                {showFormatted ? (
+                  <StoppingPointLabel
+                    stoppingPoint={data.stoppingPoint}
+                    automationTuning={data.automationTuning}
+                  />
+                ) : (
+                  data.stoppingPoint
+                )}
+              </Text>
+            </SimpleTable.RowCell>
+          </SimpleTable.Row>
+        </SimpleTable>
       </Stack>
     );
   });
 
   story('Edit Single Project Settings', () => {
-    function Example({projectSlug}: {projectSlug: string}) {
-      const organization = useOrganization();
-      const queryClient = useQueryClient();
-      const {data: knownAgents} = useQuery(
-        knownAgentIntegrationsQueryOptions({organization})
-      );
+    const [data, setData] = useState(() => SeerProjectSettingFixture());
+    const stoppingPointOptions = useStoppingPointSelectOptions();
 
-      const {data: agentSelectOptions = []} = useQuery(
-        seerAgentIntegrationsSelectQueryOptions({organization})
-      );
-      const stoppingPointOptions = useStoppingPointSelectOptions();
-
-      const {data, isPending, isError, error} = useQuery({
-        ...getSeerProjectSettingsQueryOptions({
-          organization,
-          project: {slug: projectSlug ?? ''},
-        }),
-        enabled: !!projectSlug,
-      });
-
-      if (isPending) {
-        return (
-          <Flex justify="center" padding="xl">
-            <LoadingIndicator />
-          </Flex>
-        );
-      }
-
-      if (isError) {
-        return (
-          <Flex justify="center" padding="xl">
-            <Text variant="muted">{t('Error: %s', error.message)}</Text>
-          </Flex>
-        );
-      }
-
-      if (!data) {
-        return (
-          <Flex justify="center" padding="xl">
-            <Text variant="muted">{t('No data found')}</Text>
-          </Flex>
-        );
-      }
-
-      return (
-        <Stack gap="lg">
-          <FieldGroup>
-            <AutoSaveForm
-              name="agentOption"
-              schema={seerProjectSettingsSchema}
-              initialValue={coalesePreferredAgent(data.agent, data.integrationId)}
-              mutationOptions={getMutateSeerProjectSettingsOptions({
-                organization,
-                project: {slug: projectSlug},
-                queryClient,
-                knownAgents,
-              })}
-            >
-              {field => (
-                <field.Layout.Row
-                  label={t('Agent')}
-                  hintText={t(
-                    'Select which agent should handle autofix for this project.'
-                  )}
-                >
-                  <field.Select
-                    multiple={false}
-                    value={field.state.value}
-                    onChange={field.handleChange}
-                    options={agentSelectOptions}
-                  />
-                </field.Layout.Row>
-              )}
-            </AutoSaveForm>
-          </FieldGroup>
-          <FieldGroup>
-            <AutoSaveForm
-              name="stoppingPoint"
-              schema={seerProjectSettingsSchema}
-              initialValue={data.stoppingPoint}
-              mutationOptions={getMutateSeerProjectSettingsOptions({
-                organization,
-                project: {slug: projectSlug},
-                queryClient,
-              })}
-            >
-              {field => (
-                <field.Layout.Row
-                  label={t('Stopping Point')}
-                  hintText={t(
-                    'Choose which step Seer should stop at when running automatically.'
-                  )}
-                >
-                  <field.Select
-                    value={field.state.value}
-                    onChange={field.handleChange}
-                    options={stoppingPointOptions}
-                  />
-                </field.Layout.Row>
-              )}
-            </AutoSaveForm>
-          </FieldGroup>
-        </Stack>
-      );
-    }
-
-    const [projectSlug, setProjectSlug] = useQueryState('project', parseAsString);
+    const mutateOptions = getFakeMutateOptions(update =>
+      setData(current => applyUpdate(current, update))
+    );
 
     return (
       <Stack gap="lg">
-        <Storybook.SelectProject
-          projectSlug={projectSlug}
-          setProjectSlug={setProjectSlug}
-        />
-        {projectSlug ? (
-          <Example projectSlug={projectSlug} />
-        ) : (
-          <Flex justify="center" padding="xl">
-            <Text variant="muted">Select a project to view the story</Text>
-          </Flex>
-        )}
+        <Text variant="muted">
+          {t(
+            'Saving %s: agent=%s stoppingPoint=%s',
+            data.projectSlug,
+            data.agent,
+            data.stoppingPoint
+          )}
+        </Text>
+        <FieldGroup>
+          <AutoSaveForm
+            name="agentOption"
+            schema={seerProjectSettingsSchema}
+            initialValue={coalesePreferredAgent(data.agent, data.integrationId)}
+            mutationOptions={mutateOptions}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('Agent')}
+                hintText={t('Select which agent should handle autofix for this project.')}
+              >
+                <field.Select
+                  multiple={false}
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  options={AGENT_SELECT_OPTIONS}
+                />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+        </FieldGroup>
+        <FieldGroup>
+          <AutoSaveForm
+            name="stoppingPoint"
+            schema={seerProjectSettingsSchema}
+            initialValue={data.stoppingPoint}
+            mutationOptions={mutateOptions}
+          >
+            {field => (
+              <field.Layout.Row
+                label={t('Stopping Point')}
+                hintText={t(
+                  'Choose which step Seer should stop at when running automatically.'
+                )}
+              >
+                <field.Select
+                  value={field.state.value}
+                  onChange={field.handleChange}
+                  options={stoppingPointOptions}
+                />
+              </field.Layout.Row>
+            )}
+          </AutoSaveForm>
+        </FieldGroup>
       </Stack>
     );
   });
@@ -300,29 +253,31 @@ export default Storybook.story('SeerProjectSettings', story => {
   story('Autofix Projects Settings', () => {
     const [showFormatted, setShowFormatted] = useState(false);
 
-    const organization = useOrganization();
-
-    const queryOptions = infiniteQueryOptions({
-      ...getInfiniteSeerProjectsSettingsQueryOptions({
-        organization,
-        query: {
-          per_page: 25,
-          query: MutableSearch.fromQueryObject({
-            reposCount: '>0',
-          }),
-        },
-      }),
-      select: ({pages}) => pages.flatMap(page => page.json),
+    const result = useInfiniteQuery({
+      queryKey: ['stories', 'seer-projects-settings'],
+      queryFn: async ({
+        pageParam,
+      }): Promise<{headers: {Link?: string}; json: SeerProjectSettingResponse[]}> => {
+        await sleep(300);
+        const rows = SeerProjectSettingsListFixture();
+        return {
+          headers: {},
+          json: rows.slice(pageParam * PAGE_SIZE, (pageParam + 1) * PAGE_SIZE),
+        };
+      },
+      initialPageParam: 0,
+      getNextPageParam: (lastPage, _pages, lastPageParam) =>
+        lastPage.json.length < PAGE_SIZE ? undefined : lastPageParam + 1,
+      staleTime: Infinity,
     });
-    const result = useInfiniteQuery(queryOptions);
-    useFetchAllPages({result});
-    const {data, isPending, isError, error} = result;
+    const {isPending, isError, error} = result;
+    const data = result.data?.pages.flatMap(page => page.json);
 
     return (
       <ListItemCheckboxProvider
-        hits={data?.length ?? 0}
+        hits={SeerProjectSettingsListFixture().length}
         knownIds={data?.map(item => item.projectId) ?? []}
-        endpointOptions={safeParseQueryKey(queryOptions.queryKey)?.options}
+        endpointOptions={undefined}
       >
         <Stack gap="xl">
           <Flex as="label" gap="md" htmlFor="showFormatted">
@@ -352,14 +307,14 @@ export default Storybook.story('SeerProjectSettings', story => {
               <InfiniteTable.Status>
                 <LoadingError message={error?.message} />
               </InfiniteTable.Status>
-            ) : data.length === 0 ? (
+            ) : data?.length === 0 ? (
               <InfiniteTable.Empty>{t('No projects found')}</InfiniteTable.Empty>
             ) : (
               <Fragment>
                 <InfiniteTable.Body
                   estimateSize={() => 41}
                   queryResult={result}
-                  select={_ => _ ?? []}
+                  select={pages => pages?.pages.flatMap(page => page.json) ?? []}
                 >
                   {item => (
                     <InfiniteTable.Row>
@@ -378,7 +333,10 @@ export default Storybook.story('SeerProjectSettings', story => {
                       <InfiniteTable.RowCell>
                         <Text>
                           {showFormatted ? (
-                            <PreferredAgentLabel settings={item} />
+                            <PreferredAgentLabel
+                              settings={item}
+                              knownAgents={KNOWN_AGENTS}
+                            />
                           ) : (
                             item.agent
                           )}
@@ -409,100 +367,95 @@ export default Storybook.story('SeerProjectSettings', story => {
   });
 
   story('Autofix Bulk Dropdown Menus', () => {
-    function Example({projectSlugs}: {projectSlugs: string[]}) {
-      const {projects} = useProjects();
-      const selectedIds = projectSlugs
-        .map(slug => projects.find(p => p.slug === slug)?.id)
-        .filter(defined);
-      const [lastAgent, setLastAgent] = useState<AutofixAgentSelectOption | undefined>(
-        undefined
-      );
-      const [lastStoppingPoint, setLastStoppingPoint] = useState<
-        SeerAutofixStoppingPoint | undefined
-      >(undefined);
+    const [rows, setRows] = useState(() => SeerProjectSettingsListFixture().slice(0, 3));
+    const [lastAgent, setLastAgent] = useState<AutofixAgentSelectOption | undefined>(
+      undefined
+    );
+    const [lastStoppingPoint, setLastStoppingPoint] = useState<
+      SeerAutofixStoppingPoint | undefined
+    >(undefined);
+    const queryClient = useQueryClient();
 
-      const organization = useOrganization();
-      const queryClient = useQueryClient();
-      const projectsById = useProjectsById();
-      const {data: knownAgents} = useQuery(
-        knownAgentIntegrationsQueryOptions({organization})
-      );
-
-      const {mutate} = useMutation(
-        getMutateSeerProjectsSettingsOptions({
-          organization,
-          projectsById,
-          queryClient,
-          knownAgents,
-        })
-      );
-
-      return (
-        <Stack gap="xl">
-          <Flex gap="md">
-            <PreferredAgentDropdownMenu
-              isDisabled={false}
-              onChange={value => {
-                setLastAgent(value);
-                mutate({
-                  query: '',
-                  selectedIds,
-                  agentOption: value,
-                });
-              }}
-            />
-            <StoppingPointDropdownMenu
-              isDisabled={false}
-              onChange={value => {
-                setLastStoppingPoint(value);
-                mutate({
-                  query: '',
-                  selectedIds,
-                  stoppingPoint: value,
-                });
-              }}
-            />
-          </Flex>
-          <pre>
-            agent: {lastAgent} | stoppingPoint: {lastStoppingPoint}
-          </pre>
-        </Stack>
-      );
-    }
-
-    const [projectSlugs, setProjectSlugs] = useQueryState(
-      'projects',
-      parseAsArrayOf(parseAsString).withDefault([])
+    const {mutate, isPending} = useMutation(
+      {
+        mutationFn: async (update: SeerProjectSettingUpdatePayload) => {
+          await sleep(400);
+          setRows(current => current.map(row => applyUpdate(row, update)));
+          return update;
+        },
+      },
+      queryClient
     );
 
     return (
-      <Stack gap="lg">
-        <Storybook.SelectProjects
-          projectSlugs={projectSlugs}
-          setProjectSlugs={setProjectSlugs}
-        />
-        {projectSlugs.length ? (
-          <Example projectSlugs={projectSlugs} />
-        ) : (
-          <Flex justify="center" padding="xl">
-            <Text variant="muted">Select a project to view the story</Text>
-          </Flex>
-        )}
+      <Stack gap="xl">
+        <Flex gap="md">
+          <PreferredAgentDropdownMenu
+            isDisabled={isPending}
+            onChange={value => {
+              setLastAgent(value);
+              mutate({agentOption: value});
+            }}
+          />
+          <StoppingPointDropdownMenu
+            isDisabled={isPending}
+            onChange={value => {
+              setLastStoppingPoint(value);
+              mutate({stoppingPoint: value});
+            }}
+          />
+        </Flex>
+        <pre>
+          agent: {lastAgent} | stoppingPoint: {lastStoppingPoint}
+        </pre>
+        <SimpleTable
+          style={{gridTemplateColumns: '2fr repeat(2, 1fr)'}}
+          header={
+            <SimpleTable.HeaderRow>
+              <SimpleTable.HeaderCell>{t('Project')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell>{t('Agent')}</SimpleTable.HeaderCell>
+              <SimpleTable.HeaderCell>{t('Stopping Point')}</SimpleTable.HeaderCell>
+            </SimpleTable.HeaderRow>
+          }
+        >
+          {rows.map(row => (
+            <SimpleTable.Row key={row.projectId}>
+              <SimpleTable.RowCell>
+                <Text bold>{row.projectSlug}</Text>
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell>
+                <Text>
+                  <PreferredAgentLabel settings={row} knownAgents={KNOWN_AGENTS} />
+                </Text>
+              </SimpleTable.RowCell>
+              <SimpleTable.RowCell>
+                <Text>
+                  <StoppingPointLabel
+                    stoppingPoint={row.stoppingPoint}
+                    automationTuning={row.automationTuning}
+                  />
+                </Text>
+              </SimpleTable.RowCell>
+            </SimpleTable.Row>
+          ))}
+        </SimpleTable>
       </Stack>
     );
   });
 });
 
-function PreferredAgentLabel({settings}: {settings: SeerProjectSettingResponse}) {
-  const organization = useOrganization();
-  const {data: knownAgents} = useQuery(
-    knownAgentIntegrationsQueryOptions({organization})
-  );
+function PreferredAgentLabel({
+  settings,
+  knownAgents,
+}: {
+  knownAgents: AgentIntegration[];
+  settings: SeerProjectSettingResponse;
+}) {
   return (
     <Fragment>
       {settings.agent === 'seer'
         ? t('Seer Agent')
-        : (knownAgents?.find(i => i.id === settings.integrationId)?.name ??
+        : (knownAgents.find(i => i.id === settings.integrationId)?.name ??
           `${settings.agent} - ${settings.integrationId}`)}
     </Fragment>
   );

--- a/tests/js/fixtures/seerProjectSetting.ts
+++ b/tests/js/fixtures/seerProjectSetting.ts
@@ -1,0 +1,76 @@
+import {CodingAgentProvider} from 'sentry/components/events/autofix/types';
+import type {SeerProjectSettingResponse} from 'sentry/utils/seer/types';
+
+export function SeerProjectSettingFixture(
+  params: Partial<SeerProjectSettingResponse> = {}
+): SeerProjectSettingResponse {
+  return {
+    agent: 'seer',
+    autoCreatePr: false,
+    automationTuning: 'medium',
+    integrationId: null,
+    projectId: '2',
+    projectSlug: 'checkout-api',
+    reposCount: 2,
+    scannerAutomation: true,
+    stoppingPoint: 'solution',
+    ...params,
+  };
+}
+
+export function SeerProjectSettingsListFixture(): SeerProjectSettingResponse[] {
+  return [
+    SeerProjectSettingFixture(),
+    SeerProjectSettingFixture({
+      projectId: '3',
+      projectSlug: 'storefront-web',
+      reposCount: 1,
+      stoppingPoint: 'root_cause',
+    }),
+    SeerProjectSettingFixture({
+      projectId: '4',
+      projectSlug: 'payments-worker',
+      reposCount: 3,
+      agent: CodingAgentProvider.CLAUDE_CODE_AGENT,
+      integrationId: '1001',
+      stoppingPoint: 'open_pr',
+      autoCreatePr: true,
+    }),
+    SeerProjectSettingFixture({
+      projectId: '5',
+      projectSlug: 'mobile-ios',
+      reposCount: 1,
+      stoppingPoint: 'off',
+      automationTuning: 'off',
+      scannerAutomation: false,
+    }),
+    SeerProjectSettingFixture({
+      projectId: '6',
+      projectSlug: 'mobile-android',
+      reposCount: 1,
+      stoppingPoint: 'code_changes',
+    }),
+    SeerProjectSettingFixture({
+      projectId: '7',
+      projectSlug: 'search-service',
+      reposCount: 4,
+      agent: CodingAgentProvider.CURSOR_BACKGROUND_AGENT,
+      integrationId: '1002',
+      stoppingPoint: 'solution',
+    }),
+    SeerProjectSettingFixture({
+      projectId: '8',
+      projectSlug: 'notifications',
+      reposCount: 2,
+      stoppingPoint: 'root_cause',
+      automationTuning: 'low',
+    }),
+    SeerProjectSettingFixture({
+      projectId: '9',
+      projectSlug: 'billing-cron',
+      reposCount: 1,
+      stoppingPoint: 'open_pr',
+      automationTuning: 'high',
+    }),
+  ];
+}


### PR DESCRIPTION
## Why

Stories are the surface visual QA captures, and today the ones that show data fetch it from whatever org the dev server proxies to. That makes them non-deterministic and, on the production proxy, unsafe to screenshot. The test fixtures already describe realistic objects, and lint already grants story files access to `tests/js/fixtures`, but the bundler alias that would let a story import them was only set for jest and pointed at a directory that no longer exists (`fixtures/js-stubs`). No story used a fixture as a result.

## What

- **Bundler:** `sentry-fixture/*` now resolves to `tests/js/fixtures` in every build, matching `tsconfig.json` and `jest.config.ts`. The `IS_TEST` flag had no other use and is gone.
- **Lint:** `*.stories.tsx` files may no longer import `sentry/api`, `sentry/utils/api/apiOptions`, `sentry/utils/api/apiFetch`, or `sentry/utils/queryClient`. The message points at fixtures. Modules that wrap those (per-feature `*QueryOptions` helpers) are not enumerable by a path rule, so this catches the direct cases and the convention covers the rest.
- **Stories moved onto fixtures:**
  - `useAggregatedQueryKeys.stories.tsx`: the demo of request batching now batches against a local query function over three `TeamFixture`s and logs the single combined call to the console instead of relying on the network tab and the org's real teams.
  - `replayList.stories.tsx`: renders three pages of replays derived deterministically from `ReplayListFixture` (varied users, browsers, durations, activity) through a local infinite query with the same response shape the real endpoint produces. The project and environment pickers, which only made sense against live data, are gone.
  - `seerProjectSettings.stories.tsx`: all four stories render from a new `SeerProjectSettingFixture` (and a list variant) with local mutation options that update React state, so the auto-save forms and bulk dropdowns still visibly change values.
  - `autofix.stories.tsx`: the "Live Autofix run" story picked a real issue and drove real Seer runs through `useExplorerAutofix`. That is a live demo by design and cannot be served from fixtures without a mock API layer, so it and its helpers are removed. The four static conversation stories in that file are unchanged.

One caveat: `PreferredAgentDropdownMenu` fetches its options internally (`seerAgentIntegrationsSelectQueryOptions`), so the bulk-dropdown story still issues that one request at runtime even though the story file imports nothing banned. Components that fetch for themselves are outside what an import rule can catch; that component would need a data prop to be fully fixture-driven.

Visual verification was not run for this PR: the changes are to stories and build configuration, and this session's dev server was not available for a browser pass.

## Verification

- `pnpm typecheck` passes.
- `pnpm run lint:js` passes on every changed file, including the new stories rule.
- `prek` passes on the changed files.

https://claude.ai/code/session_018d6yv4s3FR9D4iEmKPtvef
