### PR TITLE
ref(api): Declare serializer expand/collapse keys and the fields they toggle

### DIFF
--- a/src/sentry/api/serializers/base.py
+++ b/src/sentry/api/serializers/base.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Mapping, MutableMapping, Sequence
-from typing import Any, Generic, TypeVar, overload
+from collections.abc import Callable, Iterable, Mapping, MutableMapping, Sequence
+from typing import Any, ClassVar, Generic, TypeVar, overload
 
 from django.contrib.auth.models import AnonymousUser
 
+from sentry.api.serializers.shaping import ResponseShaping, ShapingKind, is_requested
 from sentry.users.models.user import User
 from sentry.users.services.user.model import RpcUser
 from sentry.utils.tracing import set_span_data, start_span
@@ -158,6 +159,25 @@ class Serializer(Generic[T]):
     from ``T`` via ``# type: ignore[return-value]`` — concrete subclasses
     override ``serialize`` with a real body that genuinely returns ``T``.
     """
+
+    #: The ``?expand=`` / ``?collapse=`` values this serializer honours, each
+    #: mapped to the response fields it toggles. Serializers that accept those
+    #: parameters set ``self.expand`` / ``self.collapse`` in ``__init__`` and read
+    #: them through ``_expand`` / ``_collapse``, which only accept declared keys.
+    shaping: ClassVar[ResponseShaping | None] = None
+    expand: Iterable[str] | None
+    collapse: Iterable[str] | None
+
+    def _expand(self, key: str) -> bool:
+        """Whether ``key`` was requested via ``?expand=``. ``key`` must be in ``shaping``."""
+        return self._is_requested("expand", key)
+
+    def _collapse(self, key: str) -> bool:
+        """Whether ``key`` was requested via ``?collapse=``. ``key`` must be in ``shaping``."""
+        return self._is_requested("collapse", key)
+
+    def _is_requested(self, kind: ShapingKind, key: str) -> bool:
+        return is_requested(self, kind, key)
 
     def __call__(
         self,

--- a/src/sentry/api/serializers/models/group.py
+++ b/src/sentry/api/serializers/models/group.py
@@ -15,6 +15,7 @@ from django.db.models import Min, prefetch_related_objects
 from sentry import tagstore
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.constants import LOG_LEVELS
 from sentry.eventtypes import EventTypeStr
 from sentry.integrations.mixins.issues import IssueBasicIntegration
@@ -250,7 +251,19 @@ def _get_level_label(group: Group) -> GroupLevelStr:
     return LOG_LEVELS.get(group.level, "unknown")
 
 
+# Shared by every group serializer; the stream serializer extends it.
+GROUP_SHAPING = ResponseShaping(
+    expand={"derivedData": ("derivedData",)},
+    collapse={
+        "stats": ("count", "userCount", "firstSeen", "lastSeen"),
+        "unhandled": ("isUnhandled",),
+    },
+)
+
+
 class GroupSerializerBase(Serializer, ABC):
+    shaping = GROUP_SHAPING
+
     def __init__(
         self,
         collapse=None,
@@ -481,17 +494,6 @@ class GroupSerializerBase(Serializer, ABC):
         self, generic_issue_list: Sequence[Group], user
     ) -> Mapping[Group, SeenStats]:
         pass
-
-    def _expand(self, key) -> bool:
-        if self.expand is None:
-            return False
-
-        return key in self.expand
-
-    def _collapse(self, key) -> bool:
-        if self.collapse is None:
-            return False
-        return key in self.collapse
 
     def _get_status(self, attrs: Mapping[str, Any], obj: Group):
         status = obj.status

--- a/src/sentry/api/serializers/models/group_stream.py
+++ b/src/sentry/api/serializers/models/group_stream.py
@@ -14,6 +14,7 @@ from sentry import features, release_health, tsdb
 from sentry.api.serializers import serialize
 from sentry.api.serializers.models.actor import ActorSerializerResponse
 from sentry.api.serializers.models.group import (
+    GROUP_SHAPING,
     BaseGroupSerializerResponse,
     GroupAnnotation,
     GroupLevelStr,
@@ -304,7 +305,29 @@ class StreamGroupSerializerSnubaResponse(TypedDict):
     matchingEventEnvironment: NotRequired[str | None]
 
 
+# The issue stream honours the shared group keys plus its own; the OpenAPI
+# `expand`/`collapse` parameters for the group index endpoints derive from this.
+GROUP_STREAM_SHAPING = GROUP_SHAPING.extend(
+    expand={
+        "sessions": ("sessionCount",),
+        "inbox": ("inbox",),
+        "owners": ("owners",),
+        "integrationIssues": ("integrationIssues",),
+        "sentryAppIssues": ("sentryAppIssues",),
+        "latestEventHasAttachments": ("latestEventHasAttachments",),
+    },
+    collapse={
+        "base": tuple(BaseGroupSerializerResponse.__annotations__),
+        "stats": ("stats", "count", "userCount", "firstSeen", "lastSeen"),
+        "lifetime": ("lifetime",),
+        "filtered": ("filtered",),
+    },
+)
+
+
 class StreamGroupSerializerSnuba(GroupSerializerSnuba, GroupStatsMixin):
+    shaping = GROUP_STREAM_SHAPING
+
     def __init__(
         self,
         environment_ids: list[int] | None = None,

--- a/src/sentry/api/serializers/models/organization_member/base.py
+++ b/src/sentry/api/serializers/models/organization_member/base.py
@@ -6,6 +6,7 @@ from django.contrib.auth.models import AnonymousUser
 
 from sentry import roles
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.integrations.models.external_actor import ExternalActor
 from sentry.models.organizationmember import OrganizationMember
 from sentry.users.models.user import User
@@ -18,6 +19,8 @@ from .utils import get_organization_id
 
 @register(OrganizationMember)
 class OrganizationMemberSerializer(Serializer):
+    shaping = ResponseShaping(expand={"externalUsers": ("externalUsers",)})
+
     def __init__(self, expand: Sequence[str] | None = None) -> None:
         self.expand = expand or []
 
@@ -41,7 +44,7 @@ class OrganizationMemberSerializer(Serializer):
             email_map[u["id"]] = u["email"]
 
         external_users_map = defaultdict(list)
-        if "externalUsers" in self.expand:
+        if self._expand("externalUsers"):
             organization_id = get_organization_id(item_list)
             external_actors = list(
                 ExternalActor.objects.filter(
@@ -129,7 +132,7 @@ class OrganizationMemberSerializer(Serializer):
             "roleName": roles.get(obj.role).name,  # Deprecated
         }
 
-        if "externalUsers" in self.expand:
+        if self._expand("externalUsers"):
             data["externalUsers"] = attrs.get("externalUsers", [])
 
         return data

--- a/src/sentry/api/serializers/models/organization_member/scim.py
+++ b/src/sentry/api/serializers/models/organization_member/scim.py
@@ -2,6 +2,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 
 from sentry.api.serializers import Serializer
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.core.endpoints.scim.constants import SCIM_SCHEMA_USER
 from sentry.models.organizationmember import OrganizationMember
 
@@ -9,6 +10,8 @@ from .response import OrganizationMemberSCIMSerializerResponse
 
 
 class OrganizationMemberSCIMSerializer(Serializer[OrganizationMemberSCIMSerializerResponse]):
+    shaping = ResponseShaping(expand={"active": ("active",)})
+
     def __init__(self, expand: Sequence[str] | None = None) -> None:
         self.expand = expand or []
 
@@ -24,7 +27,7 @@ class OrganizationMemberSCIMSerializer(Serializer[OrganizationMemberSCIMSerializ
             "meta": {"resourceType": "User"},
             "sentryOrgRole": obj.role,
         }
-        if "active" in self.expand:
+        if self._expand("active"):
             result["active"] = True
 
         return result

--- a/src/sentry/api/serializers/models/project.py
+++ b/src/sentry/api/serializers/models/project.py
@@ -15,6 +15,7 @@ from django.utils import timezone
 from sentry import features, options, projectoptions, quotas, release_health, roles
 from sentry.api.serializers import Serializer, register, serialize
 from sentry.api.serializers.models.team import get_org_roles
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.app import env
 from sentry.auth.access import Access
 from sentry.auth.superuser import is_active_superuser
@@ -82,6 +83,17 @@ TRANSACTION_STATS_COUNT = "count(span.duration)"
 LATEST_DEPLOYS_KEY: Final = "latestDeploys"
 UNUSED_ON_FRONTEND_FEATURES: Final = "unusedFeatures"
 ORGANIZATION_KEY: Final = "organization"
+
+# `options` is gathered here but only emitted by the organization project and
+# detailed project serializers, whose response types carry the field.
+PROJECT_SHAPING = ResponseShaping(
+    expand={
+        "transaction_stats": ("transactionStats",),
+        "session_stats": ("sessionStats",),
+        "options": ("options",),
+    },
+    collapse={UNUSED_ON_FRONTEND_FEATURES: ("features",)},
+)
 
 
 # These features are not used on the frontend,
@@ -334,6 +346,8 @@ class ProjectSerializer(Serializer):
     such as "show all projects for this organization", and its attributes be kept to a minimum.
     """
 
