### PR TITLE
feat(smart-assignment): Fuzzy-match candidates

### DIFF
--- a/src/sentry/options/defaults.py
+++ b/src/sentry/options/defaults.py
@@ -1397,6 +1397,14 @@ register(
     default=0.10,
     flags=FLAG_MODIFIABLE_RATE | FLAG_AUTOMATOR_MODIFIABLE,
 )
+# Fuzzy resolution always runs after an exact email miss so its proposal can be
+# inspected. This controls whether that proposal is used in the delivered prediction.
+register(
+    "seer.smart_assignment.fuzzy_user_matching.enabled",
+    type=Bool,
+    default=False,
+    flags=FLAG_MODIFIABLE_BOOL | FLAG_AUTOMATOR_MODIFIABLE,
+)
 
 # Spread child run_auto_transition_issues_* tasks across this many seconds
 # after each schedule tick, to smooth burst load (DB/signals/queues).

--- a/src/sentry/seer/smart_assignment/delivery.py
+++ b/src/sentry/seer/smart_assignment/delivery.py
@@ -6,6 +6,7 @@ from uuid import UUID
 
 from django.utils import timezone
 
+from sentry import options
 from sentry.models.activity import Activity
 from sentry.models.group import Group
 from sentry.organizations.services.organization import organization_service
@@ -128,7 +129,27 @@ def _validate_resolve_verdict(
             users = user_service.get_many_by_email(
                 emails=[value], organization_id=organization_id, is_verified=False
             )
-            resolved.append(users[0].id if users else None)
+            if users:
+                resolved.append(users[0].id)
+                continue
+            fuzzy_matching_enabled = options.get(
+                "seer.smart_assignment.fuzzy_user_matching.enabled"
+            )
+            fuzzy_user_id = user_service.resolve_fuzzy_user(
+                organization_id=organization_id,
+                email=value,
+                name=candidate.name,
+            )
+            # Shadow mode logs the proposed user for review while leaving this candidate
+            # unresolved, so scoring and assignment continue to see the pre-fuzzy result.
+            logger.info(
+                "smart_assignment.delivery.fuzzy_user_resolution",
+                extra={
+                    **log_extra,
+                    "user_id": fuzzy_user_id,
+                },
+            )
+            resolved.append(fuzzy_user_id if fuzzy_matching_enabled else None)
             continue
 
         if candidate.identifier_kind == "username":

--- a/src/sentry/seer/smart_assignment/models.py
+++ b/src/sentry/seer/smart_assignment/models.py
@@ -93,6 +93,7 @@ class SmartAssignmentPayload(BaseModel):
 
 
 class RankedCandidate(BaseModel):
+    name: str | None = None
     identifier: str
     identifier_kind: Literal["email", "username"]
     reason: str = ""

--- a/src/sentry/users/services/user/impl.py
+++ b/src/sentry/users/services/user/impl.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Callable, MutableMapping
 from typing import Any
 from uuid import uuid4
@@ -49,6 +50,7 @@ from sentry.users.services.user.serial import (
     serialize_user_avatar,
 )
 from sentry.users.services.user.service import UserService
+from sentry.utils import metrics
 
 logger = logging.getLogger("user:provisioning")
 
@@ -103,6 +105,46 @@ class DatabaseBackedUserService(UserService):
             for user in user_query
             for email in emails_by_user_ids[user.id]
         ]
