### PR TITLE
ref(auth): Always include organization slug in SSO errors

### DIFF
--- a/src/sentry/api/exceptions.py
+++ b/src/sentry/api/exceptions.py
@@ -82,7 +82,6 @@ class SsoRequired(SentryAPIException):
         organization: Organization | RpcOrganization,
         request: HttpRequest,
         after_login_redirect=None,
-        include_organization_slug: bool = False,
     ):
         login_url = reverse("sentry-auth-organization", args=[organization.slug])
         if is_using_customer_domain(request):
@@ -92,10 +91,7 @@ class SsoRequired(SentryAPIException):
             query_params = {REDIRECT_FIELD_NAME: after_login_redirect}
             login_url = construct_link_with_query(path=login_url, query_params=query_params)
 
-        organization_extra = (
-            {"organizationSlug": organization.slug} if include_organization_slug else {}
-        )
-        super().__init__(loginUrl=login_url, **organization_extra)
+        super().__init__(loginUrl=login_url, organizationSlug=organization.slug)
 
 
 class MemberDisabledOverLimit(SentryAPIException):

--- a/src/sentry/api/permissions.py
+++ b/src/sentry/api/permissions.py
@@ -284,7 +284,6 @@ class SentryPermission(ScopedPermission):
                     organization=organization,
                     request=request,
                     after_login_redirect=after_login_redirect,
-                    include_organization_slug=True,
                 )
 
             if self.is_not_2fa_compliant(request, organization):

--- a/tests/sentry/users/api/endpoints/test_auth_index.py
+++ b/tests/sentry/users/api/endpoints/test_auth_index.py
@@ -274,7 +274,10 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
             assert response.data == {
                 "detail": {
                     "code": "sso-required",
-                    "extra": {"loginUrl": f"/auth/login/{self.organization.slug}/"},
+                    "extra": {
+                        "loginUrl": f"/auth/login/{self.organization.slug}/",
+                        "organizationSlug": self.organization.slug,
+                    },
                     "message": "Must login via SSO",
                 }
             }
@@ -331,7 +334,8 @@ class AuthVerifyEndpointSuperuserTest(AuthProviderTestCase, APITestCase):
                 "detail": {
                     "code": "sso-required",
                     "extra": {
-                        "loginUrl": f"http://{self.organization.slug}.testserver/auth/login/{self.organization.slug}/?{query_string}"
+                        "loginUrl": f"http://{self.organization.slug}.testserver/auth/login/{self.organization.slug}/?{query_string}",
+                        "organizationSlug": self.organization.slug,
                     },
                     "message": "Must login via SSO",
                 }


### PR DESCRIPTION
Follow-up to #124103. Remove the rollout-only flag so every `SsoRequired` response includes `organizationSlug`, and update auth-index coverage for the expanded response contract.

This depends on getsentry/getsentry#21958, which makes downstream staff-auth assertions compatible with additive SSO error context.

## Test plan

- `.venv/bin/pytest -n3 -svv --reuse-db tests/integration/test_api.py tests/sentry/users/api/endpoints/test_auth_index.py`
- `.venv/bin/prek run -q --files src/sentry/api/exceptions.py src/sentry/api/permissions.py tests/sentry/users/api/endpoints/test_auth_index.py`