### PR TITLE
fix(ctrl): Adds additional failure metric for connection resets, minor cleanup from #123660

### DIFF
--- a/src/sentry/integrations/api/endpoints/integration_proxy.py
+++ b/src/sentry/integrations/api/endpoints/integration_proxy.py
@@ -69,8 +69,8 @@ class IntegrationProxyFailureMetricType(StrEnum):
     INVALID_INTEGRATION = "invalid_integration"
     INVALID_CLIENT = "invalid_client"
     INVALID_MODE = "invalid_mode"
-    INVALID_SENDER = "invalid_sender"
     INVALID_IDENTITY = "invalid_identity"
+    STREAM_INTERRUPTED = "stream_interrupted"
     HOST_UNREACHABLE_ERROR = "host_unreachable_error"
     HOST_TIMEOUT_ERROR = "host_timeout_error"
     UNAUTHORIZED_ERROR = "unauthorized_error"
@@ -360,16 +360,11 @@ class InternalIntegrationProxyEndpoint(Endpoint):
     def _add_failure_metric(
         self,
         failure_type: IntegrationProxyFailureMetricType,
-        additional_tags: dict[str, str] | None = None,
     ) -> None:
-        if additional_tags is None:
-            additional_tags = {}
-        tags = {"failure_type": failure_type.value, **additional_tags}
-
         self._add_metric(
             metric_name="proxy_failure",
             sample_rate=1.0,
-            tags=tags,
+            tags={"failure_type": failure_type.value},
         )
 
     @trace
@@ -400,10 +395,18 @@ class InternalIntegrationProxyEndpoint(Endpoint):
                 try:
                     yield from r.iter_content(16 * 1024)
                 except (RequestException, ConnectionError, OSError) as e:
+                    # Django consumes this generator after the view has returned, so
+                    # handle_exception_with_details never sees these. Count them here or the
+                    # truncated response is invisible in proxy_failure.
                     logger.warning(
                         "integrations.proxy.stream_interrupted",
-                        extra={"error": str(e), "url": full_url},
+                        extra={
+                            "error": str(e),
+                            "url": full_url,
+                            "exception_class": type(e).__name__,
+                        },
                     )
+                    self._add_failure_metric(IntegrationProxyFailureMetricType.STREAM_INTERRUPTED)
                     return
 
         return StreamingHttpResponse(

--- a/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
+++ b/tests/sentry/integrations/api/endpoints/test_integration_proxy.py
@@ -161,8 +161,8 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         metric_name = "hybrid_cloud.integration_proxy.proxy_failure"
         expected_tags = {"failure_type": failure_type, **(tags or {})}
 
-        # Filter on the failure_type tag, since a single validation pass can emit more than
-        # one proxy_failure metric (a specific reason plus the wrapping category).
+        # A request emits at most one proxy_failure; the tag filter identifies which failure
+        # fired rather than disambiguating multiple emissions for the same request.
         matching_mock_calls = [
             call
             for call in mock_metrics.call_args_list
@@ -233,6 +233,13 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
             count=1,
             mock_metrics=mock_metrics,
             kwargs_to_match={"sample_rate": 1.0, "tags": {"status": 400}},
+        )
+        # A fully proxied response is never counted as a failure, regardless of the
+        # upstream status code.
+        self.assert_metric_count(
+            metric_name="proxy_failure",
+            count=0,
+            mock_metrics=mock_metrics,
         )
 
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
@@ -925,6 +932,12 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
         assert proxy_response.status_code == 200
         assert b"".join(proxy_response.streaming_content) == first_chunk
 
+        self.assert_failure_metric_count(
+            failure_type=IntegrationProxyFailureMetricType.STREAM_INTERRUPTED,
+            count=1,
+            mock_metrics=mock_metrics,
+        )
+
     @override_settings(SENTRY_SUBNET_SECRET=SENTRY_SUBNET_SECRET, SILO_MODE=SiloMode.CONTROL)
     @patch.object(ExampleIntegration, "get_client")
     @patch.object(InternalIntegrationProxyEndpoint, "client", spec=IntegrationProxyClient)
@@ -960,6 +973,12 @@ class InternalIntegrationProxyEndpointTest(APITestCase):
 
         assert proxy_response.status_code == 200
         assert b"".join(proxy_response.streaming_content) == b""
+
+        self.assert_failure_metric_count(
+            failure_type=IntegrationProxyFailureMetricType.STREAM_INTERRUPTED,
+            count=1,
+            mock_metrics=mock_metrics,
+        )
 
 
 @control_silo_test


### PR DESCRIPTION
Adds failure metrics for connection resets, request exceptions

Also cleans up a couple of minor issues from #123660:
1. Unused invalid sender enum, which was split into 2 separate failure types
2. Unused `additional_tags` parameter for metrics gathering, which would likely increase metric cardinality if used.

Resolves CTRL-26