### PR TITLE
fix(releases): strip trailing slash from ?project= so the page loads

### DIFF
--- a/static/app/views/explore/releases/detail/index.spec.tsx
+++ b/static/app/views/explore/releases/detail/index.spec.tsx
@@ -1,0 +1,91 @@
+import {OrganizationFixture} from 'sentry-fixture/organization';
+import {ProjectFixture} from 'sentry-fixture/project';
+import {ReleaseFixture} from 'sentry-fixture/release';
+import {ReleaseMetaFixture} from 'sentry-fixture/releaseMeta';
+import {ReleaseProjectFixture} from 'sentry-fixture/releaseProject';
+
+import {render, waitFor} from 'sentry-test/reactTestingLibrary';
+import type {RouterConfig} from 'sentry-test/reactTestingLibrary';
+
+import {ProjectsStore} from 'sentry/stores/projectsStore';
+import type {ReleaseProject} from 'sentry/types/release';
+import ReleasesDetailContainer from 'sentry/views/explore/releases/detail';
+
+describe('ReleasesDetailContainer', () => {
+  const organization = OrganizationFixture();
+  const project = ReleaseProjectFixture({
+    id: 1,
+    slug: 'sentry-android-shop',
+    platform: 'android',
+  }) as Required<ReleaseProject>;
+  const release = ReleaseFixture({
+    version: 'test-release',
+    projects: [project],
+  });
+  const releaseMeta = ReleaseMetaFixture({
+    version: 'test-release',
+    projects: [project],
+  });
+
+  function renderContainer(query: Record<string, string | string[]>) {
+    const pathname = `/organizations/${organization.slug}/explore/releases/test-release/`;
+    const initialRouterConfig: RouterConfig = {
+      location: {pathname, query},
+      route: '/organizations/:orgId/explore/releases/:release/',
+    };
+
+    return render(<ReleasesDetailContainer />, {
+      organization,
+      initialRouterConfig,
+    });
+  }
+
+  beforeEach(() => {
+    MockApiClient.clearMockResponses();
+    jest.clearAllMocks();
+
+    ProjectsStore.reset();
+    ProjectsStore.loadInitialData([ProjectFixture({id: String(project.id), slug: project.slug})]);
+
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/test-release/meta/',
+      method: 'GET',
+      body: releaseMeta,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/test-release/',
+      method: 'GET',
+      body: release,
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/releases/test-release/deploys/',
+      method: 'GET',
+      body: [],
+    });
+    MockApiClient.addMockResponse({
+      url: '/organizations/org-slug/sessions/',
+      method: 'GET',
+      body: {groups: []},
+    });
+  });
+
+  it('strips a trailing slash from the project query param', async () => {
+    const {router} = renderContainer({project: '1/'});
+
+    await waitFor(() => {
+      expect(router.location.query.project).toBe('1');
+    });
+  });
+
+  it('keeps the project query param unchanged when there is no trailing slash', async () => {
+    const {router} = renderContainer({project: '1'});
+
+    // Give effects a chance to run; the URL must stay untouched.
+    await waitFor(() => {
+      expect(router.location.query.project).toBe('1');
+    });
+    expect(router.location.pathname).toBe(
+      `/organizations/${organization.slug}/explore/releases/test-release/`
+    );
+  });
+});

--- a/static/app/views/explore/releases/detail/index.spec.tsx
+++ b/static/app/views/explore/releases/detail/index.spec.tsx
@@ -45,7 +45,9 @@ describe('ReleasesDetailContainer', () => {
     jest.clearAllMocks();
 
     ProjectsStore.reset();
-    ProjectsStore.loadInitialData([ProjectFixture({id: String(project.id), slug: project.slug})]);
+    ProjectsStore.loadInitialData([
+      ProjectFixture({id: String(project.id), slug: project.slug}),
+    ]);
 
     MockApiClient.addMockResponse({
       url: '/organizations/org-slug/releases/test-release/meta/',

--- a/static/app/views/explore/releases/detail/index.tsx
+++ b/static/app/views/explore/releases/detail/index.tsx
@@ -241,6 +241,27 @@ function ReleasesDetailContainer() {
 
   useRouteAnalyticsParams({release});
 
+  // Strip trailing slashes from the project query param, e.g. `?project=123/`
+  // fails backend validation (it is neither a decimal id nor a slug) and the
+  // page would otherwise render blank because 400 errors are filtered out
+  // below. Replaces the URL so the requests pick up the cleaned value.
+  useEffect(() => {
+    const project = location.query.project;
+
+    if (typeof project === 'string' && project !== project.replace(/\/+$/, '')) {
+      navigate(
+        {
+          ...location,
+          query: {
+            ...location.query,
+            project: project.replace(/\/+$/, ''),
+          },
+        },
+        {replace: true}
+      );
+    }
+  }, [location, navigate]);
+
   // Remove global date time from URL
   useEffect(() => {
     const {start, end, statsPeriod, utc, ...restQuery} = location.query;


### PR DESCRIPTION
## Problem

When a release detail URL has a trailing slash on the `?project=` parameter value (e.g. `.../explore/releases/testrelease@1.0/?project=12345/`), the page enters a loading state and then renders **blank** — no error message, no invalid project warning.

Closes #117298

## Root cause

Two behaviors stack:

1. The backend's `ProjectIdOrSlugField` validation rejects `"12345/"` — it is neither a decimal id (`isdecimal()` fails because of the slash) nor a valid slug (`MIXED_SLUG_PATTERN` does not allow `/`) — so the release endpoint responds **400 "Invalid project"**.
2. On the frontend, `ReleasesDetail` deliberately filters 400s out of `visibleErrors` ("Only show non-400 errors"), so the error is swallowed. `release` stays `undefined`, `project` can't be resolved, and the component returns `null` — a silent blank page.

## Solution

Normalize the `project` query param on mount in `ReleasesDetailContainer`: if it carries trailing slashes, strip them and replace the URL (same `navigate(..., {replace: true})` pattern already used there to drop global datetime params from the URL). All requests then pick up the cleaned value and the page loads normally.

## Recipes

- [x] Reproduce on `master`: `?project=12345/` → blank page, no error
- [x] With the fix: URL rewrites to `?project=12345` and the release detail page loads
- [x] No trailing slash → URL untouched
- [x] Added `index.spec.tsx` covering both cases

## Evidence

```
PASS static/app/views/explore/releases/detail/index.spec.tsx
Tests: 2 passed, 2 total
```

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.