### PR TITLE
ref(dynamic-sampling): query project span counts from EAP on settings page

### DIFF
--- a/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
+++ b/src/sentry/api/endpoints/organization_sampling_project_span_counts.py
@@ -9,24 +9,15 @@ from sentry.api.bases import OrganizationEndpoint, OrganizationPermission
 from sentry.api.exceptions import ResourceDoesNotExist
 from sentry.api.utils import get_date_range_from_params
 from sentry.constants import ObjectStatus
+from sentry.dynamic_sampling.per_org.queries import get_eap_span_counts_by_root_project
 from sentry.models.organization import Organization
 from sentry.models.project import Project
-from sentry.sentry_metrics.querying.data import (
-    MetricsAPIQueryResultsTransformer,
-    MQLQuery,
-    run_queries,
-)
-from sentry.sentry_metrics.querying.types import QueryOrder, QueryType
-from sentry.sentry_metrics.use_case_id_registry import UseCaseID
-from sentry.sentry_metrics.utils import STRING_NOT_FOUND, resolve_weak
-from sentry.snuba.metrics import SpanMRI
-from sentry.snuba.referrer import Referrer
-from sentry.utils.dates import parse_stats_period
 
 
 @cell_silo_endpoint
 class OrganizationSamplingProjectSpanCountsEndpoint(OrganizationEndpoint):
-    """Endpoint for retrieving project span counts in all orgs."""
+    """Received span counts of an organization, grouped by the project that started
+    the trace and the project that owns the span."""
 
     owner = ApiOwner.TELEMETRY_EXPERIENCE
     permission_classes = (OrganizationPermission,)
@@ -35,7 +26,10 @@ class OrganizationSamplingProjectSpanCountsEndpoint(OrganizationEndpoint):
     }
 
     def get(self, request: Request, organization: Organization) -> Response:
-        self._check_feature(request, organization)
+        if not features.has(
+            "organizations:dynamic-sampling-custom", organization, actor=request.user
+        ):
+            raise ResourceDoesNotExist
 
         start, end = get_date_range_from_params(request.GET)
         # We are purposely not filtering on team membership, as all users should be able to see the span counts
@@ -44,42 +38,25 @@ class OrganizationSamplingProjectSpanCountsEndpoint(OrganizationEndpoint):
         projects = list(
             Project.objects.filter(organization=organization, status=ObjectStatus.ACTIVE)
         )
+        slugs_by_id = {project.id: project.slug for project in projects}
 
-        transformer = MetricsAPIQueryResultsTransformer()
-
-        # Try to resolve the `target_project_id` tag first, as otherwise the query will
-        # fail to resolve the column and raise a validation error.
-        # When the tag is not present, we can simply return with an empty result set, as this
-        # means that there are no spans ingested yet.
-        if resolve_weak(UseCaseID.SPANS, organization.id, "target_project_id") == STRING_NOT_FOUND:
-            results = transformer.transform([])
-            return Response(status=200, data=results)
-
-        mql = f"sum({SpanMRI.COUNT_PER_ROOT_PROJECT.value}) by (project,target_project_id)"
-        query = MQLQuery(mql=mql, order=QueryOrder.DESC, limit=10000)
-        results = run_queries(
-            mql_queries=[query],
+        span_counts = get_eap_span_counts_by_root_project(
+            organization,
+            projects,
             start=start,
             end=end,
-            interval=self._interval_from_request(request),
-            organization=organization,
-            projects=projects,
             environments=self.get_environments(request, organization),
-            referrer=Referrer.DYNAMIC_SAMPLING_SETTINGS_GET_SPAN_COUNTS.value,
-            query_type=QueryType.TOTALS,
-        ).apply_transformer(transformer)
+        )
+        rows = [
+            {
+                "by": {
+                    "project": slugs_by_id[span_count.root_project_id],
+                    "target_project_id": str(span_count.project_id),
+                },
+                "totals": span_count.count,
+            }
+            for span_count in span_counts
+            if span_count.root_project_id in slugs_by_id and span_count.project_id in slugs_by_id
+        ]
 
