### PR TITLE
feat(autofix): surface missing GitHub App permissions in the UI

### DIFF
--- a/src/sentry/integrations/api/serializers/models/integration.py
+++ b/src/sentry/integrations/api/serializers/models/integration.py
@@ -19,13 +19,26 @@ from sentry.integrations.services.integration import (
     integration_service,
 )
 from sentry.integrations.types import IntegrationIssueConfigField
-from sentry.integrations.utils.github_permissions import get_missing_github_app_permissions
+from sentry.integrations.utils.github_permission_tiers import get_permission_tiers
+from sentry.integrations.utils.github_permissions import (
+    GITHUB_APP_REQUIRED_PERMISSIONS,
+    get_missing_github_app_permissions,
+)
 from sentry.organizations.services.organization import RpcOrganization, organization_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.users.models.user import User
 from sentry.users.services.user import RpcUser
 
 logger = logging.getLogger(__name__)
+
+
+class MissingFeature(TypedDict):
+    """A feature the installation can no longer support, named by the permission
+    tier it falls short of, so the update-permissions modal can list them."""
+
+    key: str
+    name: str
+    description: str
 
 
 class OrganizationIntegrationResponse(TypedDict):
@@ -77,6 +90,9 @@ class IntegrationSerializerResponse(TypedDict):
     accountType: str | None
     scopes: list[str] | None
     outOfDate: bool | None
+    # GitHub only: the feature tiers this installation is missing, oldest first.
+    # None for providers without a permissions model.
+    missingFeatures: list[MissingFeature] | None
     status: str
     provider: IntegrationProviderInfo
 
@@ -93,10 +109,19 @@ class IntegrationSerializer(Serializer):
         provider = obj.get_provider()
 
         out_of_date = None
+        missing_features: list[MissingFeature] | None = None
 
         match provider.key:
             case "github":
                 out_of_date = bool(get_missing_github_app_permissions(obj.metadata))
+                # Oldest feature first, matching the PR-iteration comment's order.
+                tiers = get_permission_tiers(
+                    obj.metadata.get("permissions", {}), GITHUB_APP_REQUIRED_PERMISSIONS
+                )
+                missing_features = [
+                    {"key": tier.key, "name": tier.name, "description": tier.description}
+                    for tier in reversed(tiers)
+                ]
             case "slack":
                 out_of_date = SlackScope.APP_MENTIONS_READ not in (obj.metadata.get("scopes") or [])
 
@@ -108,6 +133,7 @@ class IntegrationSerializer(Serializer):
             "accountType": obj.metadata.get("account_type"),
             "scopes": obj.metadata.get("scopes"),
             "outOfDate": out_of_date,
+            "missingFeatures": missing_features,
             "status": obj.get_status_display(),
             "provider": serialize_provider(provider),
         }

--- a/src/sentry/integrations/utils/github_permission_tiers.py
+++ b/src/sentry/integrations/utils/github_permission_tiers.py
@@ -1,0 +1,207 @@
+"""Which Sentry features a GitHub App installation loses when it is missing permissions.
+
+Every permission the app asks for arrived with a feature, and an installation
+sits at whichever version of the app it last accepted. Upgrades only ever raised
+requirements, so the tiers below are totally ordered by ``PermissionTier.order``
+and an installation should be a point on that order: satisfying one tier implies
+satisfying every lower one. An install is described by how far up it got, and
+the copy to show names the tiers above that point.
+
+``order`` is what encodes the chain, not the declaration order of ``TIERS``.
+A new feature gets the next number up; the numbers are spaced by one only
+because nothing has ever needed to slot in between.
+
+Tiers are keyed on scope *and* level, not scope alone. Several scopes were
+already held at ``read`` long before a later feature raised them to ``write``:
+``contents:read`` predates Seer entirely while ``contents:write`` is what lets
+Autofix push a branch, and the same split applies to ``pull_requests``. A tier
+declares only the raise it introduced; everything it inherits belongs to the
+lower tiers returned alongside it.
+
+``BASELINE_TIER`` sits at the bottom as the catchall. It declares no scopes and
+instead speaks for whatever the app requires that no other tier claims, which is
+both the permissions predating the history we have and any scope a future app
+version starts requiring before someone adds a tier for it.
+
+A set that is not a point on the order -- satisfying a tier while falling short
+of a lower one -- is a combination we do not understand, so it is logged and
+treated as nothing to say rather than guessed at. That is also what a missing
+tier declaration looks like from here, which is the point: drift surfaces as a
+warning instead of as confident but wrong copy.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from sentry.integrations.utils.github_permissions import PERMISSION_LEVELS
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PermissionTier:
+    key: str
+    # Position on the chain. Higher is newer, and satisfying this tier means
+    # satisfying every tier below it.
+    order: int
+    name: str
+    description: str
+    # The permission raise this tier introduced, as scope -> minimum level. Not
+    # the full set the feature needs: the rest came with lower tiers. Empty on
+    # BASELINE_TIER, whose requirements are derived by exclusion instead.
+    introduced: Mapping[str, str] = field(default_factory=dict)
+
+
+BASELINE_TIER = PermissionTier(
+    key="baseline",
+    order=0,
+    name="Various earlier features",
+    description=(
+        "Including issue linking, commit tracking, and keeping repository data up to date."
+    ),
+)
+
+PR_COMMENTS_TIER = PermissionTier(
+    key="pull_request_comments",
+    order=1,
+    name="Pull request comments",
+    description="Comment on pull requests to link them to the Sentry issues they caused.",
+    introduced={"pull_requests": "write"},
+)
+
+CODE_REVIEW_TIER = PermissionTier(
+    key="code_review",
+    order=2,
+    name="Seer Code Review",
+    description="Review your pull requests and report the result as a check run.",
+    introduced={"checks": "write", "statuses": "write"},
+)
+
+AUTOFIX_PULL_REQUESTS_TIER = PermissionTier(
+    key="autofix_pull_requests",
+    order=3,
+    name="Autofix pull requests",
+    description="Push a branch and open a pull request with a fix for an issue.",
+    introduced={"contents": "write"},
+)
+
+PR_ITERATION_TIER = PermissionTier(
+    key="pr_iteration",
+    order=4,
+    name="Pull request iteration",
+    description=(
+        "Read GitHub Actions logs and re-run jobs, so Seer can get a pull "
+        "request it opened to a passing build."
+    ),
+    introduced={
+        "actions": "write",
+        "code_quality": "read",
+        "security_events": "read",
+    },
+)
+
+TIERS: tuple[PermissionTier, ...] = tuple(
+    sorted(
+        (
+            BASELINE_TIER,
+            PR_COMMENTS_TIER,
+            CODE_REVIEW_TIER,
+            AUTOFIX_PULL_REQUESTS_TIER,
+            PR_ITERATION_TIER,
+        ),
+        key=lambda tier: tier.order,
+        reverse=True,
+    )
+)
+
+
+def _level(level: str | None) -> int:
+    return PERMISSION_LEVELS.get(level or "", 0)
+
+
+def _falls_short(permissions: Mapping[str, str], requirements: Mapping[str, str]) -> bool:
+    return any(
+        _level(permissions.get(scope)) < _level(level) for scope, level in requirements.items()
+    )
+
+
+def _baseline_tier_reqs(required_permissions: Mapping[str, str]) -> dict[str, str]:
+    """The requirements in ``required_permissions`` that no tier claims a scope for.
+
+    These are what ``BASELINE_TIER`` speaks for. A scope showing up here that we
+    did not expect to means the app started requiring something new and nobody
+    added a tier for it, so users are being asked to accept a permission we
+    cannot name a feature for.
+    """
+    claimed: dict[str, int] = {}
+    for tier in TIERS:
+        for scope, level in tier.introduced.items():
+            claimed[scope] = max(claimed.get(scope, 0), _level(level))
+
+    return {
+        scope: level
+        for scope, level in required_permissions.items()
+        if claimed.get(scope, 0) < _level(level)
+    }
+
+
+def _requirements(
+    tier: PermissionTier, required_permissions: Mapping[str, str]
+) -> Mapping[str, str]:
+    if tier is BASELINE_TIER:
+        return _baseline_tier_reqs(required_permissions)
+
+    return tier.introduced
+
+
+def get_permission_tiers(
+    permissions: Mapping[str, str], required_permissions: Mapping[str, str]
+) -> list[PermissionTier]:
+    """Tiers an install holding ``permissions`` falls short of, highest order first.
+
+    ``permissions`` is the installation's own scope -> level map as GitHub
+    reports it in ``Integration.metadata["permissions"]``; ``required_permissions``
+    is what the current app version asks for, from the
+    ``github-app.required-permissions`` option.
+
+    Empty when the install is current. When its permissions are not a point on
+    the order we cannot trust the state, so rather than guess we log it and
+    conservatively assume every tier is missing, returning them all. That covers
+    both an inconsistent set and falling short of ``BASELINE_TIER``, whose
+    permissions predate everything. Scopes beyond what any tier asks for are
+    ignored. A level we do not recognise counts as not held.
+    """
+    behind = [
+        tier
+        for tier in TIERS
+        if _falls_short(permissions, _requirements(tier, required_permissions))
+    ]
+    if not behind:
+        return []
+
+    if BASELINE_TIER in behind:
+        logger.warning(
+            "github_permission_tiers.short_of_baseline",
+            extra={
+                "expected_permissions": dict(_baseline_tier_reqs(required_permissions)),
+                "permissions": dict(permissions),
+            },
+        )
+        return list(TIERS)
+
+    lowest = min(tier.order for tier in behind)
+    expected = {tier.order for tier in TIERS if tier.order >= lowest}
+    if {tier.order for tier in behind} != expected:
+        logger.warning(
+            "github_permission_tiers.inconsistent_permissions",
+            extra={
+                "behind_tiers": [tier.key for tier in behind],
+                "permissions": dict(permissions),
+            },
+        )
+        return list(TIERS)
+
+    return behind

--- a/src/sentry/integrations/utils/github_permission_tiers.py
+++ b/src/sentry/integrations/utils/github_permission_tiers.py
@@ -36,7 +36,10 @@ import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 
-from sentry.integrations.utils.github_permissions import PERMISSION_LEVELS
+from sentry.integrations.utils.github_permissions import (
+    GITHUB_APP_REQUIRED_PERMISSIONS,
+    PERMISSION_LEVELS,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,7 +63,7 @@ BASELINE_TIER = PermissionTier(
     order=0,
     name="Various earlier features",
     description=(
-        "Including issue linking, commit tracking, and keeping repository data up to date."
+        "Linking to Sentry Issues, Suspect Commits, and keeping repository data up to date."
     ),
 )
 
@@ -68,7 +71,7 @@ PR_COMMENTS_TIER = PermissionTier(
     key="pull_request_comments",
     order=1,
     name="Pull request comments",
-    description="Comment on pull requests to link them to the Sentry issues they caused.",
+    description="Comments on your pull requests to link them to the Sentry issues they caused.",
     introduced={"pull_requests": "write"},
 )
 
@@ -76,7 +79,7 @@ CODE_REVIEW_TIER = PermissionTier(
     key="code_review",
     order=2,
     name="Seer Code Review",
-    description="Review your pull requests and report the result as a check run.",
+    description="Seer Code Review: Reviews your pull requests and reports the results as a check run.",
     introduced={"checks": "write", "statuses": "write"},
 )
 
@@ -84,7 +87,7 @@ AUTOFIX_PULL_REQUESTS_TIER = PermissionTier(
     key="autofix_pull_requests",
     order=3,
     name="Autofix pull requests",
-    description="Push a branch and open a pull request with a fix for an issue.",
+    description="Seer Autofix: Pushes a branch and opens a pull request with a fix for an issue.",
     introduced={"contents": "write"},
 )
 
@@ -93,8 +96,8 @@ PR_ITERATION_TIER = PermissionTier(
     order=4,
     name="Pull request iteration",
     description=(
-        "Read GitHub Actions logs and re-run jobs, so Seer can get a pull "
-        "request it opened to a passing build."
+        "Seer PR Iteration: Reads GitHub Actions logs and re-run jobs, so Seer Autofix "
+        "can get a pull request it opened to a passing build."
     ),
     introduced={
         "actions": "write",
@@ -164,8 +167,8 @@ def get_permission_tiers(
 
     ``permissions`` is the installation's own scope -> level map as GitHub
     reports it in ``Integration.metadata["permissions"]``; ``required_permissions``
-    is what the current app version asks for, from the
-    ``github-app.required-permissions`` option.
+    is what the current app version asks for. Most callers want
+    ``get_missing_permission_tiers``, which passes ``GITHUB_APP_REQUIRED_PERMISSIONS``.
 
     Empty when the install is current. When its permissions are not a point on
     the order we cannot trust the state, so rather than guess we log it and
@@ -205,3 +208,16 @@ def get_permission_tiers(
         return list(TIERS)
 
     return behind
+
+
+def get_missing_permission_tiers(permissions: Mapping[str, str]) -> list[PermissionTier]:
+    """The feature tiers an installation holding ``permissions`` falls short of.
+
+    Feed in the install's own scope -> level map (from
+    ``Integration.metadata["permissions"]``) and get back the tiers it is missing,
+    highest order first. A non-empty result *is* the "missing permissions" signal:
+    each tier names a feature that stops working, and an install with everything
+    the app requires comes back empty. Thin wrapper over ``get_permission_tiers``
+    that compares against ``GITHUB_APP_REQUIRED_PERMISSIONS``.
+    """
+    return get_permission_tiers(permissions, GITHUB_APP_REQUIRED_PERMISSIONS)

--- a/src/sentry/integrations/utils/github_permissions.py
+++ b/src/sentry/integrations/utils/github_permissions.py
@@ -1,21 +1,20 @@
-"""
-when you update the app, if and only if you want warnings to show in different places in the UI
-then you should update the option with the new expected required permissions and their required level
+"""The permissions the current GitHub App version requests, and helpers to
+compare an installation against them.
 
-if you don't update the option, nothing will break since the option only lists out required permissions:
-if the user's integration contains more permissions than we expect we just ignore it, since there are
-inconsistencies with what permissions we store in the metadata anyways based on whether the integration
-is for an org or a single user
+``GITHUB_APP_REQUIRED_PERMISSIONS`` is the source of truth for what the app asks
+for. It lives in the codebase (it used to be the ``github-app.required-permissions``
+option) because it is not a secret and has to stay in lockstep with the app's
+declared permissions and the tiers in ``github_permission_tiers``. Update it
+whenever the app's required permissions change.
 
-at the moment there's no way to gate warnings in the UI by which perm is missing, but we can add that
-where the warnings are implemented since this API returns the list of missing scopes / levels
+We only ever compare against it as a floor: an installation holding *more* than
+we expect is ignored, since what GitHub reports in the integration metadata
+already varies by whether the install is for an org or a single user.
 """
 
 import logging
 from collections.abc import Mapping
 from typing import Any, TypedDict
