### PR TITLE
Ab/create tooltip component for annotations

### DIFF
--- a/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
+++ b/static/app/views/dashboards/widgets/timeSeriesWidget/timeSeriesWidgetVisualization.tsx
@@ -426,6 +426,7 @@ export function TimeSeriesWidgetVisualization(props: TimeSeriesWidgetVisualizati
     alignInMiddle: props.plottables.some(plottable => plottable instanceof Bars),
     annotations: props.droppedData,
     showDroppedData: props.showDroppedData,
+    utc: utc ?? false,
     yAxisIndex: yAxes.length,
   });
 

--- a/static/app/views/explore/components/chart/droppedDataBand/droppedDataTooltip.spec.tsx
+++ b/static/app/views/explore/components/chart/droppedDataBand/droppedDataTooltip.spec.tsx
@@ -1,0 +1,94 @@
+import {render, screen} from 'sentry-test/reactTestingLibrary';
+
+import type {DataFidelityAnnotation} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
+import {
+  DroppedDataTooltip,
+  type DroppedDataTooltipData,
+  getDroppedDataTooltipData,
+} from 'sentry/views/explore/components/chart/droppedDataBand/droppedDataTooltip';
+import type {Bucket} from 'sentry/views/explore/components/chart/droppedDataBand/utils';
+
+const RANGE = 'Jul 7 2:00 AM — Jul 8 2:00 AM (UTC)';
+const GIB = 1024 ** 3;
+
+function makeData(
+  overrides: Partial<DroppedDataTooltipData> = {}
+): DroppedDataTooltipData {
+  return {categoryLabel: 'Spans', droppedCount: 40, ...overrides};
+}
+
+describe('DroppedDataTooltip', () => {
+  it('shows a raw dropped count when accepted volume is unavailable', () => {
+    render(<DroppedDataTooltip data={makeData()} range={RANGE} />);
+
+    expect(screen.getByText('Total Dropped')).toBeInTheDocument();
+    expect(screen.getByText('40')).toBeInTheDocument();
+    expect(screen.queryByText(/Rejected/)).not.toBeInTheDocument();
+    expect(screen.getByText(RANGE)).toBeInTheDocument();
+    expect(screen.getByText('Click for Details')).toBeInTheDocument();
+  });
+
+  it('shows a percentage and count ratio when accepted count is present', () => {
+    render(<DroppedDataTooltip data={makeData({acceptedCount: 200})} range={RANGE} />);
+    // 40 / (40 + 200) = 17%.
+    expect(screen.getByText('17%')).toBeInTheDocument();
+    expect(screen.getByText('Spans Rejected')).toBeInTheDocument();
+    expect(screen.getByText('40/240')).toBeInTheDocument();
+  });
+
+  it('shows the payloads row when byte totals are present', () => {
+    render(
+      <DroppedDataTooltip
+        data={makeData({droppedBytes: 26 * GIB, acceptedBytes: 224 * GIB})}
+        range={RANGE}
+      />
+    );
+
+    expect(screen.getByText('Payloads Rejected')).toBeInTheDocument();
+    expect(screen.getByText('26.0 GiB/250.0 GiB')).toBeInTheDocument();
+  });
+
+  it('does not render reason breakdowns', () => {
+    render(<DroppedDataTooltip data={makeData()} range={RANGE} />);
+
+    expect(screen.queryByText('Quota exceeded')).not.toBeInTheDocument();
+  });
+});
+
+describe('getDroppedDataTooltipData', () => {
+  function makeBucket(category: string): Bucket {
+    const annotation: DataFidelityAnnotation = {
+      category,
+      droppedCount: 40,
+      start: 0,
+      end: 1000,
+      label: 'Quota exceeded',
+      reason: 'over_quota',
+      type: 'system',
+    };
+    return {annotations: [annotation], start: 0, end: 1000, severity: 4, total: 40};
+  }
+
+  it('maps known categories to friendly labels', () => {
+    expect(getDroppedDataTooltipData(makeBucket('span')).categoryLabel).toBe('Spans');
+    expect(getDroppedDataTooltipData(makeBucket('log_item')).categoryLabel).toBe('Logs');
+    expect(getDroppedDataTooltipData(makeBucket('trace_metric')).categoryLabel).toBe(
+      'Metrics'
+    );
+  });
+
+  it('falls back to the raw category for unknown categories', () => {
+    expect(getDroppedDataTooltipData(makeBucket('unknown_thing')).categoryLabel).toBe(
+      'unknown_thing'
+    );
+  });
+
+  it('uses the bucket total as the dropped count and omits fields the API does not send yet', () => {
+    const data = getDroppedDataTooltipData(makeBucket('span'));
+
+    expect(data.droppedCount).toBe(40);
+    expect(data.acceptedCount).toBeUndefined();
+    expect(data.droppedBytes).toBeUndefined();
+    expect(data.acceptedBytes).toBeUndefined();
+  });
+});

