### PR TITLE
feat(event formatter): list every thread, with state and frame counts

### DIFF
--- a/src/sentry/issues/formatting/limits.py
+++ b/src/sentry/issues/formatting/limits.py
@@ -1,6 +1,6 @@
 """Per-section size limits. Sections apply these caps
 as they render, so output stays bounded. ``None`` means no cap; ``max_frames``/
-``max_breadcrumbs``/``max_threads`` are count caps.
+``max_breadcrumbs``/``max_threads_listed`` are count caps.
 """
 
 from __future__ import annotations
@@ -19,8 +19,11 @@ class Limits:
     max_contexts_chars: int | None = None
     max_evidence_chars: int | None = None
     max_frames: int = 16
+    # how many threads get a stacktrace. Every thread is still listed.
+    max_thread_stacktraces: int = 8
+    # a mobile crash can carry dozens of threads; list them all up to here
+    max_threads_listed: int = 64
     max_breadcrumbs: int = 10
-    max_threads: int = 8
 
 
 LIMITS_DEFAULT = Limits(

--- a/src/sentry/issues/formatting/sections.py
+++ b/src/sentry/issues/formatting/sections.py
@@ -23,7 +23,13 @@ from sentry.issues.formatting.formatter import (
     truncate,
 )
 from sentry.issues.formatting.limits import LIMITS_DEFAULT, Limits
-from sentry.issues.formatting.models import EventObject, Frame, Stacktrace, contains_filtered
+from sentry.issues.formatting.models import (
+    EventObject,
+    Frame,
+    Stacktrace,
+    ThreadDetails,
+    contains_filtered,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -248,22 +254,37 @@ def user_section(model: EventObject, limits: Limits) -> Section | None:
     return Section(title="User", groups=(Group(items=present),))
 
 
+def _thread_flags(thread: ThreadDetails) -> str | None:
+    flags = [name for name, on in (("crashed", thread.crashed), ("current", thread.current)) if on]
+    return ", ".join(flags) or None
+
+
 def threads_section(model: EventObject, limits: Limits) -> Section | None:
+    # every thread gets listed, including ones with no stacktrace: on a mobile crash the
+    # crashed thread often has none, and its state is the thing worth seeing. Only the first
+    # few carry a stacktrace, since those are what cost.
     groups: list[Group] = []
+    stacktraces = 0
     for thread in model.threads:
-        # only threads that carry a stacktrace are worth rendering
-        st = thread.stacktrace
-        if not (st and st.frames):
-            continue
         # checked before appending, not after: testing at the bottom lets a zero cap through
-        # with one thread already rendered
-        if len(groups) >= limits.max_threads:  # bound total output by thread count
+        # with one thread already listed
+        if len(groups) >= limits.max_threads_listed:
             break
+        st = thread.stacktrace
+        frames = len(st.frames) if st else 0
+
         label = thread.name or (str(thread.id) if thread.id is not None else "Thread")
         items: list[Any] = [Text(label)]
-        if thread.crashed:
-            items.append(Field("Crashed", "Yes"))
-        items.append(Code(_render_stacktrace(st, limits)))
+        if thread.id is not None:
+            items.append(Field("ID", str(thread.id)))
+        if thread.state:
+            items.append(Field("State", thread.state))
+        if flags := _thread_flags(thread):
+            items.append(Field("Flags", flags))
+        items.append(Field("Frames", str(frames)))
+        if frames and stacktraces < limits.max_thread_stacktraces:
+            items.append(Code(_render_stacktrace(st, limits)))  # type: ignore[arg-type]
+            stacktraces += 1
         groups.append(Group(items=tuple(items)))
 
     if not groups:

--- a/tests/sentry/issues/formatting/test_sections.py
+++ b/tests/sentry/issues/formatting/test_sections.py
@@ -248,11 +248,15 @@ def test_threads_zero_cap_renders_nothing() -> None:
         threads=[ThreadDetails(name=f"T{i}", stacktrace=stacktrace) for i in range(5)],
     )
     assert (
-        _render(threads_section, event, MD, dataclasses.replace(LIMITS_DEFAULT, max_threads=0))
+        _render(
+            threads_section, event, MD, dataclasses.replace(LIMITS_DEFAULT, max_threads_listed=0)
+        )
         == ""
     )
     # and the cap is still filled exactly when it is non-zero
-    out = _render(threads_section, event, MD, dataclasses.replace(LIMITS_DEFAULT, max_threads=2))
+    out = _render(
+        threads_section, event, MD, dataclasses.replace(LIMITS_DEFAULT, max_threads_listed=2)
+    )
     assert [f"T{i}" in out for i in range(5)] == [True, True, False, False, False]
 
 
@@ -361,28 +365,54 @@ def test_section_empty_renders_nothing(section: SectionFn) -> None:
     assert _render(section, EventObject(title="t"), MD, LIMITS_DEFAULT) == ""
 
 
-def test_threads_only_with_stacktrace() -> None:
+def test_threads_lists_every_thread_including_stacktrace_less_ones() -> None:
+    # a crashed thread often carries no stacktrace on a mobile crash, and dropping it loses the
+    # one row that matters
     with_st = ThreadDetails(
-        name="main", crashed=True, stacktrace=Stacktrace(frames=[Frame(function="f", line_no=1)])
+        name="main",
+        state="RUNNABLE",
+        stacktrace=Stacktrace(frames=[Frame(function="f", line_no=1)]),
     )
-    without_st = ThreadDetails(name="worker")
-    event = EventObject(title="t", threads=[with_st, without_st])
+    crashed_no_st = ThreadDetails(id=8157, name="GameThread", crashed=True, state="WAITING")
+    event = EventObject(title="t", threads=[with_st, crashed_no_st])
     out = _render(threads_section, event, MD, LIMITS_DEFAULT)
+
     assert "main" in out
-    assert "**Crashed:** Yes" in out
-    assert "worker" not in out
+    assert "GameThread" in out
+    assert "**State:** RUNNABLE" in out
+    assert "**State:** WAITING" in out
+    assert "**Flags:** crashed" in out
+    assert "**ID:** 8157" in out
+    # the stacktrace-less thread reports zero frames rather than vanishing
+    assert "**Frames:** 0" in out
+    assert "**Frames:** 1" in out
 
 
-def test_threads_capped_by_max_threads() -> None:
-    # more threads than max_threads -> section output is bounded by the count cap
+def test_threads_reports_both_flags() -> None:
+    event = EventObject(title="t", threads=[ThreadDetails(name="main", crashed=True, current=True)])
+    assert "**Flags:** crashed, current" in _render(threads_section, event, MD, LIMITS_DEFAULT)
+
+
+def test_threads_cap_stacktraces_without_dropping_the_listing() -> None:
+    # the stacktraces are what cost, so they are capped separately from the listing
     frame = Frame(function="f", line_no=1)
     threads = [
         ThreadDetails(name=f"t{i}", stacktrace=Stacktrace(frames=[frame])) for i in range(20)
     ]
     event = EventObject(title="t", threads=threads)
-    tight = dataclasses.replace(LIMITS_DEFAULT, max_threads=3)
+    tight = dataclasses.replace(LIMITS_DEFAULT, max_thread_stacktraces=3)
     out = _render(threads_section, event, MD, tight)
-    assert out.count("```") == 3 * 2  # one fenced stacktrace per rendered thread, capped at 3
+
+    assert out.count("```") == 3 * 2  # three fenced stacktraces
+    for i in range(20):
+        assert f"t{i}" in out  # but every thread is still listed
+
+
+def test_threads_listing_is_bounded() -> None:
+    threads = [ThreadDetails(name=f"t{i}") for i in range(20)]
+    event = EventObject(title="t", threads=threads)
+    tight = dataclasses.replace(LIMITS_DEFAULT, max_threads_listed=3)
+    out = _render(threads_section, event, MD, tight)
     assert "t0" in out and "t2" in out
     assert "t3" not in out
 


### PR DESCRIPTION
The section skipped any thread without a stacktrace, never rendered state, and gave no frame counts. On a mobile crash that is the worst case: a 39 thread Unreal crash rendered as a few stacktraces with the crashed thread missing entirely, because it had zero frames.

Lists every thread now with its id, state, flags and frame count, which is what the MCP's own thread table carries. Splits the count cap in two: max_threads_listed bounds the listing, max_thread_stacktraces bounds how many carry a stacktrace, since the stacktraces are what cost. The old max_threads did both jobs at 8 and so had to drop threads to stay small.

Flags replace the Crashed field, matching the MCP, which also surfaces `current`.

