### PR TITLE
fix(l10n): disambiguate duration "m" label from millions abbreviation with msgctxt

### DIFF
--- a/bin/merge-catalogs
+++ b/bin/merge-catalogs
@@ -34,7 +34,11 @@ def cli(locale):
     for frontend_msg in frontend:
         if frontend_msg.id == "":
             continue
-        msg = catalog.get(frontend_msg.id)
+        # Look up the message with its translation context so
+        # context-specific msgids (e.g. tp('duration', 'm')) stay separate
+        # from context-less msgids with the same text. The context travels
+        # with the Message itself when it is written back.
+        msg = catalog.get(frontend_msg.id, frontend_msg.context)
 
         # If the message is not yet in the catalog, then insert it as
         # such.

--- a/bin/merge-catalogs
+++ b/bin/merge-catalogs
@@ -14,7 +14,7 @@ def merge_message(msg, frontend_msg):
         (fn, lineno) for fn, lineno in msg.locations if not fn.endswith(JS_EXTENSIONS)
     ]
     if (not msg.user_comments or not non_js_locations) and frontend_msg.user_comments:
-        msg.user_comments = frontend_msg.usr_comments
+        msg.user_comments = frontend_msg.user_comments
     msg.locations = non_js_locations + frontend_msg.locations
 
 

--- a/build-utils/po-catalog-loader.ts
+++ b/build-utils/po-catalog-loader.ts
@@ -4,6 +4,10 @@ import {po} from 'gettext-parser';
 // PO references are whitespace-delimited `path:line` values from JS and TS modules.
 const FRONTEND_REFERENCE = /(?:^|\s)[^\s:]+\.[jt]sx?:/;
 