-
-from sentry import options
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +37,29 @@ PERMISSION_LEVELS = {
     "admin": 3,
 }
 
+# The union of every permission the app's features expect, as scope -> minimum
+# level. Each scope is introduced by one of the tiers in github_permission_tiers,
+# except the last group, which predates them and is spoken for by BASELINE_TIER:
+#   actions:write, code_quality:read, security_events:read  -> PR iteration
+#   contents:write                                          -> Autofix pull requests
+#   checks:write, statuses:write                            -> Seer code review
+#   pull_requests:write                                     -> PR comments
+#   administration:read, issues:write, metadata:read,
+#   repository_hooks:write                                  -> baseline (earlier features)
+GITHUB_APP_REQUIRED_PERMISSIONS: dict[str, str] = {
+    "actions": "write",
+    "administration": "read",
+    "checks": "write",
+    "code_quality": "read",
+    "contents": "write",
+    "issues": "write",
+    "metadata": "read",
+    "pull_requests": "write",
+    "repository_hooks": "write",
+    "security_events": "read",
+    "statuses": "write",
+}
+
 
 def _quantify_github_app_permissions(
     permissions: Mapping[str, str],
@@ -48,18 +70,17 @@ def _quantify_github_app_permissions(
 def get_missing_github_app_permissions(
     metadata: Mapping[str, Any],
 ) -> list[MissingGithubAppPermission] | None:
-    required_permissions = options.get(GITHUB_APP_REQUIRED_PERMISSIONS_OPTION)
-    if not required_permissions:
-        return None
-
     try:
-        expected_permissions = _quantify_github_app_permissions(required_permissions)
+        expected_permissions = _quantify_github_app_permissions(GITHUB_APP_REQUIRED_PERMISSIONS)
         actual_permissions = _quantify_github_app_permissions(metadata.get("permissions", {}))
     except KeyError:
         # If either dict has an unknown permission level, don't enforce anything.
         logger.error(
             "github_permissions.malformed_permissions",
-            extra={"required": required_permissions, "actual": metadata.get("permissions")},
+            extra={
+                "required": GITHUB_APP_REQUIRED_PERMISSIONS,
+                "actual": metadata.get("permissions"),
+            },
         )
         return None
 

--- a/src/sentry/seer/autofix/github_perms.py
+++ b/src/sentry/seer/autofix/github_perms.py
@@ -7,10 +7,11 @@ from typing import TYPE_CHECKING
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import RpcIntegration, integration_service
-from sentry.integrations.utils.github_permissions import (
-    get_github_permissions_update_url,
-    get_missing_github_app_permissions,
+from sentry.integrations.utils.github_permission_tiers import (
+    PermissionTier,
+    get_missing_permission_tiers,
 )
+from sentry.integrations.utils.github_permissions import get_github_permissions_update_url
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.seer.autofix.constants import SEER_GITHUB_PROVIDERS
@@ -24,9 +25,11 @@ logger = logging.getLogger(__name__)
 @dataclass(frozen=True)
 class MissingGithubPermissions:
     integration: RpcIntegration
-    # Required permissions the installation does not hold. Never empty: an
-    # install with everything it needs is not reported as missing anything.
-    missing_scopes: list[str]
+    # Feature tiers the installation falls short of, highest order first. Never
+    # empty: an install with everything it needs is not reported as missing
+    # anything. Their presence is the "missing permissions" signal; each tier
+    # names a feature that stops working.
+    missing_tiers: list[PermissionTier]
     # The Repository row this was resolved for, so callers can log an id
     # instead of the repo's full name.
     repository_id: int
@@ -117,8 +120,8 @@ def get_blocked_pr_iteration_permissions(
 def get_missing_permissions_by_repo(
     organization: Organization, repo_names: Collection[str]
 ) -> dict[str, MissingGithubPermissions]:
-    """Map each of `repo_names` whose GitHub App install is missing a required
-    permission to what it is missing. Repos with a complete install, no active
+    """Map each of `repo_names` whose GitHub App install is missing a feature
+    tier to the tiers it is missing. Repos with a complete install, no active
     org-scoped GitHub repository row, or no integration are absent.
     """
     if not repo_names:
@@ -155,11 +158,10 @@ def get_missing_permissions_by_repo(
             )
             continue
 
-        missing = get_missing_github_app_permissions(integration.metadata)
-        missing_scopes = [permission["expected"]["scope"] for permission in (missing or [])]
-        if missing_scopes:
+        missing_tiers = get_missing_permission_tiers(integration.metadata.get("permissions", {}))
+        if missing_tiers:
             missing_by_repo[repo_name] = MissingGithubPermissions(
-                integration=integration, missing_scopes=missing_scopes, repository_id=repository_id
+                integration=integration, missing_tiers=missing_tiers, repository_id=repository_id
             )
 
     for repo_name in set(repo_names) - resolved:

--- a/src/sentry/seer/autofix/pr_iteration/missing_permissions.py
+++ b/src/sentry/seer/autofix/pr_iteration/missing_permissions.py
@@ -42,6 +42,7 @@ from sentry import analytics
 from sentry.analytics.events.pr_iteration_events import (
     AiAutofixPrIterationMissingPermissionsEvent,
 )
+from sentry.integrations.utils.github_permission_tiers import PR_ITERATION_TIER, PermissionTier
 from sentry.locks import locks
 from sentry.models.organization import Organization
 from sentry.scm.factory import new as make_scm
@@ -63,7 +64,7 @@ def get_missing_permissions_marker(seer_run: SeerRun, repo_name: str) -> dict[st
 
 
 def record_missing_permissions_marker(
-    seer_run: SeerRun, repo_name: str, *, missing_scopes: list[str], pr_id: int | None
+    seer_run: SeerRun, repo_name: str, *, missing_tiers: list[str], pr_id: int | None
 ) -> None:
     record_run_marker(
         seer_run,
@@ -71,29 +72,52 @@ def record_missing_permissions_marker(
         repo_name,
         {
             "commented_at": timezone.now().isoformat(),
-            "missing_scopes": missing_scopes,
+            "missing_tiers": missing_tiers,
             "pr_id": pr_id,
         },
     )
 
 
-def _scopes_tag(missing_scopes: Iterable[str]) -> str:
-    """Stable metrics-tag rendering of a set of missing scopes.
+def _tiers_tag(tiers: Iterable[PermissionTier]) -> str:
+    """Stable metrics-tag rendering of a set of missing feature tiers.
 
-    Sorted and deduped so the same set is always one time series, and joined on
-    "-" rather than "," because dogstatsd separates tags with commas on the wire.
+    Sorted and deduped by tier key so the same set is always one time series,
+    and joined on "-" rather than "," because dogstatsd separates tags with
+    commas on the wire.
     """
-    return "-".join(sorted(set(missing_scopes))) or "none"
+    return "-".join(sorted({tier.key for tier in tiers})) or "none"
 
 
 def _comment_body(url: str) -> str:
     return (
-        "⚠️ **Seer needs additional GitHub permissions**\n\n"
-        "Seer wants to keep iterating on this pull request to get CI passing, but the "
-        "Sentry GitHub App installation is missing permissions it needs to read the failing "
-        "checks and push a fix.\n\n"
+        "⚠️ Sentry needs additional GitHub App permissions\n\n"
+        "The Sentry GitHub App installation for this repository is missing permissions it "
+        "needs to keep iterating on this pull request to get CI passing.\n\n"
         f"Review and accept the updated permissions to let Seer continue: {url}"
     )
+
+
+def _warn_if_unexpected_missing_tiers(
+    info: MissingGithubPermissions,
+    log_ctx: PrIterationLogContext,
+    log_fields: dict[str, Any],
+) -> None:
+    """Log when the install is missing more than the PR iteration tier.
+
+    PR iteration is the newest tier, so an install we block here should be short
+    of *only* it: anyone who accepted the Autofix-pull-requests permissions
+    already holds everything below. Missing any other tier too means the install
+    is in a shape we did not expect it to reach this path in, so surface it.
+    Logged at error level because this module routes every unexpected state
+    through ``log_ctx.error`` (see ``PrIterationLogContext``).
+    """
+    if any(tier is not PR_ITERATION_TIER for tier in info.missing_tiers):
+        log_ctx.error(
+            "autofix.pr_iteration.missing_permissions.unexpected_missing_tiers",
+            exc_info=False,
+            missing_tiers=[tier.key for tier in info.missing_tiers],
+            **log_fields,
+        )
 
 
 def repos_missing_permissions(
@@ -110,7 +134,7 @@ def repos_missing_permissions(
 
 def _comment_failed(
     reason: str,
-    scopes_tag: str,
+    tiers_tag: str,
     log_ctx: PrIterationLogContext,
     log_fields: dict[str, Any],
     *,
@@ -118,7 +142,7 @@ def _comment_failed(
 ) -> bool:
     metrics.incr(
         "autofix.pr_iteration.missing_permissions.comment_failed",
-        tags={"missing_scopes": scopes_tag, "reason": reason},
+        tags={"missing_tiers": tiers_tag, "reason": reason},
     )
     log_ctx.error(
         "autofix.pr_iteration.missing_permissions.comment_failed",
@@ -136,7 +160,7 @@ def _post_comment(
     log_ctx: PrIterationLogContext,
     log_fields: dict[str, Any],
 ) -> bool:
-    scopes_tag = _scopes_tag(info.missing_scopes)
+    tiers_tag = _tiers_tag(info.missing_tiers)
     url = info.installation_url
     if url is None:
         # Org-owned installs need the account login to build the path; without
@@ -153,17 +177,18 @@ def _post_comment(
     try:
         scm = make_scm(organization.id, info.repository_id, referrer="seer")
     except Exception:
-        return _comment_failed("scm_init_failed", scopes_tag, log_ctx, log_fields)
+        return _comment_failed("scm_init_failed", tiers_tag, log_ctx, log_fields)
 
     if not isinstance(scm, CreatePullRequestCommentProtocol):
         return _comment_failed(
-            "unsupported_provider", scopes_tag, log_ctx, log_fields, exc_info=False
+            "unsupported_provider", tiers_tag, log_ctx, log_fields, exc_info=False
         )
 
+    _warn_if_unexpected_missing_tiers(info, log_ctx, log_fields)
     try:
         scm_actions.create_pull_request_comment(scm, str(pr_number), _comment_body(url))
     except Exception:
-        return _comment_failed("post_failed", scopes_tag, log_ctx, log_fields)
+        return _comment_failed("post_failed", tiers_tag, log_ctx, log_fields)
     return True
 
 
@@ -187,8 +212,8 @@ def get_blocking_permissions(
     metrics.incr(
         "autofix.pr_iteration.missing_permissions.blocked",
         tags={
-            "missing_scopes": _scopes_tag(
-                scope for info in missing_by_repo.values() for scope in info.missing_scopes
+            "missing_tiers": _tiers_tag(
+                tier for info in missing_by_repo.values() for tier in info.missing_tiers
             )
         },
     )
@@ -367,7 +392,7 @@ def post_missing_permissions_comment(
         record_missing_permissions_marker(
             seer_run,
             repo_name,
-            missing_scopes=info.missing_scopes,
+            missing_tiers=[tier.key for tier in info.missing_tiers],
             pr_id=pr_id,
         )
 
@@ -375,10 +400,10 @@ def post_missing_permissions_comment(
 
     metrics.incr(
         "autofix.pr_iteration.missing_permissions.commented",
-        tags={"missing_scopes": _scopes_tag(info.missing_scopes)},
+        tags={"missing_tiers": _tiers_tag(info.missing_tiers)},
     )
     log_ctx.info(
         "autofix.pr_iteration.missing_permissions.commented",
-        missing_scopes=info.missing_scopes,
+        missing_tiers=[tier.key for tier in info.missing_tiers],
         **log_fields,
     )

--- a/static/app/components/events/autofix/autofixGithubAppPermissionsModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixGithubAppPermissionsModal.spec.tsx
@@ -4,35 +4,77 @@ import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 
 describe('AutofixGithubAppPermissionsModal', () => {
-  it('renders the modal', async () => {
+  it('renders the coding-agent handoff variant', async () => {
     renderGlobalModal();
 
     act(() => {
-      openModal(deps => <AutofixGithubAppPermissionsModal {...deps} />);
+      openModal(deps => (
+        <AutofixGithubAppPermissionsModal {...deps} variant="coding_agent_handoff" />
+      ));
     });
 
     expect(await screen.findByText('Update GitHub App Permissions')).toBeInTheDocument();
     expect(screen.getByText(/does not have sufficient permissions/)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', {name: 'GitHub App installation settings'})
+    ).toBeInTheDocument();
   });
 
-  it('uses a custom first sentence and always links settings in the body', async () => {
+  it('renders the pr-iteration variant', async () => {
+    renderGlobalModal();
+
+    act(() => {
+      openModal(deps => (
+        <AutofixGithubAppPermissionsModal {...deps} variant="pr_iteration" />
+      ));
+    });
+
+    expect(
+      await screen.findByText(
+        /Seer needs additional GitHub App permissions to keep iterating on the pull requests in this run/
+      )
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Review and accept the updated permissions to let Seer continue/)
+    ).toBeInTheDocument();
+  });
+
+  it('renders the integration-settings variant with its missing features', async () => {
     renderGlobalModal();
 
     act(() => {
       openModal(deps => (
         <AutofixGithubAppPermissionsModal
           {...deps}
-          description="Seer had trouble talking to GitHub while running Autofix."
+          variant="integration_settings"
+          missingFeatures={[
+            {
+              key: 'code_review',
+              name: 'Seer Code Review',
+              description: 'Seer Code Review: Reviews your pull requests.',
+            },
+            {
+              key: 'pr_iteration',
+              name: 'Pull request iteration',
+              description:
+                'Seer PR Iteration: Reads GitHub Actions logs and re-runs jobs.',
+            },
+          ]}
         />
       ));
     });
 
     expect(
-      await screen.findByText(/Seer had trouble talking to GitHub while running Autofix/)
+      await screen.findByText(
+        'This installation is missing permissions for the following features:'
+      )
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('link', {name: 'GitHub App installation settings'})
-    ).toHaveAttribute('href', 'https://github.com/settings/installations/');
+      screen.getByText('Seer Code Review: Reviews your pull requests.')
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Seer PR Iteration: Reads GitHub Actions logs and re-runs jobs.')
+    ).toBeInTheDocument();
   });
 
   it('uses a provided installation URL', async () => {
@@ -43,7 +85,11 @@ describe('AutofixGithubAppPermissionsModal', () => {
 
     act(() => {
       openModal(deps => (
-        <AutofixGithubAppPermissionsModal {...deps} installationUrl={installationUrl} />
+        <AutofixGithubAppPermissionsModal
+          {...deps}
+          variant="coding_agent_handoff"
+          installationUrl={installationUrl}
+        />
       ));
     });
 
@@ -58,7 +104,9 @@ describe('AutofixGithubAppPermissionsModal', () => {
     renderGlobalModal();
 
     act(() => {
-      openModal(deps => <AutofixGithubAppPermissionsModal {...deps} />);
+      openModal(deps => (
+        <AutofixGithubAppPermissionsModal {...deps} variant="coding_agent_handoff" />
+      ));
     });
 
     const updateButton = await screen.findByRole('button', {name: 'Update Permissions'});

--- a/static/app/components/events/autofix/autofixGithubAppPermissionsModal.spec.tsx
+++ b/static/app/components/events/autofix/autofixGithubAppPermissionsModal.spec.tsx
@@ -1,118 +1,111 @@
 import {act, renderGlobalModal, screen} from 'sentry-test/reactTestingLibrary';
 
 import {openModal} from 'sentry/actionCreators/modal';
-import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
+import {
+  CodingAgentHandoffPermissionsModal,
+  IntegrationSettingsPermissionsModal,
+  PrIterationPermissionsModal,
+} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 
-describe('AutofixGithubAppPermissionsModal', () => {
-  it('renders the coding-agent handoff variant', async () => {
-    renderGlobalModal();
+const DEFAULT_INSTALLATIONS_URL = 'https://github.com/settings/installations/';
 
-    act(() => {
-      openModal(deps => (
-        <AutofixGithubAppPermissionsModal {...deps} variant="coding_agent_handoff" />
-      ));
+describe('GitHub App permissions modals', () => {
+  describe('PrIterationPermissionsModal', () => {
+    it('renders the pr-iteration copy', async () => {
+      renderGlobalModal();
+
+      act(() => {
+        openModal(deps => <PrIterationPermissionsModal {...deps} />);
+      });
+
+      expect(
+        await screen.findByText(
+          /Seer needs additional GitHub App permissions to keep iterating on the pull requests in this run/
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText(/Review and accept the updated permissions to let Seer continue/)
+      ).toBeInTheDocument();
     });
-
-    expect(await screen.findByText('Update GitHub App Permissions')).toBeInTheDocument();
-    expect(screen.getByText(/does not have sufficient permissions/)).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', {name: 'GitHub App installation settings'})
-    ).toBeInTheDocument();
   });
 
-  it('renders the pr-iteration variant', async () => {
-    renderGlobalModal();
+  describe('CodingAgentHandoffPermissionsModal', () => {
+    it('renders the coding-agent copy and links settings', async () => {
+      renderGlobalModal();
 
-    act(() => {
-      openModal(deps => (
-        <AutofixGithubAppPermissionsModal {...deps} variant="pr_iteration" />
-      ));
+      act(() => {
+        openModal(deps => <CodingAgentHandoffPermissionsModal {...deps} />);
+      });
+
+      expect(
+        await screen.findByText(/does not have sufficient permissions/)
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('link', {name: 'GitHub App installation settings'})
+      ).toHaveAttribute('href', DEFAULT_INSTALLATIONS_URL);
     });
 
-    expect(
-      await screen.findByText(
-        /Seer needs additional GitHub App permissions to keep iterating on the pull requests in this run/
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/Review and accept the updated permissions to let Seer continue/)
-    ).toBeInTheDocument();
+    it('uses a provided installation URL for the button and link', async () => {
+      const installationUrl =
+        'https://github.com/organizations/example-org/settings/installations/654321/permissions/update';
+
+      renderGlobalModal();
+
+      act(() => {
+        openModal(deps => (
+          <CodingAgentHandoffPermissionsModal
+            {...deps}
+            installationUrl={installationUrl}
+          />
+        ));
+      });
+
+      const updateButton = await screen.findByRole('button', {
+        name: 'Update Permissions',
+      });
+      expect(updateButton).toHaveAttribute('href', installationUrl);
+      expect(
+        screen.getByRole('link', {name: 'GitHub App installation settings'})
+      ).toHaveAttribute('href', installationUrl);
+    });
   });
 
-  it('renders the integration-settings variant with its missing features', async () => {
-    renderGlobalModal();
+  describe('IntegrationSettingsPermissionsModal', () => {
+    it('lists the missing features', async () => {
+      renderGlobalModal();
 
-    act(() => {
-      openModal(deps => (
-        <AutofixGithubAppPermissionsModal
-          {...deps}
-          variant="integration_settings"
-          missingFeatures={[
-            {
-              key: 'code_review',
-              name: 'Seer Code Review',
-              description: 'Seer Code Review: Reviews your pull requests.',
-            },
-            {
-              key: 'pr_iteration',
-              name: 'Pull request iteration',
-              description:
-                'Seer PR Iteration: Reads GitHub Actions logs and re-runs jobs.',
-            },
-          ]}
-        />
-      ));
+      act(() => {
+        openModal(deps => (
+          <IntegrationSettingsPermissionsModal
+            {...deps}
+            missingFeatures={[
+              {
+                key: 'code_review',
+                name: 'Seer Code Review',
+                description: 'Seer Code Review: Reviews your pull requests.',
+              },
+              {
+                key: 'pr_iteration',
+                name: 'Pull request iteration',
+                description:
+                  'Seer PR Iteration: Reads GitHub Actions logs and re-runs jobs.',
+              },
+            ]}
+          />
+        ));
+      });
+
+      expect(
+        await screen.findByText(
+          'This installation is missing permissions for the following features:'
+        )
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Seer Code Review: Reviews your pull requests.')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('Seer PR Iteration: Reads GitHub Actions logs and re-runs jobs.')
+      ).toBeInTheDocument();
     });
-
-    expect(
-      await screen.findByText(
-        'This installation is missing permissions for the following features:'
-      )
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('Seer Code Review: Reviews your pull requests.')
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText('Seer PR Iteration: Reads GitHub Actions logs and re-runs jobs.')
-    ).toBeInTheDocument();
-  });
-
-  it('uses a provided installation URL', async () => {
-    const installationUrl =
-      'https://github.com/organizations/example-org/settings/installations/654321/permissions/update';
-
-    renderGlobalModal();
-
-    act(() => {
-      openModal(deps => (
-        <AutofixGithubAppPermissionsModal
-          {...deps}
-          variant="coding_agent_handoff"
-          installationUrl={installationUrl}
-        />
-      ));
-    });
-
-    const updateButton = await screen.findByRole('button', {name: 'Update Permissions'});
-    expect(updateButton).toHaveAttribute('href', installationUrl);
-    expect(
-      screen.getByRole('link', {name: 'GitHub App installation settings'})
-    ).toHaveAttribute('href', installationUrl);
-  });
-
-  it('renders update permissions button linking to GitHub settings', async () => {
-    renderGlobalModal();
-
-    act(() => {
-      openModal(deps => (
-        <AutofixGithubAppPermissionsModal {...deps} variant="coding_agent_handoff" />
-      ));
-    });
-
-    const updateButton = await screen.findByRole('button', {name: 'Update Permissions'});
-    expect(updateButton).toHaveAttribute(
-      'href',
-      'https://github.com/settings/installations/'
-    );
   });
 });

--- a/static/app/components/events/autofix/autofixGithubAppPermissionsModal.tsx
+++ b/static/app/components/events/autofix/autofixGithubAppPermissionsModal.tsx
@@ -1,18 +1,26 @@
 import {Fragment} from 'react';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
-import {Grid} from '@sentry/scraps/layout';
+import {Grid, Stack} from '@sentry/scraps/layout';
 import {ExternalLink} from '@sentry/scraps/link';
 import {Heading, Text} from '@sentry/scraps/text';
 
 import type {ModalRenderProps} from 'sentry/actionCreators/modal';
 import {t, tct} from 'sentry/locale';
 
+interface MissingFeature {
+  description: string;
+  key: string;
+  name: string;
+}
+
 interface AutofixGithubAppPermissionsModalProps extends ModalRenderProps {
-  /** First sentence. The linked "update settings" sentence is always appended. */
-  description?: string;
+  /** Which flow opened the modal; selects the copy. */
+  variant: 'pr_iteration' | 'coding_agent_handoff' | 'integration_settings';
   /** GitHub permissions URL for the install. Falls back to GitHub's installations index. */
   installationUrl?: string;
+  /** Feature tiers the install is missing; rendered by the `integration_settings` variant. */
+  missingFeatures?: MissingFeature[];
 }
 
 const DEFAULT_INSTALLATIONS_URL = 'https://github.com/settings/installations/';
@@ -23,11 +31,15 @@ export function AutofixGithubAppPermissionsModal({
   Footer,
   closeModal,
   installationUrl,
-  description = t(
-    'The Sentry GitHub App does not have sufficient permissions to launch a coding agent.'
-  ),
+  variant,
+  missingFeatures,
 }: AutofixGithubAppPermissionsModalProps) {
   const settingsUrl = installationUrl ?? DEFAULT_INSTALLATIONS_URL;
+
+  const settingsSentence = tct(
+    'Please update your [link:GitHub App installation settings] to grant the required permissions.',
+    {link: <ExternalLink href={settingsUrl} />}
+  );
 
   return (
     <Fragment>
@@ -35,13 +47,35 @@ export function AutofixGithubAppPermissionsModal({
         <Heading as="h3">{t('Update GitHub App Permissions')}</Heading>
       </Header>
       <Body>
-        <Text as="p">
-          {description}{' '}
-          {tct(
-            'Please update your [link:GitHub App installation settings] to grant the required permissions.',
-            {link: <ExternalLink href={settingsUrl} />}
-          )}
-        </Text>
+        {variant === 'pr_iteration' ? (
+          <Text as="p">
+            {t(
+              'Seer needs additional GitHub App permissions to keep iterating on the pull requests in this run and get CI passing.'
+            )}{' '}
+            {t('Review and accept the updated permissions to let Seer continue.')}
+          </Text>
+        ) : variant === 'coding_agent_handoff' ? (
+          <Text as="p">
+            {t(
+              'The Sentry GitHub App does not have sufficient permissions to launch a coding agent.'
+            )}{' '}
+            {settingsSentence}
+          </Text>
+        ) : (
+          <Stack gap="lg">
+            <Text as="p">
+              {t('This installation is missing permissions for the following features:')}
+            </Text>
+            <ul>
+              {missingFeatures?.map(feature => (
+                <li key={feature.key}>
+                  <Text>{feature.description}</Text>
+                </li>
+              ))}
+            </ul>
+            <Text as="p">{settingsSentence}</Text>
+          </Stack>
+        )}
       </Body>
       <Footer>
         <Grid flow="column" align="center" gap="md">

--- a/static/app/components/events/autofix/autofixGithubAppPermissionsModal.tsx
+++ b/static/app/components/events/autofix/autofixGithubAppPermissionsModal.tsx
@@ -1,4 +1,5 @@
 import {Fragment} from 'react';
+import type {ReactNode} from 'react';
 
 import {Button, LinkButton} from '@sentry/scraps/button';
 import {Grid, Stack} from '@sentry/scraps/layout';
@@ -14,69 +15,38 @@ interface MissingFeature {
   name: string;
 }
 
-interface AutofixGithubAppPermissionsModalProps extends ModalRenderProps {
-  /** Which flow opened the modal; selects the copy. */
-  variant: 'pr_iteration' | 'coding_agent_handoff' | 'integration_settings';
-  /** GitHub permissions URL for the install. Falls back to GitHub's installations index. */
-  installationUrl?: string;
-  /** Feature tiers the install is missing; rendered by the `integration_settings` variant. */
-  missingFeatures?: MissingFeature[];
-}
-
 const DEFAULT_INSTALLATIONS_URL = 'https://github.com/settings/installations/';
 
-export function AutofixGithubAppPermissionsModal({
+interface VariantProps extends ModalRenderProps {
+  /** GitHub permissions URL for the install. Falls back to GitHub's installations index. */
+  installationUrl?: string;
+}
+
+/** The linked "update settings" sentence shared by a few of the variants. */
+function updateSettingsSentence(installationUrl?: string) {
+  return tct(
+    'Please update your [link:GitHub App installation settings] to grant the required permissions.',
+    {link: <ExternalLink href={installationUrl ?? DEFAULT_INSTALLATIONS_URL} />}
+  );
+}
+
+/** Shared chrome (heading + footer) that each variant renders its body into. */
+function PermissionsModal({
   Header,
   Body,
   Footer,
   closeModal,
   installationUrl,
-  variant,
-  missingFeatures,
-}: AutofixGithubAppPermissionsModalProps) {
+  children,
+}: VariantProps & {children: ReactNode}) {
   const settingsUrl = installationUrl ?? DEFAULT_INSTALLATIONS_URL;
-
-  const settingsSentence = tct(
-    'Please update your [link:GitHub App installation settings] to grant the required permissions.',
-    {link: <ExternalLink href={settingsUrl} />}
-  );
 
   return (
     <Fragment>
       <Header closeButton>
         <Heading as="h3">{t('Update GitHub App Permissions')}</Heading>
       </Header>
-      <Body>
-        {variant === 'pr_iteration' ? (
-          <Text as="p">
-            {t(
-              'Seer needs additional GitHub App permissions to keep iterating on the pull requests in this run and get CI passing.'
-            )}{' '}
-            {t('Review and accept the updated permissions to let Seer continue.')}
-          </Text>
-        ) : variant === 'coding_agent_handoff' ? (
-          <Text as="p">
-            {t(
-              'The Sentry GitHub App does not have sufficient permissions to launch a coding agent.'
-            )}{' '}
-            {settingsSentence}
-          </Text>
-        ) : (
-          <Stack gap="lg">
-            <Text as="p">
-              {t('This installation is missing permissions for the following features:')}
-            </Text>
-            <ul>
-              {missingFeatures?.map(feature => (
-                <li key={feature.key}>
-                  <Text>{feature.description}</Text>
-                </li>
-              ))}
-            </ul>
-            <Text as="p">{settingsSentence}</Text>
-          </Stack>
-        )}
-      </Body>
+      <Body>{children}</Body>
       <Footer>
         <Grid flow="column" align="center" gap="md">
           <Button onClick={closeModal}>{t('Remind me later')}</Button>
@@ -93,5 +63,57 @@ export function AutofixGithubAppPermissionsModal({
         </Grid>
       </Footer>
     </Fragment>
+  );
+}
+
+/** PR-iteration flow: Seer is blocked from iterating on the run's pull requests. */
+export function PrIterationPermissionsModal(props: VariantProps) {
+  return (
+    <PermissionsModal {...props}>
+      <Text as="p">
+        {t(
+          'Seer needs additional GitHub App permissions to keep iterating on the pull requests in this run and get CI passing.'
+        )}{' '}
+        {t('Review and accept the updated permissions to let Seer continue.')}
+      </Text>
+    </PermissionsModal>
+  );
+}
+
+/** Coding-agent handoff flow. */
+export function CodingAgentHandoffPermissionsModal(props: VariantProps) {
+  return (
+    <PermissionsModal {...props}>
+      <Text as="p">
+        {t(
+          'The Sentry GitHub App does not have sufficient permissions to launch a coding agent.'
+        )}{' '}
+        {updateSettingsSentence(props.installationUrl)}
+      </Text>
+    </PermissionsModal>
+  );
+}
+
+/** Integration settings page: names the feature tiers the install is missing. */
+export function IntegrationSettingsPermissionsModal({
+  missingFeatures,
+  ...props
+}: VariantProps & {missingFeatures?: MissingFeature[]}) {
+  return (
+    <PermissionsModal {...props}>
+      <Stack gap="lg">
+        <Text as="p">
+          {t('This installation is missing permissions for the following features:')}
+        </Text>
+        <ul>
+          {missingFeatures?.map(feature => (
+            <li key={feature.key}>
+              <Text>{feature.description}</Text>
+            </li>
+          ))}
+        </ul>
+        <Text as="p">{updateSettingsSentence(props.installationUrl)}</Text>
+      </Stack>
+    </PermissionsModal>
   );
 }

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -989,6 +989,7 @@ export function useExplorerAutofix(
               <AutofixGithubAppPermissionsModal
                 {...deps}
                 installationUrl={installationUrl}
+                variant="coding_agent_handoff"
               />
             ));
           }

--- a/static/app/components/events/autofix/useExplorerAutofix.tsx
+++ b/static/app/components/events/autofix/useExplorerAutofix.tsx
@@ -9,7 +9,7 @@ import {
   clearIndicators,
 } from 'sentry/actionCreators/indicator';
 import {AutofixCursorGithubAccessModal} from 'sentry/components/events/autofix/autofixCursorGithubAccessModal';
-import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
+import {CodingAgentHandoffPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {AutofixGithubCopilotPurchaseModal} from 'sentry/components/events/autofix/autofixGithubCopilotPurchaseModal';
 import {
   continueRunData,
@@ -986,10 +986,9 @@ export function useExplorerAutofix(
           if (permissionFailures.length > 0) {
             const installationUrl = permissionFailures[0]?.github_installation_url;
             openModal(deps => (
-              <AutofixGithubAppPermissionsModal
+              <CodingAgentHandoffPermissionsModal
                 {...deps}
                 installationUrl={installationUrl}
-                variant="coding_agent_handoff"
               />
             ));
           }

--- a/static/app/components/events/autofix/v3/drawer.spec.tsx
+++ b/static/app/components/events/autofix/v3/drawer.spec.tsx
@@ -7,7 +7,7 @@ import {AutofixWarnings} from 'sentry/components/events/autofix/v3/drawer';
 describe('AutofixWarnings', () => {
   const organization = OrganizationFixture();
 
-  it('deduplicates repo names', () => {
+  it('renders the generic missing-permissions banner without repo names', () => {
     render(
       <AutofixWarnings
         groupId="1"
@@ -18,24 +18,7 @@ describe('AutofixWarnings', () => {
           },
           {
             warning_type: 'github_app_permissions',
-            repo_name: 'getsentry/sentry',
-          },
-        ]}
-      />,
-      {organization}
-    );
-
-    expect(screen.getAllByText('getsentry/sentry')).toHaveLength(1);
-    expect(screen.getByText(/Seer can't fix the failing CI/)).toBeInTheDocument();
-  });
-
-  it('renders fallback copy when repo names are missing', () => {
-    render(
-      <AutofixWarnings
-        groupId="1"
-        warnings={[
-          {
-            warning_type: 'github_app_permissions',
+            repo_name: 'getsentry/seer',
           },
         ]}
       />,
@@ -44,9 +27,11 @@ describe('AutofixWarnings', () => {
 
     expect(
       screen.getByText(
-        "Seer can't fix the failing CI on your pull request because the configured GitHub App is missing permissions. Update the app."
+        'Seer needs more GitHub App permissions to keep fixing CI on your pull requests.'
       )
     ).toBeInTheDocument();
-    expect(screen.queryByText(/on your pull request in/)).not.toBeInTheDocument();
+    // The banner no longer enumerates the affected repositories.
+    expect(screen.queryByText('getsentry/sentry')).not.toBeInTheDocument();
+    expect(screen.queryByText('getsentry/seer')).not.toBeInTheDocument();
   });
 });

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -5,7 +5,7 @@ import {Button, LinkButton} from '@sentry/scraps/button';
 import {Flex, Stack} from '@sentry/scraps/layout';
 import {useModal} from '@sentry/scraps/modal';
 
-import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
+import {PrIterationPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import {getReferrerFromBlocks} from 'sentry/components/events/autofix/autofixReferrer';
 import {getAutofixRunId} from 'sentry/components/events/autofix/autofixRunId';
 import {
@@ -173,11 +173,7 @@ function InstallationPermissionsButton({installationUrl}: {installationUrl?: str
       size="xs"
       onClick={() =>
         openModal(deps => (
-          <AutofixGithubAppPermissionsModal
-            {...deps}
-            installationUrl={installationUrl}
-            variant="pr_iteration"
-          />
+          <PrIterationPermissionsModal {...deps} installationUrl={installationUrl} />
         ))
       }
     >

--- a/static/app/components/events/autofix/v3/drawer.tsx
+++ b/static/app/components/events/autofix/v3/drawer.tsx
@@ -1,4 +1,4 @@
-import {Fragment, useCallback, useMemo} from 'react';
+import {useCallback, useMemo} from 'react';
 
 import {Alert} from '@sentry/scraps/alert';
 import {Button, LinkButton} from '@sentry/scraps/button';
@@ -21,7 +21,7 @@ import {useForceBashMode} from 'sentry/components/events/autofix/v3/useForceBash
 import {artifactToMarkdown} from 'sentry/components/events/autofix/v3/utils';
 import {Placeholder} from 'sentry/components/placeholder';
 import {IconClose} from 'sentry/icons';
-import {t, tct} from 'sentry/locale';
+import {t} from 'sentry/locale';
 import type {Group} from 'sentry/types/group';
 import type {Project} from 'sentry/types/project';
 import {defined} from 'sentry/utils/defined';
@@ -176,7 +176,7 @@ function InstallationPermissionsButton({installationUrl}: {installationUrl?: str
           <AutofixGithubAppPermissionsModal
             {...deps}
             installationUrl={installationUrl}
-            description={t('Seer had trouble talking to GitHub while running Autofix.')}
+            variant="pr_iteration"
           />
         ))
       }
@@ -239,17 +239,6 @@ export function AutofixWarnings({
       <ConfigurationPermissionsButton />
     );
 
-  const repoNames = [
-    ...new Set(permissionWarnings.map(w => w.repo_name).filter(defined)),
-  ];
-
-  const repoNamesNode = repoNames.map((repoName, index) => (
-    <Fragment key={repoName}>
-      {index > 0 && ', '}
-      <code>{repoName}</code>
-    </Fragment>
-  ));
-
   return (
     <Stack gap="md" padding="md 2xl 0">
       <Alert
@@ -267,16 +256,9 @@ export function AutofixWarnings({
           </Flex>
         }
       >
-        {repoNames.length
-          ? tct(
-              "Seer can't fix the failing CI on your pull request because the configured GitHub App for [repoNames] is missing permissions. Update the app.",
-              {
-                repoNames: repoNamesNode,
-              }
-            )
-          : t(
-              "Seer can't fix the failing CI on your pull request because the configured GitHub App is missing permissions. Update the app."
-            )}
+        {t(
+          'Seer needs more GitHub App permissions to keep fixing CI on your pull requests.'
+        )}
       </Alert>
     </Stack>
   );

--- a/static/app/types/integrations.tsx
+++ b/static/app/types/integrations.tsx
@@ -462,6 +462,8 @@ interface CommonIntegration {
   organizationIntegrationStatus: ObjectStatus;
   provider: OrganizationIntegrationProvider;
   status: ObjectStatus;
+  /** GitHub only: feature tiers this installation is missing, oldest first. */
+  missingFeatures?: Array<{description: string; key: string; name: string}> | null;
   outOfDate?: boolean | null;
 }
 

--- a/static/app/utils/integrations/useAutoOpenPermissionsModal.tsx
+++ b/static/app/utils/integrations/useAutoOpenPermissionsModal.tsx
@@ -3,7 +3,6 @@ import {useQueryState} from 'nuqs';
 
 import {openModal} from 'sentry/actionCreators/modal';
 import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
-import {t} from 'sentry/locale';
 import type {
   IntegrationProvider,
   OrganizationIntegration,
@@ -21,10 +20,9 @@ export function openGithubPermissionsUpdateModal(integration: OrganizationIntegr
   openModal(deps => (
     <AutofixGithubAppPermissionsModal
       {...deps}
+      variant="integration_settings"
       installationUrl={getProviderPermissionsUrl(integration) ?? undefined}
-      description={t(
-        'This GitHub App installation is missing permissions required for the latest features.'
-      )}
+      missingFeatures={integration.missingFeatures ?? undefined}
     />
   ));
 }

--- a/static/app/utils/integrations/useAutoOpenPermissionsModal.tsx
+++ b/static/app/utils/integrations/useAutoOpenPermissionsModal.tsx
@@ -2,7 +2,7 @@ import {useEffect, useRef} from 'react';
 import {useQueryState} from 'nuqs';
 
 import {openModal} from 'sentry/actionCreators/modal';
-import {AutofixGithubAppPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
+import {IntegrationSettingsPermissionsModal} from 'sentry/components/events/autofix/autofixGithubAppPermissionsModal';
 import type {
   IntegrationProvider,
   OrganizationIntegration,
@@ -18,9 +18,8 @@ import {getProviderPermissionsUrl} from 'sentry/views/settings/organizationRepos
  */
 export function openGithubPermissionsUpdateModal(integration: OrganizationIntegration) {
   openModal(deps => (
-    <AutofixGithubAppPermissionsModal
+    <IntegrationSettingsPermissionsModal
       {...deps}
-      variant="integration_settings"
       installationUrl={getProviderPermissionsUrl(integration) ?? undefined}
       missingFeatures={integration.missingFeatures ?? undefined}
     />

--- a/tests/sentry/integrations/api/serializers/models/test_integration.py
+++ b/tests/sentry/integrations/api/serializers/models/test_integration.py
@@ -3,6 +3,7 @@ from unittest.mock import call, patch
 
 from sentry.api.serializers import serialize
 from sentry.integrations.api.serializers.models.integration import IntegrationConfigSerializer
+from sentry.integrations.utils.github_permission_tiers import PR_ITERATION_TIER
 from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS
 from sentry.organizations.services.organization import organization_service
 from sentry.shared_integrations.exceptions import ApiError
@@ -54,6 +55,46 @@ class IntegrationSerializerTest(TestCase):
         result = serialize(integration, self.user)
 
         assert result["outOfDate"] is False
+
+    def test_github_missing_features_lists_tiers_oldest_first(self) -> None:
+        # only the PR iteration tier is missing.
+        integration = self.create_provider_integration(
+            provider="github",
+            external_id="3",
+            name="octocat",
+            metadata={
+                "permissions": {
+                    "administration": "read",
+                    "issues": "write",
+                    "metadata": "read",
+                    "repository_hooks": "write",
+                    "pull_requests": "write",
+                    "checks": "write",
+                    "statuses": "write",
+                    "contents": "write",
+                }
+            },
+        )
+
+        result = serialize(integration, self.user)
+
+        assert result["outOfDate"] is True
+        assert result["missingFeatures"] == [
+            {
+                "key": PR_ITERATION_TIER.key,
+                "name": PR_ITERATION_TIER.name,
+                "description": PR_ITERATION_TIER.description,
+            }
+        ]
+
+    def test_non_github_provider_has_no_missing_features(self) -> None:
+        integration = self.create_provider_integration(
+            provider="opsgenie", external_id="opsgenie:2", name="Team B", metadata={}
+        )
+
+        result = serialize(integration, self.user)
+
+        assert result["missingFeatures"] is None
 
     def test_full_organizations_are_scoped_to_each_batch(self) -> None:
         other_organization = self.create_organization()

--- a/tests/sentry/integrations/api/serializers/models/test_integration.py
+++ b/tests/sentry/integrations/api/serializers/models/test_integration.py
@@ -1,12 +1,12 @@
+from unittest import mock
 from unittest.mock import call, patch
 
 from sentry.api.serializers import serialize
 from sentry.integrations.api.serializers.models.integration import IntegrationConfigSerializer
-from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS_OPTION
+from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS
 from sentry.organizations.services.organization import organization_service
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.testutils.silo import control_silo_test
 
 
@@ -29,7 +29,7 @@ class IntegrationSerializerTest(TestCase):
 
         assert result["outOfDate"] is None
 
-    @override_options({GITHUB_APP_REQUIRED_PERMISSIONS_OPTION: {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_github_out_of_date_when_missing_permissions(self) -> None:
         integration = self.create_provider_integration(
             provider="github",
@@ -42,7 +42,7 @@ class IntegrationSerializerTest(TestCase):
 
         assert result["outOfDate"] is True
 
-    @override_options({GITHUB_APP_REQUIRED_PERMISSIONS_OPTION: {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_github_not_out_of_date_when_permissions_satisfied(self) -> None:
         integration = self.create_provider_integration(
             provider="github",

--- a/tests/sentry/integrations/utils/test_github_permission_tiers.py
+++ b/tests/sentry/integrations/utils/test_github_permission_tiers.py
@@ -6,6 +6,7 @@ from sentry.integrations.utils.github_permission_tiers import (
     BASELINE_TIER,
     TIERS,
     _baseline_tier_reqs,
+    get_missing_permission_tiers,
     get_permission_tiers,
 )
 
@@ -172,3 +173,10 @@ def test_tiers_are_exposed_highest_order_first() -> None:
 def test_the_baseline_is_the_lowest_tier_and_claims_no_scopes() -> None:
     assert BASELINE_TIER.order == min(tier.order for tier in TIERS)
     assert BASELINE_TIER.introduced == {}
+
+
+def test_get_missing_permission_tiers_compares_against_the_required_permissions() -> None:
+    # An install holding everything the app requires is missing no tiers...
+    assert get_missing_permission_tiers(REQUIRED_PERMISSIONS) == []
+    # ...and one holding nothing is missing every tier.
+    assert [tier.key for tier in get_missing_permission_tiers({})] == ALL_KEYS

--- a/tests/sentry/integrations/utils/test_github_permission_tiers.py
+++ b/tests/sentry/integrations/utils/test_github_permission_tiers.py
@@ -1,0 +1,174 @@
+from unittest import mock
+
+import pytest
+
+from sentry.integrations.utils.github_permission_tiers import (
+    BASELINE_TIER,
+    TIERS,
+    _baseline_tier_reqs,
+    get_permission_tiers,
+)
+
+REQUIRED_PERMISSIONS = {
+    "actions": "write",
+    "administration": "read",
+    "checks": "write",
+    "code_quality": "read",
+    "contents": "write",
+    "issues": "write",
+    "metadata": "read",
+    "pull_requests": "write",
+    "repository_hooks": "write",
+    "security_events": "read",
+    "statuses": "write",
+}
+
+UP_TO_DATE = REQUIRED_PERMISSIONS
+
+MISSING_PR_ITERATION = {
+    "administration": "read",
+    "checks": "write",
+    "contents": "write",
+    "issues": "write",
+    "metadata": "read",
+    "pull_requests": "write",
+    "repository_hooks": "write",
+    "statuses": "write",
+}
+
+MISSING_AUTOFIX_PRS = {**MISSING_PR_ITERATION, "contents": "read"}
+
+MISSING_CODE_REVIEW = {
+    "administration": "read",
+    "contents": "read",
+    "issues": "write",
+    "metadata": "read",
+    "pull_requests": "write",
+    "repository_hooks": "write",
+}
+
+MISSING_PR_COMMENTS = {**MISSING_CODE_REVIEW, "pull_requests": "read"}
+
+ALL_KEYS = [
+    "pr_iteration",
+    "autofix_pull_requests",
+    "code_review",
+    "pull_request_comments",
+    "baseline",
+]
+
+
+def _keys(permissions, required=None):
+    tiers = get_permission_tiers(permissions, required or REQUIRED_PERMISSIONS)
+    return [tier.key for tier in tiers]
+
+
+@pytest.mark.parametrize(
+    ("permissions", "expected"),
+    [
+        (UP_TO_DATE, []),
+        (MISSING_PR_ITERATION, ALL_KEYS[:1]),
+        (MISSING_AUTOFIX_PRS, ALL_KEYS[:2]),
+        (MISSING_CODE_REVIEW, ALL_KEYS[:3]),
+        (MISSING_PR_COMMENTS, ALL_KEYS[:4]),
+        ({}, ALL_KEYS),
+    ],
+)
+def test_tiers_for_production_permission_sets(permissions, expected) -> None:
+    assert _keys(permissions) == expected
+
+
+def test_scopes_beyond_what_any_tier_asks_for_are_ignored() -> None:
+    assert _keys({**UP_TO_DATE, "packages": "write", "pages": "admin"}) == []
+
+
+def test_a_level_above_the_watermark_still_satisfies_the_tier() -> None:
+    assert _keys({**UP_TO_DATE, "contents": "admin"}) == []
+
+
+def test_an_unrecognised_level_counts_as_not_held() -> None:
+    assert _keys({**UP_TO_DATE, "actions": "sudo"}) == ALL_KEYS[:1]
+
+
+def test_contents_read_falls_short_of_the_autofix_write_watermark() -> None:
+    assert _keys({**MISSING_PR_ITERATION, "contents": "write"}) == ALL_KEYS[:1]
+    assert _keys({**MISSING_PR_ITERATION, "contents": "read"}) == ALL_KEYS[:2]
+
+
+def test_pull_requests_read_falls_short_of_the_pr_comments_watermark() -> None:
+    assert _keys({**MISSING_CODE_REVIEW, "pull_requests": "write"}) == ALL_KEYS[:3]
+    assert _keys({**MISSING_CODE_REVIEW, "pull_requests": "read"}) == ALL_KEYS[:4]
+
+
+@mock.patch("sentry.integrations.utils.github_permission_tiers.logger.warning")
+def test_a_newer_tier_held_without_an_older_one_is_inconsistent(mock_warning) -> None:
+    assert _keys({**UP_TO_DATE, "contents": "read"}) == ALL_KEYS
+
+    assert mock_warning.call_args[0][0] == "github_permission_tiers.inconsistent_permissions"
+    assert mock_warning.call_args[1]["extra"]["behind_tiers"] == ["autofix_pull_requests"]
+
+
+@mock.patch("sentry.integrations.utils.github_permission_tiers.logger.warning")
+def test_a_gap_in_the_middle_of_the_chain_is_inconsistent(mock_warning) -> None:
+    assert _keys({**UP_TO_DATE, "actions": "read", "checks": "read"}) == ALL_KEYS
+
+    assert mock_warning.call_args[1]["extra"]["behind_tiers"] == ["pr_iteration", "code_review"]
+
+
+@mock.patch("sentry.integrations.utils.github_permission_tiers.logger.warning")
+def test_a_requirement_no_tier_claims_falls_short_of_baseline(
+    mock_warning,
+) -> None:
+    required = {**REQUIRED_PERMISSIONS, "packages": "write"}
+    assert _keys(UP_TO_DATE, required) == ALL_KEYS
+
+    assert mock_warning.call_args[0][0] == "github_permission_tiers.short_of_baseline"
+    assert mock_warning.call_args[1]["extra"]["expected_permissions"] == {
+        "administration": "read",
+        "issues": "write",
+        "metadata": "read",
+        "repository_hooks": "write",
+        "packages": "write",
+    }
+
+
+@mock.patch("sentry.integrations.utils.github_permission_tiers.logger.warning")
+def test_a_consistent_run_is_not_warned_about(mock_warning) -> None:
+    assert _keys(MISSING_AUTOFIX_PRS) == ALL_KEYS[:2]
+
+    mock_warning.assert_not_called()
+
+
+def test_unclaimed_requirements_is_what_the_baseline_speaks_for() -> None:
+    assert _baseline_tier_reqs(REQUIRED_PERMISSIONS) == {
+        "administration": "read",
+        "issues": "write",
+        "metadata": "read",
+        "repository_hooks": "write",
+    }
+
+
+def test_unclaimed_requirements_reports_a_raise_beyond_any_tier() -> None:
+    assert _baseline_tier_reqs({"contents": "admin"}) == {"contents": "admin"}
+    assert _baseline_tier_reqs({"contents": "write"}) == {}
+
+
+def test_every_tier_key_is_unique() -> None:
+    keys = [tier.key for tier in TIERS]
+    assert len(keys) == len(set(keys))
+
+
+def test_every_tier_order_is_unique() -> None:
+    orders = [tier.order for tier in TIERS]
+    assert len(orders) == len(set(orders))
+
+
+def test_tiers_are_exposed_highest_order_first() -> None:
+    orders = [tier.order for tier in TIERS]
+    assert orders == sorted(orders, reverse=True)
+    assert [tier.key for tier in TIERS] == ALL_KEYS
+
+
+def test_the_baseline_is_the_lowest_tier_and_claims_no_scopes() -> None:
+    assert BASELINE_TIER.order == min(tier.order for tier in TIERS)
+    assert BASELINE_TIER.introduced == {}

--- a/tests/sentry/integrations/utils/test_github_permissions.py
+++ b/tests/sentry/integrations/utils/test_github_permissions.py
@@ -1,18 +1,16 @@
+from unittest import mock
+
 import pytest
 
 from sentry.integrations.utils.github_permissions import (
-    GITHUB_APP_REQUIRED_PERMISSIONS_OPTION,
     get_github_permissions_update_url,
     get_missing_github_app_permissions,
 )
-from sentry.testutils.helpers.options import override_options
 
 
-@pytest.mark.django_db
 @pytest.mark.parametrize(
     ("required_permissions", "permissions", "expected"),
     [
-        (None, {"contents": "read"}, None),
         ({}, {"contents": "read"}, None),
         (
             {"contents": "read", "pull_requests": "write"},
@@ -52,12 +50,11 @@ from sentry.testutils.helpers.options import override_options
     ],
 )
 def test_get_missing_github_app_permissions(required_permissions, permissions, expected) -> None:
-    options = (
-        {}
-        if required_permissions is None
-        else {GITHUB_APP_REQUIRED_PERMISSIONS_OPTION: required_permissions}
-    )
-    with override_options(options):
+    with mock.patch.dict(
+        "sentry.integrations.utils.github_permissions.GITHUB_APP_REQUIRED_PERMISSIONS",
+        required_permissions,
+        clear=True,
+    ):
         assert get_missing_github_app_permissions({"permissions": permissions}) == expected
 
 

--- a/tests/sentry/seer/autofix/pr_iteration/test_missing_permissions.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_missing_permissions.py
@@ -8,12 +8,17 @@ from sentry.analytics.events.pr_iteration_events import (
     AiAutofixPrIterationMissingPermissionsEvent,
 )
 from sentry.integrations.services.integration import RpcIntegration
+from sentry.integrations.utils.github_permission_tiers import (
+    AUTOFIX_PULL_REQUESTS_TIER,
+    PR_ITERATION_TIER,
+    get_missing_permission_tiers,
+)
 from sentry.seer.agent.client_models import RepoPRState, SeerRunState
 from sentry.seer.autofix.github_perms import MissingGithubPermissions
 from sentry.seer.autofix.pr_iteration.logs import PrIterationLogContext
 from sentry.seer.autofix.pr_iteration.missing_permissions import (
     MISSING_PERMISSIONS_EXTRA,
-    _scopes_tag,
+    _tiers_tag,
     block_iteration_for_missing_permissions,
     get_missing_permissions_marker,
     post_missing_permissions_comment,
@@ -30,21 +35,41 @@ RUN_ID = 1
 INTEGRATION_ID = 42
 
 
+# Install holding everything up to and including Autofix; only the PR iteration
+# tier is missing, which is the shape the PR-iteration gate expects to see.
+_ONLY_PR_ITERATION_MISSING = {
+    "administration": "read",
+    "issues": "write",
+    "metadata": "read",
+    "repository_hooks": "write",
+    "pull_requests": "write",
+    "checks": "write",
+    "statuses": "write",
+    "contents": "write",
+}
+# Holds through Seer Code Review but not Autofix, so both Autofix and PR
+# iteration tiers are missing -- more than the gate expects.
+_MISSING_AUTOFIX_AND_PR_ITERATION = {
+    k: v for k, v in _ONLY_PR_ITERATION_MISSING.items() if k != "contents"
+}
+
+
 def _perms(
     integration_id: int = INTEGRATION_ID,
     repository_id: int = 123,
-    missing_scopes: list[str] | None = None,
+    permissions: dict[str, str] | None = None,
 ) -> MissingGithubPermissions:
+    perms = permissions if permissions is not None else _ONLY_PR_ITERATION_MISSING
     return MissingGithubPermissions(
         integration=RpcIntegration(
             id=integration_id,
             provider="github",
             external_id=str(integration_id),
             name="octocat",
-            metadata={},
+            metadata={"permissions": perms},
             status=0,
         ),
-        missing_scopes=missing_scopes if missing_scopes is not None else ["contents"],
+        missing_tiers=get_missing_permission_tiers(perms),
         repository_id=repository_id,
     )
 
@@ -150,7 +175,7 @@ class BlockIterationForMissingPermissionsTest(TestCase):
     def test_skips_the_queue_once_the_marker_is_set(self, mock_get_perms, mock_delay) -> None:
         mock_get_perms.return_value = {REPO_NAME: _perms()}
         self.seer_run.update(
-            extras={MISSING_PERMISSIONS_EXTRA: {REPO_NAME: {"missing_scopes": ["contents"]}}}
+            extras={MISSING_PERMISSIONS_EXTRA: {REPO_NAME: {"missing_tiers": ["pr_iteration"]}}}
         )
 
         assert self._run(_state(getsentry__sentry=7)) is True
@@ -209,21 +234,61 @@ class PostMissingPermissionsCommentTest(TestCase):
         actions.create_pull_request_comment.assert_called_once()
         _, pr_number, body = actions.create_pull_request_comment.call_args[0]
         assert pr_number == "7"
-        assert "additional GitHub permissions" in body
+        assert "additional GitHub App permissions" in body
         assert f"/settings/installations/{INTEGRATION_ID}/permissions/update" in body
         assert self.mock_make_scm.call_args[0] == (self.organization.id, 123)
+
+    def test_comment_body_is_generic_and_lists_no_features(self, mock_get_perms) -> None:
+        mock_get_perms.return_value = {REPO_NAME: _perms()}
+        actions = self._stub_scm()
+
+        self._post()
+
+        _, _, body = actions.create_pull_request_comment.call_args[0]
+        assert body.startswith("⚠️ Sentry needs additional GitHub App permissions")
+        assert f"/settings/installations/{INTEGRATION_ID}/permissions/update" in body
+        # The copy no longer enumerates the missing feature tiers.
+        assert "following features" not in body
+        assert "Seer Autofix" not in body
+
+    def test_warns_when_more_than_the_pr_iteration_tier_is_missing(self, mock_get_perms) -> None:
+        mock_get_perms.return_value = {
+            REPO_NAME: _perms(permissions=_MISSING_AUTOFIX_AND_PR_ITERATION)
+        }
+        actions = self._stub_scm()
+
+        with self.assertLogs(MODULE, level="ERROR") as logs:
+            self._post()
+
+        actions.create_pull_request_comment.assert_called_once()
+        unexpected = [
+            r
+            for r in logs.records
+            if r.msg == "autofix.pr_iteration.missing_permissions.unexpected_missing_tiers"
+        ]
+        assert len(unexpected) == 1
+        assert unexpected[0].missing_tiers == ["pr_iteration", "autofix_pull_requests"]
+
+    def test_no_warning_when_only_the_pr_iteration_tier_is_missing(self, mock_get_perms) -> None:
+        mock_get_perms.return_value = {REPO_NAME: _perms(permissions=_ONLY_PR_ITERATION_MISSING)}
+        actions = self._stub_scm()
+
+        with self.assertNoLogs(MODULE, level="ERROR"):
+            self._post()
+
+        actions.create_pull_request_comment.assert_called_once()
 
         self.seer_run.refresh_from_db()
         marker = get_missing_permissions_marker(self.seer_run, REPO_NAME)
         assert marker is not None
-        assert marker["missing_scopes"] == ["contents"]
+        assert marker["missing_tiers"] == ["pr_iteration"]
         assert marker["pr_id"] == 4242
 
     def test_stays_silent_once_marked(self, mock_get_perms) -> None:
         mock_get_perms.return_value = {REPO_NAME: _perms()}
         actions = self._stub_scm()
         self.seer_run.update(
-            extras={MISSING_PERMISSIONS_EXTRA: {REPO_NAME: {"missing_scopes": ["contents"]}}}
+            extras={MISSING_PERMISSIONS_EXTRA: {REPO_NAME: {"missing_tiers": ["pr_iteration"]}}}
         )
 
         with patch("sentry.analytics.record") as mock_record:
@@ -280,7 +345,9 @@ class PostMissingPermissionsCommentTest(TestCase):
         actions = self._stub_scm()
 
         def _mark(run: SeerRun) -> None:
-            run.extras = {MISSING_PERMISSIONS_EXTRA: {REPO_NAME: {"missing_scopes": ["contents"]}}}
+            run.extras = {
+                MISSING_PERMISSIONS_EXTRA: {REPO_NAME: {"missing_tiers": ["pr_iteration"]}}
+            }
 
         with patch.object(SeerRun, "refresh_from_db", autospec=True, side_effect=_mark):
             self._post()
@@ -339,19 +406,25 @@ class PostMissingPermissionsCommentTest(TestCase):
         actions.create_pull_request_comment.assert_not_called()
 
 
-class ScopesTagTest(TestCase):
+class TiersTagTest(TestCase):
     def test_sorts_and_dedupes_for_a_stable_series(self) -> None:
-        assert _scopes_tag(["pull_requests", "contents"]) == "contents-pull_requests"
-        assert _scopes_tag(["contents", "pull_requests"]) == "contents-pull_requests"
-        assert _scopes_tag(["contents", "contents"]) == "contents"
+        assert (
+            _tiers_tag([PR_ITERATION_TIER, AUTOFIX_PULL_REQUESTS_TIER])
+            == "autofix_pull_requests-pr_iteration"
+        )
+        assert (
+            _tiers_tag([AUTOFIX_PULL_REQUESTS_TIER, PR_ITERATION_TIER])
+            == "autofix_pull_requests-pr_iteration"
+        )
+        assert _tiers_tag([PR_ITERATION_TIER, PR_ITERATION_TIER]) == "pr_iteration"
 
     def test_avoids_the_dogstatsd_tag_separator(self) -> None:
         # dogstatsd joins the tag list with "," on the wire, so a comma in a
         # value would split into bogus tags.
-        assert "," not in _scopes_tag(["contents", "checks", "actions"])
+        assert "," not in _tiers_tag([PR_ITERATION_TIER, AUTOFIX_PULL_REQUESTS_TIER])
 
     def test_empty(self) -> None:
-        assert _scopes_tag([]) == "none"
+        assert _tiers_tag([]) == "none"
 
 
 @patch(f"{MODULE}.metrics.incr")
@@ -364,12 +437,12 @@ class MissingPermissionsMetricsTest(TestCase):
             organization=self.organization, seer_run_state_id=RUN_ID, user_id=self.user.id
         )
 
-    def test_blocked_tag_unions_scopes_across_repos(
+    def test_blocked_tag_unions_tiers_across_repos(
         self, mock_get_perms, _mock_delay, mock_incr
     ) -> None:
         mock_get_perms.return_value = {
-            REPO_NAME: _perms(1, missing_scopes=["pull_requests", "contents"]),
-            OTHER_REPO_NAME: _perms(2, missing_scopes=["contents", "checks"]),
+            REPO_NAME: _perms(1, permissions=_MISSING_AUTOFIX_AND_PR_ITERATION),
+            OTHER_REPO_NAME: _perms(2, permissions=_ONLY_PR_ITERATION_MISSING),
         }
 
         state = _state(getsentry__sentry=7, getsentry__seer=9)
@@ -382,7 +455,7 @@ class MissingPermissionsMetricsTest(TestCase):
 
         blocked = [c for c in mock_incr.call_args_list if c[0][0].endswith(".blocked")]
         assert len(blocked) == 1
-        assert blocked[0][1]["tags"] == {"missing_scopes": "checks-contents-pull_requests"}
+        assert blocked[0][1]["tags"] == {"missing_tiers": "autofix_pull_requests-pr_iteration"}
 
 
 @patch(f"{MODULE}.metrics.incr")
@@ -396,7 +469,7 @@ class CommentedMetricTagTest(TestCase):
 
     def test_commented_tag_is_per_repo(self, mock_get_perms, mock_incr) -> None:
         mock_get_perms.return_value = {
-            REPO_NAME: _perms(missing_scopes=["pull_requests", "contents"])
+            REPO_NAME: _perms(permissions=_MISSING_AUTOFIX_AND_PR_ITERATION)
         }
         _patch_scm(self)
 
@@ -412,4 +485,4 @@ class CommentedMetricTagTest(TestCase):
 
         commented = [c for c in mock_incr.call_args_list if c[0][0].endswith(".commented")]
         assert len(commented) == 1
-        assert commented[0][1]["tags"] == {"missing_scopes": "contents-pull_requests"}
+        assert commented[0][1]["tags"] == {"missing_tiers": "autofix_pull_requests-pr_iteration"}

--- a/tests/sentry/seer/autofix/test_github_perms.py
+++ b/tests/sentry/seer/autofix/test_github_perms.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
-from unittest import mock
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.utils.github_permission_tiers import PR_ITERATION_TIER
 from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
@@ -28,6 +28,15 @@ from sentry.utils import json
 
 REPO_NAME = "getsentry/sentry"
 LOGGER_NAME = "sentry.seer.autofix.github_perms"
+
+_FULL_PERMISSIONS = dict(GITHUB_APP_REQUIRED_PERMISSIONS)
+# Holds everything up to and including Autofix; only the PR iteration tier is
+# missing (its scopes are dropped from the full set).
+_MISSING_PR_ITERATION = {
+    scope: level
+    for scope, level in _FULL_PERMISSIONS.items()
+    if scope not in PR_ITERATION_TIER.introduced
+}
 
 
 def _block(
@@ -90,7 +99,7 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             organization=self.organization,
             provider="github",
             external_id="9999",
-            metadata={"permissions": {"contents": "read"}},
+            metadata={"permissions": _MISSING_PR_ITERATION},
         )
         self.repo = self.create_repo(
             project=self.create_project(organization=self.organization),
@@ -99,18 +108,16 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             integration_id=self.integration.id,
         )
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_a_pr_exists_and_feedback_is_queued(self) -> None:
         missing = get_blocked_pr_iteration_permissions(
             self.organization, _state(pr_number=7), has_actionable_feedback=True
         )
 
         assert set(missing) == {REPO_NAME}
-        assert missing[REPO_NAME].missing_scopes == ["contents"]
+        assert [tier.key for tier in missing[REPO_NAME].missing_tiers] == ["pr_iteration"]
         assert missing[REPO_NAME].installation_id == "9999"
         assert missing[REPO_NAME].repository_id == self.repo.id
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_silent_without_actionable_feedback(self) -> None:
         assert (
             get_blocked_pr_iteration_permissions(
@@ -119,7 +126,6 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             == {}
         )
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_silent_before_the_pr_is_created(self) -> None:
         assert (
             get_blocked_pr_iteration_permissions(
@@ -128,8 +134,15 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             == {}
         )
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "read"}, clear=True)
     def test_silent_when_the_install_is_healthy(self) -> None:
+        healthy = self.create_integration(
+            organization=self.organization,
+            provider="github",
+            external_id="8888",
+            metadata={"permissions": _FULL_PERMISSIONS},
+        )
+        Repository.objects.filter(id=self.repo.id).update(integration_id=healthy.id)
+
         assert (
             get_blocked_pr_iteration_permissions(
                 self.organization, _state(pr_number=7), has_actionable_feedback=True
@@ -145,7 +158,7 @@ class GetMissingPermissionsByRepoTest(TestCase):
             organization=self.organization,
             provider="github",
             external_id="9999",
-            metadata={"permissions": {"contents": "read"}},
+            metadata={"permissions": _MISSING_PR_ITERATION},
         )
         self.repo = self.create_repo(
             project=self.create_project(organization=self.organization),
@@ -154,12 +167,11 @@ class GetMissingPermissionsByRepoTest(TestCase):
             integration_id=self.integration.id,
         )
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_reports_the_repository_the_install_was_resolved_for(self) -> None:
         missing = get_missing_permissions_by_repo(self.organization, [REPO_NAME])
 
         assert missing[REPO_NAME].repository_id == self.repo.id
-        assert missing[REPO_NAME].missing_scopes == ["contents"]
+        assert [tier.key for tier in missing[REPO_NAME].missing_tiers] == ["pr_iteration"]
 
     def _assert_warns(self, organization: Organization, repo_name: str, reason: str) -> None:
         with self.assertLogs(LOGGER_NAME, level="WARNING") as logs:
@@ -169,33 +181,27 @@ class GetMissingPermissionsByRepoTest(TestCase):
         assert logs.records[0].__dict__["reason"] == reason
         assert logs.records[0].__dict__["organization_id"] == organization.id
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_without_a_repository_row(self) -> None:
         self._assert_warns(self.organization, "org/unknown", "no_repository_row")
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_repository_is_not_active(self) -> None:
         self.repo.update(status=ObjectStatus.PENDING_DELETION)
 
         self._assert_warns(self.organization, REPO_NAME, "no_repository_row")
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_repository_belongs_to_another_org(self) -> None:
         self._assert_warns(self.create_organization(), REPO_NAME, "no_repository_row")
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_repository_has_no_integration(self) -> None:
         Repository.objects.filter(id=self.repo.id).update(integration_id=None)
 
         self._assert_warns(self.organization, REPO_NAME, "no_integration_id")
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_integration_is_gone(self) -> None:
         Repository.objects.filter(id=self.repo.id).update(integration_id=self.integration.id + 1000)
 
         self._assert_warns(self.organization, REPO_NAME, "integration_not_found")
 
-    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_quiet_when_every_repo_resolves(self) -> None:
         with self.assertNoLogs(LOGGER_NAME, level="WARNING"):
             assert set(get_missing_permissions_by_repo(self.organization, [REPO_NAME])) == {
@@ -215,7 +221,7 @@ class InstallationUrlTest(TestCase):
         rpc_integration = integration_service.get_integration(integration_id=integration.id)
         assert rpc_integration is not None
         return MissingGithubPermissions(
-            integration=rpc_integration, missing_scopes=["workflows"], repository_id=1
+            integration=rpc_integration, missing_tiers=[PR_ITERATION_TIER], repository_id=1
         )
 
     def test_user_installation_links_personal_namespace(self) -> None:

--- a/tests/sentry/seer/autofix/test_github_perms.py
+++ b/tests/sentry/seer/autofix/test_github_perms.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from unittest import mock
 
 from sentry.constants import ObjectStatus
 from sentry.integrations.services.integration import integration_service
+from sentry.integrations.utils.github_permissions import GITHUB_APP_REQUIRED_PERMISSIONS
 from sentry.models.organization import Organization
 from sentry.models.repository import Repository
 from sentry.seer.agent.client_models import (
@@ -22,7 +24,6 @@ from sentry.seer.autofix.github_perms import (
     get_missing_permissions_by_repo,
 )
 from sentry.testutils.cases import TestCase
-from sentry.testutils.helpers.options import override_options
 from sentry.utils import json
 
 REPO_NAME = "getsentry/sentry"
@@ -98,7 +99,7 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             integration_id=self.integration.id,
         )
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_a_pr_exists_and_feedback_is_queued(self) -> None:
         missing = get_blocked_pr_iteration_permissions(
             self.organization, _state(pr_number=7), has_actionable_feedback=True
@@ -109,7 +110,7 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
         assert missing[REPO_NAME].installation_id == "9999"
         assert missing[REPO_NAME].repository_id == self.repo.id
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_silent_without_actionable_feedback(self) -> None:
         assert (
             get_blocked_pr_iteration_permissions(
@@ -118,7 +119,7 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             == {}
         )
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_silent_before_the_pr_is_created(self) -> None:
         assert (
             get_blocked_pr_iteration_permissions(
@@ -127,7 +128,7 @@ class GetBlockedPrIterationPermissionsTest(TestCase):
             == {}
         )
 
-    @override_options({"github-app.required-permissions": {"contents": "read"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "read"}, clear=True)
     def test_silent_when_the_install_is_healthy(self) -> None:
         assert (
             get_blocked_pr_iteration_permissions(
@@ -153,7 +154,7 @@ class GetMissingPermissionsByRepoTest(TestCase):
             integration_id=self.integration.id,
         )
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_reports_the_repository_the_install_was_resolved_for(self) -> None:
         missing = get_missing_permissions_by_repo(self.organization, [REPO_NAME])
 
@@ -168,33 +169,33 @@ class GetMissingPermissionsByRepoTest(TestCase):
         assert logs.records[0].__dict__["reason"] == reason
         assert logs.records[0].__dict__["organization_id"] == organization.id
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_without_a_repository_row(self) -> None:
         self._assert_warns(self.organization, "org/unknown", "no_repository_row")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_repository_is_not_active(self) -> None:
         self.repo.update(status=ObjectStatus.PENDING_DELETION)
 
         self._assert_warns(self.organization, REPO_NAME, "no_repository_row")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_repository_belongs_to_another_org(self) -> None:
         self._assert_warns(self.create_organization(), REPO_NAME, "no_repository_row")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_repository_has_no_integration(self) -> None:
         Repository.objects.filter(id=self.repo.id).update(integration_id=None)
 
         self._assert_warns(self.organization, REPO_NAME, "no_integration_id")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_warns_when_the_integration_is_gone(self) -> None:
         Repository.objects.filter(id=self.repo.id).update(integration_id=self.integration.id + 1000)
 
         self._assert_warns(self.organization, REPO_NAME, "integration_not_found")
 
-    @override_options({"github-app.required-permissions": {"contents": "write"}})
+    @mock.patch.dict(GITHUB_APP_REQUIRED_PERMISSIONS, {"contents": "write"}, clear=True)
     def test_quiet_when_every_repo_resolves(self) -> None:
         with self.assertNoLogs(LOGGER_NAME, level="WARNING"):
             assert set(get_missing_permissions_by_repo(self.organization, [REPO_NAME])) == {

--- a/tests/sentry/seer/endpoints/test_group_ai_autofix.py
+++ b/tests/sentry/seer/endpoints/test_group_ai_autofix.py
@@ -4,6 +4,7 @@ from unittest.mock import ANY, Mock, patch
 
 from sentry.integrations.services.integration import RpcIntegration
 from sentry.integrations.types import ExternalProviders
+from sentry.integrations.utils.github_permission_tiers import PR_ITERATION_TIER
 from sentry.issues.action_log import SYSTEM_ACTOR, ActionSource, action_context_scope
 from sentry.issues.action_log.types import GroupActionActor, TriggerAutofixAction
 from sentry.models.activity import Activity
@@ -321,7 +322,7 @@ class GroupAutofixEndpointTest(APITestCase, SnubaTestCase):
                     status=0,
                 ),
                 repository_id=1,
-                missing_scopes=["contents"],
+                missing_tiers=[PR_ITERATION_TIER],
             )
         }
 


### PR DESCRIPTION
Route the three flows that hit missing GitHub App permissions through a
shared AutofixGithubAppPermissionsModal:

- pr_iteration: the Seer drawer's banner drops the inline repo names for
  "Seer needs more GitHub App permissions to keep fixing CI on your pull
  requests", and the modal gets clearer copy in place of the old generic
  "Seer had trouble talking to GitHub while running Autofix" line.
- coding_agent_handoff: same copy as before.
- integration_settings: the integrations settings page modal lists the
  feature tiers the install is missing (from the serializer's new
  missingFeatures field) so users see what the permissions unlock.

Wires the three callers (drawer, coding-agent handoff, integration detail
page) and adds missingFeatures to the OrganizationIntegration type.


Part of [AIML-3446](https://linear.app/getsentry/issue/AIML-3446/explain-missing-github-app-permissions-in-update-alerts)
