### PR TITLE
fix(i18n): correct Russian translation typo for 'Disable'

### DIFF
--- a/src/sentry/locale/ru/LC_MESSAGES/django.po
+++ b/src/sentry/locale/ru/LC_MESSAGES/django.po
@@ -12586,7 +12586,7 @@ msgstr "Расписание"
 #: static/app/views/settings/projectMetrics/blockButton.tsx:45
 #: static/app/views/settings/projectMetrics/blockButton.tsx:47
 msgid "Disable"
-msgstr "Выключтиь"
+msgstr "Выключить"
 
 #: static/app/components/modals/bulkEditMonitorsModal.tsx:96
 #: static/app/views/monitors/details.tsx:115


### PR DESCRIPTION
Fixes the Russian translation typo reported in #120651.

`msgid "Disable"` was translated as `Выключтиь`, which is not a valid Russian word (transposed letters). Corrected to `Выключить` (the correct verb form for "disable/turn off").

Verified this was the only occurrence of the typo in `src/sentry/locale/ru/LC_MESSAGES/django.po`.

Closes #120651

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.