### PR TITLE
test(api): Validate mock responses against backend contracts

### DIFF
--- a/static/app/__mocks__/api.tsx
+++ b/static/app/__mocks__/api.tsx
@@ -2,6 +2,12 @@ import isEqual from 'lodash/isEqual';
 
 import type * as ApiNamespace from 'sentry/api';
 import type {ResponseMeta} from 'sentry/types/api';
+import type {ApiMapping} from 'sentry/utils/api/apiContracts.generated';
+import {
+  getApiUrl,
+  type ExtractPathParams,
+  type OptionalPathParams,
+} from 'sentry/utils/api/getApiUrl';
 import {RequestError} from 'sentry/utils/requestError/requestError';
 
 const RealApi = jest.requireActual<typeof ApiNamespace>('sentry/api');
@@ -59,6 +65,24 @@ interface ResponseType extends ResponseMeta {
 }
 
 type MockResponse = [resp: ResponseType, mock: jest.Mock];
+
+type ContractMockResponse<TPath extends keyof ApiMapping> = Omit<
+  Partial<ResponseType>,
+  'body' | 'method' | 'status' | 'statusCode' | 'url'
+> & {
+  // ApiMapping describes successful JSON responses, not error or empty responses.
+  status?: 200 | 201 | 202 | 208;
+  statusCode?: 200 | 201 | 202 | 208;
+} & (ExtractPathParams<TPath> extends never
+    ? {path?: never}
+    : {path: Record<ExtractPathParams<TPath>, string | number>}) &
+  {
+    [TMethod in keyof ApiMapping[TPath] & string]: {
+      body: ApiMapping[TPath][TMethod] extends {response: infer TResponse}
+        ? TResponse
+        : never;
+    } & (TMethod extends 'GET' ? {method?: TMethod} : {method: TMethod});
+  }[keyof ApiMapping[TPath] & string];
 
 /**
  * Compare two records. `want` is all the entries we want to have the same value in `check`
@@ -136,6 +160,20 @@ class Client implements ApiNamespace.Client {
     };
 
     return dataMatcher;
+  }
+
+  /**
+   * Mock a successful JSON response using the backend's route and method contract.
+   * Defaults to GET. Path parameters are encoded just like getApiUrl.
+   * Use addMockResponse for errors, empty responses, or undocumented endpoints.
+   */
+  static addContractResponse<TPath extends keyof ApiMapping>(
+    route: TPath,
+    response: ContractMockResponse<NoInfer<TPath>>
+  ) {
+    const {path, ...options} = response;
+    const url = getApiUrl(route, ...([{path}] as OptionalPathParams<TPath>));
+    return Client.addMockResponse({...options, url, method: options.method ?? 'GET'});
   }
 
   // Returns a jest mock that represents Client.request calls

--- a/static/app/api.spec.tsx
+++ b/static/app/api.spec.tsx
@@ -20,6 +20,104 @@ describe('api', () => {
     fetchMock.resetMocks();
   });
 