-        return Response(status=200, data=results)
-
-    def _check_feature(self, request: Request, organization: Organization) -> None:
-        if not features.has(
-            "organizations:dynamic-sampling-custom", organization, actor=request.user
-        ):
-            raise ResourceDoesNotExist
-
-    def _interval_from_request(self, request: Request) -> int:
-        """
-        Extracts the interval of the query from the request payload.
-        """
-        interval = parse_stats_period(request.GET.get("interval", "1h"))
-        return int(3600 if interval is None else interval.total_seconds())
+        return Response(status=200, data={"data": [rows], "start": start, "end": end})

--- a/src/sentry/dynamic_sampling/per_org/queries.py
+++ b/src/sentry/dynamic_sampling/per_org/queries.py
@@ -15,6 +15,7 @@ from sentry.dynamic_sampling.tasks.common import (
     ACTIVE_ORGS_VOLUMES_DEFAULT_TIME_INTERVAL,
     OrganizationDataVolume,
 )
+from sentry.models.environment import Environment
 from sentry.models.organization import Organization
 from sentry.models.project import Project
 from sentry.search.eap.constants import SAMPLING_MODE_HIGHEST_ACCURACY
@@ -40,6 +41,7 @@ class DynamicSamplingQueryFilters(StrEnum):
 
 class DynamicSamplingQueryFields(StrEnum):
     DSC_PROJECT_ID = "sentry.dsc.project_id"
+    PROJECT_ID = "project.id"
     DSC_TRANSACTION = "sentry.dsc.transaction"
     COUNT = "count()"
     COUNT_SAMPLE = "count_sample()"
@@ -62,6 +64,15 @@ class ProjectTransactionCounts:
     project_id: int
     org_id: int
     transaction_counts: list[tuple[str, float]]
+
+
+@dataclass(order=True)
+class RootProjectSpanCount:
+    """Spans received by ``project_id`` from traces that started in ``root_project_id``."""
+
+    root_project_id: int
+    project_id: int
+    count: float
 
 
 def _get_aggregate_int(row: Mapping[str, Any], column: str) -> int:
@@ -242,6 +253,63 @@ def get_eap_project_volumes(
         )
 
     return project_volumes
