### PR TITLE
feat(hybridcloud): Record replication outcomes at the outbox receiver

### DIFF
--- a/src/sentry/hybridcloud/outbox/category.py
+++ b/src/sentry/hybridcloud/outbox/category.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
-from collections.abc import Collection, Mapping, Sequence
+from collections.abc import Callable, Collection, Mapping, Sequence
 from enum import IntEnum
 from typing import TYPE_CHECKING, Any, cast
 
 from sentry.hybridcloud.outbox.signals import process_cell_outbox, process_control_outbox
+from sentry.silo.base import SiloMode
+from sentry.utils import metrics
 
 if TYPE_CHECKING:
     from sentry.db.models import BaseModel
@@ -13,6 +15,28 @@ if TYPE_CHECKING:
 
 _outbox_categories_for_scope: dict[int, set[OutboxCategory]] = {}
 _used_categories: set[OutboxCategory] = set()
+
+
+def _run_replication_handler(
+    category: OutboxCategory, direction: str, action: str, handler: Callable[[], None]
+) -> None:
+    tags = {
+        "silo": SiloMode.get_current_mode().value.lower(),
+        "category": category.name,
+        "direction": direction,
+        "action": action,
+    }
+    try:
+        with metrics.timer("hybridcloud.replication.handler.duration", tags=tags, sample_rate=1.0):
+            handler()
+    except Exception:
+        metrics.incr(
+            "hybridcloud.replication.processed", tags={**tags, "outcome": "error"}, sample_rate=1.0
+        )
+        raise
+    metrics.incr(
+        "hybridcloud.replication.processed", tags={**tags, "outcome": "success"}, sample_rate=1.0
+    )
 
 
 class OutboxCategory(IntEnum):
@@ -89,11 +113,24 @@ class OutboxCategory(IntEnum):
                 cast(Any, model), object_identifier, cell_name=None
             )
             if maybe_instance is None:
-                model.handle_async_deletion(
-                    identifier=object_identifier, shard_identifier=shard_identifier, payload=payload
+                _run_replication_handler(
+                    self,
+                    "cell_to_control",
+                    "delete",
+                    lambda: model.handle_async_deletion(
+                        identifier=object_identifier,
+                        shard_identifier=shard_identifier,
+                        payload=payload,
+                    ),
                 )
             else:
-                maybe_instance.handle_async_replication(shard_identifier=shard_identifier)
+                instance = maybe_instance
+                _run_replication_handler(
+                    self,
+                    "cell_to_control",
+                    "replicate",
+                    lambda: instance.handle_async_replication(shard_identifier=shard_identifier),
+                )
 
         process_cell_outbox.connect(receiver, weak=False, sender=self)
 
@@ -112,15 +149,26 @@ class OutboxCategory(IntEnum):
                 cast(Any, model), object_identifier, cell_name=cell_name
             )
             if maybe_instance is None:
-                model.handle_async_deletion(
-                    identifier=object_identifier,
-                    cell_name=cell_name,
-                    shard_identifier=shard_identifier,
-                    payload=payload,
+                _run_replication_handler(
+                    self,
+                    "control_to_cell",
+                    "delete",
+                    lambda: model.handle_async_deletion(
+                        identifier=object_identifier,
+                        cell_name=cell_name,
+                        shard_identifier=shard_identifier,
+                        payload=payload,
+                    ),
                 )
             else:
-                maybe_instance.handle_async_replication(
-                    shard_identifier=shard_identifier, cell_name=cell_name
+                instance = maybe_instance
+                _run_replication_handler(
+                    self,
+                    "control_to_cell",
+                    "replicate",
+                    lambda: instance.handle_async_replication(
+                        shard_identifier=shard_identifier, cell_name=cell_name
+                    ),
                 )
 
         process_control_outbox.connect(receiver, weak=False, sender=self)

--- a/tests/sentry/hybridcloud/outbox/test_category.py
+++ b/tests/sentry/hybridcloud/outbox/test_category.py
@@ -1,0 +1,113 @@
+from unittest.mock import Mock, call, patch
+
+import pytest
+
+from sentry.hybridcloud.outbox.category import OutboxCategory, _run_replication_handler
+from sentry.models.authprovider import AuthProvider
+from sentry.silo.base import SiloMode
+from sentry.testutils.factories import Factories
+from sentry.testutils.outbox import outbox_runner
+from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.testutils.silo import all_silo_test, assume_test_silo_mode, create_test_cells
+
+
+@django_db_all(transaction=True)
+@all_silo_test(cells=create_test_cells("us"))
+@patch("sentry.hybridcloud.outbox.category.metrics")
+def test_control_model_replication_records_success(mock_metrics: Mock) -> None:
+    user = Factories.create_user()
+    org = Factories.create_organization(owner=user)
+    mock_metrics.reset_mock()
+
+    with assume_test_silo_mode(SiloMode.CONTROL), outbox_runner():
+        # all_silo_test also runs under MONOLITH, where assume_test_silo_mode is a no-op.
+        expected_silo = SiloMode.get_current_mode().value.lower()
+        AuthProvider.objects.create(organization_id=org.id, provider="abc", config={"a": 1})
+
+    assert mock_metrics.incr.mock_calls == [
+        call(
+            "hybridcloud.replication.processed",
+            tags={
+                "silo": expected_silo,
+                "category": "AUTH_PROVIDER_UPDATE",
+                "direction": "control_to_cell",
+                "action": "replicate",
+                "outcome": "success",
+            },
+            sample_rate=1.0,
+        )
+    ]
+
+
+@patch("sentry.hybridcloud.outbox.category.metrics")
+def test_run_replication_handler_records_error_and_reraises(mock_metrics: Mock) -> None:
+    def failing_handler() -> None:
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _run_replication_handler(
+            OutboxCategory.TEAM_UPDATE, "cell_to_control", "delete", failing_handler
+        )
+
+    assert mock_metrics.incr.mock_calls == [
+        call(
+            "hybridcloud.replication.processed",
+            tags={
+                "silo": SiloMode.get_current_mode().value.lower(),
+                "category": "TEAM_UPDATE",
+                "direction": "cell_to_control",
+                "action": "delete",
+                "outcome": "error",
+            },
+            sample_rate=1.0,
+        )
+    ]
+
+
+@patch("sentry.hybridcloud.outbox.category.metrics")
+def test_run_replication_handler_times_the_handler(mock_metrics: Mock) -> None:
+    _run_replication_handler(
+        OutboxCategory.USER_UPDATE, "control_to_cell", "replicate", lambda: None
+    )
+
+    assert mock_metrics.timer.mock_calls[0] == call(
+        "hybridcloud.replication.handler.duration",
+        tags={
+            "silo": SiloMode.get_current_mode().value.lower(),
+            "category": "USER_UPDATE",
+            "direction": "control_to_cell",
+            "action": "replicate",
+        },
+        sample_rate=1.0,
+    )
+
+
+@django_db_all(transaction=True)
+@all_silo_test(cells=create_test_cells("us"))
+@patch("sentry.hybridcloud.outbox.category.metrics")
+def test_control_model_deletion_records_delete_action(mock_metrics: Mock) -> None:
+    user = Factories.create_user()
+    org = Factories.create_organization(owner=user)
+    with assume_test_silo_mode(SiloMode.CONTROL), outbox_runner():
+        auth_provider = AuthProvider.objects.create(
+            organization_id=org.id, provider="abc", config={"a": 1}
+        )
+    mock_metrics.reset_mock()
+
+    with assume_test_silo_mode(SiloMode.CONTROL), outbox_runner():
+        expected_silo = SiloMode.get_current_mode().value.lower()
+        auth_provider.delete()
+
+    assert mock_metrics.incr.mock_calls == [
+        call(
+            "hybridcloud.replication.processed",
+            tags={
+                "silo": expected_silo,
+                "category": "AUTH_PROVIDER_UPDATE",
+                "direction": "control_to_cell",
+                "action": "delete",
+                "outcome": "success",
+            },
+            sample_rate=1.0,
+        )
+    ]


### PR DESCRIPTION
## What

Makes the replicated model's outbox handler emit metrics, via a small wrapper in the two receivers built by `OutboxCategory.connect_*_model_updates`:

- `hybridcloud.replication.processed`: counter tagged silo, category, direction, action, result (success / failure)
- `hybridcloud.replication.handler.duration`: timer, same tags

Retry behaviour is unchanged.

## Why

Part of CTRL-48 / CTRL-4. Right now we don't have metrics to monitor whether a replication succeeded. Since all replicated categories pass through this funnel, this adds a counter and makes availability SLI a ratio.