### PR TITLE
ref(preprod): Switch snapshot tasks to the preprod.snapshots namespace

### DIFF
--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -887,8 +887,8 @@ def _process_chunk(
 
 @instrumented_task(
     name="sentry.preprod.tasks.process_snapshot_comparison_chunk",
-    namespace=preprod_tasks,
-    alias_namespace=preprod_snapshots_tasks,
+    namespace=preprod_snapshots_tasks,
+    alias_namespace=preprod_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=CHUNK_PROCESSING_DEADLINE,
@@ -943,8 +943,8 @@ def process_snapshot_comparison_chunk(
 
 @instrumented_task(
     name="sentry.preprod.tasks.compare_snapshots",
-    namespace=preprod_tasks,
-    alias_namespace=preprod_snapshots_tasks,
+    namespace=preprod_snapshots_tasks,
+    alias_namespace=preprod_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=300,
@@ -1331,8 +1331,8 @@ def _finalize_if_all_chunks_done(
 
 @instrumented_task(
     name="sentry.preprod.tasks.finalize_snapshot_comparison",
-    namespace=preprod_tasks,
-    alias_namespace=preprod_snapshots_tasks,
+    namespace=preprod_snapshots_tasks,
+    alias_namespace=preprod_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=300,

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -109,8 +109,8 @@ def _upload_archive_multipart(session: Session, key: str, tmp: IO[bytes]) -> Non
 
 @instrumented_task(
     name="sentry.preprod.tasks.build_snapshot_images_zip",
-    namespace=preprod_tasks,
-    alias_namespace=preprod_snapshots_tasks,
+    namespace=preprod_snapshots_tasks,
+    alias_namespace=preprod_tasks,
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=900,
 )

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -56,8 +56,8 @@ def get_snapshot_pr_comment_reporting_criteria(project: Project) -> SnapshotChan
 
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_snapshot_pr_comment",
-    namespace=preprod_tasks,
-    alias_namespace=preprod_snapshots_tasks,
+    namespace=preprod_snapshots_tasks,
+    alias_namespace=preprod_tasks,
     processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=60),
@@ -234,8 +234,8 @@ def create_preprod_snapshot_pr_comment_task(
 
 @instrumented_task(
     name="sentry.preprod.tasks.post_snapshot_pr_comment",
-    namespace=preprod_tasks,
-    alias_namespace=preprod_snapshots_tasks,
+    namespace=preprod_snapshots_tasks,
+    alias_namespace=preprod_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=4, on=(ApiError, ConnectionError, TimeoutError)),

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -50,8 +50,8 @@ APPROVE_SNAPSHOT_ACTION_IDENTIFIER = "approve_snapshots"
 
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_snapshot_status_check",
-    namespace=preprod_tasks,
-    alias_namespace=preprod_snapshots_tasks,
+    namespace=preprod_snapshots_tasks,
+    alias_namespace=preprod_tasks,
     processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=60),
@@ -363,8 +363,8 @@ def _compute_snapshot_status(
 
 @instrumented_task(
     name="sentry.preprod.tasks.post_snapshot_status_check",
-    namespace=preprod_tasks,
-    alias_namespace=preprod_snapshots_tasks,
+    namespace=preprod_snapshots_tasks,
+    alias_namespace=preprod_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=4, on=(ApiError, ConnectionError, TimeoutError)),


### PR DESCRIPTION
Make `preprod.snapshots` the primary namespace for the eight snapshot tasks so producers emit it and snapshot comparisons, archive builds, PR comments, and status checks can be identified and routed separately from other preprod work. Task names, retry policies, and deadlines are unchanged. Routing matches namespace strings exactly, so with no explicit route the new namespace lands on the same default topic and pool as `preprod` does today; configure a route only if snapshot work should move to a dedicated pool later.

Stacked on #123840, which must be fully deployed first so every worker already recognizes `preprod.snapshots`. `preprod` stays registered as an alias so workers keep draining activations queued under the old namespace. The alias can be removed in a follow-up once no `preprod`-namespaced snapshot activations remain.
