### PR TITLE
feat(replays): add an optional limit to the replay count ids

### DIFF
--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -1125,6 +1125,17 @@ class ReplayParams:
         description="If true, return issue IDs rather than counts.",
     )
 
+    ID_LIMIT = OpenApiParameter(
+        name="limit",
+        location="query",
+        required=False,
+        type=OpenApiTypes.INT,
+        description=(
+            "Maximum number of replay IDs to return per identifier. Only applies with "
+            "`returnIds`. Defaults to, and is capped at, 51."
+        ),
+    )
+
 
 class NotificationParams:
     TRIGGER_TYPE = OpenApiParameter(

--- a/src/sentry/replays/endpoints/organization_replay_count.py
+++ b/src/sentry/replays/endpoints/organization_replay_count.py
@@ -27,7 +27,7 @@ from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.ratelimits.config import RateLimitConfig
 from sentry.replays.permissions import has_replay_permission
-from sentry.replays.usecases.replay_counts import get_replay_counts
+from sentry.replays.usecases.replay_counts import MAX_REPLAY_COUNT, get_replay_counts
 from sentry.search.eap.types import SupportedTraceItemType
 from sentry.snuba.dataset import Dataset
 from sentry.types.ratelimit import RateLimit, RateLimitCategory
@@ -46,6 +46,7 @@ class ReplayCountQueryParamsValidator(serializers.Serializer):
         default=Dataset.Discover.value,
     )
     returnIds = serializers.BooleanField(default=False)
+    limit = serializers.IntegerField(required=False, min_value=1, max_value=MAX_REPLAY_COUNT)
 
 
 @cell_silo_endpoint
@@ -86,6 +87,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsEndpointBase):
             VisibilityParams.QUERY,
             ReplayParams.DATA_SOURCE,
             ReplayParams.RETURN_IDS,
