### PR TITLE
feat(api): Mark experimental public endpoints as PUBLIC_EXPERIMENTAL

### DIFF
--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversation_details.py
@@ -134,7 +134,7 @@ class AIConversationDetailsResponse(TypedDict):
 @extend_schema(tags=["Explore"])
 @cell_silo_endpoint
 class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
-    publish_status = {"GET": ApiPublishStatus.PUBLIC}
+    publish_status = {"GET": ApiPublishStatus.PUBLIC_EXPERIMENTAL}
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
     @extend_schema(
@@ -166,8 +166,6 @@ class OrganizationAIConversationDetailsEndpoint(OrganizationEventsEndpointBase):
         self, request: Request, organization: Organization, conversation_id: str
     ) -> Response[AIConversationDetailsResponse] | Response[DetailResponse] | Response[None]:
         """Return spans recorded for one AI conversation in start-time order.
-
-        **Experimental:** This API is under active development and may change.
 
         Message, tool, and response attributes contain their recorded string values.
         Without an explicit range, Sentry widens the search across available retention.

--- a/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
+++ b/src/sentry/ai_monitoring/endpoints/organization_ai_conversations.py
@@ -206,7 +206,7 @@ def _build_conversation_response(
 @cell_silo_endpoint
 class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
     publish_status = {
-        "GET": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC_EXPERIMENTAL,
     }
     owner = ApiOwner.TELEMETRY_EXPERIENCE
 
@@ -241,8 +241,6 @@ class OrganizationAIConversationsEndpoint(OrganizationEventsEndpointBase):
         Response[list[AIConversationResponse]] | Response[ValidationErrorResponse] | Response[None]
     ):
         """Return AI conversations ordered by latest span time.
-
-        **Experimental:** This API is under active development and may change.
 
         `query` uses Sentry search syntax against spans. A conversation matches when
         any span matches. Summary values then include all conversation spans inside

--- a/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
+++ b/src/sentry/api/endpoints/release_thresholds/release_threshold_status_index.py
@@ -115,7 +115,7 @@ class ReleaseThresholdStatusIndexSerializer(
 class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
     owner: ApiOwner = ApiOwner.REPLAY
     publish_status = {
-        "GET": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC_EXPERIMENTAL,
     }
 
     @extend_schema(
@@ -135,8 +135,6 @@ class ReleaseThresholdStatusIndexEndpoint(OrganizationReleasesBaseEndpoint):
         self, request: Request, organization: Organization | RpcOrganization
     ) -> Response[dict[str, list[EnrichedThreshold]]] | Response[ValidationErrorResponse]:
         r"""
-        **`[WARNING]`**: This API is an experimental Alpha feature and is subject to change!
-
         List all derived statuses of releases that fall within the provided start/end datetimes.
 
         Constructs a response key'd off \{`release_version`\}-\{`project_slug`\} that lists thresholds with their status for *specified* projects.

--- a/src/sentry/seer/endpoints/group_ai_autofix.py
+++ b/src/sentry/seer/endpoints/group_ai_autofix.py
@@ -200,7 +200,7 @@ class ExplorerAutofixRequestSerializer(CamelSnakeSerializer):
 class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin, GroupAiEndpoint):
     publish_status = {
         "POST": ApiPublishStatus.PUBLIC,
-        "GET": ApiPublishStatus.PUBLIC,
+        "GET": ApiPublishStatus.PUBLIC_EXPERIMENTAL,
     }
     formatter_adapter = staticmethod(format_autofix)
     owner = ApiOwner.ML_AI
@@ -551,8 +551,6 @@ class GroupAutofixEndpoint(ConditionalGetResponseMixin, FormattableResponseMixin
         - Root Cause Analysis
         - Proposed Solution
         - Generated code changes
-
-        This endpoint although documented is still experimental and the payload may change in the future.
         """
         try:
             state = get_autofix_agent_state(group.organization, group.id)


### PR DESCRIPTION
Four `PUBLIC` endpoints (the two AI conversation endpoints, the autofix state `GET`, and release threshold statuses) already warned in their docstrings that they may change. This moves them to `PUBLIC_EXPERIMENTAL` and removes the hand-written warnings, since the docs hook added in #123914 now prepends a single notice.