### PR TITLE
ref(preprod): Drop the preprod alias from snapshot tasks

### DIFF
--- a/src/sentry/preprod/snapshots/tasks.py
+++ b/src/sentry/preprod/snapshots/tasks.py
@@ -53,7 +53,7 @@ from sentry.preprod.snapshots.reconstruction import reconstruct_base_manifest
 from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import preprod_snapshots_tasks, preprod_tasks
+from sentry.taskworker.namespaces import preprod_snapshots_tasks
 from sentry.utils import metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
 
@@ -888,7 +888,6 @@ def _process_chunk(
 @instrumented_task(
     name="sentry.preprod.tasks.process_snapshot_comparison_chunk",
     namespace=preprod_snapshots_tasks,
-    alias_namespace=preprod_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=CHUNK_PROCESSING_DEADLINE,
@@ -944,7 +943,6 @@ def process_snapshot_comparison_chunk(
 @instrumented_task(
     name="sentry.preprod.tasks.compare_snapshots",
     namespace=preprod_snapshots_tasks,
-    alias_namespace=preprod_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=300,
@@ -1332,7 +1330,6 @@ def _finalize_if_all_chunks_done(
 @instrumented_task(
     name="sentry.preprod.tasks.finalize_snapshot_comparison",
     namespace=preprod_snapshots_tasks,
-    alias_namespace=preprod_tasks,
     retry=Retry(times=3),
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=300,

--- a/src/sentry/preprod/snapshots/zip_tasks.py
+++ b/src/sentry/preprod/snapshots/zip_tasks.py
@@ -23,7 +23,7 @@ from sentry.preprod.snapshots.zip_builder import (
 )
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import preprod_snapshots_tasks, preprod_tasks
+from sentry.taskworker.namespaces import preprod_snapshots_tasks
 from sentry.users.services.user.service import user_service
 from sentry.utils.email import MessageBuilder
 
@@ -110,7 +110,6 @@ def _upload_archive_multipart(session: Session, key: str, tmp: IO[bytes]) -> Non
 @instrumented_task(
     name="sentry.preprod.tasks.build_snapshot_images_zip",
     namespace=preprod_snapshots_tasks,
-    alias_namespace=preprod_tasks,
     silo_mode=SiloMode.CELL,
     processing_deadline_duration=900,
 )

--- a/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
+++ b/src/sentry/preprod/vcs/pr_comments/snapshot_tasks.py
@@ -34,7 +34,7 @@ from sentry.preprod.vcs.status_checks.snapshots.config import (
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import preprod_snapshots_tasks, preprod_tasks
+from sentry.taskworker.namespaces import preprod_snapshots_tasks
 
 logger = logging.getLogger(__name__)
 
@@ -57,7 +57,6 @@ def get_snapshot_pr_comment_reporting_criteria(project: Project) -> SnapshotChan
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_snapshot_pr_comment",
     namespace=preprod_snapshots_tasks,
-    alias_namespace=preprod_tasks,
     processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=60),
@@ -235,7 +234,6 @@ def create_preprod_snapshot_pr_comment_task(
 @instrumented_task(
     name="sentry.preprod.tasks.post_snapshot_pr_comment",
     namespace=preprod_snapshots_tasks,
-    alias_namespace=preprod_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=4, on=(ApiError, ConnectionError, TimeoutError)),

--- a/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
+++ b/src/sentry/preprod/vcs/status_checks/snapshots/tasks.py
@@ -40,7 +40,7 @@ from sentry.preprod.vcs.tasks import update_preprod_snapshot_vcs
 from sentry.shared_integrations.exceptions import ApiError
 from sentry.silo.base import SiloMode
 from sentry.tasks.base import instrumented_task
-from sentry.taskworker.namespaces import preprod_snapshots_tasks, preprod_tasks
+from sentry.taskworker.namespaces import preprod_snapshots_tasks
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,6 @@ APPROVE_SNAPSHOT_ACTION_IDENTIFIER = "approve_snapshots"
 @instrumented_task(
     name="sentry.preprod.tasks.create_preprod_snapshot_status_check",
     namespace=preprod_snapshots_tasks,
-    alias_namespace=preprod_tasks,
     processing_deadline_duration=60,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=60),
@@ -364,7 +363,6 @@ def _compute_snapshot_status(
 @instrumented_task(
     name="sentry.preprod.tasks.post_snapshot_status_check",
     namespace=preprod_snapshots_tasks,
-    alias_namespace=preprod_tasks,
     processing_deadline_duration=30,
     silo_mode=SiloMode.CELL,
     retry=Retry(times=3, delay=4, on=(ApiError, ConnectionError, TimeoutError)),


### PR DESCRIPTION
Remove the `preprod` alias registration from the eight snapshot tasks so they are registered exclusively under `preprod.snapshots`. The alias only existed to let workers drain activations queued under the old namespace while producers switched over.

Stacked on #124209. Merge only after that PR has fully rolled out and no `preprod`-namespaced snapshot activations remain, including delayed retries, since a worker without the alias reports a terminal `FAILURE` for them.