+            ReplayParams.ID_LIMIT,
         ],
         responses={
             200: inline_sentry_response_serializer("ReplayCounts", dict[int, int]),
@@ -124,6 +126,7 @@ class OrganizationReplayCountEndpoint(OrganizationEventsEndpointBase):
                 query_params["query"],
                 query_params["data_source"],
                 return_ids=query_params["returnIds"],
+                limit=query_params.get("limit"),
             )
         except (InvalidSearchQuery, ValueError) as e:
             return Response({"detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)

--- a/src/sentry/replays/usecases/replay_counts.py
+++ b/src/sentry/replays/usecases/replay_counts.py
@@ -50,24 +50,41 @@ _DATASET_QUERY_FUNCS: dict[Dataset, _DatasetQueryFunc] = {
 
 @overload
 def get_replay_counts(
-    snuba_params: SnubaParams, query: str, data_source: str | Dataset, *, return_ids: Literal[True]
+    snuba_params: SnubaParams,
+    query: str,
+    data_source: str | Dataset,
+    *,
+    return_ids: Literal[True],
+    limit: int | None = None,
 ) -> dict[int, list[str]]: ...
 
 
 @overload
 def get_replay_counts(
-    snuba_params: SnubaParams, query: str, data_source: str | Dataset, *, return_ids: Literal[False]
+    snuba_params: SnubaParams,
+    query: str,
+    data_source: str | Dataset,
+    *,
+    return_ids: Literal[False],
+    limit: int | None = None,
 ) -> dict[int, int]: ...
 
 
 def get_replay_counts(
-    snuba_params: SnubaParams, query: str, data_source: str | Dataset, *, return_ids: bool
+    snuba_params: SnubaParams,
+    query: str,
+    data_source: str | Dataset,
+    *,
+    return_ids: bool,
+    limit: int | None = None,
 ) -> dict[int, list[str]] | dict[int, int]:
     """
     Queries snuba/clickhouse for replay count of each identifier (usually an issue or transaction).
     - Identifier is parsed from 'query' (select column), and 'snuba_params' is used to filter on time range + project_id
     - If the identifier is 'replay_id', the returned count is always 1. Use this to check the existence of replay_ids
     - Set the flag 'return_ids' to get the replay_ids (32 char hex strings) for each identifier
+    - 'limit' caps how many ids each identifier gets, for callers that only want a few. Ignored
+      when returning counts, and never above MAX_REPLAY_COUNT.
     """
 
     if snuba_params.start is None or snuba_params.end is None or snuba_params.organization is None:
@@ -95,7 +112,7 @@ def get_replay_counts(
     )
 
     if return_ids:
-        return _get_replay_ids(replay_results, replay_ids_mapping)
+        return _get_replay_ids(replay_results, replay_ids_mapping, limit)
     else:
         return _get_counts(replay_results, replay_ids_mapping)
 
@@ -225,17 +242,18 @@ def _get_counts(replay_results: Any, replay_ids_mapping: dict[str, list[int]]) -
 
 
 def _get_replay_ids(
-    replay_results: Any, replay_ids_mapping: dict[str, list[int]]
+    replay_results: Any, replay_ids_mapping: dict[str, list[int]], limit: int | None = None
 ) -> dict[int, list[str]]:
     """
     Get replay ids associated with each identifier (identifier -> [replay_id]) (ex identifier: issue_id)
     Can think of it as the inverse of _get_replay_id_mappings, excluding the replay_ids that don't exist
     """
+    cap = MAX_REPLAY_COUNT if limit is None else min(limit, MAX_REPLAY_COUNT)
     ret: dict[int, list[str]] = defaultdict(list)
     for row in replay_results["data"]:
         identifiers = replay_ids_mapping[row["rid"]]
         for identifier in identifiers:
-            if len(ret[identifier]) < MAX_REPLAY_COUNT:
+            if len(ret[identifier]) < cap:
                 ret[identifier].append(row["rid"])
     return ret
 

--- a/tests/sentry/replays/endpoints/test_organization_replay_count.py
+++ b/tests/sentry/replays/endpoints/test_organization_replay_count.py
@@ -204,6 +204,56 @@ class OrganizationReplayCountEndpointTest(
             expected[event_c.group.id],
         )
 
+    def test_return_ids_respects_limit(self) -> None:
+        replay1_id = uuid.uuid4().hex
+        replay2_id = uuid.uuid4().hex
+        for replay_id in (replay1_id, replay2_id):
+            self.store_replays(
+                mock_replay(
+                    datetime.datetime.now() - datetime.timedelta(seconds=22),
+                    self.project.id,
+                    replay_id,
+                )
+            )
+        event = self.store_event(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "timestamp": self.min_ago.isoformat(),
+                "contexts": {"replay": {"replay_id": replay1_id}},
+                "fingerprint": ["group-limit"],
+            },
+            project_id=self.project.id,
+        )
+        self.store_event(
+            data={
+                "event_id": uuid.uuid4().hex,
+                "timestamp": self.min_ago.isoformat(),
+                "contexts": {"replay": {"replay_id": replay2_id}},
+                "fingerprint": ["group-limit"],
+            },
+            project_id=self.project.id,
+        )
+        assert event.group is not None
+
+        query: dict[str, Any] = {
+            "query": f"issue.id:[{event.group.id}]",
+            "returnIds": True,
+        }
+        with self.feature(self.features):
+            unlimited = self.client.get(self.url, query, format="json")
+            limited = self.client.get(self.url, {**query, "limit": 1}, format="json")
+
+        assert unlimited.status_code == 200, unlimited.content
+        assert len(unlimited.data[event.group.id]) == 2
+        assert limited.status_code == 200, limited.content
+        assert len(limited.data[event.group.id]) == 1
+
+    def test_limit_is_rejected_outside_its_range(self) -> None:
+        query: dict[str, Any] = {"query": "issue.id:[1]", "returnIds": True}
+        with self.feature(self.features):
+            assert self.client.get(self.url, {**query, "limit": 0}).status_code == 400
+            assert self.client.get(self.url, {**query, "limit": 52}).status_code == 400
+
     def test_simple_performance(self) -> None:
         replay1_id = uuid.uuid4().hex
         replay2_id = uuid.uuid4().hex


### PR DESCRIPTION
returnIds returns up to MAX_REPLAY_COUNT (51) ids per identifier, which is right for the issue Replays tab since it lists them, but more than a caller that only shows a few needs. The MCP was one such caller and capped on its own side; an optional limit lets any client ask for fewer instead.

Optional and capped at MAX_REPLAY_COUNT, so the default response is unchanged and no existing caller is affected.