+// Jed concatenates the translation context and msgid with this delimiter when
+// looking up context-specific messages (see `Jed.context_delimiter`).
+const CONTEXT_DELIMITER = '\u0004';
+
 type CatalogMetadata = {
   domain: string;
   lang: string;
@@ -14,25 +18,28 @@ type CompiledPoCatalog = Record<string, string[] | CatalogMetadata>;
 
 const poCatalogLoader: LoaderDefinition = function (source) {
   const catalog = po.parse(source);
-  const messages = catalog.translations[''];
   const output: CompiledPoCatalog = Object.create(null);
 
-  for (const messageId in messages) {
-    if (!messageId) {
-      continue;
-    }
+  for (const [msgctxt, messages] of Object.entries(catalog.translations)) {
+    for (const messageId in messages) {
+      if (!messageId) {
+        continue;
+      }
 
-    const message = messages[messageId];
-    const reference = message.comments?.reference;
-    if (!reference || !FRONTEND_REFERENCE.test(reference)) {
-      continue;
-    }
+      const message = messages[messageId];
+      const reference = message.comments?.reference;
+      if (!reference || !FRONTEND_REFERENCE.test(reference)) {
+        continue;
+      }
 
-    if (message.msgstr.includes('')) {
-      continue;
-    }
+      if (message.msgstr.includes('')) {
+        continue;
+      }
 
-    output[messageId] = message.msgstr;
+      // Jed looks up context-specific messages as `msgctxt\u0004msgid`
+      const key = msgctxt ? `${msgctxt}${CONTEXT_DELIMITER}${messageId}` : messageId;
+      output[key] = message.msgstr;
+    }
   }
 
   const lang = catalog.headers.Language;

--- a/build-utils/ts-extract-gettext.ts
+++ b/build-utils/ts-extract-gettext.ts
@@ -23,6 +23,7 @@ const FUNCTION_NAMES: Record<string, string[]> = {
   tn: ['msgid', 'msgid_plural', 'count'],
   tct: ['msgid'],
   tctCode: ['msgid'],
+  tp: ['msgctxt', 'msgid'],
 };
 
 function getTsScriptKind(filePath: string): ts.ScriptKind {

--- a/src/sentry/locale/en/LC_MESSAGES/django.po
+++ b/src/sentry/locale/en/LC_MESSAGES/django.po
@@ -2914,6 +2914,12 @@ msgstr ""
 msgid "m"
 msgstr ""
 
+#: static/app/utils/duration/getDuration.tsx:51
+#: static/app/utils/duration/getDuration.tsx:52
+msgctxt "duration"
+msgid "m"
+msgstr ""
+
 #: templatetags/sentry_helpers.py:165
 msgid "k"
 msgstr ""

--- a/src/sentry/locale/ru/LC_MESSAGES/django.po
+++ b/src/sentry/locale/ru/LC_MESSAGES/django.po
@@ -2925,6 +2925,12 @@ msgstr "млрд"
 msgid "m"
 msgstr "млн"
 
+#: static/app/utils/duration/getDuration.tsx:51
+#: static/app/utils/duration/getDuration.tsx:52
+msgctxt "duration"
+msgid "m"
+msgstr "м"
+
 #: templatetags/sentry_helpers.py:165
 msgid "k"
 msgstr "тыс"

--- a/static/app/locale.tsx
+++ b/static/app/locale.tsx
@@ -336,6 +336,30 @@ function gettext(string: string, ...args: FormatArg[]): string {
 }
 
 /**
+ * Translates a string to the current locale, disambiguating it with a
+ * translation context.
+ *
+ * Use this instead of `t` when the same msgid is used with different meanings
+ * (e.g. `m` as the millions abbreviation vs. the minute abbreviation), since
+ * gettext contexts map to separate msgctxt entries in the catalog.
+ *
+ * See the sprintf-js library [0] for specifics on the argument
+ * parameterization format.
+ *
+ * [0]: https://github.com/alexei/sprintf.js
+ */
+function pgettext(context: string, string: string, ...args: FormatArg[]): string {
+  const val: string = getClient().pgettext(context, string);
+
+  if (args.length === 0) {
+    staticTranslations.add(val);
+    return mark(val);
+  }
+
+  return mark(format(val, args) as string);
+}
+
+/**
  * Translates a singular and plural string to the current locale. Supports
  * argument parameterization, and will use the first argument as the counter to
  * determine which message to use.
@@ -419,5 +443,6 @@ export {
   gettext as t,
   gettextComponentTemplate as tct,
   ngettext as tn,
+  pgettext as tp,
   gettextDescription as td,
 };

--- a/static/app/utils/duration/getDuration.spec.tsx
+++ b/static/app/utils/duration/getDuration.spec.tsx
@@ -33,16 +33,19 @@ describe('getDuration()', () => {
     });
 
     it('uses the duration-context label for extraShort minutes', () => {
-      const {getDuration: localizedGetDuration} = require('sentry/utils/duration/getDuration');
+      const {
+        getDuration: localizedGetDuration,
+      } = require('sentry/utils/duration/getDuration');
       expect(localizedGetDuration(122, 0, false, true)).toBe('2м');
     });
 
     it('uses the duration-context label for extraShort months', () => {
-      const {getDuration: localizedGetDuration} = require('sentry/utils/duration/getDuration');
+      const {
+        getDuration: localizedGetDuration,
+      } = require('sentry/utils/duration/getDuration');
       expect(localizedGetDuration(604800 * 12, 0, false, true)).toBe('3м');
     });
   });
-
 
   it('should format durations', () => {
     expect(getDuration(0.0001, 0, false, false, false, MICROSECOND)).toBe(

--- a/static/app/utils/duration/getDuration.spec.tsx
+++ b/static/app/utils/duration/getDuration.spec.tsx
@@ -1,7 +1,49 @@
 import {getDuration} from 'sentry/utils/duration/getDuration';
 import {MICROSECOND, MINUTE, MONTH} from 'sentry/utils/formatters';
 
+// Mirrors what the po-catalog-loader emits for the Russian catalog: the
+// context-less "m" (millions, used by small_count()) and the
+// "duration"-context "m" (extra-short month/minute label) are separate
+// entries, so a locale can translate them independently.
+// See https://github.com/getsentry/sentry/issues/124240
+const RU_DURATION_LOCALE_DATA = {
+  '': {domain: 'sentry', lang: 'ru', plural_forms: 'nplurals=2; plural=(n != 1);'},
+  m: ['млн'],
+  'duration\u0004m': ['м'],
+};
+
 describe('getDuration()', () => {
+  describe('with a locale that distinguishes duration "m" from millions "m"', () => {
+    beforeEach(() => {
+      // DURATION_LABELS is resolved once at module scope, so a fresh
+      // evaluation of getDuration is needed after the locale switch.
+      jest.resetModules();
+      require('sentry/locale').setLocale(RU_DURATION_LOCALE_DATA);
+    });
+
+    afterEach(() => {
+      jest.resetModules();
+      require('sentry/locale').setLocale({
+        '': {
+          domain: 'sentry',
+          lang: 'en',
+          plural_forms: 'nplurals=2; plural=(n != 1);',
+        },
+      });
+    });
+
+    it('uses the duration-context label for extraShort minutes', () => {
+      const {getDuration: localizedGetDuration} = require('sentry/utils/duration/getDuration');
+      expect(localizedGetDuration(122, 0, false, true)).toBe('2м');
+    });
+
+    it('uses the duration-context label for extraShort months', () => {
+      const {getDuration: localizedGetDuration} = require('sentry/utils/duration/getDuration');
+      expect(localizedGetDuration(604800 * 12, 0, false, true)).toBe('3м');
+    });
+  });
+
+
   it('should format durations', () => {
     expect(getDuration(0.0001, 0, false, false, false, MICROSECOND)).toBe(
       '100 microseconds'

--- a/static/app/utils/duration/getDuration.tsx
+++ b/static/app/utils/duration/getDuration.tsx
@@ -1,4 +1,4 @@
-import {t, tn} from 'sentry/locale';
+import {t, tn, tp} from 'sentry/locale';
 import {
   DAY,
   HOUR,
@@ -44,7 +44,12 @@ const DURATION_LABELS = {
   hr: t('hr'),
   hour: t('hour'),
   hours: t('hours'),
-  m: t('m'),
+  // Single-letter month and minute labels share the msgid "m" with the
+  // millions abbreviation used by `small_count()`. The "duration" context
+  // keeps them as separate catalog entries so locales can translate each
+  // meaning independently (e.g. Russian: "м" vs "млн").
+  mExtraShortMonth: tp('duration', 'm'),
+  mExtraShortMinute: tp('duration', 'm'),
   min: t('min'),
   minute: t('minute'),
   minutes: t('minutes'),
@@ -98,7 +103,7 @@ export function getDuration(
   if (absValue >= MONTH || minimumUnit === MONTH) {
     const {label, result} = roundWithFixed(msValue / MONTH, fixedDigits);
     if (extraShort) {
-      return `${label}${DURATION_LABELS.m}`;
+      return `${label}${DURATION_LABELS.mExtraShortMonth}`;
     }
     if (abbreviation) {
       return `${label}${DURATION_LABELS.mo}`;
@@ -140,7 +145,7 @@ export function getDuration(
   if (absValue >= MINUTE || minimumUnit === MINUTE) {
     const {label, result} = roundWithFixed(msValue / MINUTE, fixedDigits);
     if (extraShort) {
-      return `${label}${DURATION_LABELS.m}`;
+      return `${label}${DURATION_LABELS.mExtraShortMinute}`;
     }
     if (abbreviation) {
       return `${label}${DURATION_LABELS.min}`;


### PR DESCRIPTION
## Problem

The single-character msgid `"m"` was shared by three different meanings:

1. **Millions** — `small_count()` in `src/sentry/templatetags/sentry_helpers.py` (`_("m")`)
2. **Extra-short month label** — `DURATION_LABELS` in `static/app/utils/duration/getDuration.tsx`
3. **Extra-short minute label** — `DURATION_LABELS` in `static/app/utils/duration/getDuration.tsx`

Because gettext maps one msgid to one msgstr per locale, the Russian catalog carries the *millions* translation («млн») for all three. With `unitStyle="extraShort"` (`TimeSince` → `getRelativeDate` → `getDuration`), durations under a month rendered as «5млн» ("5 millions") instead of «5м» ("5 min").

Fixes #124240

## Solution

Route the extra-short month/minute labels through gettext **translation contexts** (msgctxt), keeping `small_count()`'s millions meaning as the context-less `"m"`. Jed already supports `pgettext` lookups at runtime (`msgctxt\u0004msgid` keys), and the extraction script already knows the `pgettext` signature — the pipeline pieces just weren't wired up for frontend use.

### Changes

- **`static/app/locale.tsx`**: add `tp` (a `pgettext` wrapper) alongside `t`/`tn`, so ambiguous single-letter msgids can be disambiguated with a context.
- **`static/app/utils/duration/getDuration.tsx`**: the extra-short month/minute labels now use `tp('duration', 'm')`.
- **`build-utils/ts-extract-gettext.ts`**: register `tp: ['msgctxt', 'msgid']` so context-bearing calls are extracted with their `msgctxt`.
- **`build-utils/po-catalog-loader.ts`**: previously only read `translations['']`, silently dropping all context-specific entries. Now iterates all contexts and emits entries in the `msgctxt\u0004msgid` key format Jed looks up.
- **`bin/merge-catalogs`**: `catalog.get(frontend_msg.id)` matched context-specific msgids against the context-less entry (the source of the collision). Now looks up with `catalog.get(id, context)`; the context travels with the `Message` when written back.
- **`en`/`ru` catalogs**: surgically add the new `msgctxt "duration"` entry (ru: «м»; other locales fill in via Transifex). The next `make merge-locale-catalogs` + Transifex sync will refresh references across the remaining locales.

`small_count()` and its «млн» translation are untouched.

## Verification

- `pnpm run typecheck` — clean
- `pnpm run lint:js` (oxlint) on changed files — 0 errors
- Jest: all duration/locale/timeSince/relativeTime suites pass (126 tests), including two new regression tests asserting that with a Russian-style catalog `getDuration(122, 0, false, true)` → `'2м'` and months → `'3м'` (not «млн»)
- End-to-end: `pnpm run build-js-po` extracts the `msgctxt "duration"` entry; `bin/merge-catalogs` verified to keep plain `"m"` → «млн» and create the separate context entry; `po-catalog-loader` output verified to resolve via `Jed.pgettext('duration', 'm')`