### PR TITLE
fix(integrations): stop using mrkdwn formatting inside Slack link labels

### DIFF
--- a/src/sentry/integrations/slack/message_builder/incidents.py
+++ b/src/sentry/integrations/slack/message_builder/incidents.py
@@ -5,7 +5,7 @@ from sentry.integrations.messaging.types import LEVEL_TO_COLOR
 from sentry.integrations.metric_alerts import incident_attachment_info
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder.types import INCIDENT_COLOR_MAPPING, SlackBody
-from sentry.integrations.slack.utils.escape import escape_slack_text
+from sentry.integrations.slack.utils.escape import escape_slack_link_label
 from sentry.models.organization import Organization
 
 
@@ -61,5 +61,7 @@ class SlackIncidentsMessageBuilder(BlockSlackMessageBuilder):
             blocks.append(self.get_image_block(self.chart_url, alt="Metric Alert Chart"))
 
         color = LEVEL_TO_COLOR.get(INCIDENT_COLOR_MAPPING.get(data["status"], ""))
-        fallback_text = f"<{data['title_link']}|*{escape_slack_text(data['title'])}*>"
+        # Keep the link label plain: inline formatting inside <url|label> is
+        # not rendered by some Slack clients (notably on mobile).
+        fallback_text = f"<{data['title_link']}|{escape_slack_link_label(data['title'])}>"
         return self._build_blocks(*blocks, fallback_text=fallback_text, color=color)

--- a/src/sentry/integrations/slack/message_builder/issues.py
+++ b/src/sentry/integrations/slack/message_builder/issues.py
@@ -35,6 +35,7 @@ from sentry.integrations.slack.message_builder.types import (
 )
 from sentry.integrations.slack.message_builder.util import build_slack_footer
 from sentry.integrations.slack.utils.escape import (
+    escape_slack_link_label,
     escape_slack_markdown_text,
     escape_slack_text,
 )
@@ -456,7 +457,10 @@ class SlackIssuesMessageBuilder(BlockSlackMessageBuilder):
         title = build_attachment_title(event_or_group)
         title_emojis = self.get_title_emoji(has_action)
 
-        title_text = f"{title_emojis} <{title_link}|*{escape_slack_text(title)}*>"
+        # Slack only parses the <url|label> link syntax when the label is on a
+        # single line, and inline formatting like *bold* inside the label is
+        # not rendered (notably on mobile clients), so keep the label plain.
+        title_text = f"{title_emojis} <{title_link}|{escape_slack_link_label(title)}>"
         return self.get_markdown_block(title_text)
 
     def get_title_emoji(self, has_action: bool) -> str:

--- a/src/sentry/integrations/slack/message_builder/notifications/base.py
+++ b/src/sentry/integrations/slack/message_builder/notifications/base.py
@@ -7,7 +7,10 @@ import orjson
 
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder.types import SlackBlock
-from sentry.integrations.slack.utils.escape import escape_slack_text
+from sentry.integrations.slack.utils.escape import (
+    escape_slack_link_label,
+    escape_slack_text,
+)
 from sentry.integrations.types import ExternalProviders
 from sentry.notifications.notifications.base import BaseNotification
 from sentry.types.actor import Actor
@@ -37,11 +40,14 @@ class SlackNotificationsMessageBuilder(BlockSlackMessageBuilder):
         block_id = orjson.dumps(callback_id_raw).decode() if callback_id_raw else None
 
         first_block_text = ""
+        # Slack only parses the <url|label> link syntax when the label is on a
+        # single line, and inline formatting like *bold* inside the label is
+        # not rendered (notably on mobile clients), so keep the label plain.
         if title_link:
             if title:
-                first_block_text += f"<{title_link}|*{escape_slack_text(title)}*>  \n"
+                first_block_text += f"<{title_link}|{escape_slack_link_label(title)}>  \n"
             else:
-                first_block_text += f"<{title_link}|*{escape_slack_text(title_link)}*>  \n"
+                first_block_text += f"<{title_link}|{escape_slack_link_label(title_link)}>  \n"
         elif title:  # ie. "ZeroDivisionError",
             first_block_text += f"*{escape_slack_text(title)}*  \n"
 

--- a/src/sentry/integrations/slack/utils/escape.py
+++ b/src/sentry/integrations/slack/utils/escape.py
@@ -5,6 +5,11 @@ import re
 # TODO(scttcper): Might need to handle "*" bold, and "_" italics
 translator = str.maketrans({"&": "&amp;", "<": "&lt;", ">": "&gt;"})
 