+    shaping = PROJECT_SHAPING
+
     def __init__(
         self,
         environment_id: str | None = None,
@@ -356,17 +370,6 @@ class ProjectSerializer(Serializer):
         self.expand = expand
         self.expand_context = expand_context or {}
         self.collapse = collapse
-
-    def _expand(self, key: str) -> bool:
-        if self.expand is None:
-            return False
-
-        return key in self.expand
-
-    def _collapse(self, key: str) -> bool:
-        if self.collapse is None:
-            return False
-        return key in self.collapse
 
     def get_attrs(
         self, item_list: Sequence[Project], user: User | RpcUser | AnonymousUser, **kwargs: Any
@@ -759,6 +762,8 @@ class _DeployDict(TypedDict):
 
 
 class ProjectSummarySerializer(ProjectWithTeamSerializer):
+    shaping = PROJECT_SHAPING.extend(collapse={LATEST_DEPLOYS_KEY: (LATEST_DEPLOYS_KEY,)})
+
     def __init__(self, access: Access | None = None, **kwargs):
         self.access = access
         super().__init__(**kwargs)
@@ -1039,6 +1044,9 @@ class DetailedProjectResponse(ProjectWithTeamResponseDict):
 
 
 class DetailedProjectSerializer(ProjectWithTeamSerializer):
+    # Collapsing `organization` reduces it to `{id, slug}` rather than omitting it.
+    shaping = PROJECT_SHAPING.extend(collapse={ORGANIZATION_KEY: (ORGANIZATION_KEY,)})
+
     def get_attrs(
         self, item_list: Sequence[Project], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> dict[Project, dict[str, Any]]:

--- a/src/sentry/api/serializers/models/projectcodeowners.py
+++ b/src/sentry/api/serializers/models/projectcodeowners.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any
 
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.integrations.api.serializers.models.repository_project_path_config import (
     RepositoryProjectPathConfigSerializer,
 )
@@ -15,6 +16,18 @@ logger = logging.getLogger(__name__)
 
 @register(ProjectCodeOwners)
 class ProjectCodeOwnersSerializer(Serializer):
+    # `renameIdentifier` and `hasTargetingContext` rewrite the embedded schema
+    # in place rather than adding a field.
+    shaping = ResponseShaping(
+        expand={
+            "codeMapping": ("codeMapping",),
+            "ownershipSyntax": ("ownershipSyntax",),
+            "errors": ("errors",),
+            "renameIdentifier": (),
+            "hasTargetingContext": (),
+        },
+    )
+
     def __init__(
         self,
         expand=None,
@@ -91,23 +104,23 @@ class ProjectCodeOwnersSerializer(Serializer):
             "provider": attrs.get("provider", "unknown"),
         }
 
-        if "codeMapping" in self.expand:
+        if self._expand("codeMapping"):
             config = attrs.get("codeMapping", {})
             data["codeMapping"] = serialize(
                 config, user=user, serializer=RepositoryProjectPathConfigSerializer()
             )
 
-        if "ownershipSyntax" in self.expand:
+        if self._expand("ownershipSyntax"):
             data["ownershipSyntax"] = convert_schema_to_rules_text(obj.schema)
 
-        if "errors" in self.expand:
+        if self._expand("errors"):
             _, errors = build_codeowners_associations(obj.raw, obj.project)
             data["errors"] = errors
 
-        if "renameIdentifier" in self.expand and hasattr(obj, "schema") and obj.schema:
+        if self._expand("renameIdentifier") and hasattr(obj, "schema") and obj.schema:
             self.rename_schema_identifier_for_parsing(obj.schema)
 
-        if "hasTargetingContext" in self.expand:
+        if self._expand("hasTargetingContext"):
             if obj.schema and obj.schema.get("rules"):
                 for rule in obj.schema["rules"]:
                     for rule_owner in rule["owners"]:

--- a/src/sentry/api/serializers/models/repository.py
+++ b/src/sentry/api/serializers/models/repository.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Any, TypedDict
 
 from sentry.api.serializers import Serializer, register
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.models.repository import Repository
 from sentry.models.repositorysettings import RepositorySettings
 
@@ -41,12 +42,11 @@ class RepositorySettingsSerializer(Serializer[RepositorySettingsSerializerRespon
 
 @register(Repository)
 class RepositorySerializer(Serializer[RepositorySerializerResponse]):
+    shaping = ResponseShaping(expand={"settings": ("settings",)})
+
     def __init__(self, expand: Sequence[str] | None = None) -> None:
         super().__init__()
         self.expand = expand or []
-
-    def _expand(self, key: str) -> bool:
-        return key in self.expand
 
     def get_attrs(
         self, item_list: Sequence[Repository], user: Any, **kwargs: Any

--- a/src/sentry/api/serializers/models/rule.py
+++ b/src/sentry/api/serializers/models/rule.py
@@ -9,6 +9,7 @@ from django.db.models import Prefetch, Q, prefetch_related_objects
 from rest_framework import serializers
 
 from sentry.api.serializers import Serializer, register
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.constants import ObjectStatus
 from sentry.db.models.manager.base_query_set import BaseQuerySet
 from sentry.integrations.services.integration.model import RpcIntegration
@@ -117,8 +118,13 @@ class RuleSerializerResponse(RuleSerializerResponseOptional):
     snooze: bool
 
 
+RULE_SHAPING = ResponseShaping(expand={"lastTriggered": ("lastTriggered",)})
+
+
 @register(Rule)
 class RuleSerializer(Serializer[RuleSerializerResponse]):
+    shaping = RULE_SHAPING
+
     def __init__(
         self,
         expand: list[str] | None = None,
@@ -225,7 +231,7 @@ class RuleSerializer(Serializer[RuleSerializerResponse]):
             if len(errors):
                 result[rule]["errors"] = errors
 
-        if "lastTriggered" in self.expand:
+        if self._expand("lastTriggered"):
             last_triggered_lookup: dict[int, datetime] = {}
             if item_list:
                 rule_ids = [rule.id for rule in item_list]
@@ -367,6 +373,8 @@ class RuleSerializer(Serializer[RuleSerializerResponse]):
 
 
 class WorkflowEngineRuleSerializer(Serializer):
+    shaping = RULE_SHAPING
+
     def __init__(
         self,
         expand: list[str] | None = None,
@@ -597,7 +605,7 @@ class WorkflowEngineRuleSerializer(Serializer):
             integration_cache = {i.id: i for i in integrations}
 
         last_triggered_lookup: dict[int, datetime] = {}
-        if "lastTriggered" in self.expand:
+        if self._expand("lastTriggered"):
             last_triggered_lookup = self._fetch_workflow_last_triggered(item_list)
 
         result: dict[Workflow, dict[str, Any]] = defaultdict(dict)
@@ -775,7 +783,7 @@ class WorkflowEngineRuleSerializer(Serializer):
             if len(errors):
                 result[workflow]["errors"] = errors
 
-            if "lastTriggered" in self.expand:
+            if self._expand("lastTriggered"):
                 result[workflow]["last_triggered"] = last_triggered_lookup.get(workflow.id, None)
 
             result[workflow]["actions"] = serialized_actions

--- a/src/sentry/api/serializers/models/team.py
+++ b/src/sentry/api/serializers/models/team.py
@@ -11,6 +11,7 @@ from django.db.models import Count
 
 from sentry import roles
 from sentry.api.serializers import Serializer, register, serialize
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.app import env
 from sentry.auth.access import (
     Access,
@@ -160,8 +161,19 @@ class TeamSerializerResponse(BaseTeamSerializerResponse, _TeamSerializerResponse
     pass
 
 
+# `collapse` is accepted for backwards compatibility but no team key honours it.
+TEAM_SHAPING = ResponseShaping(
+    expand={
+        "projects": ("projects",),
+        "externalTeams": ("externalTeams",),
+        "organization": ("organization",),
+    },
+)
+
+
 @register(Team)
 class BaseTeamSerializer(Serializer):
+    shaping = TEAM_SHAPING
     expand: Sequence[str] | None
     collapse: Sequence[str] | None
     access: Access | None
@@ -175,17 +187,6 @@ class BaseTeamSerializer(Serializer):
         self.collapse = collapse
         self.expand = expand
         self.access = access
-
-    def _expand(self, key: str) -> bool:
-        if self.expand is None:
-            return False
-
-        return key in self.expand
-
-    def _collapse(self, key: str) -> bool:
-        if self.collapse is None:
-            return False
-        return key in self.collapse
 
     def get_attrs(
         self, item_list: Sequence[Team], user: User | RpcUser | AnonymousUser, **kwargs: Any
@@ -397,6 +398,8 @@ def get_team_memberships(team_ids: list[int]) -> list[TeamMembership]:
 
 
 class TeamSCIMSerializer(Serializer[OrganizationTeamSCIMSerializerResponse]):
+    shaping = ResponseShaping(expand={"members": ("members",)})
+
     def __init__(
         self,
         expand: Sequence[str] | None = None,
@@ -407,11 +410,11 @@ class TeamSCIMSerializer(Serializer[OrganizationTeamSCIMSerializerResponse]):
         self, item_list: Sequence[Team], user: User | RpcUser | AnonymousUser, **kwargs: Any
     ) -> dict[Team, dict[str, Any]]:
         result: dict[int, dict[str, Any]] = {
-            team.id: ({"members": []} if "members" in self.expand else {}) for team in item_list
+            team.id: ({"members": []} if self._expand("members") else {}) for team in item_list
         }
         teams_by_id = {t.id: t for t in item_list}
 
-        if teams_by_id and "members" in self.expand:
+        if teams_by_id and self._expand("members"):
             team_ids = [t.id for t in item_list]
             team_memberships = get_team_memberships(team_ids=team_ids)
 

--- a/src/sentry/api/serializers/shaping.py
+++ b/src/sentry/api/serializers/shaping.py
@@ -1,0 +1,247 @@
+"""
+Declarative ``?expand=`` / ``?collapse=`` response shaping.
+
+Many serializers accept ``expand`` and ``collapse`` lists that add or remove
+response fields. Historically each serializer checked ``key in self.expand``
+against string literals scattered through ``serialize``, so the set of accepted
+values, and which response fields each one toggled, existed nowhere in one
+place. A serializer now declares them once::
+
+    class TeamSerializer(Serializer[TeamSerializerResponse]):
+        shaping = ResponseShaping(
+            expand={"projects": ("projects",), "externalTeams": ("externalTeams",)},
+        )
+
+and reads them through ``self._expand(key)`` / ``self._collapse(key)``, which
+refuse a key the declaration does not list. The declarations feed the OpenAPI
+``expand``/``collapse`` parameter enums and the ``x-sentry-expand`` /
+``x-sentry-collapse`` operation extensions that tell API consumers which
+response fields each value controls.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass, field
+from types import UnionType
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+    is_typeddict,
+)
+
+from sentry.utils.env import in_test_environment
+
+if TYPE_CHECKING:
+    from sentry.api.serializers.base import Serializer
+
+logger = logging.getLogger(__name__)
+
+ShapingKind = Literal["expand", "collapse"]
+SHAPING_KINDS: tuple[ShapingKind, ...] = ("expand", "collapse")
+
+# Response fields a shaping key maps to. An empty tuple is allowed for keys
+# that change how existing fields are rendered rather than adding or removing
+# any (documented on the serializer that declares them).
+Fields = tuple[str, ...]
+
+
+class UndeclaredShapingKey(LookupError):
+    """A serializer checked an ``expand``/``collapse`` key it does not declare."""
+
+
+@dataclass(frozen=True)
+class ResponseShaping:
+    """
+    The ``?expand=`` and ``?collapse=`` values a serializer honours, each mapped
+    to the response fields it adds (expand) or removes or reduces (collapse).
+    """
+
+    expand: Mapping[str, Fields] = field(default_factory=dict)
+    collapse: Mapping[str, Fields] = field(default_factory=dict)
+
+    @property
+    def expand_keys(self) -> tuple[str, ...]:
+        return tuple(sorted(self.expand))
+
+    @property
+    def collapse_keys(self) -> tuple[str, ...]:
+        return tuple(sorted(self.collapse))
+
+    def keys(self, kind: ShapingKind) -> tuple[str, ...]:
+        return tuple(sorted(self.mapping(kind)))
+
+    def mapping(self, kind: ShapingKind) -> Mapping[str, Fields]:
+        return self.expand if kind == "expand" else self.collapse
+
+    def fields(self) -> frozenset[str]:
+        """Every response field some key toggles."""
+        return frozenset(
+            name
+            for mapping in (self.expand, self.collapse)
+            for names in mapping.values()
+            for name in names
+        )
+
+    def extend(
+        self,
+        *,
+        expand: Mapping[str, Fields] | None = None,
+        collapse: Mapping[str, Fields] | None = None,
+    ) -> ResponseShaping:
+        """A shaping with more keys, for a subclass that honours everything its base does."""
+        return ResponseShaping(
+            expand={**self.expand, **(expand or {})},
+            collapse={**self.collapse, **(collapse or {})},
+        )
+
+    def merge(self, other: ResponseShaping) -> ResponseShaping:
+        """The union of two shapings; a key present in both maps to the union of its fields."""
+        return ResponseShaping(
+            expand=_merge_mappings(self.expand, other.expand),
+            collapse=_merge_mappings(self.collapse, other.collapse),
+        )
+
+    def as_dict(self) -> dict[str, dict[str, list[str]]]:
+        """A JSON-friendly form, keys sorted, for the OpenAPI extensions."""
+        return {
+            kind: {key: list(self.mapping(kind)[key]) for key in self.keys(kind)}
+            for kind in SHAPING_KINDS
+            if self.mapping(kind)
+        }
+
+
+def _merge_mappings(a: Mapping[str, Fields], b: Mapping[str, Fields]) -> dict[str, Fields]:
+    merged = dict(a)
+    for key, names in b.items():
+        merged[key] = tuple(dict.fromkeys((*merged.get(key, ()), *names)))
+    return merged
+
+
+def is_requested(serializer: Any, kind: ShapingKind, key: str) -> bool:
+    """
+    Whether ``key`` was requested through the serializer's ``expand`` /
+    ``collapse`` attribute. ``None`` (the parameter was not given) means no key
+    is requested, matching the historical per-serializer helpers.
+
+    The key must be declared in the serializer's ``shaping``; an undeclared key
+    raises in tests and is logged once elsewhere, so a typo cannot silently
+    disable a branch.
+    """
+    shaping = get_response_shaping(type(serializer))
+    if shaping is None or key not in shaping.mapping(kind):
+        _report_undeclared(type(serializer), kind, key)
+    requested: Iterable[str] | None = getattr(serializer, kind, None)
+    return requested is not None and key in requested
+
+
+_reported: set[tuple[type, str, str]] = set()
+
+
+def _report_undeclared(serializer_cls: type, kind: ShapingKind, key: str) -> None:
+    message = (
+        f"{serializer_cls.__name__} checks {kind}={key!r} but its `shaping` does not declare it"
+    )
+    if in_test_environment():
+        raise UndeclaredShapingKey(message)
+    marker = (serializer_cls, kind, key)
+    if marker not in _reported:
+        _reported.add(marker)
+        logger.warning(
+            "serializer.shaping.undeclared",
+            extra={"serializer": serializer_cls.__name__, "kind": kind, "key": key},
+        )
+
+
+def get_response_shaping(serializer_cls: type) -> ResponseShaping | None:
+    """The shaping a serializer class declares (or inherits), if any."""
+    shaping = getattr(serializer_cls, "shaping", None)
+    return shaping if isinstance(shaping, ResponseShaping) else None
+
+
+def all_response_shapings() -> dict[type[Serializer[Any]], ResponseShaping]:
+    """
+    Every imported serializer with a shaping, mapped to it. Subclasses that
+    inherit a declaration are included, since they honour the same keys.
+    """
+    from sentry.api.serializers.base import Serializer
+
+    found: dict[type[Serializer[Any]], ResponseShaping] = {}
+    for cls in _walk_subclasses(Serializer):
+        shaping = get_response_shaping(cls)
+        if shaping is not None:
+            found[cls] = shaping
+    return found
+
+
+def _walk_subclasses(cls: type) -> Iterator[type]:
+    seen: set[type] = set()
+    stack = [cls]
+    while stack:
+        current = stack.pop()
+        for sub in current.__subclasses__():
+            if sub not in seen:
+                seen.add(sub)
+                stack.append(sub)
+                yield sub
+
+
+def response_type_of(serializer_cls: type) -> type | None:
+    """
+    The TypedDict a serializer's ``serialize`` returns, from its return
+    annotation or its ``Serializer[T]`` parameter. ``None`` when the shape is
+    not declared as a TypedDict (or its annotation cannot be resolved).
+    """
+    try:
+        hints = get_type_hints(serializer_cls.serialize)
+    except Exception:
+        hints = {}
+    candidate = unwrap_response_type(hints.get("return"))
+    if candidate is not None:
+        return candidate
+    for base in getattr(serializer_cls, "__orig_bases__", ()):
+        for arg in get_args(base):
+            candidate = unwrap_response_type(arg)
+            if candidate is not None:
+                return candidate
+    return None
+
+
+def unwrap_response_type(hint: Any) -> type | None:
+    """``list[T]``, ``Sequence[T]`` and ``T | None`` all describe ``T``; return it when it is a TypedDict."""
+    if hint is None:
+        return None
+    if is_typeddict(hint):
+        return hint
+    origin = get_origin(hint)
+    if origin is None:
+        return None
+    if origin is Union or origin is UnionType:
+        typed = [t for t in (unwrap_response_type(a) for a in get_args(hint)) if t is not None]
+        return typed[0] if len(typed) == 1 else None
+    args = get_args(hint)
+    if args:
+        return unwrap_response_type(args[0])
+    return None
+
+
+def shaping_for_response_type(hint: Any) -> ResponseShaping | None:
+    """
+    The combined shaping of every serializer that produces ``hint`` (a
+    TypedDict, or a list/optional of one). Used by the OpenAPI build to attach
+    expand/collapse information to a response schema.
+    """
+    response_type = unwrap_response_type(hint)
+    if response_type is None:
+        return None
+    combined: ResponseShaping | None = None
+    for serializer_cls, shaping in all_response_shapings().items():
+        if response_type_of(serializer_cls) is response_type:
+            combined = shaping if combined is None else combined.merge(shaping)
+    return combined

--- a/src/sentry/apidocs/extensions.py
+++ b/src/sentry/apidocs/extensions.py
@@ -10,7 +10,19 @@ from drf_spectacular.plumbing import build_basic_type
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import Direction
 
+from sentry.api.serializers.shaping import shaping_for_response_type
 from sentry.apidocs.spectacular_ports import resolve_type_hint
+
+# Attached to a response schema whose serializer declares expand/collapse keys;
+# `sentry.apidocs.hooks` lifts it onto the operation and strips it again.
+SHAPING_EXTENSION = "x-sentry-shaping"
+
+
+def with_response_shaping(schema: Any, hint: Any) -> Any:
+    shaping = shaping_for_response_type(hint)
+    if shaping is not None and isinstance(schema, dict):
+        schema[SHAPING_EXTENSION] = shaping.as_dict()
+    return schema
 
 
 class TokenAuthExtension(OpenApiAuthenticationExtension):
@@ -57,7 +69,8 @@ class SentryResponseSerializerExtension(OpenApiSerializerExtension):
         if "return" not in type_hints:
             raise TypeError("Please type the return value of the serializer with a TypedDict")
 
-        return resolve_type_hint(type_hints["return"])
+        hint = type_hints["return"]
+        return with_response_shaping(resolve_type_hint(hint), hint)
 
 
 class SentryInlineResponseSerializerExtension(OpenApiSerializerExtension):
@@ -74,7 +87,9 @@ class SentryInlineResponseSerializerExtension(OpenApiSerializerExtension):
         return self.target.__name__
 
     def map_serializer(self, auto_schema: AutoSchema, direction: Direction) -> Any:
-        return resolve_type_hint(self.target.typeSchema)
+        return with_response_shaping(
+            resolve_type_hint(self.target.typeSchema), self.target.typeSchema
+        )
 
 
 class RestrictedJsonFieldExtension(OpenApiSerializerFieldExtension):

--- a/src/sentry/apidocs/hooks.py
+++ b/src/sentry/apidocs/hooks.py
@@ -9,8 +9,10 @@ from drf_spectacular.generators import EndpointEnumerator, SchemaGenerator
 
 from sentry.api.api_owners import ApiOwner
 from sentry.api.api_publish_status import ApiPublishStatus
+from sentry.api.serializers.shaping import SHAPING_KINDS
 from sentry.apidocs.api_ownership_allowlist_dont_modify import API_OWNERSHIP_ALLOWLIST_DONT_MODIFY
 from sentry.apidocs.build import OPENAPI_TAGS
+from sentry.apidocs.extensions import SHAPING_EXTENSION
 from sentry.apidocs.utils import SentryApiBuildError
 
 HTTP_METHOD_NAME = Literal[
@@ -233,6 +235,7 @@ def custom_postprocessing_hook(result: Any, generator: Any, **kwargs: Any) -> An
 
     _fix_issue_paths(result)
     _fix_nullable_enums(result)
+    _stamp_response_shaping(result)
 
     # Fetch schema component references
     schema_components = result["components"]["schemas"]
@@ -322,6 +325,74 @@ def _fix_nullable_enums(node: Any) -> None:
     elif isinstance(node, list):
         for item in node:
             _fix_nullable_enums(item)
+
+
+def _stamp_response_shaping(result: Any) -> None:
+    """
+    Record, on every operation that accepts ``expand`` or ``collapse``, which
+    response fields each accepted value adds or removes, as
+    ``x-sentry-expand`` / ``x-sentry-collapse``: ``{value: [field, ...]}``.
+
+    The mapping comes from the ``x-sentry-shaping`` marker the serializer
+    extensions leave on the response schema, restricted to the values the
+    parameter's enum documents. The marker is stripped afterwards so the
+    published schemas are unchanged.
+    """
+    components = result.get("components", {}).get("schemas", {})
+    for endpoints in result["paths"].values():
+        for method_info in endpoints.values():
+            parameters = {
+                param["name"]: param
+                for param in method_info.get("parameters", [])
+                if param.get("in") == "query" and param.get("name") in SHAPING_KINDS
+            }
+            if not parameters:
+                continue
+            shaping = _response_shaping(method_info, components)
+            if not shaping:
+                continue
+            for kind, param in parameters.items():
+                mapping = shaping.get(kind)
+                if not mapping:
+                    continue
+                allowed = _parameter_enum(param)
+                method_info[f"x-sentry-{kind}"] = {
+                    key: fields
+                    for key, fields in mapping.items()
+                    if allowed is None or key in allowed
+                }
+    _strip_shaping_markers(result)
+
+
+def _response_shaping(method_info: Mapping[str, Any], components: Mapping[str, Any]) -> Any:
+    for code in ("200", "201"):
+        content = method_info.get("responses", {}).get(code, {}).get("content", {})
+        schema = content.get("application/json", {}).get("schema")
+        if not schema:
+            continue
+        schema = dereference_schema(schema, components)
+        marker = schema.get(SHAPING_EXTENSION)
+        if marker is None and "items" in schema:
+            marker = dereference_schema(schema["items"], components).get(SHAPING_EXTENSION)
+        if marker is not None:
+            return marker
+    return None
+
+
+def _parameter_enum(param: Mapping[str, Any]) -> set[str] | None:
+    schema = param.get("schema", {})
+    enum = schema.get("enum") or schema.get("items", {}).get("enum")
+    return set(enum) if enum else None
+
+
+def _strip_shaping_markers(node: Any) -> None:
+    if isinstance(node, dict):
+        node.pop(SHAPING_EXTENSION, None)
+        for value in node.values():
+            _strip_shaping_markers(value)
+    elif isinstance(node, list):
+        for item in node:
+            _strip_shaping_markers(item)
 
 
 def _fix_issue_paths(result: Any) -> Any:

--- a/src/sentry/apidocs/parameters.py
+++ b/src/sentry/apidocs/parameters.py
@@ -6,6 +6,8 @@ from drf_spectacular.utils import OpenApiParameter
 
 from sentry import constants
 from sentry.api.helpers.projects import PROJECT_ID_OR_SLUG_SCHEMA
+from sentry.api.serializers.models.group_stream import GROUP_STREAM_SHAPING
+from sentry.api.serializers.models.team import TEAM_SHAPING
 from sentry.search.eap.types import SupportedTraceItemType
 from sentry.snuba.dataset import Dataset
 from sentry.snuba.sessions import STATS_PERIODS
@@ -451,17 +453,12 @@ class IssueParams:
         required=False,
     )
 
+    # Derived from the issue stream serializer so the documented values cannot
+    # drift from the ones the serializer honours.
     GROUP_INDEX_EXPAND = OpenApiParameter(
         name="expand",
         description="Additional data to include in the response.",
-        enum=[
-            "inbox",
-            "owners",
-            "sessions",
-            "integrationIssues",
-            "sentryAppIssues",
-            "latestEventHasAttachments",
-        ],
+        enum=list(GROUP_STREAM_SHAPING.expand_keys),
         location=OpenApiParameter.QUERY,
         type=OpenApiTypes.STR,
         required=False,
@@ -471,7 +468,7 @@ class IssueParams:
     GROUP_INDEX_COLLAPSE = OpenApiParameter(
         name="collapse",
         description="Fields to remove from the response to improve query performance.",
-        enum=["stats", "lifetime", "base", "unhandled", "filtered"],
+        enum=list(GROUP_STREAM_SHAPING.collapse_keys),
         location=OpenApiParameter.QUERY,
         type=OpenApiTypes.STR,
         required=False,
@@ -1080,8 +1077,9 @@ List of strings to opt out of certain pieces of data. Supports `organization`.
         location="query",
         required=False,
         type=str,
+        enum=list(TEAM_SHAPING.expand_keys),
         description="""
-List of strings to opt in to additional data. Supports `projects`, `externalTeams`.
+List of strings to opt in to additional data.
 """,
     )
 

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_detector.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.db.models import Q, Subquery
 
 from sentry.api.serializers import Serializer, serialize
+from sentry.api.serializers.shaping import ResponseShaping
 
 if TYPE_CHECKING:
     from sentry.incidents.endpoints.serializers.alert_rule import (
@@ -56,6 +57,10 @@ class WorkflowEngineDetectorSerializer(Serializer):
     """
     A temporary serializer to be used by the old alert rule endpoints to return data read from the new ACI models
     """
+
+    shaping = ResponseShaping(
+        expand={"latestIncident": ("latestIncident",), "eventTypes": ("eventTypes",)},
+    )
 
     def __init__(self, expand: list[str] | None = None, prepare_component_fields: bool = False):
         self.expand = expand or []
@@ -336,7 +341,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
         # Note: originalAlertRuleId comes from AlertRuleActivity snapshots, which were not
         # migrated to the workflow engine. This field will always be None for detectors.
 
-        if "latestIncident" in self.expand:
+        if self._expand("latestIncident"):
             # to get the actions for a detector, we need to go from detector -> workflow -> action filters for that workflow -> actions
             detector_workflow_values = DetectorWorkflow.objects.filter(
                 detector__in=detector_ids
@@ -402,7 +407,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
             result[detector]["snuba_query_id"] = snuba_query.id
 
         # Only query for event types if they will be included in the output
-        if "eventTypes" in self.expand:
+        if self._expand("eventTypes"):
             event_types_by_snuba_query: defaultdict[int, list[str]] = defaultdict(list)
             for event_type in SnubaQueryEventType.objects.filter(
                 snuba_query_id__in=snuba_query_ids
@@ -461,7 +466,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
         if not obj.enabled:
             data["snooze"] = True
 
-        if "latestIncident" in self.expand:
+        if self._expand("latestIncident"):
             data["latestIncident"] = attrs.get("latestIncident", None)
 
         extrapolation_mode = attrs.get("extrapolationMode")
@@ -470,7 +475,7 @@ class WorkflowEngineDetectorSerializer(Serializer):
 
         # Only include eventTypes when explicitly requested (e.g., in detail views)
         # to match DetailedAlertRuleSerializer behavior
-        if "eventTypes" in self.expand:
+        if self._expand("eventTypes"):
             data["eventTypes"] = attrs.get("event_types", [])
 
         return data

--- a/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
+++ b/src/sentry/incidents/endpoints/serializers/workflow_engine_incident.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar
 from django.contrib.auth.models import AnonymousUser
 
 from sentry.api.serializers import Serializer, serialize
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.incidents.endpoints.serializers.incident import (
     DetailedIncidentSerializerResponse,
     IncidentSerializerResponse,
@@ -35,6 +36,8 @@ from sentry.workflow_engine.models import (
 
 
 class WorkflowEngineIncidentSerializer(Serializer):
+    shaping = ResponseShaping(expand={"activities": ("activities",)})
+
     def __init__(self, expand: list[str] | None = None) -> None:
         self.expand = expand or []
 
@@ -105,7 +108,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
                 results[open_period]["incident_id"] = fake_id
                 results[open_period]["incident_identifier"] = fake_id
 
-        if "activities" in self.expand:
+        if self._expand("activities"):
             gopas = list(
                 GroupOpenPeriodActivity.objects.filter(group_open_period__in=item_list).order_by(
                     "date_added", "id"
@@ -191,7 +194,7 @@ class WorkflowEngineIncidentSerializer(Serializer):
             "organizationId": str(obj.project.organization.id),
             "projects": attrs["projects"],
             "alertRule": attrs["alert_rule"],
-            "activities": attrs["activities"] if "activities" in self.expand else None,
+            "activities": attrs["activities"] if self._expand("activities") else None,
             "status": self.get_incident_status(obj.group.priority, obj.date_ended),
             "statusMethod": (
                 IncidentStatusMethod.RULE_TRIGGERED.value

--- a/src/sentry/monitors/serializers.py
+++ b/src/sentry/monitors/serializers.py
@@ -9,6 +9,7 @@ from django.db.models import prefetch_related_objects
 
 from sentry.api.serializers import ProjectSerializerResponse, Serializer, register, serialize
 from sentry.api.serializers.models.actor import ActorSerializer, ActorSerializerResponse
+from sentry.api.serializers.shaping import ResponseShaping
 from sentry.models.environment import Environment
 from sentry.models.project import Project
 from sentry.monitors.models import (
@@ -196,6 +197,8 @@ class MonitorBulkEditResponse:
 
 @register(Monitor)
 class MonitorSerializer(Serializer[MonitorSerializerResponse]):
+    shaping = ResponseShaping(expand={"alertRule": ("alertRule",)})
+
     def __init__(self, environments=None, expand=None):
         self.environments = environments
         self.expand = expand
@@ -317,12 +320,6 @@ class MonitorSerializer(Serializer[MonitorSerializerResponse]):
 
         return result
 
-    def _expand(self, key) -> bool:
-        if self.expand is None:
-            return False
-
-        return key in self.expand
-
 
 class MonitorCheckInSerializerResponseOptional(TypedDict, total=False):
     groups: list[str]
@@ -344,6 +341,8 @@ class MonitorCheckInSerializerResponse(MonitorCheckInSerializerResponseOptional)
 
 @register(MonitorCheckIn)
 class MonitorCheckInSerializer(Serializer[MonitorCheckInSerializerResponse]):
+    shaping = ResponseShaping(expand={"groups": ("groups",)})
+
     def __init__(self, start=None, end=None, expand=None, organization_id=None, project_id=None):
         self.start = start  # timestamp of the beginning of the specified date range
         self.end = end  # timestamp of the end of the specified date range
@@ -417,12 +416,6 @@ class MonitorCheckInSerializer(Serializer[MonitorCheckInSerializerResponse]):
             result["groups"] = attrs.get("groups", [])
 
         return result
-
-    def _expand(self, key) -> bool:
-        if self.expand is None:
-            return False
-
-        return key in self.expand
 
 
 @register(CheckinProcessingError)

--- a/tests/apidocs/test_hooks.py
+++ b/tests/apidocs/test_hooks.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 import pytest
 
+from sentry.apidocs.extensions import SHAPING_EXTENSION
 from sentry.apidocs.hooks import (
     _ENDPOINT_SERVERS,
     _fix_nullable_enums,
@@ -241,3 +242,83 @@ class FixNullableEnumsTest(TestCase):
                 {"type": "object", "nullable": True},
             ],
         }
+
+
+class ResponseShapingTest(TestCase):
+    def _operation(self, **extra: Any) -> dict[str, Any]:
+        return {
+            "tags": ["Teams"],
+            "description": "List teams",
+            "operationId": "list teams",
+            "parameters": [
+                {
+                    "in": "query",
+                    "name": "expand",
+                    "description": "Additional data to include in the response.",
+                    "schema": {"type": "array", "items": {"enum": ["projects", "externalTeams"]}},
+                },
+                {
+                    "in": "query",
+                    "name": "collapse",
+                    "description": "Fields to remove.",
+                    "schema": {"enum": ["organization"]},
+                },
+            ],
+            "responses": {
+                "200": {
+                    "content": {
+                        "application/json": {"schema": {"$ref": "#/components/schemas/TeamList"}}
+                    }
+                }
+            },
+            **extra,
+        }
+
+    def test_stamps_expand_and_collapse_from_the_response_shaping(self) -> None:
+        result = {
+            "components": {
+                "schemas": {
+                    "TeamList": {
+                        "type": "array",
+                        "items": {"$ref": "#/components/schemas/Team"},
+                    },
+                    "Team": {
+                        "type": "object",
+                        "properties": {"id": {"type": "string"}},
+                        SHAPING_EXTENSION: {
+                            "expand": {
+                                "projects": ["projects"],
+                                "externalTeams": ["externalTeams"],
+                                "organization": ["organization"],
+                            },
+                            "collapse": {"organization": ["organization"]},
+                        },
+                    },
+                }
+            },
+            "paths": {"/api/0/teams/": {"get": self._operation()}},
+        }
+
+        processed = custom_postprocessing_hook(result, None)
+
+        operation = processed["paths"]["/api/0/teams/"]["get"]
+        # Restricted to the values the parameter's enum documents.
+        assert operation["x-sentry-expand"] == {
+            "projects": ["projects"],
+            "externalTeams": ["externalTeams"],
+        }
+        assert operation["x-sentry-collapse"] == {"organization": ["organization"]}
+        # The marker never reaches the published components.
+        assert SHAPING_EXTENSION not in processed["components"]["schemas"]["Team"]
+
+    def test_operation_without_shaping_parameters_is_untouched(self) -> None:
+        operation = self._operation(parameters=[])
+        result = {
+            "components": {"schemas": {"TeamList": {"type": "array", "items": {"type": "object"}}}},
+            "paths": {"/api/0/teams/": {"get": operation}},
+        }
+
+        processed = custom_postprocessing_hook(result, None)
+
+        assert "x-sentry-expand" not in processed["paths"]["/api/0/teams/"]["get"]
+        assert "x-sentry-collapse" not in processed["paths"]["/api/0/teams/"]["get"]

--- a/tests/sentry/api/serializers/test_shaping.py
+++ b/tests/sentry/api/serializers/test_shaping.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from typing import TypedDict
+
+import pytest
+
+from sentry.api.serializers import Serializer
+from sentry.api.serializers.shaping import (
+    ResponseShaping,
+    UndeclaredShapingKey,
+    all_response_shapings,
+    get_response_shaping,
+    response_type_of,
+    shaping_for_response_type,
+)
+
+
+class _WidgetResponse(TypedDict, total=False):
+    id: str
+    stats: dict[str, int]
+    owners: list[str]
+
+
+class _WidgetSerializer(Serializer[_WidgetResponse]):
+    shaping = ResponseShaping(
+        expand={"owners": ("owners",)},
+        collapse={"stats": ("stats",)},
+    )
+
+    def __init__(self, expand: list[str] | None = None, collapse: list[str] | None = None):
+        self.expand = expand
+        self.collapse = collapse
+
+
+class _DetailedWidgetSerializer(_WidgetSerializer):
+    shaping = _WidgetSerializer.shaping.extend(expand={"history": ("history",)})
+
+
+class _UnshapedSerializer(Serializer[_WidgetResponse]):
+    def __init__(self) -> None:
+        self.expand = ["owners"]
+
+
+def test_declared_key_reflects_request() -> None:
+    assert _WidgetSerializer(expand=["owners"])._expand("owners")
+    assert not _WidgetSerializer(expand=["stats"])._expand("owners")
+    assert _WidgetSerializer(collapse=["stats"])._collapse("stats")
+
+
+def test_none_means_nothing_requested() -> None:
+    serializer = _WidgetSerializer()
+    assert not serializer._expand("owners")
+    assert not serializer._collapse("stats")
+
+
+def test_undeclared_key_raises_in_tests() -> None:
+    with pytest.raises(UndeclaredShapingKey):
+        _WidgetSerializer(expand=["typo"])._expand("typo")
+    # A key declared for the other kind is still undeclared for this one.
+    with pytest.raises(UndeclaredShapingKey):
+        _WidgetSerializer(collapse=["owners"])._collapse("owners")
+    with pytest.raises(UndeclaredShapingKey):
+        _UnshapedSerializer()._expand("owners")
+
+
+def test_extend_keeps_base_keys() -> None:
+    shaping = get_response_shaping(_DetailedWidgetSerializer)
+    assert shaping is not None
+    assert shaping.expand_keys == ("history", "owners")
+    assert shaping.collapse_keys == ("stats",)
+    assert _DetailedWidgetSerializer(expand=["history"])._expand("history")
+
+
+def test_merge_unions_fields() -> None:
+    merged = ResponseShaping(expand={"a": ("x",)}).merge(
+        ResponseShaping(expand={"a": ("y",), "b": ("z",)}, collapse={"c": ("w",)})
+    )
+    assert merged.expand == {"a": ("x", "y"), "b": ("z",)}
+    assert merged.collapse == {"c": ("w",)}
+    assert merged.as_dict() == {"expand": {"a": ["x", "y"], "b": ["z"]}, "collapse": {"c": ["w"]}}
+
+
+def test_response_type_resolution() -> None:
+    assert response_type_of(_WidgetSerializer) is _WidgetResponse
+    shaping = shaping_for_response_type(list[_WidgetResponse])
+    assert shaping is not None
+    # Both widget serializers produce the same TypedDict; their keys combine.
+    assert shaping.expand_keys == ("history", "owners")
+
+
+def _load_shaped_serializers() -> None:
+    # Import every module that declares a shaping so the registry walk sees it.
+    import sentry.api.serializers.models.group_stream  # noqa: F401
+    import sentry.api.serializers.models.organization_member.base  # noqa: F401
+    import sentry.api.serializers.models.organization_member.scim  # noqa: F401
+    import sentry.api.serializers.models.project  # noqa: F401
+    import sentry.api.serializers.models.projectcodeowners  # noqa: F401
+    import sentry.api.serializers.models.repository  # noqa: F401
+    import sentry.api.serializers.models.rule  # noqa: F401
+    import sentry.api.serializers.models.team  # noqa: F401
+    import sentry.incidents.endpoints.serializers.workflow_engine_detector  # noqa: F401
+    import sentry.incidents.endpoints.serializers.workflow_engine_incident  # noqa: F401
+    import sentry.monitors.serializers  # noqa: F401
+
+
+def _response_fields(serializer_cls: type) -> set[str] | None:
+    """
+    The response keys a serializer and its subclasses declare. A base serializer
+    may gather a field (``options`` on projects) that only a subclass emits.
+    """
+    fields: set[str] = set()
+    found = False
+    stack = [serializer_cls]
+    while stack:
+        cls = stack.pop()
+        response_type = response_type_of(cls)
+        if response_type is not None:
+            found = True
+            fields.update(response_type.__annotations__)
+        stack.extend(cls.__subclasses__())
+    return fields if found else None
+
+
+def test_every_mapped_field_exists_on_the_response_type() -> None:
+    _load_shaped_serializers()
+    shapings = all_response_shapings()
+    assert len(shapings) >= 11, sorted(cls.__name__ for cls in shapings)
+
+    unverifiable: list[str] = []
+    for serializer_cls, shaping in shapings.items():
+        if serializer_cls.__module__.startswith("tests."):
+            continue
+        if "shaping" not in vars(serializer_cls):
+            # Inherited: the declaring base is checked, and a subclass that
+            # narrows the response (SharedGroupSerializer) still runs the base's
+            # get_attrs, so it must keep the base keys declared.
+            continue
+        fields = _response_fields(serializer_cls)
+        if fields is None:
+            unverifiable.append(serializer_cls.__name__)
+            continue
+        missing = shaping.fields() - fields
+        assert not missing, f"{serializer_cls.__name__} maps to unknown fields {sorted(missing)}"
+
+    # Serializers whose response shape is not a resolvable TypedDict cannot be
+    # checked: ProjectCodeOwnersSerializer has no return annotation, and the
+    # detector serializer's annotation is a TYPE_CHECKING-only import. Shrink
+    # this list by typing (or importing) their `serialize` return value.
+    assert sorted(unverifiable) == [
+        "ProjectCodeOwnersSerializer",
+        "WorkflowEngineDetectorSerializer",
+    ]
+
+
+def test_openapi_parameter_enums_match_the_serializers() -> None:
+    from sentry.api.serializers.models.group_stream import GROUP_STREAM_SHAPING
+    from sentry.api.serializers.models.team import TEAM_SHAPING
+    from sentry.apidocs.parameters import IssueParams, TeamParams
+
+    assert IssueParams.GROUP_INDEX_EXPAND.enum == list(GROUP_STREAM_SHAPING.expand_keys)
+    assert IssueParams.GROUP_INDEX_COLLAPSE.enum == list(GROUP_STREAM_SHAPING.collapse_keys)
+    assert TeamParams.EXPAND.enum == list(TEAM_SHAPING.expand_keys)
+
+
+def test_group_stream_keys_cover_the_stream_response() -> None:
+    from sentry.api.serializers.models.group_stream import (
+        GROUP_STREAM_SHAPING,
+        StreamGroupSerializerSnubaResponse,
+    )
+
+    response_fields: set[str] = set(StreamGroupSerializerSnubaResponse.__annotations__)
+    assert GROUP_STREAM_SHAPING.fields() <= response_fields
+    assert "base" in GROUP_STREAM_SHAPING.collapse
+    assert set(GROUP_STREAM_SHAPING.collapse["base"]) >= {"id", "title", "culprit"}


### PR DESCRIPTION
## Why

Many serializers accept `expand` and `collapse` lists that add or remove response fields, but each one checked `key in self.expand` against string literals scattered through `serialize`. The set of accepted values, and which response fields each toggles, existed nowhere in one place: the OpenAPI parameter enums were retyped by hand (and had drifted: the issue stream honours `derivedData`, which the enum omitted), the response TypedDicts only said a field was optional, and the generated frontend contracts (#124178) cannot say "with `expand=owners`, `owners` is present".

## What

**`sentry/api/serializers/shaping.py`** adds `ResponseShaping(expand={value: (field, ...)}, collapse={...})`. A serializer declares it once as `shaping = ...` and reads it through `self._expand(key)` / `self._collapse(key)`, now provided by the base `Serializer`. A key the declaration does not list raises `UndeclaredShapingKey` in tests and logs once elsewhere, so a typo can no longer silently disable a branch. `None` still means "nothing requested", as every per-serializer helper did before. `all_response_shapings()`, `response_type_of()` and `shaping_for_response_type()` expose the serializer-to-key mapping for tooling. `extend()` lets a subclass add keys to its base's declaration.

**Migrated** (response content unchanged, only the check moved):

| Serializer | expand | collapse |
|---|---|---|
| `GroupSerializerBase` (and `GroupSerializer`, `GroupSerializerSnuba`, `StreamGroupSerializer`, `SharedGroupSerializer`) | `derivedData` | `stats`, `unhandled` |
| `StreamGroupSerializerSnuba` | + `sessions`, `inbox`, `owners`, `integrationIssues`, `sentryAppIssues`, `latestEventHasAttachments` | + `base`, `lifetime`, `filtered`, `stats` |
| `ProjectSerializer` (and `ProjectWithTeam`, `ProjectWithOrganization`) | `transaction_stats`, `session_stats`, `options` | `unusedFeatures` |
| `ProjectSummarySerializer` | inherited | + `latestDeploys` |
| `DetailedProjectSerializer` | inherited | + `organization` |
| `BaseTeamSerializer` / `TeamSerializer` | `projects`, `externalTeams`, `organization` | (none; the parameter is accepted but no key honours it) |
| `TeamSCIMSerializer` | `members` | |
| `RepositorySerializer` | `settings` | |
| `RuleSerializer`, `WorkflowEngineRuleSerializer` | `lastTriggered` | |
| `ProjectCodeOwnersSerializer` | `codeMapping`, `ownershipSyntax`, `errors`, `renameIdentifier`, `hasTargetingContext` | |
| `OrganizationMemberSerializer` (and subclasses) | `externalUsers` | |
| `OrganizationMemberSCIMSerializer` | `active` | |
| `MonitorSerializer` | `alertRule` | |
| `MonitorCheckInSerializer` | `groups` | |
| `WorkflowEngineDetectorSerializer` | `latestIncident`, `eventTypes` | |
| `WorkflowEngineIncidentSerializer` | `activities` | |

**OpenAPI.** `IssueParams.GROUP_INDEX_EXPAND` / `GROUP_INDEX_COLLAPSE` and `TeamParams.EXPAND` now take their `enum` from the serializer declarations (the group index expand enum gains `derivedData`; the team expand parameter gains an enum with `organization`). The serializer extensions attach an `x-sentry-shaping` marker to a response schema whose serializer declares keys; `custom_postprocessing_hook` lifts it onto every operation that declares an `expand`/`collapse` parameter as `x-sentry-expand` / `x-sentry-collapse` (`{value: [field, ...]}`, restricted to the parameter's enum) and strips the marker, so published component schemas are unchanged. In the current spec this stamps the organization issues list, the repositories list and team details.

**Scoped down, on purpose:**

- `GROUP_DETAILS_EXPAND` / `GROUP_DETAILS_COLLAPSE` stay hand-written. Those values (`inbox`, `owners`, `forecast`, `release`, `tags`, ...) are handled in `GroupDetailsEndpoint` itself, not in a serializer, so there is no serializer to derive them from. Moving that logic into a serializer is a separate change.
- `WorkflowEngineCombinedRuleSerializer` only forwards `expand` to the detector and rule serializers and checks nothing itself, so it declares no shaping.
- `renameIdentifier` and `hasTargetingContext` on code owners rewrite the embedded schema in place rather than adding a field, so they map to no fields.

## Verification

- `tests/sentry/api/serializers/test_shaping.py` (9 tests: validation semantics, extend/merge, response-type resolution, every declared field exists on the serializer's response TypedDict, parameter enums equal the declarations, stream keys cover the stream response) and `tests/apidocs/test_hooks.py` (11, 2 new for the stamping) pass locally.
- `make build-spectacular-docs` with `--validate --fail-on-warn`, deref, and `pnpm run validate-api-examples` pass. The built spec has no leftover marker.
- `prek` passes on every changed file. mypy could not be run reliably from this worktree; CI holds that check.

https://claude.ai/code/session_018d6yv4s3FR9D4iEmKPtvef
