### PR TITLE
feat(github): Mention Seer code review and Autofix on integration page

### DIFF
--- a/src/sentry/integrations/github/integration.py
+++ b/src/sentry/integrations/github/integration.py
@@ -140,6 +140,21 @@ FEATURES = [
         """,
         IntegrationFeatures.TICKET_RULES,
     ),
+    FeatureDescription(
+        """
+        Get automated code reviews from Seer on your GitHub pull requests,
+        surfacing bugs and issues before they reach production.
+        """,
+        IntegrationFeatures.SEER_CONTEXT,
+    ),
+    FeatureDescription(
+        """
+        Let Seer's Autofix find the root cause of your Sentry issues and open a
+        pull request with the fix, iterating on review comments and CI feedback
+        until the PR is ready to merge.
+        """,
+        IntegrationFeatures.SEER_CONTEXT,
+    ),
 ]
 
 metadata = IntegrationMetadata(


### PR DESCRIPTION
Add two feature descriptions to the GitHub integration's detail page: one
for Seer's automated code reviews on pull requests, and one for Autofix
opening a fix PR and iterating on it. PR iteration is framed as part of the
Autofix line item rather than a separate feature.

