### PR TITLE
feat(pr-iter): record review bots and CI results for iterations

### DIFF
--- a/src/sentry/analytics/events/pr_iteration_events.py
+++ b/src/sentry/analytics/events/pr_iteration_events.py
@@ -1,3 +1,4 @@
+from dataclasses import field
 from typing import Literal
 
 from sentry import analytics
@@ -50,6 +51,29 @@ class AiAutofixPrIterationFeedbackBatchCompletedEvent(analytics.Event):
     duration_ms: int
     outcome: str
 
+    # Review bots behind the feedback the drain consumed, sorted and deduped.
+    feedback_bot_slugs: list[str] = field(default_factory=list)
+
+    # Commit SHAs this iteration pushed. Empty unless the outcome is already_pushed.
+    head_shas: list[str] = field(default_factory=list)
+
+
+@analytics.eventclass("ai.autofix.pr_iteration.check_suite_concluded")
+class AiAutofixPrIterationCheckSuiteConcludedEvent(analytics.Event):
+    """One CI check suite that concluded on a PR with an Autofix run.
+
+    Join to a feedback batch on ``head_sha``.
+    """
+
+    organization_id: int
+    run_id: int
+    head_sha: str
+    conclusion: str
+    app_name: str
+    check_suite_id: int
+    updated_at: str | None = None
+
 
 analytics.register(AiAutofixPrIterationMissingPermissionsEvent)
 analytics.register(AiAutofixPrIterationFeedbackBatchCompletedEvent)
+analytics.register(AiAutofixPrIterationCheckSuiteConcludedEvent)

--- a/src/sentry/analytics/events/pr_iteration_events.py
+++ b/src/sentry/analytics/events/pr_iteration_events.py
@@ -52,7 +52,7 @@ class AiAutofixPrIterationFeedbackBatchCompletedEvent(analytics.Event):
     outcome: str
 
     # Review bots behind the feedback the drain consumed, sorted and deduped.
-    feedback_bot_slugs: list[str] = field(default_factory=list)
+    feedback_bot_logins: list[str] = field(default_factory=list)
 
     # Commit SHAs this iteration pushed. Empty unless the outcome is already_pushed.
     head_shas: list[str] = field(default_factory=list)

--- a/src/sentry/seer/autofix/autofix_agent.py
+++ b/src/sentry/seer/autofix/autofix_agent.py
@@ -338,6 +338,13 @@ def get_iterations(state: SeerRunState) -> list[Iteration]:
     return iterations
 
 
+def iteration_repos(iteration: Iteration) -> set[str]:
+    """The repositories this iteration changed."""
+    return {
+        patch.repo_name for block in iteration.blocks for patch in (block.merged_file_patches or [])
+    }
+
+
 def get_latest_iteration_index(state: SeerRunState) -> int:
     try:
         iterations = get_iterations(state)