+  describe('addContractResponse', () => {
+    const route = '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/';
+    const path = {organizationIdOrSlug: 'org-slug', projectIdOrSlug: 'project-slug'};
+
+    it('registers a GET response with encoded parameters, matchers, and headers', async () => {
+      const body = [{id: '1', name: 'production', isHidden: false}];
+      const mock = MockApiClient.addContractResponse(route, {
+        path: {...path, projectIdOrSlug: 'project/slash'},
+        method: undefined,
+        body,
+        headers: {Link: 'next-page'},
+        match: [MockApiClient.matchQuery({visibility: 'visible'})],
+      });
+      const url = '/projects/org-slug/project%2Fslash/environments/';
+
+      const [json, , response] = await api.requestPromise(url, {
+        query: {visibility: 'visible'},
+        includeAllArgs: true,
+      });
+
+      expect(json).toEqual(body);
+      expect(response?.getResponseHeader('Link')).toBe('next-page');
+      expect(mock).toHaveBeenCalledWith(
+        url,
+        expect.objectContaining({query: {visibility: 'visible'}})
+      );
+    });
+
+    it('registers a response for an explicit PUT method', async () => {
+      const body = [{id: '1', name: 'production', isHidden: true}];
+      const mock = MockApiClient.addContractResponse(route, {path, method: 'PUT', body});
+
+      await expect(
+        api.requestPromise('/projects/org-slug/project-slug/environments/', {
+          method: 'PUT',
+        })
+      ).resolves.toEqual(body);
+      expect(mock).toHaveBeenCalledTimes(1);
+    });
+
+    it('supports routes without path parameters', async () => {
+      MockApiClient.addContractResponse('/organizations/', {body: []});
+
+      await expect(api.requestPromise('/organizations/')).resolves.toEqual([]);
+    });
+
+    it('requires the GET response shape when the method is omitted', () => {
+      MockApiClient.addContractResponse(route, {
+        path,
+        // @ts-expect-error GET requires every environment to have an id.
+        body: [{name: 'production', isHidden: false}],
+      });
+      // @ts-expect-error A successful response body is required.
+      MockApiClient.addContractResponse(route, {path});
+    });
+
+    it('checks fixture values and rejects undeclared fields on inline responses', () => {
+      const invalidFixture = {id: 1, name: 'production', isHidden: false};
+      MockApiClient.addContractResponse(route, {
+        path,
+        // @ts-expect-error Environment IDs on the wire are strings.
+        body: [invalidFixture],
+      });
+      MockApiClient.addContractResponse(route, {
+        path,
+        // @ts-expect-error displayName is not part of the backend response.
+        body: [{id: '1', name: 'production', isHidden: false, displayName: 'Production'}],
+      });
+    });
+
+    it('requires a contract for the route and method', () => {
+      // @ts-expect-error This route does not have a response contract.
+      MockApiClient.addContractResponse('/api-tokens/', {body: []});
+      MockApiClient.addContractResponse(route, {
+        path,
+        // @ts-expect-error The route only has GET and PUT response contracts.
+        method: 'POST',
+        body: [],
+      });
+      MockApiClient.addContractResponse(
+        '/projects/$organizationIdOrSlug/$projectIdOrSlug/custom-inbound-filters/',
+        // @ts-expect-error GET returns a list, but POST returns a single filter.
+        {path, method: 'POST', body: []}
+      );
+    });
+
+    it('requires path parameters and rejects error status codes', () => {
+      // @ts-expect-error Both organization and project path parameters are required.
+      MockApiClient.addContractResponse(route, {body: []});
+      MockApiClient.addContractResponse(route, {
+        path,
+        body: [],
+        // @ts-expect-error Error responses must use addMockResponse.
+        statusCode: 500,
+      });
+    });
+  });
+
   describe('Client', () => {
     describe('cancel()', () => {
       it('should abort any open XHR requests', () => {

--- a/static/app/views/settings/project/projectEnvironments.spec.tsx
+++ b/static/app/views/settings/project/projectEnvironments.spec.tsx
@@ -62,10 +62,13 @@ describe('ProjectEnvironments', () => {
     ['active', false, "You don't have any environments yet."],
     ['hidden', true, "You don't have any hidden environments."],
   ])('renders the %s empty state', async (_label, isHidden, message) => {
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/environments/',
-      body: [],
-    });
+    MockApiClient.addContractResponse(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/',
+      {
+        path: {organizationIdOrSlug: 'org-slug', projectIdOrSlug: 'project-slug'},
+        body: [],
+      }
+    );
 
     renderComponent(isHidden);
 
@@ -73,10 +76,13 @@ describe('ProjectEnvironments', () => {
   });
 
   it('renders active environments', async () => {
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/environments/',
-      body: EnvironmentsFixture(),
-    });
+    MockApiClient.addContractResponse(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/',
+      {
+        path: {organizationIdOrSlug: 'org-slug', projectIdOrSlug: 'project-slug'},
+        body: EnvironmentsFixture().map(({id, name}) => ({id, name, isHidden: false})),
+      }
+    );
 
     renderComponent(false);
 
@@ -86,10 +92,13 @@ describe('ProjectEnvironments', () => {
   });
 
   it('shows event counts per environment', async () => {
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/environments/',
-      body: EnvironmentsFixture(),
-    });
+    MockApiClient.addContractResponse(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/',
+      {
+        path: {organizationIdOrSlug: 'org-slug', projectIdOrSlug: 'project-slug'},
+        body: EnvironmentsFixture().map(({id, name}) => ({id, name, isHidden: false})),
+      }
+    );
     MockApiClient.addMockResponse({
       url: '/projects/org-slug/project-slug/tags/environment/values/',
       body: [
@@ -107,10 +116,13 @@ describe('ProjectEnvironments', () => {
   });
 
   it('filters environments and persists the search query', async () => {
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/environments/',
-      body: EnvironmentsFixture(),
-    });
+    MockApiClient.addContractResponse(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/',
+      {
+        path: {organizationIdOrSlug: 'org-slug', projectIdOrSlug: 'project-slug'},
+        body: EnvironmentsFixture().map(({id, name}) => ({id, name, isHidden: false})),
+      }
+    );
 
     const {router} = renderComponent(false);
 
@@ -136,14 +148,25 @@ describe('ProjectEnvironments', () => {
     ['%app_env%', '%2525app_env%2525'],
     ['us%2Feast', 'us%25252Feast'],
   ])('double-encodes environment path params for %s', async (name, encodedName) => {
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/environments/',
-      body: [{id: '1', name}],
-    });
-    const hideMock = MockApiClient.addMockResponse({
-      url: `/projects/org-slug/project-slug/environments/${encodedName}/`,
-      method: 'PUT',
-    });
+    MockApiClient.addContractResponse(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/',
+      {
+        path: {organizationIdOrSlug: 'org-slug', projectIdOrSlug: 'project-slug'},
+        body: [{id: '1', name, isHidden: false}],
+      }
+    );
+    const hideMock = MockApiClient.addContractResponse(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/$environment/',
+      {
+        path: {
+          organizationIdOrSlug: 'org-slug',
+          projectIdOrSlug: 'project-slug',
+          environment: encodeURIComponent(name),
+        },
+        method: 'PUT',
+        body: {id: '1', name, isHidden: true},
+      }
+    );
 
     renderComponent(false);
 
@@ -158,14 +181,29 @@ describe('ProjectEnvironments', () => {
   });
 
   it('renders hidden environments and unhides them', async () => {
-    MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/environments/',
-      body: HiddenEnvironmentsFixture(),
-    });
-    const showMock = MockApiClient.addMockResponse({
-      url: '/projects/org-slug/project-slug/environments/zzz/',
-      method: 'PUT',
-    });
+    MockApiClient.addContractResponse(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/',
+      {
+        path: {organizationIdOrSlug: 'org-slug', projectIdOrSlug: 'project-slug'},
+        body: HiddenEnvironmentsFixture().map(({id, name}) => ({
+          id,
+          name,
+          isHidden: true,
+        })),
+      }
+    );
+    const showMock = MockApiClient.addContractResponse(
+      '/projects/$organizationIdOrSlug/$projectIdOrSlug/environments/$environment/',
+      {
+        path: {
+          organizationIdOrSlug: 'org-slug',
+          projectIdOrSlug: 'project-slug',
+          environment: 'zzz',
+        },
+        method: 'PUT',
+        body: {id: '1', name: 'zzz', isHidden: false},
+      }
+    );
 
     renderComponent(true);
 


### PR DESCRIPTION
Mock API response bodies can now be checked against the generated backend contract with `MockApiClient.addContractResponse(route, options)`. The helper infers the body from the route and HTTP method, requires the route's path parameters, and defaults to GET. It retains the existing request matchers, response headers, timing options, and returned Jest mock.

The pilot migrates the project environment settings tests' list and hide/unhide responses. Typechecking exposed missing `isHidden` fields and empty PUT response bodies; the migrated mocks now supply the backend's response shape. Type assertions cover missing fields, incorrect fixture IDs, unsupported routes/methods, method-specific response shapes, and error status codes. Existing `addMockResponse` remains available for errors, empty responses, and endpoints without contracts.

Stacked on #124179. Enforcement is at TypeScript compile time against the available success-response contracts; it does not add runtime schema validation. Whole-project typechecking, the three focused Jest suites, and pre-commit checks pass locally.
