### PR TITLE
fix(issueList): default row graph period to auto to follow global time range

### DIFF
--- a/static/app/views/issueList/overview.spec.tsx
+++ b/static/app/views/issueList/overview.spec.tsx
@@ -346,6 +346,7 @@ describe('IssueList', () => {
       await waitFor(() => {
         expect(testRouter.location.query).toEqual({
           cursor: '1443575000:0:0',
+          groupStatsPeriod: 'auto',
           page: '1',
           project: '3559',
           query: DEFAULT_QUERY,
@@ -364,6 +365,7 @@ describe('IssueList', () => {
       await waitFor(() => {
         expect(testRouter.location.query).toEqual({
           cursor: '1443574000:0:0',
+          groupStatsPeriod: 'auto',
           page: '2',
           project: '3559',
           query: DEFAULT_QUERY,
@@ -378,6 +380,7 @@ describe('IssueList', () => {
       await waitFor(() => {
         expect(testRouter.location.query).toEqual({
           cursor: '1443575000:0:1',
+          groupStatsPeriod: 'auto',
           page: '1',
           project: '3559',
           query: DEFAULT_QUERY,
@@ -512,6 +515,7 @@ describe('IssueList', () => {
 
       await waitFor(() => {
         expect(testRouter.location.query).toEqual({
+          groupStatsPeriod: 'auto',
           project: project.id.toString(),
           query: 'is:ignored',
           statsPeriod: '14d',
@@ -632,7 +636,39 @@ describe('IssueList', () => {
         expect(fetchDataMock).toHaveBeenLastCalledWith(
           '/organizations/org-slug/issues/',
           expect.objectContaining({
-            data: 'collapse=stats&collapse=unhandled&expand=owners&expand=inbox&limit=25&project=99&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&shortIdLookup=1&statsPeriod=14d',
+            data: 'collapse=stats&collapse=unhandled&expand=owners&expand=inbox&groupStatsPeriod=auto&limit=25&project=99&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&shortIdLookup=1&statsPeriod=14d',
+          })
+        );
+      });
+    });
+
+    it('defaults the row graph period to auto so it follows the global time range', async () => {
+      const {rerender} = render(<IssueListOverview />, {
+        initialRouterConfig: merge({}, initialRouterConfig, {
+          location: {
+            query: {
+              query: DEFAULT_QUERY,
+            },
+          },
+        }),
+      });
+
+      act(() =>
+        PageFiltersStore.onInitializeUrlState({
+          projects: [99],
+          environments: [],
+          datetime: {period: '14d', start: null, end: null, utc: null},
+        })
+      );
+
+      rerender(<IssueListOverview />);
+
+      await waitFor(() => {
+        expect(fetchDataMock).toHaveBeenNthCalledWith(
+          2,
+          '/organizations/org-slug/issues/',
+          expect.objectContaining({
+            data: 'collapse=stats&collapse=unhandled&expand=owners&expand=inbox&groupStatsPeriod=auto&limit=25&project=99&query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&shortIdLookup=1&statsPeriod=14d',
           })
         );
       });

--- a/static/app/views/issueList/overview.tsx
+++ b/static/app/views/issueList/overview.tsx
@@ -81,10 +81,10 @@ import {
 } from './utils';
 
 const MAX_ITEMS = 25;
-// the default period for the graph in each issue row
-const DEFAULT_GRAPH_STATS_PERIOD = '24h';
 // the allowed period choices for graph in each issue row
 const DYNAMIC_COUNTS_STATS_PERIODS = new Set(['14d', '24h', 'auto']);
+// when no explicit period is chosen, follow the global time range selector
+const DEFAULT_GRAPH_STATS_PERIOD = 'auto';
 const MAX_ISSUES_COUNT = 100;
 
 interface Props {
@@ -272,7 +272,9 @@ function IssueListOverviewInner({
     }
 
     const groupStatsPeriod = getGroupStatsPeriod();
-    if (groupStatsPeriod !== DEFAULT_GRAPH_STATS_PERIOD) {
+    // The backend treats a missing groupStatsPeriod as '24h', so 'auto'
+    // (follow the global time range) has to be sent explicitly.
+    if (groupStatsPeriod !== '24h') {
       params.groupStatsPeriod = groupStatsPeriod;
     }
 


### PR DESCRIPTION
## Problem

The per-row sparkline graphs in the issue list always defaulted to a **24h** window, regardless of what was selected in the global time range selector. Users had to manually click the `3d` toggle every time they changed the date selector, because the graph did not update along with it (see the issue for a screen recording).

Closes #115090

## Solution

Default `groupStatsPeriod` to `'auto'` (which already exists as a supported value: it makes the backend compute stats over the range selected by the global date selector, with an appropriate rollup) instead of hardcoding `'24h'`, when no explicit period is chosen in the URL.

Two changes in `static/app/views/issueList/overview.tsx`:

1. `DEFAULT_GRAPH_STATS_PERIOD` is now `'auto'`.
2. `getEndpointParams` now sends `groupStatsPeriod` explicitly whenever it is not `'24h'` — including when it equals the new default — because the backend (`calculate_stats_period`) treats a **missing** `groupStatsPeriod` as `'24h'`, which would silently undo the new default.

The existing `24h`/`<selection period>` toggles in the Trend column header keep working: the `auto` toggle is now active by default and the `24h` quick-toggle remains available to opt out.

## Recipes

- [x] Reproduce the issue on `master` — graphs stay at 24h while the header selector says e.g. 14d
- [x] Apply the fix and verify the graphs follow the global selection
- [x] Update the affected tests and add a regression test asserting `groupStatsPeriod=auto` is sent to the API by default

## Evidence

```
PASS static/app/views/issueList/overview.spec.tsx
Tests: 29 passed, 29 total
```

The request to `/organizations/<org>/issues/` now includes `groupStatsPeriod=auto` by default, so stats come back keyed under `'auto'` (computed from `start`/`end` derived from the global selection) and are rendered by the existing `statsPeriod` plumbing end-to-end.

One behavior note for reviewers: because `transitionTo` serializes endpoint params into the URL query, the URL now shows `groupStatsPeriod=auto` when no explicit period is chosen. This makes the default shareable/restorable via the URL — the corresponding tests were updated to reflect it.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.