--- a/static/app/views/explore/components/chart/droppedDataBand/droppedDataTooltip.tsx
+++ b/static/app/views/explore/components/chart/droppedDataBand/droppedDataTooltip.tsx
@@ -1,0 +1,170 @@
+import {Fragment, useCallback} from 'react';
+
+import {Container, Flex, Stack} from '@sentry/scraps/layout';
+import {useRenderToString} from '@sentry/scraps/renderToString';
+import {Separator} from '@sentry/scraps/separator';
+import {Text} from '@sentry/scraps/text';
+
+import {defaultFormatAxisLabel} from 'sentry/components/charts/components/tooltip';
+import {t, tct} from 'sentry/locale';
+import {formatBytesBase2} from 'sentry/utils/bytes/formatBytesBase2';
+import {formatAbbreviatedNumber} from 'sentry/utils/formatters';
+import type {Bucket} from 'sentry/views/explore/components/chart/droppedDataBand/utils';
+
+/**
+ * EAP data categories we annotate (see `DATASET_TO_CATEGORY` in
+ * `src/sentry/api/helpers/data_annotations.py`).
+ */
+const CATEGORY_LABELS: Record<string, string> = {
+  span: t('Spans'),
+  log_item: t('Logs'),
+  trace_metric: t('Metrics'),
+};
+
+function getCategoryLabel(category: string): string {
+  return CATEGORY_LABELS[category] ?? category;
+}
+
+/**
+ * The values the tooltip renders. Every figure is the same drop rate,
+ * `dropped / (dropped + accepted)`, in a different unit:
+ *
+ * - Header "Total Dropped": the count rate rendered as a percentage.
+ * - "{Category} Rejected": the count rate rendered as `dropped/total`.
+ * - "Payloads Rejected": the byte rate rendered as `dropped/total`.
+ *
+ * Only `droppedCount` is available from the API today; `acceptedCount` and the
+ * byte totals are added by a follow-up backend change. The tooltip degrades
+ * when they are absent: the header shows a raw dropped count instead of a
+ * percentage, and the ratio/payload rows are hidden.
+ */
+export interface DroppedDataTooltipData {
+  categoryLabel: string;
+  droppedCount: number;
+  /**
+   * Accepted bytes for the same bucket + category. With `droppedBytes` this
+   * forms the payloads `dropped/total` row.
+   */
+  acceptedBytes?: number;
+  /**
+   * Accepted count for the same bucket + category. With `droppedCount` this
+   * forms the header percentage and the count `dropped/total` row.
+   */
+  acceptedCount?: number;
+  /**
+   * Dropped bytes for the bucket ("payloads").
+   */
+  droppedBytes?: number;
+}
+
+export function getDroppedDataTooltipData(bucket: Bucket): DroppedDataTooltipData {
+  // A bucket is always built from at least one annotation (see
+  // `groupIntoBuckets`), and every annotation shares the same category.
+  const [firstAnnotation] = bucket.annotations;
+  return {
+    droppedCount: bucket.total,
+    categoryLabel: firstAnnotation ? getCategoryLabel(firstAnnotation.category) : '',
+  };
+}
+
+interface DroppedDataTooltipProps {
+  bucket: Bucket;
+  utc: boolean;
+}
+
+function RatioRow({
+  label,
+  dropped,
+  total,
+}: {
+  dropped: string;
+  label: React.ReactNode;
+  total: string;
+}) {
+  return (
+    <Flex justify="between" gap="2xl">
+      <Text variant="muted">{label}</Text>
+      <Text tabular>{`${dropped}/${total}`}</Text>
+    </Flex>
+  );
+}
+
+export function DroppedDataTooltip({bucket, utc}: DroppedDataTooltipProps) {
+  const {droppedCount, categoryLabel, acceptedCount, droppedBytes, acceptedBytes} =
+    getDroppedDataTooltipData(bucket);
+
+  // Count rate: header percentage + the "{Category} Rejected" row.
+  const hasCounts = typeof acceptedCount === 'number';
+  const countTotal = hasCounts ? droppedCount + acceptedCount! : undefined;
+  const percentage =
+    countTotal && countTotal > 0
+      ? Math.round((droppedCount / countTotal) * 100)
+      : undefined;
+
+  // Byte rate: the "Payloads Rejected" row.
+  const hasBytes = typeof droppedBytes === 'number' && typeof acceptedBytes === 'number';
+  const byteTotal = hasBytes ? droppedBytes! + acceptedBytes! : undefined;
+
+  const range = defaultFormatAxisLabel(
+    bucket.start,
+    /* isTimestamp */ true,
+    utc,
+    /* showTimeInTooltip */ true,
+    /* addSecondsToTimeFormat */ false,
+    /* bucketSize */ bucket.end - bucket.start
+  );
+
+  return (
+    <Fragment>
+      <Container padding="md xl">
+        <Stack gap="sm">
+          <Flex justify="between" gap="2xl">
+            <Text bold>{t('Total Dropped')}</Text>
+            <Text bold tabular>
+              {percentage === undefined
+                ? formatAbbreviatedNumber(droppedCount)
+                : `${percentage}%`}
+            </Text>
+          </Flex>
+          {(hasCounts || hasBytes) && (
+            <Separator orientation="horizontal" border="primary" />
+          )}
+          {hasCounts && (
+            <RatioRow
+              label={tct('[category] Rejected', {category: categoryLabel})}
+              dropped={formatAbbreviatedNumber(droppedCount)}
+              total={formatAbbreviatedNumber(countTotal!)}
+            />
+          )}
+          {hasBytes && (
+            <RatioRow
+              label={t('Payloads Rejected')}
+              dropped={formatBytesBase2(droppedBytes!)}
+              total={formatBytesBase2(byteTotal!)}
+            />
+          )}
+        </Stack>
+      </Container>
+      <div className="tooltip-footer tooltip-footer-centered">
+        <Stack gap="xs" align="center">
+          <Text size="sm" variant="accent">
+            {range}
+          </Text>
+          <Text size="sm" variant="accent">
+            {t('Click for Details')}
+          </Text>
+        </Stack>
+      </div>
+      <div className="tooltip-arrow arrow-top" />
+    </Fragment>
+  );
+}
+
+export function useDroppedDataTooltipFormatter(utc: boolean) {
+  const renderToString = useRenderToString();
+
+  return useCallback(
+    (bucket: Bucket) => renderToString(<DroppedDataTooltip bucket={bucket} utc={utc} />),
+    [renderToString, utc]
+  );
+}

