### PR TITLE
ref(seer): Tag ViewerContext resolution by endpoint

### DIFF
--- a/src/sentry/seer/signed_seer_api.py
+++ b/src/sentry/seer/signed_seer_api.py
@@ -55,6 +55,7 @@ seer_grouping_default_connection_pool = connection_from_url(
 
 def _resolve_viewer_context(
     explicit: SeerViewerContext | None = None,
+    endpoint: str | None = None,
 ) -> ViewerContext | None:
     """Merge explicit SeerViewerContext with the contextvar.
 
@@ -80,11 +81,12 @@ def _resolve_viewer_context(
             extra={
                 "explicit_org_id": explicit_vc.organization_id,
                 "explicit_user_id": explicit_vc.user_id,
+                "endpoint": endpoint,
             },
         )
         metrics.incr(
             "seer.viewer_context_resolution",
-            tags={"outcome": "contextvar_missing"},
+            tags={"outcome": "contextvar_missing", "endpoint": endpoint or "unknown"},
         )
         return explicit_vc
 
@@ -100,6 +102,7 @@ def _resolve_viewer_context(
                     "field": "organization_id",
                     "contextvar": org_id,
                     "explicit": explicit_vc.organization_id,
+                    "endpoint": endpoint,
                 },
             )
             has_mismatch = True
@@ -113,6 +116,7 @@ def _resolve_viewer_context(
                     "field": "user_id",
                     "contextvar": user_id,
                     "explicit": explicit_vc.user_id,
+                    "endpoint": endpoint,
                 },
             )
             has_mismatch = True
@@ -123,6 +127,7 @@ def _resolve_viewer_context(
         tags={
             "outcome": "mismatch" if has_mismatch else "match",
             "has_project": str(vc.project_id is not None).lower(),
+            "endpoint": endpoint or "unknown",
         },
     )
 
@@ -160,7 +165,7 @@ def make_signed_seer_api_request(
         **auth_headers,
     }
 
-    resolved = _resolve_viewer_context(viewer_context)
+    resolved = _resolve_viewer_context(viewer_context, endpoint=parsed.path)
     observe_viewer_context_propagation("seer_rpc_out", ctx=resolved)
     if resolved:
         try:

--- a/tests/sentry/seer/test_signed_seer_api.py
+++ b/tests/sentry/seer/test_signed_seer_api.py
@@ -13,6 +13,7 @@ from sentry.viewer_context import ActorType, ViewerContext, viewer_context_scope
 
 REQUEST_BODY = b'{"b": 12, "thing": "thing"}'
 PATH = "/v0/some/url"
+DYNAMIC_PATH = "/v0/issues/similar-issues/grouping-record/delete/123456"
 
 
 def run_test_case(
@@ -111,18 +112,32 @@ def test_missing_secret_emits_unsigned_request_metric(mock_metrics: MagicMock) -
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize("path", [PATH, f"{PATH}?dogs=great"])
+@pytest.mark.parametrize(
+    ("path", "endpoint"),
+    [
+        (PATH, PATH),
+        (f"{PATH}?dogs=great", PATH),
+        (DYNAMIC_PATH, DYNAMIC_PATH),
+    ],
+)
 @patch("sentry.seer.signed_seer_api.metrics.timer")
-def test_times_request(mock_metrics_timer: MagicMock, path: str) -> None:
+def test_times_request(mock_metrics_timer: MagicMock, path: str, endpoint: str) -> None:
     run_test_case(path=path)
     mock_metrics_timer.assert_called_with(
         "seer.request_to_seer",
         sample_rate=1.0,
-        tags={
-            # In both cases the path is the same, because query params are stripped
-            "endpoint": PATH,
-        },
+        tags={"endpoint": endpoint},
     )
+
+
+@pytest.mark.django_db
+@patch("sentry.seer.signed_seer_api._resolve_viewer_context")
+def test_resolves_viewer_context_with_endpoint(mock_resolve: MagicMock) -> None:
+    mock_resolve.return_value = None
+
+    run_test_case(path=f"{DYNAMIC_PATH}?plan_tier=business")
+
+    mock_resolve.assert_called_once_with(None, endpoint=DYNAMIC_PATH)
 
 
 class TestResolveViewerContext:
@@ -144,7 +159,9 @@ class TestResolveViewerContext:
     def test_explicit_only_warns_contextvar_missing(
         self, mock_logger: MagicMock, mock_metrics: MagicMock
     ) -> None:
-        result = _resolve_viewer_context(SeerViewerContext(organization_id=99, user_id=5))
+        result = _resolve_viewer_context(
+            SeerViewerContext(organization_id=99, user_id=5), endpoint="/v1/automation/summarize"
+        )
         assert result is not None
         assert result.organization_id == 99
         assert result.user_id == 5
@@ -154,11 +171,25 @@ class TestResolveViewerContext:
             extra={
                 "explicit_org_id": 99,
                 "explicit_user_id": 5,
+                "endpoint": "/v1/automation/summarize",
             },
         )
         mock_metrics.incr.assert_called_once_with(
             "seer.viewer_context_resolution",
-            tags={"outcome": "contextvar_missing"},
+            tags={"outcome": "contextvar_missing", "endpoint": "/v1/automation/summarize"},
+        )
+
+    @patch("sentry.seer.signed_seer_api.metrics")
+    @patch("sentry.seer.signed_seer_api.logger")
+    def test_explicit_only_without_endpoint(
+        self, mock_logger: MagicMock, mock_metrics: MagicMock
+    ) -> None:
+        _resolve_viewer_context(SeerViewerContext(organization_id=99))
+
+        assert mock_logger.warning.call_args[1]["extra"]["endpoint"] is None
+        mock_metrics.incr.assert_called_once_with(
+            "seer.viewer_context_resolution",
+            tags={"outcome": "contextvar_missing", "endpoint": "unknown"},
         )
 
     def test_contextvar_with_token(self) -> None:
@@ -198,16 +229,23 @@ class TestResolveViewerContext:
         )
         ctx = ViewerContext(organization_id=42, user_id=7, actor_type=ActorType.USER, token=token)
         with viewer_context_scope(ctx):
-            result = _resolve_viewer_context(SeerViewerContext(organization_id=999))
+            result = _resolve_viewer_context(
+                SeerViewerContext(organization_id=999), endpoint="/v1/automation/summarize"
+            )
 
         assert result is not None
         assert result.organization_id == 999
         assert result.token is None
         mock_logger.warning.assert_called_once()
         assert mock_logger.warning.call_args[0][0] == "seer.viewer_context_mismatch"
+        assert mock_logger.warning.call_args[1]["extra"]["endpoint"] == "/v1/automation/summarize"
         mock_metrics.incr.assert_called_once_with(
             "seer.viewer_context_resolution",
-            tags={"outcome": "mismatch", "has_project": "false"},
+            tags={
+                "outcome": "mismatch",
+                "has_project": "false",
+                "endpoint": "/v1/automation/summarize",
+            },
         )
 
     @patch("sentry.seer.signed_seer_api.metrics")
@@ -222,7 +260,7 @@ class TestResolveViewerContext:
         assert result.project_id == 100
         mock_metrics.incr.assert_called_once_with(
             "seer.viewer_context_resolution",
-            tags={"outcome": "match", "has_project": "true"},
+            tags={"outcome": "match", "has_project": "true", "endpoint": "unknown"},
         )
 
     @patch("sentry.seer.signed_seer_api.metrics")
@@ -235,7 +273,7 @@ class TestResolveViewerContext:
         assert result.project_id is None
         mock_metrics.incr.assert_called_once_with(
             "seer.viewer_context_resolution",
-            tags={"outcome": "match", "has_project": "false"},
+            tags={"outcome": "match", "has_project": "false", "endpoint": "unknown"},
         )
 
     def test_no_mismatch_keeps_token(self) -> None:


### PR DESCRIPTION
ViewerContext resolution diagnostics now include the Seer request path in both
warning logs and `seer.viewer_context_resolution` metrics. This makes remaining
legacy explicit-only and mismatch callers identifiable by endpoint before
`SeerViewerContext` is removed.

The tag uses the parsed request path directly, excluding query parameters while
preserving path segments. Calls to `_resolve_viewer_context` outside the request
chokepoint retain an `unknown` metric value for compatibility.

Part of [AIML-3206](https://linear.app/getsentry/issue/AIML-3206).