+
+    def resolve_fuzzy_user(
+        self,
+        organization_id: int,
+        email: str | None = None,
+        name: str | None = None,
+    ) -> int | None:
+        identity_pattern, inferred_name = _identity_pattern(email)
+        name_pattern = _name_pattern(name or inferred_name)
+        if not identity_pattern and not name_pattern:
+            metrics.incr("user.resolve_fuzzy_user", tags={"outcome": "empty"}, sample_rate=1.0)
+            return None
+
+        query = Q()
+        if identity_pattern:
+            query |= Q(emails__email__iregex=rf"^{identity_pattern}@")
+            query |= Q(username__iregex=rf"^{identity_pattern}$")
+        if name_pattern:
+            query |= Q(name__iregex=rf"^{name_pattern}$")
+
+        user_ids = list(
+            User.objects.filter(
+                query,
+                is_active=True,
+                orgmembermapping_set__organization_id=organization_id,
+            )
+            .exclude(is_sentry_app=True)
+            .values_list("id", flat=True)
+            .distinct()[:2]
+        )
+
+        if len(user_ids) == 1:
+            metrics.incr("user.resolve_fuzzy_user", tags={"outcome": "hit"}, sample_rate=1.0)
+            return user_ids[0]
+        if len(user_ids) > 1:
+            metrics.incr("user.resolve_fuzzy_user", tags={"outcome": "ambiguous"}, sample_rate=1.0)
+            return None
+
+        metrics.incr("user.resolve_fuzzy_user", tags={"outcome": "none"}, sample_rate=1.0)
+        return None
 
     def get_by_username(
         self, username: str, with_valid_password: bool = True, is_active: bool | None = None
@@ -389,3 +431,58 @@ class DatabaseBackedUserService(UserService):
             return serialize_rpc_user(user)
 
     _FQ = _UserFilterQuery()
+
+
+def _identity_pattern(value: str | None) -> tuple[str | None, str | None]:
+    if not value:
+        return None, None
+    value = value.strip()
+    inferred_name = None
+
+    # Commit authors are often formatted as `Dana Reed <dana.reed@example.com>`.
+    # Keep the display name as another matching signal and parse the email inside `<...>`.
+    angled = re.match(r"^(?P<name>.*?)\s*<\s*(?P<email>[^<>]+)\s*>\s*$", value)
+    if angled:
+        inferred_name = angled.group("name").strip() or None
+        value = angled.group("email").strip()
+
+    local, separator, domain = value.lower().partition("@")
+    if not separator or not local or not domain:
+        return None, inferred_name
+
+    # GitHub noreply addresses encode the login after `+`, for example
+    # `12345+dana@users.noreply.github.com`. With no `+`, use the local part as-is.
+    token = local.split("+", 1)[-1] if domain == "users.noreply.github.com" else local
+
+    # Treat `.`, `_`, and `-` as interchangeable between known chunks. `dana.reed`
+    # becomes `dana[._-]*reed`, matching `dana_reed`, `dana-reed`, or `danareed`
+    parts = [part for part in re.split(r"[._-]+", token) if part]
+    if not parts:
+        return None, inferred_name
+    if len(parts) > 1 and not inferred_name:
+        inferred_name = " ".join(parts)
+    pattern = r"[._-]*".join(re.escape(part) for part in parts)
+    return pattern, inferred_name
+
+
+def _name_pattern(value: str | None) -> str | None:
+    parts = (value or "").split()
+    if not parts:
+        return None
+    if len(parts) == 1:
+        return re.escape(parts[0])
+
+    first, *middle, last = parts
+    if not middle:
+        # `John Smith` may refer to `John Smith`, `John G Smith`, or
+        # `John George Smith`, but the first and last names must stay exact.
+        return rf"{re.escape(first)}(?:\s+\S+)*\s+{re.escape(last)}"
+
+    # When middle names are supplied, preserve them as evidence but make the complete
+    # middle section optional so `John G Smith` can still match `John Smith`.
+    # A one-letter initial accepts an optional period; `G` and `G.` are equivalent.
+    middle_pattern = r"\s+".join(
+        rf"{re.escape(part.rstrip('.'))}\.?" if len(part.rstrip(".")) == 1 else re.escape(part)
+        for part in middle
+    )
+    return rf"{re.escape(first)}(?:\s+{middle_pattern})?\s+{re.escape(last)}"

--- a/src/sentry/users/services/user/service.py
+++ b/src/sentry/users/services/user/service.py
@@ -121,6 +121,22 @@ class UserService(RpcService):
 
     @rpc_method
     @abstractmethod
+    def resolve_fuzzy_user(
+        self,
+        *,
+        organization_id: int,
+        email: str | None = None,
+        name: str | None = None,
+    ) -> int | None:
+        """Return the one org member a hint uniquely matches, or None.
+
+        Matches email local-part on another domain, separator-normalized forms,
+        constructed names, and equivalent username forms. Returns None when
+        zero or more than one org member matches.
+        """
+
+    @rpc_method
+    @abstractmethod
     def get_by_username(
         self, *, username: str, with_valid_password: bool = True, is_active: bool | None = None
     ) -> list[RpcUser]:

--- a/tests/sentry/seer/smart_assignment/test_delivery.py
+++ b/tests/sentry/seer/smart_assignment/test_delivery.py
@@ -11,6 +11,7 @@ from sentry.seer.models.run import SeerAgentRun, SeerRun, SeerRunType
 from sentry.seer.smart_assignment.delivery import deliver_smart_assignment_result
 from sentry.seer.smart_assignment.models import SEER_FEATURE_ID, SmartAssignmentScore
 from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.options import override_options
 from sentry.types.activity import ActivityType
 
 METRICS_PATH = "sentry.seer.smart_assignment.delivery.metrics"
@@ -201,6 +202,98 @@ class DeliverSmartAssignmentResultTest(TestCase):
         self._deliver(result)
 
         assert self._extras()["predicted_assignee_user_ids"] == [carol.id]
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @override_options({"seer.smart_assignment.fuzzy_user_matching.enabled": True})
+    @patch(METRICS_PATH)
+    def test_email_kind_fuzzy_matches_local_part(self, mock_metrics: MagicMock) -> None:
+        dana = self.create_user(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        self.create_member(user=dana, organization=self.organization)
+        self._deliver(
+            {
+                "candidates": [
+                    {
+                        "identifier": "dana.reed@gmail.com",
+                        "identifier_kind": "email",
+                        "reason": "unlinked commit author",
+                        "confidence": "low",
+                    }
+                ]
+            }
+        )
+
+        assert self._extras()["predicted_assignee_user_ids"] == [dana.id]
+        self._assert_outcome(mock_metrics, "resolved")
+
+    @patch(METRICS_PATH)
+    def test_fuzzy_matching_can_be_disabled(self, mock_metrics: MagicMock) -> None:
+        dana = self.create_user(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        self.create_member(user=dana, organization=self.organization)
+        with (
+            override_options({"seer.smart_assignment.fuzzy_user_matching.enabled": False}),
+            patch("sentry.seer.smart_assignment.delivery.logger") as mock_logger,
+        ):
+            self._deliver(
+                {
+                    "candidates": [
+                        {
+                            "identifier": "dana.reed@gmail.com",
+                            "identifier_kind": "email",
+                        }
+                    ]
+                }
+            )
+
+        assert self._extras()["predicted_assignee_user_ids"] == [None]
+        log_extra = mock_logger.info.call_args.kwargs["extra"]
+        assert log_extra["user_id"] == dana.id
+        self._assert_outcome(mock_metrics, "unlinked")
+
+    @override_options({"seer.smart_assignment.fuzzy_user_matching.enabled": True})
+    @patch(METRICS_PATH)
+    def test_email_kind_ambiguous_local_part_is_unlinked(self, mock_metrics: MagicMock) -> None:
+        self.create_member(
+            user=self.create_user(email="alice@sentry.io", username="alice-work"),
+            organization=self.organization,
+        )
+        self.create_member(
+            user=self.create_user(email="alice@contractor.io", username="alice-contract"),
+            organization=self.organization,
+        )
+        self._deliver(
+            {
+                "candidates": [
+                    {
+                        "identifier": "alice@gmail.com",
+                        "identifier_kind": "email",
+                        "reason": "unlinked commit author",
+                        "confidence": "low",
+                    }
+                ]
+            }
+        )
+
+        assert self._extras()["predicted_assignee_user_ids"] == [None]
+        self._assert_outcome(mock_metrics, "unlinked")
+
+    @override_options({"seer.smart_assignment.fuzzy_user_matching.enabled": True})
+    @patch(METRICS_PATH)
+    def test_email_kind_fuzzy_matches_name(self, mock_metrics: MagicMock) -> None:
+        dana = self.create_user(email="other@sentry.io", name="Dana Reed", username="dreed")
+        self.create_member(user=dana, organization=self.organization)
+        self._deliver(
+            {
+                "candidates": [
+                    {
+                        "name": "Dana Reed",
+                        "identifier": "unrelated@gmail.com",
+                        "identifier_kind": "email",
+                    }
+                ]
+            }
+        )
+
+        assert self._extras()["predicted_assignee_user_ids"] == [dana.id]
         self._assert_outcome(mock_metrics, "resolved")
 
     @patch(METRICS_PATH)

--- a/tests/sentry/users/services/test_user.py
+++ b/tests/sentry/users/services/test_user.py
@@ -108,3 +108,111 @@ class UserServiceTest(TestCase):
         # Test removing non-existent permission returns False
         removed = user_service.remove_permission(user_id=self.user.id, permission="superuser.write")
         assert removed is False
+
+
+@all_silo_test
+class ResolveFuzzyUserTest(TestCase):
+    def _member(self, *, email: str, name: str = "", username: str | None = None, **kwargs):
+        user = self.create_user(email=email, name=name, username=username or email, **kwargs)
+        self.create_member(user=user, organization=self.organization)
+        return user
+
+    def _resolve(self, **kwargs) -> int | None:
+        return user_service.resolve_fuzzy_user(organization_id=self.organization.id, **kwargs)
+
+    def test_exact_email(self) -> None:
+        dana = self._member(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        assert self._resolve(email="dana.reed@sentry.io") == dana.id
+
+    def test_exact_unverified_email(self) -> None:
+        dana = self._member(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        self.create_useremail(user=dana, email="dana.reed@gmail.com", is_verified=False)
+        assert self._resolve(email="dana.reed@gmail.com") == dana.id
+
+    def test_local_part_on_other_domain(self) -> None:
+        dana = self._member(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        assert self._resolve(email="dana.reed@gmail.com") == dana.id
+
+    def test_normalized_local_part(self) -> None:
+        dana = self._member(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        assert self._resolve(email="dana_reed@gmail.com") == dana.id
+
+    def test_does_not_allow_separators_inside_a_chunk(self) -> None:
+        self._member(email="d.a.n.a@sentry.io", name="Other", username="other")
+        assert self._resolve(email="dana@gmail.com") is None
+
+    def test_name_from_dotted_local_part(self) -> None:
+        dana = self._member(email="other@sentry.io", name="Dana Reed", username="dreed")
+        assert self._resolve(email="dana.reed@gmail.com") == dana.id
+
+    def test_explicit_name(self) -> None:
+        dana = self._member(email="other@sentry.io", name="Dana Reed", username="dreed")
+        assert self._resolve(name="Dana Reed") == dana.id
+
+    def test_name_allows_middle_name(self) -> None:
+        john = self._member(email="other@sentry.io", name="John Grant Smith", username="jsmith")
+        assert self._resolve(name="John Smith") == john.id
+
+    def test_middle_initial_is_optional(self) -> None:
+        john = self._member(email="other@sentry.io", name="John Smith", username="jsmith")
+        assert self._resolve(name="John G Smith") == john.id
+
+    def test_middle_initial_does_not_match_another_initial(self) -> None:
+        self._member(email="other@sentry.io", name="John Q Smith", username="jsmith")
+        assert self._resolve(name="John G Smith") is None
+
+    def test_github_noreply(self) -> None:
+        dana = self._member(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        assert self._resolve(email="12345+dana@users.noreply.github.com") == dana.id
+
+    def test_github_noreply_without_plus(self) -> None:
+        dana = self._member(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        assert self._resolve(email="dana@users.noreply.github.com") == dana.id
+
+    def test_username_variant_from_email(self) -> None:
+        dana = self._member(email="other@sentry.io", name="Other", username="dana-reed")
+        assert self._resolve(email="dana.reed@gmail.com") == dana.id
+
+    def test_ambiguous_local_part(self) -> None:
+        self._member(email="alice@sentry.io", name="Alice One", username="alice1")
+        self._member(email="alice@contractor.io", name="Alice Two", username="alice2")
+        assert self._resolve(email="alice@gmail.com") is None
+
+    def test_ambiguous_name(self) -> None:
+        self._member(email="j1@sentry.io", name="John Smith", username="jsmith1")
+        self._member(email="j2@sentry.io", name="John Smith", username="jsmith2")
+        assert self._resolve(name="John Smith") is None
+
+    def test_exact_email_does_not_break_ambiguous_local_part(self) -> None:
+        self._member(email="alice@gmail.com", name="Alice Gmail", username="alice-gmail")
+        self._member(email="alice@sentry.io", name="Alice Work", username="alice-work")
+        assert self._resolve(email="alice@gmail.com") is None
+
+    def test_name_and_local_part_disagree(self) -> None:
+        self._member(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        self._member(email="other@sentry.io", name="Sam Okafor", username="sam")
+        assert self._resolve(email="sam@gmail.com", name="Dana Reed") is None
+
+    def test_outside_org_is_ignored(self) -> None:
+        outsider = self.create_user(
+            email="dana.reed@sentry.io", name="Dana Reed", username="dana-out"
+        )
+        self.create_member(user=outsider, organization=self.create_organization())
+        assert self._resolve(email="dana.reed@gmail.com") is None
+
+    def test_inactive_user_is_ignored(self) -> None:
+        self._member(
+            email="dana.reed@sentry.io", name="Dana Reed", username="dana", is_active=False
+        )
+        assert self._resolve(email="dana.reed@gmail.com") is None
+
+    def test_short_local_part_matches(self) -> None:
+        abe = self._member(email="ab@sentry.io", name="Abe", username="abe")
+        assert self._resolve(email="ab@gmail.com") == abe.id
+
+    def test_no_hints(self) -> None:
+        assert self._resolve() is None
+
+    def test_unknown_person(self) -> None:
+        self._member(email="dana.reed@sentry.io", name="Dana Reed", username="dana")
+        assert self._resolve(email="nobody@gmail.com") is None


### PR DESCRIPTION
There have been clear instances, even with Sentry employees, where hidden GitHub emails prevent us from resolving the actual person responsible for an issue. Here we attempt to fuzzy-match names (newly emitted by the Smart Assignment agent in https://github.com/getsentry/seer/pull/8185) and email addresses to users in the database, with some hopefully-comprehensive regexes that match across email domains, added/missing middle names/initials, various separators, etc.

If even 2 users match the input, we give up fuzzy matching. Better to not match than to match the OTHER John Smith.

For now, we log the results and don't actually use the fuzzy match. I want to monitor the results carefully and only enable if they look solid. 