+
+
+def get_eap_span_counts_by_root_project(
+    organization: Organization,
+    projects: Sequence[Project],
+    start: datetime,
+    end: datetime,
+    environments: Sequence[Environment] = (),
+) -> list[RootProjectSpanCount]:
+    """Received span counts of every (root project, owning project) pair in the window.
+
+    Spans of every kind count, not only segments. A span without a DSC project id
+    belongs to a trace that carried no sampling context, so its own project stands in
+    as the root project.
+    """
+    counts: defaultdict[tuple[int, int], float] = defaultdict(float)
+
+    for row in run_eap_spans_table_query_in_chunks(
+        {
+            "params": SnubaParams(
+                start=start,
+                end=end,
+                projects=list(projects),
+                environments=list(environments),
+                organization=organization,
+            ),
+            "query_string": "",
+            "selected_columns": [
+                DynamicSamplingQueryFields.DSC_PROJECT_ID,
+                DynamicSamplingQueryFields.PROJECT_ID,
+                DynamicSamplingQueryFields.COUNT,
+            ],
+            "orderby": [
+                DynamicSamplingQueryFields.DSC_PROJECT_ID,
+                DynamicSamplingQueryFields.PROJECT_ID,
+            ],
+            "referrer": Referrer.DYNAMIC_SAMPLING_SETTINGS_GET_SPAN_COUNTS.value,
+            "config": SearchResolverConfig(
+                auto_fields=True,
+                extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_SERVER_ONLY,
+            ),
+            "sampling_mode": SAMPLING_MODE_HIGHEST_ACCURACY,
+        }
+    ):
+        count = _get_aggregate_float(row, DynamicSamplingQueryFields.COUNT)
+        if count <= 0:
+            continue
+
+        project_id = _get_aggregate_int(row, DynamicSamplingQueryFields.PROJECT_ID)
+        dsc_project_id = row.get(DynamicSamplingQueryFields.DSC_PROJECT_ID)
+        root_project_id = project_id if dsc_project_id is None else int(dsc_project_id)
+        counts[(root_project_id, project_id)] += count
+
+    return [
+        RootProjectSpanCount(root_project_id=root_project_id, project_id=project_id, count=count)
+        for (root_project_id, project_id), count in sorted(counts.items())
+    ]
 
 
 def get_eap_transaction_volumes(

--- a/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
+++ b/tests/sentry/api/endpoints/test_organization_sampling_project_span_counts.py
@@ -1,203 +1,122 @@
-from datetime import timedelta
+from datetime import datetime, timedelta
+from typing import Any
 
-import pytest
-from django.urls import reverse
-
-from sentry.snuba.metrics import SpanMRI
-from sentry.testutils.cases import MetricsEnhancedPerformanceTestCase
-from sentry.testutils.helpers.datetime import freeze_time
-from sentry.testutils.pytest.fixtures import django_db_all
+from sentry.models.project import Project
+from sentry.testutils.cases import APITestCase, SnubaTestCase, SpanTestCase
+from sentry.testutils.helpers.datetime import before_now
 from sentry.testutils.silo import cell_silo_test
 
-pytestmark = [pytest.mark.sentry_metrics]
 
-
-@freeze_time(MetricsEnhancedPerformanceTestCase.MOCK_DATETIME)
 @cell_silo_test
-class OrganizationSamplingProjectSpanCountsTest(MetricsEnhancedPerformanceTestCase):
+class OrganizationSamplingProjectSpanCountsTest(APITestCase, SnubaTestCase, SpanTestCase):
+    endpoint = "sentry-api-0-organization-sampling-root-counts"
+
     def setUp(self) -> None:
         super().setUp()
         self.login_as(user=self.user)
-        self.org = self.create_organization(owner=self.user)
-        self.project_1 = self.create_project(organization=self.org, name="project_1")
-        self.project_2 = self.create_project(organization=self.org, name="project_2")
-        self.project_3 = self.create_project(organization=self.org, name="project_3")
-        self.project_4 = self.create_project(organization=self.org, name="project_4")
-        self.url = reverse(
-            "sentry-api-0-organization-sampling-root-counts",
-            kwargs={"organization_id_or_slug": self.org.slug},
+        self.root = self.create_project(organization=self.organization, teams=[self.team])
+        self.other = self.create_project(organization=self.organization, teams=[self.team])
+
+    def store_span(
+        self,
+        project: Project,
+        root: Project | None = None,
+        sample_rate: float | None = None,
+        start_ts: datetime | None = None,
+        environment: str | None = None,
+    ) -> None:
+        sentry_tags: dict[str, str] = {}
+        if root is not None:
+            sentry_tags["dsc.project_id"] = str(root.id)
+        if environment is not None:
+            sentry_tags["environment"] = environment
+        measurements = (
+            {"server_sample_rate": {"value": sample_rate}} if sample_rate is not None else None
+        )
+        self.store_spans(
+            [
+                self.create_span(
+                    {"sentry_tags": sentry_tags},
+                    organization=self.organization,
+                    project=project,
+                    start_ts=start_ts or before_now(minutes=15),
+                    measurements=measurements,
+                )
+            ]
         )
 
-        metric_data = (
-            (self.project_1.id, self.project_2.id, 12),
-            (self.project_1.id, self.project_3.id, 13),
-            (self.project_2.id, self.project_1.id, 21),
-        )
+    def get_counts(self, **params: str) -> dict[str, Any]:
+        with self.feature("organizations:dynamic-sampling-custom"):
+            response = self.get_success_response(
+                self.organization.slug, qs_params={"statsPeriod": "24h", **params}
+            )
+        return response.data
 
-        hour_ago = self.MOCK_DATETIME - timedelta(hours=1)
-        days_ago = self.MOCK_DATETIME - timedelta(days=5)
-        fifty_days_ago = self.MOCK_DATETIME - timedelta(days=50)
-
-        for project_source_id, target_project_id, span_count in metric_data:
-            self.store_metric(
-                org_id=self.org.id,
-                value=span_count,
-                project_id=int(project_source_id),
-                mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
-                tags={"target_project_id": str(target_project_id)},
-                timestamp=int(hour_ago.timestamp()),
-            )
-            self.store_metric(
-                org_id=self.org.id,
-                value=span_count,
-                project_id=int(project_source_id),
-                mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
-                tags={"target_project_id": str(target_project_id)},
-                timestamp=int(days_ago.timestamp()),
-            )
-            self.store_metric(
-                org_id=self.org.id,
-                value=span_count,
-                project_id=int(project_source_id),
-                mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
-                tags={"target_project_id": str(target_project_id)},
-                timestamp=int(fifty_days_ago.timestamp()),
-            )
+    @staticmethod
+    def row(root: Project, project: Project, totals: float) -> dict[str, Any]:
+        return {
+            "by": {"project": root.slug, "target_project_id": str(project.id)},
+            "totals": totals,
+        }
 
     def test_feature_flag_required(self) -> None:
-        response = self.client.get(self.url)
-        assert response.status_code == 404
+        self.get_error_response(self.organization.slug, status_code=404)
 
-    @django_db_all
-    def test_get_span_counts_without_permission(self) -> None:
-        user = self.create_user()
-        self.login_as(user)
+    def test_without_permission(self) -> None:
+        self.login_as(self.create_user())
 
         with self.feature("organizations:dynamic-sampling-custom"):
-            response = self.client.get(
-                self.url,
-                data={"statsPeriod": "24h"},
+            self.get_error_response(
+                self.organization.slug, qs_params={"statsPeriod": "24h"}, status_code=403
             )
 
-        assert response.status_code == 403
+    def test_counts_received_spans_by_root_and_owning_project(self) -> None:
+        self.store_span(self.root, root=self.root)
+        # Sampled at 1/2, so it stands for 2 received spans.
+        self.store_span(self.root, root=self.root, sample_rate=0.5)
+        self.store_span(self.other, root=self.root)
+        self.store_span(self.other, root=self.other)
 
-    @django_db_all
-    def test_get_span_counts_with_ingested_data_24h(self) -> None:
-        """Test span counts endpoint with actual ingested metrics data"""
-        with self.feature("organizations:dynamic-sampling-custom"):
-            response = self.client.get(
-                self.url,
-                data={"statsPeriod": "24h"},
-            )
+        data = self.get_counts()
 
-        assert response.status_code == 200
-        data = response.data  # type: ignore[attr-defined]
-        span_counts = sorted(data["data"][0], key=lambda x: x["by"]["target_project_id"])
+        assert data["data"] == [
+            [
+                self.row(self.root, self.root, 3),
+                self.row(self.root, self.other, 1),
+                self.row(self.other, self.other, 1),
+            ]
+        ]
+        assert data["end"] - data["start"] == timedelta(days=1)
 
-        assert span_counts[0]["by"]["project"] == self.project_2.name
-        assert span_counts[0]["by"]["target_project_id"] == str(self.project_1.id)
-        assert span_counts[0]["totals"] == 21.0
+    def test_span_without_dsc_project_counts_under_its_own_project(self) -> None:
+        self.store_span(self.other)
+        self.store_span(self.other, root=self.other)
 
-        assert span_counts[1]["by"]["project"] == self.project_1.name
-        assert span_counts[1]["by"]["target_project_id"] == str(self.project_2.id)
-        assert span_counts[1]["totals"] == 12.0
+        data = self.get_counts()
 
-        assert span_counts[2]["by"]["project"] == self.project_1.name
-        assert span_counts[2]["by"]["target_project_id"] == str(self.project_3.id)
-        assert span_counts[2]["totals"] == 13.0
+        assert data["data"] == [[self.row(self.other, self.other, 2)]]
 
-        assert data["end"] == MetricsEnhancedPerformanceTestCase.MOCK_DATETIME
-        assert (data["end"] - data["start"]) == timedelta(days=1)
+    def test_stats_period_selects_spans_by_time(self) -> None:
+        self.store_span(self.root, root=self.root, start_ts=before_now(days=5))
+        self.store_span(self.root, root=self.root)
 
-    @django_db_all
-    def test_get_span_counts_with_ingested_data_30d(self) -> None:
-        with self.feature("organizations:dynamic-sampling-custom"):
-            response = self.client.get(
-                self.url,
-                data={"statsPeriod": "30d"},
-            )
+        assert self.get_counts(statsPeriod="24h")["data"] == [[self.row(self.root, self.root, 1)]]
 
-        assert response.status_code == 200
-        data = response.data  # type: ignore[attr-defined]
-        span_counts = sorted(data["data"][0], key=lambda x: x["by"]["target_project_id"])
+        data = self.get_counts(statsPeriod="30d")
+        assert data["data"] == [[self.row(self.root, self.root, 2)]]
+        assert data["end"] - data["start"] == timedelta(days=30)
 
-        assert span_counts[0]["by"]["project"] == self.project_2.name
-        assert span_counts[0]["by"]["target_project_id"] == str(self.project_1.id)
-        assert span_counts[0]["totals"] == 21.0 * 2
+    def test_environment_filters_spans(self) -> None:
+        self.create_environment(project=self.root, name="prod")
+        self.store_span(self.root, root=self.root, environment="prod")
+        self.store_span(self.root, root=self.root, environment="dev")
 
-        assert span_counts[1]["by"]["project"] == self.project_1.name
-        assert span_counts[1]["by"]["target_project_id"] == str(self.project_2.id)
-        assert span_counts[1]["totals"] == 12.0 * 2
+        data = self.get_counts(environment="prod")
 
-        assert span_counts[2]["by"]["project"] == self.project_1.name
-        assert span_counts[2]["by"]["target_project_id"] == str(self.project_3.id)
-        assert span_counts[2]["totals"] == 13.0 * 2
+        assert data["data"] == [[self.row(self.root, self.root, 1)]]
 
-        assert data["end"] == MetricsEnhancedPerformanceTestCase.MOCK_DATETIME
-        assert (data["end"] - data["start"]) == timedelta(days=30)
+    def test_no_spans(self) -> None:
+        data = self.get_counts()
 
-    @django_db_all
-    def test_get_span_counts_with_many_projects(self) -> None:
-        # Create 200 projects with incrementing span counts
-        projects = []
-        days_ago = self.MOCK_DATETIME - timedelta(days=5)
-        for i in range(200):
-            project = self.create_project(organization=self.org, name=f"gen_project_{i}")
-            projects.append(project)
-
-            self.store_metric(
-                org_id=self.org.id,
-                value=i,
-                project_id=int(project.id),
-                mri=SpanMRI.COUNT_PER_ROOT_PROJECT.value,
-                tags={"target_project_id": str(self.project_1.id)},
-                timestamp=int(days_ago.timestamp()),
-            )
-
-        with self.feature("organizations:dynamic-sampling-custom"):
-            response = self.client.get(
-                self.url,
-                data={"statsPeriod": "30d"},
-            )
-
-        assert response.status_code == 200
-        data = response.data  # type: ignore[attr-defined]
-        span_counts = sorted(data["data"][0], key=lambda x: x["totals"], reverse=True)
-
-        # Verify we get all 200 projects back
-        assert len(span_counts) >= 200
-
-
-@freeze_time(MetricsEnhancedPerformanceTestCase.MOCK_DATETIME)
-@cell_silo_test
-class OrganizationSamplingProjectSpanCountsNoMetricsTest(MetricsEnhancedPerformanceTestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.login_as(user=self.user)
-        self.org = self.create_organization(owner=self.user)
-        self.project_1 = self.create_project(organization=self.org, name="project_1")
-        self.project_2 = self.create_project(organization=self.org, name="project_2")
-        self.project_3 = self.create_project(organization=self.org, name="project_3")
-        self.project_4 = self.create_project(organization=self.org, name="project_4")
-        self.url = reverse(
-            "sentry-api-0-organization-sampling-root-counts",
-            kwargs={"organization_id_or_slug": self.org.slug},
-        )
-
-    @django_db_all
-    def test_get_span_counts_with_ingested_data_30d(self) -> None:
-        with self.feature("organizations:dynamic-sampling-custom"):
-            response = self.client.get(
-                self.url,
-                data={"statsPeriod": "30d"},
-            )
-
-        assert response.status_code == 200
-
-        data = response.data  # type: ignore[attr-defined]
-        assert data["data"] == []
-        assert data["meta"] == []
-
-        assert data["end"] is None
-        assert data["start"] is None
-        assert data["intervals"] == []
+        assert data["data"] == [[]]
+        assert data["end"] - data["start"] == timedelta(days=1)


### PR DESCRIPTION
- Read the span counts of the dynamic sampling settings page from EAP instead of the generic metric `c:spans/count_per_root_project@none`.
- Add `get_eap_span_counts_by_root_project` next to the other per-org EAP queries. It counts all received spans per (root project, owning project) paired with server-only extrapolation. A span without a DSC project id counts under its own project as root.
- Keep the response rows the frontend reads (`by.project`, `by.target_project_id`, `totals`) and `start`/`end`. Drop the unused `meta`, `intervals`, and `series` fields. No frontend or getsentry code reads them.
- Rewrite the endpoint tests to store spans in EAP.

Contributes to TET-2900