### PR TITLE
fix(assisted-query): Expose numeric issue ID field

### DIFF
--- a/src/sentry/seer/assisted_query/discover_tools.py
+++ b/src/sentry/seer/assisted_query/discover_tools.py
@@ -50,6 +50,7 @@ _ALWAYS_RETURN_EVENT_FIELDS = frozenset(
         "trace.parent_span",  # Parent span ID
         "project",  # Project slug
         "issue",  # Issue short ID
+        "issue.id",  # Numeric issue ID
         "has",
         # Fields stored in contexts map, not exposed via tags
         "unreal.crash_type",
@@ -84,6 +85,7 @@ _ALWAYS_RETURN_EVENT_FIELDS = frozenset(
 _SPECIAL_FIELD_VALUE_TYPES = {
     "id": "uuid",
     "issue": "issue_short_id",
+    "issue.id": "integer",
     "timestamp": "datetime",
     "timestamp.to_hour": "datetime",
     "timestamp.to_day": "datetime",
@@ -171,13 +173,13 @@ def _is_agg_function(key: str) -> bool:
 
 def _get_static_values(key: str) -> list[dict[str, Any]] | None:
     """
-    Get values for keys with a static set of values. Returns None if the key's
-    values are dynamic and should be queried.
+    Return predefined values, an empty list for fields that should not be
+    queried, or None when values should be queried dynamically.
     """
     value_type = _SPECIAL_FIELD_VALUE_TYPES.get(key, "")
 
     if (
-        value_type in ["uuid", "issue_short_id", "datetime"]
+        value_type in ["uuid", "issue_short_id", "datetime", "integer"]
         or key.startswith("measurements.")
         or key == "device.class"
         or _is_agg_function(key)

--- a/tests/sentry/seer/assisted_query/test_discover_tools.py
+++ b/tests/sentry/seer/assisted_query/test_discover_tools.py
@@ -1,6 +1,7 @@
 from sentry.seer.assisted_query.discover_tools import (
     _ALWAYS_RETURN_EVENT_FIELDS,
     _SPECIAL_FIELD_VALUE_TYPES,
+    _get_static_values,
     get_event_filter_key_values,
     get_event_filter_keys,
 )
@@ -54,6 +55,7 @@ class TestGetEventFilterKeys(APITestCase, SnubaTestCase):
 
         assert isinstance(result, EventFilterKeysResponse)
         result_d = result.dict()
+        assert result_d["issue.id"] == {"type": "integer"}
 
         # Check tags
         for k in ["fruit", "color"]:
@@ -165,6 +167,9 @@ class TestGetEventFilterKeyValues(APITestCase, SnubaTestCase):
     def setUp(self) -> None:
         super().setUp()
         self.min_ago = before_now(minutes=1)
+
+    def test_get_static_values_integer_returns_empty(self) -> None:
+        assert _get_static_values("issue.id") == []
 
     def test_get_event_filter_key_values_tag_key(self) -> None:
         """Test getting values for a tag key"""


### PR DESCRIPTION
Assisted Query now includes `issue.id` in error field discovery, allowing the query agent to validate and execute numeric issue ID filters instead of rejecting them as unknown fields. Numeric issue IDs are identified as integers and skip value suggestions, avoiding incorrect tag-value lookups.

Refs [AIML-3179](https://linear.app/getsentry/issue/AIML-3179)
