### PR TITLE
fix(tabs): Prevent tabs from collapsing into the overflow menu when they exactly fit

### DIFF
--- a/static/app/components/core/tabs/tabList.tsx
+++ b/static/app/components/core/tabs/tabList.tsx
@@ -143,7 +143,7 @@ function useOverflowTabs({
       }
     }
 
-    const available = outerWrap.clientWidth;
+    const available = outerWrap.getBoundingClientRect().width;
 
     // Width required to render every tab, without reserving the trigger.
     const fullWidth = keys.reduce(

--- a/static/app/components/core/tabs/tabs.spec.tsx
+++ b/static/app/components/core/tabs/tabs.spec.tsx
@@ -290,21 +290,30 @@ describe('Tabs overflow', () => {
   // control how many tabs fit. The component reserves 48px for the trigger.
   const TAB_WIDTH = 100;
 
-  // Available width reported by the tab list wrapper, mutable so resizes can be
-  // simulated. jsdom has no layout engine, so all measurement is mocked.
+  // Widths reported by each tab and by the tab list wrapper, mutable so resizes
+  // can be simulated. jsdom has no layout engine, so all measurement is mocked.
+  let tabWidth = TAB_WIDTH;
   let containerWidth = 1000;
   let resizeCallbacks: ResizeObserverCallback[] = [];
   let originalResizeObserver: typeof ResizeObserver;
 
   beforeEach(() => {
+    tabWidth = TAB_WIDTH;
     containerWidth = 1000;
     resizeCallbacks = [];
 
-    // Each tab (<li role="tab">) measures TAB_WIDTH; everything else is 0.
+    // Each tab (<li role="tab">) measures tabWidth and the tab list wrapper
+    // (whose direct child is the tablist) measures containerWidth; everything
+    // else is 0.
     jest
       .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: HTMLElement) {
-        const width = this.getAttribute('role') === 'tab' ? TAB_WIDTH : 0;
+        let width = 0;
+        if (this.getAttribute('role') === 'tab') {
+          width = tabWidth;
+        } else if (this.querySelector(':scope > [role="tablist"]')) {
+          width = containerWidth;
+        }
         return {
           width,
           height: 0,
@@ -317,15 +326,6 @@ describe('Tabs overflow', () => {
           toJSON: () => ({}),
         };
       });
-
-    // Only the tab list wrapper (whose direct child is the tablist) reports the
-    // configured available width; everything else reports 0 (jsdom default).
-    Object.defineProperty(HTMLElement.prototype, 'clientWidth', {
-      configurable: true,
-      get(this: HTMLElement) {
-        return this.querySelector(':scope > [role="tablist"]') ? containerWidth : 0;
-      },
-    });
 
     // Controllable ResizeObserver so resizes can be triggered on demand (the
     // global mock is a no-op).
@@ -342,8 +342,6 @@ describe('Tabs overflow', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
-    // Remove the prototype override so the jsdom default is restored.
-    delete (HTMLElement.prototype as unknown as Record<string, unknown>).clientWidth;
     window.ResizeObserver = originalResizeObserver;
   });
 
@@ -376,6 +374,35 @@ describe('Tabs overflow', () => {
     renderTabs();
 
     expect(screen.queryByRole('button', {name: 'More tabs'})).not.toBeInTheDocument();
+  });
+
+  it('does not overflow when the tabs fill the container to a fraction of a pixel', async () => {
+    // A shrink-to-fit container is exactly as wide as its tabs, which is not a
+    // whole number of pixels. Rounding the container down would push the last
+    // tab into the menu, shrink the container around the remaining tabs, and
+    // repeat until only the first tab is left.
+    const gap = 4;
+    const realGetComputedStyle = window.getComputedStyle;
+    jest
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation(element =>
+        element.getAttribute('role') === 'tablist'
+          ? ({columnGap: `${gap}px`} as CSSStyleDeclaration)
+          : realGetComputedStyle(element)
+      );
+    tabWidth = 100.125;
+    const tabsWithGaps = TABS.length * tabWidth + (TABS.length - 1) * gap;
+    containerWidth = tabsWithGaps;
+    renderTabs();
+
+    expect(screen.queryByRole('button', {name: 'More tabs'})).not.toBeInTheDocument();
+    expect(screen.getAllByRole('tab')).toHaveLength(TABS.length);
+
+    // One pixel less than the tabs and their gaps must overflow, which only
+    // holds if the gaps are counted.
+    resizeContainerTo(tabsWithGaps - 1);
+
+    expect(await screen.findByRole('button', {name: 'More tabs'})).toBeInTheDocument();
   });
 
   it('moves tabs that do not fit into an overflow menu', async () => {


### PR DESCRIPTION
Since #123879 turned on automatic overflow for every tab list, the event navigation on the issue details page shows only the "First" tab, with the "..." trigger drawn on top of it, at every viewport width. "Latest" and "Recommended" sit in the overflow menu. `useOverflowTabs` compares the wrapper's `clientWidth`, which browsers round to a whole pixel, against the sum of the tabs' `getBoundingClientRect()` widths, which is fractional. That tab list lives in a shrink-to-fit flex item, so the wrapper is exactly as wide as its tabs (for example 223.078px, reported as 223). The check fails by a fraction of a pixel, the last tab is hidden, the wrapper shrinks around the remaining tabs, the `ResizeObserver` fires and the check fails again, until only the always-kept first tab is left and the budget is negative.

This measures the wrapper with `getBoundingClientRect().width` so both sides of the comparison come from the same source. The overflow tests now feed the container width through the same mock instead of a `clientWidth` override, and a new test covers a container that is filled to a fraction of a pixel; it fails without the fix. Verified on the issue details page against the dev UI server and in headless Chromium from 520px to 1440px.

| Description | Image |
|--------|--------|
| Before | <img src="https://raw.githubusercontent.com/aashutoshrathi/sentry/issue-124247-assets/before.png"/>) |
| After (Full Screen) | <img width="647" height="145" alt="file-fcf34ba725206519b08b293c9f7f4d1d" src="https://github.com/user-attachments/assets/1a717d24-a0dc-49b4-b931-a84b9d45c194" /> |
| After (Smaller Screens) [Recommended shortens] | <img width="556" height="145" alt="file-935940bc463817b43bbfb2cff13b2fc2" src="https://github.com/user-attachments/assets/d4e8b772-5c88-4a01-892e-f866a61ef4a1" /> |


Fixes #124247

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