--- a/src/sentry/seer/autofix/on_completion_hook.py
+++ b/src/sentry/seer/autofix/on_completion_hook.py
@@ -30,6 +30,7 @@ from sentry.seer.autofix.autofix_agent import (
     STEP_CONFIGS,
     get_iterations,
     get_latest_iteration_index,
+    iteration_repos,
     should_open_autofix_pr_as_draft,
     trigger_autofix_agent,
     trigger_coding_agent_handoff,
@@ -1119,7 +1120,7 @@ class AutofixOnCompletionHook(AgentOnCompletionHook):
         if not iterations:
             return True
 
-        return any(block.merged_file_patches for block in iterations[-1].blocks)
+        return bool(iteration_repos(iterations[-1]))
 
     @classmethod
     def _pr_iteration_push_outcome(

--- a/src/sentry/seer/autofix/pr_iteration/bot_identity.py
+++ b/src/sentry/seer/autofix/pr_iteration/bot_identity.py
@@ -1,0 +1,61 @@
+"""Map the GitHub login of a review bot to a short slug for analytics."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from sentry.integrations.github.utils import is_github_bot_login
+from sentry.seer.autofix.pr_iteration.feedback_sources.base import FeedbackSourceBase
+from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
+    GithubPrCommentFeedbackSource,
+    GithubPrReviewBodyFeedbackSource,
+    GithubPrReviewCommentFeedbackSource,
+)
+
+OTHER_BOT_SLUG = "other_bot"
+
+# Logins normalized by ``_normalize_login``: lowercase, with "[bot]" removed.
+_SLUGS_BY_LOGIN = {
+    "seer-by-sentry": "seer",
+    "seer-dev-testing": "seer",
+    "seer": "seer",
+    "coderabbitai": "coderabbit",
+    "cursor": "cursor",
+}
+
+
+def _normalize_login(login: str) -> str:
+    return login.lower().removesuffix("[bot]")
+
+
+def bot_slug(login: str | None, *, author_is_bot: bool) -> str | None:
+    """The slug for a review author. None when the author is not a bot."""
+    if not author_is_bot:
+        return None
+    if not login:
+        return OTHER_BOT_SLUG
+    return _SLUGS_BY_LOGIN.get(_normalize_login(login), OTHER_BOT_SLUG)
+
+
+def _source_bot_slug(source: FeedbackSourceBase) -> str | None:
+    """The slug for one feedback source. None when it is not a bot review."""
+    if isinstance(source, GithubPrReviewBodyFeedbackSource):
+        login = source.user.login if source.user else None
+        return bot_slug(login, author_is_bot=source.author_is_bot)
+
+    if isinstance(source, GithubPrReviewCommentFeedbackSource):
+        login = source.comment.user.login if source.comment.user else None
+        return bot_slug(login, author_is_bot=source.author_is_bot)
+
+    if isinstance(source, GithubPrCommentFeedbackSource):
+        # This source carries no bot flag, so the login is the only signal.
+        login = source.comment.user.login if source.comment.user else None
+        return bot_slug(login, author_is_bot=is_github_bot_login(login))
+
+    return None
+
+
+def bot_slugs_for_feedback(sources: Iterable[FeedbackSourceBase]) -> list[str]:
+    """The review-bot slugs behind these feedback sources, sorted and deduped."""
+    slugs = {slug for source in sources if (slug := _source_bot_slug(source)) is not None}
+    return sorted(slugs)

--- a/src/sentry/seer/autofix/pr_iteration/bot_identity.py
+++ b/src/sentry/seer/autofix/pr_iteration/bot_identity.py
@@ -1,4 +1,4 @@
-"""Map the GitHub login of a review bot to a short slug for analytics."""
+"""Collect the GitHub logins of the review bots behind feedback."""
 
 from __future__ import annotations
 
@@ -12,50 +12,31 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewCommentFeedbackSource,
 )
 
-OTHER_BOT_SLUG = "other_bot"
 
-# Logins normalized by ``_normalize_login``: lowercase, with "[bot]" removed.
-_SLUGS_BY_LOGIN = {
-    "seer-by-sentry": "seer",
-    "seer-dev-testing": "seer",
-    "seer": "seer",
-    "coderabbitai": "coderabbit",
-    "cursor": "cursor",
-}
+def _bot_login(login: str | None, *, author_is_bot: bool) -> str | None:
+    """The login of a review author. None when the author is not a bot."""
+    return login if author_is_bot and login else None
 
 
-def _normalize_login(login: str) -> str:
-    return login.lower().removesuffix("[bot]")
-
-
-def bot_slug(login: str | None, *, author_is_bot: bool) -> str | None:
-    """The slug for a review author. None when the author is not a bot."""
-    if not author_is_bot:
-        return None
-    if not login:
-        return OTHER_BOT_SLUG
-    return _SLUGS_BY_LOGIN.get(_normalize_login(login), OTHER_BOT_SLUG)
-
-
-def _source_bot_slug(source: FeedbackSourceBase) -> str | None:
-    """The slug for one feedback source. None when it is not a bot review."""
+def _source_bot_login(source: FeedbackSourceBase) -> str | None:
+    """The login for one feedback source. None when it is not a bot review."""
     if isinstance(source, GithubPrReviewBodyFeedbackSource):
         login = source.user.login if source.user else None
-        return bot_slug(login, author_is_bot=source.author_is_bot)
+        return _bot_login(login, author_is_bot=source.author_is_bot)
 
     if isinstance(source, GithubPrReviewCommentFeedbackSource):
         login = source.comment.user.login if source.comment.user else None
-        return bot_slug(login, author_is_bot=source.author_is_bot)
+        return _bot_login(login, author_is_bot=source.author_is_bot)
 
     if isinstance(source, GithubPrCommentFeedbackSource):
         # This source carries no bot flag, so the login is the only signal.
         login = source.comment.user.login if source.comment.user else None
-        return bot_slug(login, author_is_bot=is_github_bot_login(login))
+        return _bot_login(login, author_is_bot=is_github_bot_login(login))
 
     return None
 
 
-def bot_slugs_for_feedback(sources: Iterable[FeedbackSourceBase]) -> list[str]:
-    """The review-bot slugs behind these feedback sources, sorted and deduped."""
-    slugs = {slug for source in sources if (slug := _source_bot_slug(source)) is not None}
-    return sorted(slugs)
+def bot_logins_for_feedback(sources: Iterable[FeedbackSourceBase]) -> list[str]:
+    """The review-bot logins behind these feedback sources, sorted and deduped."""
+    logins = {login for source in sources if (login := _source_bot_login(source)) is not None}
+    return sorted(logins)

--- a/src/sentry/seer/autofix/pr_iteration/bot_identity.py
+++ b/src/sentry/seer/autofix/pr_iteration/bot_identity.py
@@ -13,27 +13,22 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
 )
 
 
-def _bot_login(login: str | None, *, author_is_bot: bool) -> str | None:
-    """The login of a review author. None when the author is not a bot."""
-    return login if author_is_bot and login else None
-
-
 def _source_bot_login(source: FeedbackSourceBase) -> str | None:
     """The login for one feedback source. None when it is not a bot review."""
     if isinstance(source, GithubPrReviewBodyFeedbackSource):
         login = source.user.login if source.user else None
-        return _bot_login(login, author_is_bot=source.author_is_bot)
-
-    if isinstance(source, GithubPrReviewCommentFeedbackSource):
+        is_bot = source.author_is_bot
+    elif isinstance(source, GithubPrReviewCommentFeedbackSource):
         login = source.comment.user.login if source.comment.user else None
-        return _bot_login(login, author_is_bot=source.author_is_bot)
-
-    if isinstance(source, GithubPrCommentFeedbackSource):
+        is_bot = source.author_is_bot
+    elif isinstance(source, GithubPrCommentFeedbackSource):
         # This source carries no bot flag, so the login is the only signal.
         login = source.comment.user.login if source.comment.user else None
-        return _bot_login(login, author_is_bot=is_github_bot_login(login))
+        is_bot = is_github_bot_login(login)
+    else:
+        return None
 
-    return None
+    return login if is_bot and login else None
 
 
 def bot_logins_for_feedback(sources: Iterable[FeedbackSourceBase]) -> list[str]:

--- a/src/sentry/seer/autofix/pr_iteration/emit.py
+++ b/src/sentry/seer/autofix/pr_iteration/emit.py
@@ -25,7 +25,7 @@ from sentry.analytics.events.pr_iteration_events import (
 )
 from sentry.models.group import Group
 from sentry.seer.agent.client_models import SeerRunState
-from sentry.seer.autofix.autofix_agent import get_iterations, get_latest_iteration_index
+from sentry.seer.autofix.autofix_agent import Iteration, get_iterations
 from sentry.seer.autofix.pr_iteration.details_store import (
     add_iteration,
     claim_iteration,
@@ -169,6 +169,7 @@ def record_pr_iteration_counts(
     queued_count: int,
     dropped_count: int,
     automated_feedback_count: int,
+    feedback_bot_slugs: list[str],
 ) -> None:
     """Write what the drain saw onto the row it claimed."""
     try:
@@ -187,6 +188,7 @@ def record_pr_iteration_counts(
             queued_count=queued_count,
             dropped_count=dropped_count,
             automated_feedback_count=automated_feedback_count,
+            feedback_bot_slugs=feedback_bot_slugs,
         )
     except Exception:
         log_ctx.error("autofix.pr_iteration.details.counts_failed")
@@ -210,23 +212,41 @@ def discard_pr_iteration_details(
         log_ctx.error("autofix.pr_iteration.details.discard_failed")
 
 
-def state_iteration_id(log_ctx: PrIterationLogContext, run_state: SeerRunState) -> int | None:
-    """The id the run's latest iteration was started with."""
+def _latest_iteration(log_ctx: PrIterationLogContext, run_state: SeerRunState) -> Iteration | None:
+    """The run's latest iteration, or None when it has none."""
     try:
         iterations = get_iterations(run_state)
     except Exception:
         log_ctx.error("autofix.pr_iteration.details.get_iterations_failed")
         return None
 
-    if not iterations or not iterations[-1].blocks:
+    return iterations[-1] if iterations else None
+
+
+def _iteration_id(iteration: Iteration) -> int | None:
+    """The id the iteration was started with."""
+    if not iteration.blocks:
         return None
 
-    metadata = iterations[-1].blocks[0].message.metadata or {}
+    metadata = iteration.blocks[0].message.metadata or {}
     try:
         # Prompt metadata is a string map; the id goes out stringified.
         return int(metadata[ITERATION_ID_METADATA_KEY])
     except (KeyError, TypeError, ValueError):
         return None
+
+
+def _pushed_head_shas(iteration: Iteration, run_state: SeerRunState) -> list[str]:
+    """The commit SHAs the latest iteration pushed, one for each repository."""
+    repos = {
+        patch.repo_name for block in iteration.blocks for patch in (block.merged_file_patches or [])
+    }
+    shas = {
+        pr_state.commit_sha
+        for repo in repos
+        if (pr_state := run_state.repo_pr_states.get(repo)) and pr_state.commit_sha
+    }
+    return sorted(shas)
 
 
 def _build_event(
@@ -235,6 +255,7 @@ def _build_event(
     *,
     iteration_index: int,
     outcome: str,
+    head_shas: list[str],
 ) -> AiAutofixPrIterationFeedbackBatchCompletedEvent | None:
     """The event for a finished iteration. None when its row is incomplete."""
     known = {f.name for f in fields(AiAutofixPrIterationFeedbackBatchCompletedEvent)}
@@ -246,6 +267,7 @@ def _build_event(
             iteration_index=iteration_index,
             duration_ms=duration_ms,
             outcome=outcome,
+            head_shas=head_shas,
             **payload,
         )
     except TypeError:
@@ -254,6 +276,7 @@ def _build_event(
             "iteration_index",
             "duration_ms",
             "outcome",
+            "head_shas",
         }
         log_ctx.error(
             "autofix.pr_iteration.details.incomplete_row",
@@ -276,8 +299,9 @@ def complete_pr_iteration_details(
     The row goes however the batch ended: leaving it behind would let the next
     completion hook emit this batch under a later iteration's outcome.
     """
-    iteration_id = state_iteration_id(log_ctx, run_state)
-    if iteration_id is None:
+    latest = _latest_iteration(log_ctx, run_state)
+    iteration_id = _iteration_id(latest) if latest is not None else None
+    if latest is None or iteration_id is None:
         log_ctx.error(
             "autofix.pr_iteration.details.unresolved", exc_info=False, reason="no_iteration_id"
         )
@@ -296,11 +320,17 @@ def complete_pr_iteration_details(
             log_ctx.info("autofix.pr_iteration.details.skipped", reason="already_emitted")
             return
 
+        head_shas = (
+            _pushed_head_shas(latest, run_state)
+            if outcome == PrIterationOutcome.ALREADY_PUSHED.value
+            else []
+        )
         event = _build_event(
             log_ctx,
             iteration,
-            iteration_index=get_latest_iteration_index(run_state),
+            iteration_index=latest.index,
             outcome=outcome,
+            head_shas=head_shas,
         )
         if event is None or not remove_iteration(iteration):
             return

--- a/src/sentry/seer/autofix/pr_iteration/emit.py
+++ b/src/sentry/seer/autofix/pr_iteration/emit.py
@@ -169,7 +169,7 @@ def record_pr_iteration_counts(
     queued_count: int,
     dropped_count: int,
     automated_feedback_count: int,
-    feedback_bot_slugs: list[str],
+    feedback_bot_logins: list[str],
 ) -> None:
     """Write what the drain saw onto the row it claimed."""
     try:
@@ -188,7 +188,7 @@ def record_pr_iteration_counts(
             queued_count=queued_count,
             dropped_count=dropped_count,
             automated_feedback_count=automated_feedback_count,
-            feedback_bot_slugs=feedback_bot_slugs,
+            feedback_bot_logins=feedback_bot_logins,
         )
     except Exception:
         log_ctx.error("autofix.pr_iteration.details.counts_failed")

--- a/src/sentry/seer/autofix/pr_iteration/emit.py
+++ b/src/sentry/seer/autofix/pr_iteration/emit.py
@@ -25,7 +25,7 @@ from sentry.analytics.events.pr_iteration_events import (
 )
 from sentry.models.group import Group
 from sentry.seer.agent.client_models import SeerRunState
-from sentry.seer.autofix.autofix_agent import Iteration, get_iterations
+from sentry.seer.autofix.autofix_agent import Iteration, get_iterations, iteration_repos
 from sentry.seer.autofix.pr_iteration.details_store import (
     add_iteration,
     claim_iteration,
@@ -238,12 +238,9 @@ def _iteration_id(iteration: Iteration) -> int | None:
 
 def _pushed_head_shas(iteration: Iteration, run_state: SeerRunState) -> list[str]:
     """The commit SHAs the latest iteration pushed, one for each repository."""
-    repos = {
-        patch.repo_name for block in iteration.blocks for patch in (block.merged_file_patches or [])
-    }
     shas = {
         pr_state.commit_sha
-        for repo in repos
+        for repo in iteration_repos(iteration)
         if (pr_state := run_state.repo_pr_states.get(repo)) and pr_state.commit_sha
     }
     return sorted(shas)

--- a/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
+++ b/src/sentry/seer/autofix/pr_iteration/listeners/check_suite.py
@@ -4,6 +4,10 @@ import orjson
 import sentry_sdk
 from pydantic import ValidationError
 
+from sentry import analytics
+from sentry.analytics.events.pr_iteration_events import (
+    AiAutofixPrIterationCheckSuiteConcludedEvent,
+)
 from sentry.scm.private.event_stream import scm_event_stream
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -13,6 +17,7 @@ from sentry.seer.autofix.pr_iteration.check_suites import (
     GREEN_CONCLUSIONS,
     READY_FOR_REVIEW_EXTRA,
     REVIEW_REQUESTS_EXTRA,
+    GithubCheckSuiteEvent,
     ResolvedGreenCheckSuite,
     confirm_green_check_suite,
     green_review_side_effects_enabled,
@@ -121,6 +126,31 @@ def _retrigger_deferred_iteration(
     )
 
 
+def _record_check_suite_concluded(
+    log_ctx: PrIterationLogContext,
+    *,
+    event: GithubCheckSuiteEvent,
+    organization_id: int,
+    run_id: int,
+) -> None:
+    """Record one concluded suite so Hex can join it to the batch that pushed the commit."""
+    try:
+        suite = event.check_suite
+        analytics.record(
+            AiAutofixPrIterationCheckSuiteConcludedEvent(
+                organization_id=organization_id,
+                run_id=run_id,
+                head_sha=suite.head_sha,
+                conclusion=suite.conclusion or "",
+                app_name=suite.app.name,
+                check_suite_id=suite.id,
+                updated_at=suite.updated_at,
+            )
+        )
+    except Exception:
+        log_ctx.error("autofix.pr_iteration.check_suite.analytics_failed")
+
+
 @scm_event_stream.listen_for(event_type="check_suite")
 def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
     if check_suite_event.action != "completed":
@@ -145,6 +175,12 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
         run_state = resolved.autofix_run.run_state
         log_ctx = PrIterationLogContext.for_run(
             logger, run_state, resolved.organization.id, resolved.autofix_run.group_id
+        )
+        _record_check_suite_concluded(
+            log_ctx,
+            event=resolved.event,
+            organization_id=resolved.organization.id,
+            run_id=run_state.run_id,
         )
         # Peek the queue for parked check-suite feedback on this head, then
         # ``should_defer_pr_iteration`` (GitHub sweep) only if something is
@@ -216,6 +252,9 @@ def pr_iteration_from_check_suite_listener(check_suite_event: CheckSuiteEvent):
     # line of a single check suite are found by the same search.
     log_ctx = PrIterationLogContext.for_run(
         logger, agent_state, organization_id, autofix_run.group_id
+    )
+    _record_check_suite_concluded(
+        log_ctx, event=source.event, organization_id=organization_id, run_id=agent_state.run_id
     )
 
     # Report failures here rather than only in the SCM event stream so they

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -59,7 +59,7 @@ from sentry.seer.autofix.autofix_agent import (
 )
 from sentry.seer.autofix.commit_author import commit_author_for_feedback
 from sentry.seer.autofix.constants import AutofixReferrer
-from sentry.seer.autofix.pr_iteration.bot_identity import bot_slugs_for_feedback
+from sentry.seer.autofix.pr_iteration.bot_identity import bot_logins_for_feedback
 from sentry.seer.autofix.pr_iteration.constants import PR_ITERATION_PROVIDER
 from sentry.seer.autofix.pr_iteration.details_store import (
     count_iterations_before,
@@ -602,7 +602,7 @@ def _drain_queued_autofix_feedback(
             queued_count=len(queued_items),
             dropped_count=len(dropped),
             automated_feedback_count=sum(1 for item in feedback_items if item.source.is_automated),
-            feedback_bot_slugs=bot_slugs_for_feedback([item.source for item in feedback_items]),
+            feedback_bot_logins=bot_logins_for_feedback([item.source for item in feedback_items]),
         )
 
     # a drain (from the log above) with no trigger autofix agent below it means this call never came back.

--- a/src/sentry/tasks/seer/pr_iteration.py
+++ b/src/sentry/tasks/seer/pr_iteration.py
@@ -59,6 +59,7 @@ from sentry.seer.autofix.autofix_agent import (
 )
 from sentry.seer.autofix.commit_author import commit_author_for_feedback
 from sentry.seer.autofix.constants import AutofixReferrer
+from sentry.seer.autofix.pr_iteration.bot_identity import bot_slugs_for_feedback
 from sentry.seer.autofix.pr_iteration.constants import PR_ITERATION_PROVIDER
 from sentry.seer.autofix.pr_iteration.details_store import (
     count_iterations_before,
@@ -601,6 +602,7 @@ def _drain_queued_autofix_feedback(
             queued_count=len(queued_items),
             dropped_count=len(dropped),
             automated_feedback_count=sum(1 for item in feedback_items if item.source.is_automated),
+            feedback_bot_slugs=bot_slugs_for_feedback([item.source for item in feedback_items]),
         )
 
     # a drain (from the log above) with no trigger autofix agent below it means this call never came back.

--- a/tests/sentry/seer/autofix/pr_iteration/test_bot_identity.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_bot_identity.py
@@ -44,6 +44,10 @@ def test_a_bot_review_without_a_login_records_nothing() -> None:
     assert bot_logins_for_feedback([_review_body(None, author_is_bot=True)]) == []
 
 
+def test_a_bot_without_the_suffix_is_recorded_from_its_flag() -> None:
+    assert bot_logins_for_feedback([_review_body("Copilot", author_is_bot=True)]) == ["Copilot"]
+
+
 def test_a_human_review_contributes_no_login() -> None:
     sources = [
         _review_body("some-person", author_is_bot=False),

--- a/tests/sentry/seer/autofix/pr_iteration/test_bot_identity.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_bot_identity.py
@@ -1,10 +1,4 @@
-import pytest
-
-from sentry.seer.autofix.pr_iteration.bot_identity import (
-    OTHER_BOT_SLUG,
-    bot_slug,
-    bot_slugs_for_feedback,
-)
+from sentry.seer.autofix.pr_iteration.bot_identity import bot_logins_for_feedback
 from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
 from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrCommentFeedbackSource,
@@ -12,28 +6,6 @@ from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
     GithubPrReviewCommentFeedbackSource,
 )
 from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
-
-
-@pytest.mark.parametrize(
-    "login,expected",
-    [
-        ("seer-by-sentry[bot]", "seer"),
-        ("seer-dev-testing[bot]", "seer"),
-        ("seer[bot]", "seer"),
-        ("coderabbitai[bot]", "coderabbit"),
-        ("CodeRabbitAI[bot]", "coderabbit"),
-        ("cursor[bot]", "cursor"),
-        ("some-new-reviewer[bot]", OTHER_BOT_SLUG),
-        (None, OTHER_BOT_SLUG),
-        ("", OTHER_BOT_SLUG),
-    ],
-)
-def test_a_bot_login_maps_to_its_slug(login: str | None, expected: str) -> None:
-    assert bot_slug(login, author_is_bot=True) == expected
-
-
-def test_a_human_author_gets_no_slug() -> None:
-    assert bot_slug("some-person", author_is_bot=False) is None
 
 
 def _review_body(login: str | None, *, author_is_bot: bool) -> GithubPrReviewBodyFeedbackSource:
@@ -58,31 +30,35 @@ def _pr_comment(login: str) -> GithubPrCommentFeedbackSource:
     )
 
 
-def test_the_slugs_are_sorted_and_deduped() -> None:
+def test_the_logins_are_sorted_and_deduped() -> None:
     sources = [
         _review_body("coderabbitai[bot]", author_is_bot=True),
         _review_comment("coderabbitai[bot]", author_is_bot=True),
         _review_body("seer-by-sentry[bot]", author_is_bot=True),
     ]
 
-    assert bot_slugs_for_feedback(sources) == ["coderabbit", "seer"]
+    assert bot_logins_for_feedback(sources) == ["coderabbitai[bot]", "seer-by-sentry[bot]"]
 
 
-def test_a_human_review_contributes_no_slug() -> None:
+def test_a_bot_review_without_a_login_records_nothing() -> None:
+    assert bot_logins_for_feedback([_review_body(None, author_is_bot=True)]) == []
+
+
+def test_a_human_review_contributes_no_login() -> None:
     sources = [
         _review_body("some-person", author_is_bot=False),
         _review_comment("some-person", author_is_bot=False),
     ]
 
-    assert bot_slugs_for_feedback(sources) == []
+    assert bot_logins_for_feedback(sources) == []
 
 
 def test_a_top_level_comment_is_classified_by_its_login() -> None:
-    assert bot_slugs_for_feedback([_pr_comment("cursor[bot]")]) == ["cursor"]
-    assert bot_slugs_for_feedback([_pr_comment("some-person")]) == []
+    assert bot_logins_for_feedback([_pr_comment("cursor[bot]")]) == ["cursor[bot]"]
+    assert bot_logins_for_feedback([_pr_comment("some-person")]) == []
 
 
-def test_check_suite_feedback_is_ci_and_contributes_no_slug() -> None:
+def test_check_suite_feedback_is_ci_and_contributes_no_login() -> None:
     source = CheckSuiteFeedbackSource(
         event={
             "check_suite": {
@@ -95,10 +71,10 @@ def test_check_suite_feedback_is_ci_and_contributes_no_slug() -> None:
         }
     )
 
-    assert bot_slugs_for_feedback([source]) == []
+    assert bot_logins_for_feedback([source]) == []
 
 
-def test_ui_feedback_contributes_no_slug() -> None:
+def test_ui_feedback_contributes_no_login() -> None:
     source = UserUIFeedbackSource(user_id=1, user_feedback="fix it")
 
-    assert bot_slugs_for_feedback([source]) == []
+    assert bot_logins_for_feedback([source]) == []

--- a/tests/sentry/seer/autofix/pr_iteration/test_bot_identity.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_bot_identity.py
@@ -1,0 +1,104 @@
+import pytest
+
+from sentry.seer.autofix.pr_iteration.bot_identity import (
+    OTHER_BOT_SLUG,
+    bot_slug,
+    bot_slugs_for_feedback,
+)
+from sentry.seer.autofix.pr_iteration.feedback_sources.check_suite import CheckSuiteFeedbackSource
+from sentry.seer.autofix.pr_iteration.feedback_sources.github_comment import (
+    GithubPrCommentFeedbackSource,
+    GithubPrReviewBodyFeedbackSource,
+    GithubPrReviewCommentFeedbackSource,
+)
+from sentry.seer.autofix.pr_iteration.feedback_sources.user_ui import UserUIFeedbackSource
+
+
+@pytest.mark.parametrize(
+    "login,expected",
+    [
+        ("seer-by-sentry[bot]", "seer"),
+        ("seer-dev-testing[bot]", "seer"),
+        ("seer[bot]", "seer"),
+        ("coderabbitai[bot]", "coderabbit"),
+        ("CodeRabbitAI[bot]", "coderabbit"),
+        ("cursor[bot]", "cursor"),
+        ("some-new-reviewer[bot]", OTHER_BOT_SLUG),
+        (None, OTHER_BOT_SLUG),
+        ("", OTHER_BOT_SLUG),
+    ],
+)
+def test_a_bot_login_maps_to_its_slug(login: str | None, expected: str) -> None:
+    assert bot_slug(login, author_is_bot=True) == expected
+
+
+def test_a_human_author_gets_no_slug() -> None:
+    assert bot_slug("some-person", author_is_bot=False) is None
+
+
+def _review_body(login: str | None, *, author_is_bot: bool) -> GithubPrReviewBodyFeedbackSource:
+    return GithubPrReviewBodyFeedbackSource(
+        review_id=1,
+        body="fix it",
+        user={"id": 1, "login": login},
+        author_is_bot=author_is_bot,
+    )
+
+
+def _review_comment(login: str, *, author_is_bot: bool) -> GithubPrReviewCommentFeedbackSource:
+    return GithubPrReviewCommentFeedbackSource(
+        comment={"id": 2, "body": "fix it", "user": {"id": 2, "login": login}},
+        author_is_bot=author_is_bot,
+    )
+
+
+def _pr_comment(login: str) -> GithubPrCommentFeedbackSource:
+    return GithubPrCommentFeedbackSource(
+        comment={"id": 3, "body": "@sentry fix it", "user": {"id": 3, "login": login}}
+    )
+
+
+def test_the_slugs_are_sorted_and_deduped() -> None:
+    sources = [
+        _review_body("coderabbitai[bot]", author_is_bot=True),
+        _review_comment("coderabbitai[bot]", author_is_bot=True),
+        _review_body("seer-by-sentry[bot]", author_is_bot=True),
+    ]
+
+    assert bot_slugs_for_feedback(sources) == ["coderabbit", "seer"]
+
+
+def test_a_human_review_contributes_no_slug() -> None:
+    sources = [
+        _review_body("some-person", author_is_bot=False),
+        _review_comment("some-person", author_is_bot=False),
+    ]
+
+    assert bot_slugs_for_feedback(sources) == []
+
+
+def test_a_top_level_comment_is_classified_by_its_login() -> None:
+    assert bot_slugs_for_feedback([_pr_comment("cursor[bot]")]) == ["cursor"]
+    assert bot_slugs_for_feedback([_pr_comment("some-person")]) == []
+
+
+def test_check_suite_feedback_is_ci_and_contributes_no_slug() -> None:
+    source = CheckSuiteFeedbackSource(
+        event={
+            "check_suite": {
+                "id": 1,
+                "head_sha": "abc",
+                "check_runs_url": "https://github.com/owner/repo/check-runs",
+                "app": {"name": "CI"},
+            },
+            "repository": {"html_url": "https://github.com/owner/repo"},
+        }
+    )
+
+    assert bot_slugs_for_feedback([source]) == []
+
+
+def test_ui_feedback_contributes_no_slug() -> None:
+    source = UserUIFeedbackSource(user_id=1, user_feedback="fix it")
+
+    assert bot_slugs_for_feedback([source]) == []

--- a/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_check_suite.py
@@ -4,6 +4,9 @@ from unittest.mock import ANY, MagicMock, patch
 import orjson
 from scm.helpers import iter_all_pages
 
+from sentry.analytics.events.pr_iteration_events import (
+    AiAutofixPrIterationCheckSuiteConcludedEvent,
+)
 from sentry.scm.types import CheckSuiteEvent
 from sentry.seer.agent.client_models import MemoryBlock, Message, RepoPRState, SeerRunState
 from sentry.seer.autofix.constants import AutofixReferrer
@@ -46,6 +49,10 @@ from sentry.seer.autofix.pr_iteration.listeners.check_suite import (
 )
 from sentry.seer.autofix.pr_iteration.queue import QueuedAutofixFeedback
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.analytics import (
+    assert_any_analytics_event,
+    assert_not_analytics_event,
+)
 from sentry.testutils.helpers.options import override_options
 
 CHECK_PATH = "sentry.seer.autofix.pr_iteration.listeners.check_suite"
@@ -465,6 +472,85 @@ class PrIterationFromCheckSuiteListenerTest(TestCase):
         assert autofix.run_state is not None
         mock_trigger_consume.assert_called_once()
         mock_assign.assert_not_called()
+
+    @patch("sentry.analytics.record")
+    @patch(f"{CHECK_PATH}.assign_user_for_exhausted_cap")
+    @patch(TRIGGER_CONSUME_PATH)
+    @patch(f"{CHECK_PATH}.try_enqueue_autofix_feedback", return_value=True)
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    @patch(f"{CHECK_SUITES_PATH}.resolve_check_suite_repositories")
+    def test_a_failing_suite_records_its_conclusion(
+        self,
+        mock_resolve: MagicMock,
+        mock_get_state: MagicMock,
+        _mock_enqueue: MagicMock,
+        _mock_trigger_consume: MagicMock,
+        _mock_assign: MagicMock,
+        mock_record: MagicMock,
+    ) -> None:
+        mock_resolve.return_value = [MagicMock(organization_id=self.organization.id, id=2)]
+        mock_get_state.return_value = self._agent_state()
+        raw = self._raw(pull_requests=[own_repo_pr(555)])
+        raw["check_suite"]["conclusion"] = "failure"
+
+        pr_iteration_from_check_suite_listener(self._event(raw))
+
+        assert_any_analytics_event(
+            mock_record,
+            AiAutofixPrIterationCheckSuiteConcludedEvent(
+                organization_id=self.organization.id,
+                run_id=67890,
+                head_sha="abc",
+                conclusion="failure",
+                app_name="CI",
+                check_suite_id=1,
+                updated_at="2024-01-01T00:00:00Z",
+            ),
+        )
+
+    @patch("sentry.analytics.record")
+    @patch(f"{CHECK_SUITES_PATH}.get_agent_state_from_pr_id")
+    def test_an_unhandled_suite_records_nothing(
+        self, _mock_get_state: MagicMock, mock_record: MagicMock
+    ) -> None:
+        pr_iteration_from_check_suite_listener(self._event(self._raw(), action="requested"))
+        pr_iteration_from_check_suite_listener(self._event(self._raw(), conclusion="cancelled"))
+
+        assert_not_analytics_event(mock_record, AiAutofixPrIterationCheckSuiteConcludedEvent)
+
+    @patch("sentry.analytics.record")
+    @patch(f"{CHECK_PATH}.peek_queued_autofix_feedback", return_value=[])
+    @patch(f"{CHECK_PATH}.green_review_side_effects_enabled", return_value=False)
+    @patch(f"{CHECK_PATH}.resolve_green_check_suite")
+    def test_a_green_suite_records_its_conclusion(
+        self,
+        mock_resolve: MagicMock,
+        _mock_enabled: MagicMock,
+        _mock_peek: MagicMock,
+        mock_record: MagicMock,
+    ) -> None:
+        raw = self._raw()
+        raw["check_suite"]["conclusion"] = "success"
+        resolved = MagicMock()
+        resolved.event = GithubCheckSuiteEvent(**raw)
+        resolved.organization.id = self.organization.id
+        resolved.autofix_run.run_state = self._agent_state()
+        mock_resolve.return_value = resolved
+
+        pr_iteration_from_check_suite_listener(self._event(raw, conclusion="success"))
+
+        assert_any_analytics_event(
+            mock_record,
+            AiAutofixPrIterationCheckSuiteConcludedEvent(
+                organization_id=self.organization.id,
+                run_id=67890,
+                head_sha="abc",
+                conclusion="success",
+                app_name="CI",
+                check_suite_id=1,
+                updated_at="2024-01-01T00:00:00Z",
+            ),
+        )
 
     @patch(f"{CHECK_SUITES_PATH}.sentry_sdk.capture_exception")
     @patch(TRIGGER_CONSUME_PATH)

--- a/tests/sentry/seer/autofix/pr_iteration/test_emit.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_emit.py
@@ -6,7 +6,14 @@ from django.utils import timezone
 from sentry.analytics.events.pr_iteration_events import (
     AiAutofixPrIterationFeedbackBatchCompletedEvent,
 )
-from sentry.seer.agent.client_models import MemoryBlock, Message, SeerRunState
+from sentry.seer.agent.client_models import (
+    AgentFilePatch,
+    FilePatch,
+    MemoryBlock,
+    Message,
+    RepoPRState,
+    SeerRunState,
+)
 from sentry.seer.autofix.pr_iteration.details_store import (
     open_iterations,
     remove_iterations_before,
@@ -30,18 +37,53 @@ from sentry.testutils.helpers.datetime import freeze_time
 RUN_ID = 4242
 
 
-def _run_state(*, blocks: list[MemoryBlock] | None = None) -> SeerRunState:
+def _run_state(
+    *,
+    blocks: list[MemoryBlock] | None = None,
+    commit_shas: dict[str, str] | None = None,
+) -> SeerRunState:
     return SeerRunState(
         run_id=RUN_ID,
         blocks=blocks or [],
         status="completed",
         updated_at="2024-01-01T00:00:00Z",
+        repo_pr_states={
+            repo: RepoPRState(repo_name=repo, commit_sha=sha)
+            for repo, sha in (commit_shas or {}).items()
+        },
     )
 
 
-def _iteration_block(iteration_id: int) -> MemoryBlock:
+def _patch(repo_name: str) -> AgentFilePatch:
+    return AgentFilePatch(
+        repo_name=repo_name,
+        patch=FilePatch(path="src/foo.py", type="M", added=1, removed=0),
+    )
+
+
+def _edit_block(
+    block_id: str, *, repos: list[str], pr_commit_shas: dict[str, str] | None = None
+) -> MemoryBlock:
+    """A follow-on block in the iteration that edited files in ``repos``."""
+    return MemoryBlock(
+        id=block_id,
+        pr_commit_shas=pr_commit_shas,
+        merged_file_patches=[_patch(repo) for repo in repos],
+        message=Message(role="assistant", content="edit"),
+        timestamp="2024-01-01T00:00:00Z",
+    )
+
+
+def _iteration_block(
+    iteration_id: int,
+    *,
+    repos: list[str] | None = None,
+    pr_commit_shas: dict[str, str] | None = None,
+) -> MemoryBlock:
     return MemoryBlock(
         id="block-0",
+        pr_commit_shas=pr_commit_shas,
+        merged_file_patches=[_patch(repo) for repo in repos or []],
         message=Message(
             role="assistant",
             content="iteration",
@@ -94,6 +136,7 @@ class PrIterationDetailsTest(TestCase):
                 queued_count=3,
                 dropped_count=1,
                 automated_feedback_count=1,
+                feedback_bot_slugs=["coderabbit"],
             )
         return iteration_id
 
@@ -102,10 +145,16 @@ class PrIterationDetailsTest(TestCase):
         iteration_id: int,
         *,
         outcome: str = PrIterationOutcome.ALREADY_PUSHED.value,
+        repos: list[str] | None = None,
+        commit_shas: dict[str, str] | None = None,
+        extra_blocks: list[MemoryBlock] | None = None,
     ) -> None:
         complete_pr_iteration_details(
             log_ctx=self.log_ctx,
-            run_state=_run_state(blocks=[_iteration_block(iteration_id)]),
+            run_state=_run_state(
+                blocks=[_iteration_block(iteration_id, repos=repos), *(extra_blocks or [])],
+                commit_shas=commit_shas,
+            ),
             organization_id=self.organization.id,
             outcome=outcome,
         )
@@ -132,6 +181,83 @@ class PrIterationDetailsTest(TestCase):
         assert row.data["queued_count"] == 3
         assert row.data["dropped_count"] == 1
         assert row.data["automated_feedback_count"] == 1
+        assert row.data["feedback_bot_slugs"] == ["coderabbit"]
+
+    def test_a_pushed_iteration_records_the_commit_it_pushed(self) -> None:
+        self._open()
+        iteration_id = self._trigger()
+        assert iteration_id is not None
+
+        with patch("sentry.analytics.record") as mock_record:
+            self._complete(
+                iteration_id,
+                repos=["owner/repo"],
+                commit_shas={"owner/repo": "sha-new"},
+            )
+
+        assert mock_record.call_args.args[0].head_shas == ["sha-new"]
+
+    def test_the_pushed_commit_wins_over_an_earlier_blocks_commit(self) -> None:
+        """A block records the PR head at the time it was created, so it can be stale."""
+        self._open()
+        iteration_id = self._trigger()
+        assert iteration_id is not None
+        stale = _edit_block(
+            "block-1", repos=["owner/repo"], pr_commit_shas={"owner/repo": "sha-old"}
+        )
+        pushed = _edit_block("block-2", repos=["owner/repo"])
+
+        with patch("sentry.analytics.record") as mock_record:
+            self._complete(
+                iteration_id,
+                commit_shas={"owner/repo": "sha-new"},
+                extra_blocks=[stale, pushed],
+            )
+
+        assert mock_record.call_args.args[0].head_shas == ["sha-new"]
+
+    def test_a_multi_repo_iteration_records_every_commit_it_pushed(self) -> None:
+        self._open()
+        iteration_id = self._trigger()
+        assert iteration_id is not None
+
+        with patch("sentry.analytics.record") as mock_record:
+            self._complete(
+                iteration_id,
+                repos=["owner/one", "owner/two"],
+                commit_shas={"owner/one": "sha-b", "owner/two": "sha-a"},
+            )
+
+        assert mock_record.call_args.args[0].head_shas == ["sha-a", "sha-b"]
+
+    def test_a_repo_the_iteration_did_not_touch_is_left_out(self) -> None:
+        self._open()
+        iteration_id = self._trigger()
+        assert iteration_id is not None
+
+        with patch("sentry.analytics.record") as mock_record:
+            self._complete(
+                iteration_id,
+                repos=["owner/one"],
+                commit_shas={"owner/one": "sha-a", "owner/untouched": "sha-z"},
+            )
+
+        assert mock_record.call_args.args[0].head_shas == ["sha-a"]
+
+    def test_an_iteration_that_pushed_nothing_records_no_commit(self) -> None:
+        self._open()
+        iteration_id = self._trigger()
+        assert iteration_id is not None
+
+        with patch("sentry.analytics.record") as mock_record:
+            self._complete(
+                iteration_id,
+                outcome=PrIterationOutcome.NO_CODE_CHANGES.value,
+                repos=["owner/repo"],
+                commit_shas={"owner/repo": "sha-new"},
+            )
+
+        assert mock_record.call_args.args[0].head_shas == []
 
     @freeze_time("2024-01-01 00:00:00")
     def test_the_iteration_it_opened_is_emitted_when_it_completes(self) -> None:
@@ -157,6 +283,8 @@ class PrIterationDetailsTest(TestCase):
                 queued_count=3,
                 dropped_count=1,
                 automated_feedback_count=1,
+                feedback_bot_slugs=["coderabbit"],
+                head_shas=[],
                 duration_ms=0,
                 outcome="already_pushed",
             ),
@@ -317,6 +445,8 @@ class PrIterationDetailsTest(TestCase):
                 queued_count=3,
                 dropped_count=1,
                 automated_feedback_count=1,
+                feedback_bot_slugs=["coderabbit"],
+                head_shas=[],
                 duration_ms=0,
                 outcome="no_code_changes",
             ),

--- a/tests/sentry/seer/autofix/pr_iteration/test_emit.py
+++ b/tests/sentry/seer/autofix/pr_iteration/test_emit.py
@@ -136,7 +136,7 @@ class PrIterationDetailsTest(TestCase):
                 queued_count=3,
                 dropped_count=1,
                 automated_feedback_count=1,
-                feedback_bot_slugs=["coderabbit"],
+                feedback_bot_logins=["coderabbitai[bot]"],
             )
         return iteration_id
 
@@ -181,7 +181,7 @@ class PrIterationDetailsTest(TestCase):
         assert row.data["queued_count"] == 3
         assert row.data["dropped_count"] == 1
         assert row.data["automated_feedback_count"] == 1
-        assert row.data["feedback_bot_slugs"] == ["coderabbit"]
+        assert row.data["feedback_bot_logins"] == ["coderabbitai[bot]"]
 
     def test_a_pushed_iteration_records_the_commit_it_pushed(self) -> None:
         self._open()
@@ -283,7 +283,7 @@ class PrIterationDetailsTest(TestCase):
                 queued_count=3,
                 dropped_count=1,
                 automated_feedback_count=1,
-                feedback_bot_slugs=["coderabbit"],
+                feedback_bot_logins=["coderabbitai[bot]"],
                 head_shas=[],
                 duration_ms=0,
                 outcome="already_pushed",
@@ -445,7 +445,7 @@ class PrIterationDetailsTest(TestCase):
                 queued_count=3,
                 dropped_count=1,
                 automated_feedback_count=1,
-                feedback_bot_slugs=["coderabbit"],
+                feedback_bot_logins=["coderabbitai[bot]"],
                 head_shas=[],
                 duration_ms=0,
                 outcome="no_code_changes",

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -1736,12 +1736,12 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
         self._call()
 
         (row,) = open_iterations(seer_run)
-        assert row.data["feedback_bot_slugs"] == ["coderabbit", "seer"]
+        assert row.data["feedback_bot_logins"] == ["coderabbitai[bot]", "seer-by-sentry[bot]"]
 
     @patch(f"{TASK_PATH}.trigger_autofix_agent")
     @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
     @patch(f"{TASK_PATH}.fetch_run_status")
-    def test_a_dropped_bot_review_contributes_no_slug(
+    def test_a_dropped_bot_review_contributes_no_login(
         self,
         mock_fetch: MagicMock,
         mock_pop: MagicMock,
@@ -1767,12 +1767,12 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
 
         (row,) = open_iterations(seer_run)
         assert row.data["dropped_count"] == 1
-        assert row.data["feedback_bot_slugs"] == ["coderabbit"]
+        assert row.data["feedback_bot_logins"] == ["coderabbitai[bot]"]
 
     @patch(f"{TASK_PATH}.trigger_autofix_agent")
     @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
     @patch(f"{TASK_PATH}.fetch_run_status")
-    def test_a_deduped_bot_review_contributes_no_slug(
+    def test_a_deduped_bot_review_contributes_no_login(
         self,
         mock_fetch: MagicMock,
         mock_pop: MagicMock,
@@ -1791,7 +1791,7 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
 
         (row,) = open_iterations(seer_run)
         assert row.data["dropped_count"] == 1
-        assert row.data["feedback_bot_slugs"] == ["coderabbit"]
+        assert row.data["feedback_bot_logins"] == ["coderabbitai[bot]"]
 
 
 class TriggerConsumePrIterationFeedbackTest(TestCase):

--- a/tests/sentry/tasks/seer/test_pr_iteration.py
+++ b/tests/sentry/tasks/seer/test_pr_iteration.py
@@ -879,6 +879,16 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
             )
         )
 
+    def _bot_review_feedback(self, review_id: int, login: str) -> Feedback:
+        return Feedback(
+            source=GithubPrReviewBodyFeedbackSource(
+                review_id=review_id,
+                body="fix it",
+                user={"id": review_id, "login": login},
+                author_is_bot=True,
+            )
+        )
+
     def _check_suite_feedback(self, *, updated_at: str | None = "2024-01-01T00:00:00Z") -> Feedback:
         check_suite: dict[str, Any] = {
             "id": 1,
@@ -1702,6 +1712,86 @@ class ConsumeQueuedAutofixFeedbackTest(TestCase):
         assert mock_trigger.call_args.kwargs["iteration_id"] == row.id
         assert row.data["feedback_count"] == 1
         assert row.data["dropped_count"] == 0
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_the_drain_records_the_review_bots_it_consumed(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        _mock_trigger: MagicMock,
+    ) -> None:
+        seer_run = self.create_seer_run(organization=self.organization, seer_run_state_id=67890)
+        mock_fetch.return_value = self._state_on_head()
+        mock_pop.return_value = [
+            self._queued(self._bot_review_feedback(1, "coderabbitai[bot]")),
+            self._queued(self._bot_review_feedback(2, "coderabbitai[bot]")),
+            self._queued(self._bot_review_feedback(3, "seer-by-sentry[bot]")),
+            self._queued(self._check_suite_feedback()),
+            self._ui_queued(),
+        ]
+        self._open_iteration_row()
+
+        self._call()
+
+        (row,) = open_iterations(seer_run)
+        assert row.data["feedback_bot_slugs"] == ["coderabbit", "seer"]
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_a_dropped_bot_review_contributes_no_slug(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        _mock_trigger: MagicMock,
+    ) -> None:
+        seer_run = self.create_seer_run(organization=self.organization, seer_run_state_id=67890)
+        already_processed = self._bot_review_feedback(700, "seer-by-sentry[bot]")
+        block = MemoryBlock(
+            id="b1",
+            message=Message(
+                role="assistant", metadata={"feedback": serialize_feedback([already_processed])}
+            ),
+            timestamp="2024-01-01T00:00:00Z",
+        )
+        mock_fetch.return_value = self._state(blocks=[block])
+        mock_pop.return_value = [
+            self._queued(already_processed),
+            self._queued(self._bot_review_feedback(701, "coderabbitai[bot]")),
+        ]
+        self._open_iteration_row()
+
+        self._call()
+
+        (row,) = open_iterations(seer_run)
+        assert row.data["dropped_count"] == 1
+        assert row.data["feedback_bot_slugs"] == ["coderabbit"]
+
+    @patch(f"{TASK_PATH}.trigger_autofix_agent")
+    @patch(f"{TASK_PATH}.pop_queued_autofix_feedback")
+    @patch(f"{TASK_PATH}.fetch_run_status")
+    def test_a_deduped_bot_review_contributes_no_slug(
+        self,
+        mock_fetch: MagicMock,
+        mock_pop: MagicMock,
+        _mock_trigger: MagicMock,
+    ) -> None:
+        seer_run = self.create_seer_run(organization=self.organization, seer_run_state_id=67890)
+        mock_fetch.return_value = self._state()
+        # Two bots cannot share a review id in practice: the pair pins the dedupe.
+        mock_pop.return_value = [
+            self._queued(self._bot_review_feedback(800, "coderabbitai[bot]")),
+            self._queued(self._bot_review_feedback(800, "seer-by-sentry[bot]")),
+        ]
+        self._open_iteration_row()
+
+        self._call()
+
+        (row,) = open_iterations(seer_run)
+        assert row.data["dropped_count"] == 1
+        assert row.data["feedback_bot_slugs"] == ["coderabbit"]
 
 
 class TriggerConsumePrIterationFeedbackTest(TestCase):


### PR DESCRIPTION
Two of the five CW-2013 metrics.

- `feedback_bot_slugs` on the feedback-batch event: the review bots behind the feedback a batch actually consumed. Dropped and deduped items do not count. Only bot slugs are recorded, never a human login.
- `head_shas` on the same event: the commits a batch pushed, filled only when the outcome is `already_pushed`.
- `ai.autofix.pr_iteration.check_suite_concluded`: one row for each concluded suite, so Hex can join a CI result to the batch that pushed the commit.

Push failures and no-code-change iterations already fall out of `outcome`. Timeouts are not in this PR.

Plan: `~/plans/20260911-cw-2013-bot-type-and-ci-metrics.md`

https://claude.ai/code/session_01W2xkbxFqSJ2F5uUzrc5DXB