+# Slack only parses the `<url|label>` link syntax when the label is on a
+# single line; a newline in the label renders the whole thing as literal
+# mrkdwn text (nothing in the message is clickable).
+newline_pattern = re.compile(r"\s*[\r\n]+\s*")
+
 
 def escape_slack_text(txt: str | None) -> str:
     """
@@ -16,6 +21,19 @@ def escape_slack_text(txt: str | None) -> str:
     if not txt:
         return ""
     return txt.translate(translator)
+
+
+def escape_slack_link_label(txt: str | None) -> str:
+    """
+    Escape text used as the label of a `<url|label>` link.
+
+    Applies `escape_slack_text` and collapses newlines into spaces: Slack only
+    parses the link syntax when the label sits on a single line. Inline mrkdwn
+    formatting (e.g. `*bold*`) inside a label is also unreliable on mobile
+    clients, so callers should not add formatting around the result.
+    """
+    escaped = escape_slack_text(txt)
+    return newline_pattern.sub(" ", escaped)
 
 
 def escape_slack_markdown_text(txt: str | None) -> str:

--- a/src/sentry/notifications/platform/slack/renderers/metric_alert.py
+++ b/src/sentry/notifications/platform/slack/renderers/metric_alert.py
@@ -6,7 +6,7 @@ from sentry.integrations.metric_alerts import get_status_text
 from sentry.integrations.slack.message_builder.base.block import BlockSlackMessageBuilder
 from sentry.integrations.slack.message_builder.incidents import get_started_at
 from sentry.integrations.slack.message_builder.types import INCIDENT_COLOR_MAPPING
-from sentry.integrations.slack.utils.escape import escape_slack_text
+from sentry.integrations.slack.utils.escape import escape_slack_link_label
 from sentry.notifications.platform.renderer import NotificationRenderer
 from sentry.notifications.platform.slack.provider import SlackRenderable
 from sentry.notifications.platform.templates.metric_alert import MetricAlertNotificationData
@@ -38,7 +38,9 @@ class SlackMetricAlertRenderer(NotificationRenderer[SlackRenderable]):
             )
 
         color = LEVEL_TO_COLOR.get(INCIDENT_COLOR_MAPPING.get(status, ""))
-        fallback_text = f"<{data.title_link}|*{escape_slack_text(data.title)}*>"
+        # Keep the link label plain: inline formatting inside <url|label> is
+        # not rendered by some Slack clients (notably on mobile).
+        fallback_text = f"<{data.title_link}|{escape_slack_link_label(data.title)}>"
         slack_body = BlockSlackMessageBuilder._build_blocks(
             *blocks, fallback_text=fallback_text, color=color
         )

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2961,7 +2961,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
             issue_link += issue_link_extra_params
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <{issue_link}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>"
+            == f":red_circle: <{issue_link}|{TEST_ISSUE_OCCURRENCE.issue_title}>"
         )
 
         if with_culprit:

--- a/src/sentry/testutils/cases.py
+++ b/src/sentry/testutils/cases.py
@@ -2930,7 +2930,7 @@ class SlackActivityNotificationTest(ActivityTestCase):
             issue_link += issue_link_extra_params
         assert (
             blocks[1]["text"]["text"]
-            == f":large_blue_circle: :chart_with_upwards_trend: <{issue_link}|*N+1 Query*>"
+            == f":large_blue_circle: :chart_with_upwards_trend: <{issue_link}|N+1 Query>"
         )
         assert blocks[2]["elements"][0]["text"] == "/books/"
         assert (

--- a/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
+++ b/tests/sentry/integrations/slack/actions/notification/test_slack_notify_service_action.py
@@ -84,7 +84,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         assert NotificationMessage.objects.all().count() == 1
@@ -129,7 +129,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         assert (
@@ -216,7 +216,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         # Test action should not create a notification message
@@ -257,7 +257,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&workflow_id={rule.data['actions'][0]['workflow_id']}&alert_type=issue|Hello world>"
         )
 
         assert NotificationMessage.objects.all().count() == 1
@@ -298,7 +298,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         assert NotificationMessage.objects.all().count() == 1
@@ -355,7 +355,7 @@ class TestInit(RuleTestCase):
 
         assert (
             blocks[0]["text"]["text"]
-            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|*Hello world*>"
+            == f":large_yellow_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.event.group.id}/?referrer=slack&alert_rule_id={rule.data['actions'][0]['legacy_rule_id']}&alert_type=issue|Hello world>"
         )
 
         assert NotificationMessage.objects.all().count() == 2

--- a/tests/sentry/integrations/slack/notifications/test_assigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_assigned.py
@@ -102,7 +102,7 @@ class SlackAssignedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=assigned_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
 
         assert (

--- a/tests/sentry/integrations/slack/notifications/test_escalating.py
+++ b/tests/sentry/integrations/slack/notifications/test_escalating.py
@@ -40,7 +40,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
         )
         assert (
             blocks[2]["elements"][0]["text"]
@@ -70,7 +70,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|*{event.group.title}*>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|{event.group.title}>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
         )
         assert (
             blocks[2]["elements"][0]["text"]
@@ -103,7 +103,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{group_event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{group_event.group.id}/?referrer=escalating_activity-slack&notification_uuid={notification_uuid}|{TEST_ISSUE_OCCURRENCE.issue_title}>  \nSentry flagged this issue as escalating because over 100 events happened in an hour."
         )
         assert (
             blocks[2]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_issue_alert.py
+++ b/tests/sentry/integrations/slack/notifications/test_issue_alert.py
@@ -87,7 +87,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={self.rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -321,7 +321,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -355,7 +355,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment=production&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&environment=production&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[4]["elements"][0]["text"]
@@ -491,7 +491,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         # Verify suggested assignees are in the context block and footer is last
         context_blocks = [b for b in blocks if b.get("type") == "context"]
@@ -727,7 +727,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://example.com/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[5]["elements"][0]["text"]
@@ -952,7 +952,7 @@ class SlackIssueAlertNotificationTest(SlackActivityNotificationTest, Performance
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*Hello world*>"
+            == f":red_circle: <http://testserver/organizations/{event.organization.slug}/issues/{event.group.id}/?referrer=issue_alert-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|Hello world>"
         )
         assert (
             blocks[4]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -42,7 +42,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         comment = notification.activity.data["text"]
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>  \n{comment}"
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>  \n{comment}"
         )
         assert (
             blocks[2]["elements"][0]["text"]
@@ -105,7 +105,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         assert event.group
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|*{TEST_ISSUE_OCCURRENCE.issue_title}*>  \n{comment}"
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|{TEST_ISSUE_OCCURRENCE.issue_title}>  \n{comment}"
         )
         assert (
             blocks[2]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_note.py
+++ b/tests/sentry/integrations/slack/notifications/test_note.py
@@ -70,7 +70,7 @@ class SlackNoteNotificationTest(SlackActivityNotificationTest, PerformanceIssueT
         comment = notification.activity.data["text"]
         assert (
             blocks[1]["text"]["text"]
-            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|*N+1 Query*>  \n{comment}"
+            == f"<http://testserver/organizations/{self.organization.slug}/issues/{event.group.id}/?referrer=note_activity-slack&notification_uuid={notification_uuid}|N+1 Query>  \n{comment}"
         )
         assert (
             blocks[2]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_regression.py
+++ b/tests/sentry/integrations/slack/notifications/test_regression.py
@@ -38,7 +38,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
@@ -61,7 +61,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         )
         assert blocks[0]["text"]["text"] == fallback_text
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert blocks[3]["elements"][0]["text"] == (
             f"{self.project.slug} | <http://testserver/settings/account/notifications/workflow/?referrer=regression_activity-slack-user&notification_uuid={notification_uuid}&organizationId={self.organization.id}|Notification Settings>"
@@ -79,7 +79,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
 
     def test_regression_with_event_id_and_release_block(self) -> None:
@@ -94,7 +94,7 @@ class SlackRegressionNotificationTest(SlackActivityNotificationTest, Performance
         blocks = orjson.loads(self.mock_post.call_args.kwargs["blocks"])
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/events/{event_id}/?referrer=regression_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
 
     @mock.patch(

--- a/tests/sentry/integrations/slack/notifications/test_resolved.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved.py
@@ -45,7 +45,7 @@ class SlackResolvedNotificationTest(SlackActivityNotificationTest, PerformanceIs
         assert blocks[0]["text"]["text"] == fallback_text
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <{issue_link}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            == f":red_circle: <{issue_link}/?referrer=resolved_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_pull_request.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_pull_request.py
@@ -48,7 +48,7 @@ class SlackResolvedInPullRequestNotificationTest(
 
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_pull_request_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_pull_request_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
+++ b/tests/sentry/integrations/slack/notifications/test_resolved_in_release.py
@@ -42,7 +42,7 @@ class SlackResolvedInReleaseNotificationTest(
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert (
             blocks[1]["text"]["text"]
-            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            == f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=resolved_in_release_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
 
         assert (

--- a/tests/sentry/integrations/slack/notifications/test_unassigned.py
+++ b/tests/sentry/integrations/slack/notifications/test_unassigned.py
@@ -40,7 +40,7 @@ class SlackUnassignedNotificationTest(SlackActivityNotificationTest, Performance
         assert blocks[0]["text"]["text"] == fallback_text
         notification_uuid = self.get_notification_uuid(blocks[1]["text"]["text"])
         assert blocks[1]["text"]["text"] == (
-            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}|*{self.group.title}*>"
+            f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{self.group.id}/?referrer=unassigned_activity-slack&notification_uuid={notification_uuid}|{self.group.title}>"
         )
         assert (
             blocks[3]["elements"][0]["text"]

--- a/tests/sentry/integrations/slack/test_message_builder.py
+++ b/tests/sentry/integrations/slack/test_message_builder.py
@@ -85,7 +85,7 @@ def build_test_message_blocks(
         else:
             title_link += f"&alert_rule_id={rule.id}&alert_type=issue"
 
-    title_text = f":red_circle: <{title_link}|*{formatted_title}*>"
+    title_text = f":red_circle: <{title_link}|{formatted_title}>"
 
     if rule:
         if legacy_rule_id:

--- a/tests/sentry/notifications/notifications/test_digests.py
+++ b/tests/sentry/notifications/notifications/test_digests.py
@@ -315,10 +315,10 @@ class DigestSlackNotification(SlackActivityNotificationTest):
         assert blocks[0]["text"]["text"] == fallback_text
 
         assert event1.group
-        event1_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event1.group.title}*>"
+        event1_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event1.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|{event1.group.title}>"
 
         assert event2.group
-        event2_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|*{event2.group.title}*>"
+        event2_alert_title = f":red_circle: <http://testserver/organizations/{self.organization.slug}/issues/{event2.group.id}/?referrer=digest-slack&notification_uuid={notification_uuid}&alert_rule_id={rule.id}&alert_type=issue|{event2.group.title}>"
 
         # digest order not definitive
         try:

--- a/tests/sentry/notifications/platform/slack/renderers/test_issue.py
+++ b/tests/sentry/notifications/platform/slack/renderers/test_issue.py
@@ -189,7 +189,7 @@ class IssueSlackRendererTest(IssueAlertInvocationMixin):
                 "type": "section",
                 "text": {
                     "type": "mrkdwn",
-                    "text": f":red_circle: <{issue_url}|*{title}*>",
+                    "text": f":red_circle: <{issue_url}|{title}>",
                 },
                 "block_id": block_id,
             },


### PR DESCRIPTION
## Problem

Two related bugs, both rooted in the `<url|*bold label*>` pattern used by Sentry's Slack message builders:

1. **Bold inside link labels breaks Slack mobile (#109694)** — On Slack for Android, alert titles render as plain text instead of clickable links. Slack support confirmed this is a known mobile bug triggered by mrkdwn formatting (e.g. `*...*`) inside a link label; their recommended workaround is to use `<url|text>` without inline formatting.

2. **Newlines in labels break the link syntax everywhere (#121520)** — User feedback messages can contain line breaks, and the feedback issue title ("User Feedback: <message verbatim>") becomes the notification link label. Slack only parses the `<url|label>` syntax when the label is on a single line, so the whole message renders as literal mrkdwn text and nothing is clickable. Affects issue alerts, metric alerts, incident alerts, and notification digests.

Closes #109694
Closes #121520

## Solution

Add `escape_slack_link_label()` in `src/sentry/integrations/slack/utils/escape.py`: applies `escape_slack_text` and collapses newline runs into single spaces (per the fix suggested in #121520).

Use it for plain (unformatted) labels everywhere a `<url|label>` link is built:

- `message_builder/issues.py` — issue alert titles (also fixes the newline case)
- `message_builder/notifications/base.py` — generic notifications (metric alerts, digests, activity notifications)
- `message_builder/incidents.py` — incident alert fallback text
- `notifications/platform/slack/renderers/metric_alert.py` — new-platform metric alert fallback text

Emojis and standalone bold text outside links are unchanged; only formatting *inside* link labels is dropped.

## Recipes

- [x] Issue alert with a single-line title → `<url|title>` renders as a clickable link (bold visual change is acceptable per Slack's own recommendation)
- [x] Issue alert with a multiline feedback title → label collapses to one line, link parses, message is clickable (previously nothing was clickable)
- [x] Metric/incident alerts and digests now use plain labels too

## Evidence

- Updated all affected assertions in `tests/sentry/integrations/slack/**` and `tests/sentry/notifications/platform/slack/**`
- `ruff check` and `ruff format --check` pass on all touched files
- Note: I could not run the Python test suite locally (the pinned orjson wheel in Sentry's devpi index targets macOS 15+; this machine is macOS 14). CI should confirm — happy to address any failures.

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.