### PR TITLE
fix(crons): Remap live environments during project transfer

### DIFF
--- a/src/sentry/models/project.py
+++ b/src/sentry/models/project.py
@@ -581,9 +581,16 @@ class Project(Model):
             if monitor.slug in new_monitors:
                 CellScheduledDeletion.schedule(monitor, days=0)
             else:
-                for monitor_env_id, env_id in MonitorEnvironment.objects.filter(
-                    monitor_id=monitor.id, status=MonitorStatus.ACTIVE
-                ).values_list("id", "environment_id"):
+                for monitor_env_id, env_id in (
+                    MonitorEnvironment.objects.filter(monitor_id=monitor.id)
+                    .exclude(
+                        status__in=[
+                            MonitorStatus.PENDING_DELETION,
+                            MonitorStatus.DELETION_IN_PROGRESS,
+                        ]
+                    )
+                    .values_list("id", "environment_id")
+                ):
                     MonitorEnvironment.objects.filter(id=monitor_env_id).update(
                         environment_id=Environment.get_or_create(
                             self, name=environment_names.get(env_id, None)

--- a/tests/sentry/models/test_project.py
+++ b/tests/sentry/models/test_project.py
@@ -26,7 +26,7 @@ from sentry.models.releaseprojectenvironment import ReleaseProjectEnvironment
 from sentry.models.releases.release_project import ReleaseProject
 from sentry.models.repository import Repository
 from sentry.models.rule import Rule
-from sentry.monitors.models import Monitor, MonitorEnvironment, ScheduleType
+from sentry.monitors.models import Monitor, MonitorEnvironment, MonitorStatus, ScheduleType
 from sentry.notifications.models.notificationsettingoption import NotificationSettingOption
 from sentry.notifications.types import NotificationSettingEnum
 from sentry.notifications.utils.participants import get_notification_recipients
@@ -266,6 +266,45 @@ class TestProjectTransfer(TestCase):
         assert existing_monitor.id == monitor_to.id
         assert existing_monitor.organization_id == self.to_org.id
         assert existing_monitor.project_id == monitor_to.project_id
+
+    def assert_transfer_remaps_monitor_environment(self, status: int) -> None:
+        monitor = self.create_monitor(
+            project=self.project,
+            organization=self.from_org,
+            name="test-monitor",
+            slug="test-monitor",
+        )
+        environment = self.create_environment(project=self.project, name="production")
+        monitor_environment = self.create_monitor_environment(
+            monitor=monitor,
+            environment_id=environment.id,
+            status=status,
+        )
+
+        self.project.transfer_to(organization=self.to_org)
+
+        monitor_environment.refresh_from_db()
+        transferred_environment = Environment.objects.get(id=monitor_environment.environment_id)
+        ensured_monitor_environment = MonitorEnvironment.objects.ensure_environment(
+            self.project, monitor, "production"
+        )
+
+        assert transferred_environment.organization_id == self.to_org.id
+        assert transferred_environment.name == "production"
+        assert ensured_monitor_environment.id == monitor_environment.id
+        assert MonitorEnvironment.objects.filter(monitor=monitor).count() == 1
+
+    def test_transfer_to_organization_remaps_active_monitor_environment(self) -> None:
+        self.assert_transfer_remaps_monitor_environment(MonitorStatus.ACTIVE)
+
+    def test_transfer_to_organization_remaps_ok_monitor_environment(self) -> None:
+        self.assert_transfer_remaps_monitor_environment(MonitorStatus.OK)
+
+    def test_transfer_to_organization_remaps_error_monitor_environment(self) -> None:
+        self.assert_transfer_remaps_monitor_environment(MonitorStatus.ERROR)
+
+    def test_transfer_to_organization_remaps_disabled_monitor_environment(self) -> None:
+        self.assert_transfer_remaps_monitor_environment(MonitorStatus.DISABLED)
 
     def test_transfer_to_organization_slug_collision(self) -> None:
         # give the project being transferred a slug that collides with an


### PR DESCRIPTION
Project transfers only remapped Cron monitor environments in the initial `ACTIVE` state. Environments transition to `OK` or `ERROR` after receiving check-ins, so normal environments retained their source-organization environment ID and the next check-in created a duplicate in the destination organization.

Remap every monitor environment that is not pending deletion or being deleted. Regression tests cover `ACTIVE`, `OK`, `ERROR`, and `DISABLED` environments and verify that the next environment lookup reuses the transferred row instead of creating a duplicate.

Refs #123755