--- a/static/app/views/explore/components/chart/droppedDataBand/droppedDataTooltip.tsx
+++ b/static/app/views/explore/components/chart/droppedDataBand/droppedDataTooltip.tsx
@@ -25,41 +25,15 @@ function getCategoryLabel(category: string): string {
   return CATEGORY_LABELS[category] ?? category;
 }
 
-/**
- * The values the tooltip renders. Every figure is the same drop rate,
- * `dropped / (dropped + accepted)`, in a different unit:
- *
- * - Header "Total Dropped": the count rate rendered as a percentage.
- * - "{Category} Rejected": the count rate rendered as `dropped/total`.
- * - "Payloads Rejected": the byte rate rendered as `dropped/total`.
- *
- * Only `droppedCount` is available from the API today; `acceptedCount` and the
- * byte totals are added by a follow-up backend change. The tooltip degrades
- * when they are absent: the header shows a raw dropped count instead of a
- * percentage, and the ratio/payload rows are hidden.
- */
 export interface DroppedDataTooltipData {
   categoryLabel: string;
   droppedCount: number;
-  /**
-   * Accepted bytes for the same bucket + category. With `droppedBytes` this
-   * forms the payloads `dropped/total` row.
-   */
   acceptedBytes?: number;
-  /**
-   * Accepted count for the same bucket + category. With `droppedCount` this
-   * forms the header percentage and the count `dropped/total` row.
-   */
   acceptedCount?: number;
-  /**
-   * Dropped bytes for the bucket ("payloads").
-   */
   droppedBytes?: number;
 }
 
 export function getDroppedDataTooltipData(bucket: Bucket): DroppedDataTooltipData {
-  // A bucket is always built from at least one annotation (see
-  // `groupIntoBuckets`), and every annotation shares the same category.
   const [firstAnnotation] = bucket.annotations;
   return {
     droppedCount: bucket.total,
@@ -68,8 +42,8 @@ export function getDroppedDataTooltipData(bucket: Bucket): DroppedDataTooltipDat
 }
 
 interface DroppedDataTooltipProps {
-  bucket: Bucket;
-  utc: boolean;
+  data: DroppedDataTooltipData;
+  range: string;
 }
 
 function RatioRow({
@@ -89,11 +63,9 @@ function RatioRow({
   );
 }
 
-export function DroppedDataTooltip({bucket, utc}: DroppedDataTooltipProps) {
-  const {droppedCount, categoryLabel, acceptedCount, droppedBytes, acceptedBytes} =
-    getDroppedDataTooltipData(bucket);
+export function DroppedDataTooltip({data, range}: DroppedDataTooltipProps) {
+  const {droppedCount, categoryLabel, acceptedCount, droppedBytes, acceptedBytes} = data;
 
-  // Count rate: header percentage + the "{Category} Rejected" row.
   const hasCounts = typeof acceptedCount === 'number';
   const countTotal = hasCounts ? droppedCount + acceptedCount! : undefined;
   const percentage =
@@ -101,18 +73,8 @@ export function DroppedDataTooltip({bucket, utc}: DroppedDataTooltipProps) {
       ? Math.round((droppedCount / countTotal) * 100)
       : undefined;
 
-  // Byte rate: the "Payloads Rejected" row.
   const hasBytes = typeof droppedBytes === 'number' && typeof acceptedBytes === 'number';
   const byteTotal = hasBytes ? droppedBytes! + acceptedBytes! : undefined;
-
-  const range = defaultFormatAxisLabel(
-    bucket.start,
-    /* isTimestamp */ true,
-    utc,
-    /* showTimeInTooltip */ true,
-    /* addSecondsToTimeFormat */ false,
-    /* bucketSize */ bucket.end - bucket.start
-  );
 
   return (
     <Fragment>
@@ -164,7 +126,21 @@ export function useDroppedDataTooltipFormatter(utc: boolean) {
   const renderToString = useRenderToString();
 
   return useCallback(
-    (bucket: Bucket) => renderToString(<DroppedDataTooltip bucket={bucket} utc={utc} />),
+    (bucket: Bucket) => {
+      const range = String(
+        defaultFormatAxisLabel(
+          bucket.start,
+          true,
+          utc,
+          true,
+          false,
+          bucket.end - bucket.start
+        )
+      );
+      return renderToString(
+        <DroppedDataTooltip data={getDroppedDataTooltipData(bucket)} range={range} />
+      );
+    },
     [renderToString, utc]
   );
 }

--- a/static/app/views/explore/components/chart/droppedDataBand/useDroppedDataBand.tsx
+++ b/static/app/views/explore/components/chart/droppedDataBand/useDroppedDataBand.tsx
@@ -9,11 +9,10 @@ import type {
 } from 'echarts';
 
 import {isChartHovered} from 'sentry/components/charts/utils';
-import {tn} from 'sentry/locale';
 import type {ReactEchartsRef} from 'sentry/types/echarts';
-import {escape} from 'sentry/utils';
 import {defined} from 'sentry/utils/defined';
 import type {DataFidelityAnnotation} from 'sentry/utils/timeSeries/useFetchEventsTimeSeries';
+import {useDroppedDataTooltipFormatter} from 'sentry/views/explore/components/chart/droppedDataBand/droppedDataTooltip';
 import {
   BAND_HEIGHT,
   BAND_PADDING,
@@ -63,33 +62,16 @@ interface DroppedDataSeriesProps {
   alignInMiddle: boolean;
   buckets: Bucket[];
   chartRef: React.RefObject<ReactEchartsRef | null>;
+  formatTooltip: (bucket: Bucket) => string;
   theme: Theme;
   yAxisIndex?: number;
-}
-
-function formatBucketTooltip(bucket: Bucket): string {
-  const annotationLines = bucket.annotations
-    .map(
-      annotation =>
-        `<div>${escape(annotation.label)} — ${annotation.droppedCount.toLocaleString()}</div>`
-    )
-    .join('');
-
-  return `
-<div class="tooltip-series">
-<div>
-${tn('%s event dropped', '%s events dropped', bucket.total)}
-</div>
-${annotationLines}
-</div>
-<div class="tooltip-arrow arrow-top"></div>
-`;
 }
 
 function createDroppedDataSeries({
   alignInMiddle,
   buckets,
   chartRef,
+  formatTooltip,
   theme,
   yAxisIndex,
 }: DroppedDataSeriesProps): CustomSeriesOption {
@@ -182,7 +164,7 @@ function createDroppedDataSeries({
           return '';
         }
 
-        return formatBucketTooltip(params.data as Bucket);
+        return formatTooltip(params.data as Bucket);
       },
     },
   };
@@ -201,6 +183,10 @@ interface UseDroppedDataBandParams {
    */
   showDroppedData?: boolean;
   /**
+   * Whether timestamps in the tooltip should render in UTC.
+   */
+  utc?: boolean;
+  /**
    * The index of the dummy y-axis used to convert timestamps to pixel x.
    */
   yAxisIndex?: number;
@@ -210,10 +196,12 @@ export function useDroppedDataBand({
   annotations,
   showDroppedData = true,
   alignInMiddle = false,
+  utc = false,
   yAxisIndex,
 }: UseDroppedDataBandParams) {
   const theme = useTheme();
   const chartRef = useRef<ReactEchartsRef | null>(null);
+  const formatTooltip = useDroppedDataTooltipFormatter(utc);
 
   const buckets = useMemo(
     () => groupIntoBuckets(annotations ?? []).filter(bucket => bucket.severity > 0),
@@ -231,11 +219,12 @@ export function useDroppedDataBand({
             alignInMiddle,
             buckets,
             chartRef,
+            formatTooltip,
             theme,
             yAxisIndex,
           })
         : null,
-    [alignInMiddle, buckets, theme, yAxisIndex]
+    [alignInMiddle, buckets, formatTooltip, theme, yAxisIndex]
   );
 
   if (!buckets.length || !showDroppedData) {


### PR DESCRIPTION
This is a WIP tooltip component for the annotations work. 

Caveats / missing:
- API only sends droppedCount today, but we're the outcomes accepted by amount and by bytes
- "Click for Details" will be done in a separate PR

Closes DAIN-1852