### PR TITLE
feat(explore): Add completeThrough and ingestion pipeline status to events-timeseries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,7 @@ dependencies = [
   "sentry-ophio>=1.1.3",
   # sentry-options is only used in getsentry for now
   "sentry-options>=1.2.8",
-  "sentry-protos>=0.67.0",
+  "sentry-protos>=0.69.0",
   "sentry-redis-tools>=0.5.0",
   "sentry-relay>=0.9.28",
   "sentry-scm==1.5.0",

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -229,7 +229,9 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 organization,
                 actor=request.user,
             )
-            include_measured_ingestion_delay_metadata = features.has(
+            include_measured_ingestion_delay_metadata = request.GET.get(
+                "includeMeasuredIngestionDelayMetadata"
+            ) is not None and features.has(
                 "organizations:measured-ingestion-delay-metadata",
                 organization,
                 actor=request.user,

--- a/src/sentry/api/endpoints/organization_events_timeseries.py
+++ b/src/sentry/api/endpoints/organization_events_timeseries.py
@@ -24,6 +24,7 @@ from sentry.api.endpoints.timeseries import (
     TimeSeries,
 )
 from sentry.api.helpers.data_annotations import get_dropped_data_annotations
+from sentry.api.helpers.ingestion_delay import get_ingestion_delay_seconds
 from sentry.api.utils import handle_query_errors
 from sentry.apidocs import constants as api_constants
 from sentry.apidocs.examples.discover_performance_examples import DiscoverAndPerformanceExamples
@@ -52,6 +53,7 @@ from sentry.snuba.ourlogs import OurLogs
 from sentry.snuba.preprod_size import PreprodSize
 from sentry.snuba.query_sources import QuerySource
 from sentry.snuba.referrer import Referrer, is_valid_referrer
+from sentry.snuba.rpc_dataset_common import RPCBase
 from sentry.snuba.spans_rpc import Spans
 from sentry.snuba.trace_metrics import TraceMetrics
 from sentry.snuba.utils import DATASET_LABELS, RPC_DATASETS
@@ -227,6 +229,11 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                 organization,
                 actor=request.user,
             )
+            include_measured_ingestion_delay_metadata = features.has(
+                "organizations:measured-ingestion-delay-metadata",
+                organization,
+                actor=request.user,
+            )
             return Response(
                 self.serialize_stats_data(
                     events_stats,
@@ -236,6 +243,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
                     dataset,
                     organization,
                     include_annotations,
+                    include_measured_ingestion_delay_metadata,
                 ),
                 status=200,
             )
@@ -419,6 +427,7 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
         dataset,
         organization: Organization,
         include_annotations: bool = False,
+        include_measured_ingestion_delay_metadata: bool = False,
     ) -> StatsResponse:
         # We need the current timestamp for the Ingestion Delay incomplete reason
         now = datetime.now().timestamp()
@@ -446,6 +455,18 @@ class OrganizationEventsTimeseriesEndpoint(OrganizationEventsEndpointBase):
             except Exception:
                 sentry_sdk.capture_exception()
                 stats_meta["annotations"] = []
+
+        # Only the EAP RPC datasets allow measured ingestion delay metadata
+        if include_measured_ingestion_delay_metadata and (
+            isinstance(dataset, type) and issubclass(dataset, RPCBase)
+        ):
+            try:
+                delay_seconds = get_ingestion_delay_seconds(dataset, snuba_params)
+                if delay_seconds is not None:
+                    stats_meta["estimatedIngestionDelaySeconds"] = delay_seconds
+            except Exception:
+                sentry_sdk.capture_exception()
+
         response = StatsResponse(
             meta=stats_meta,
             timeSeries=self.serialize_result(result, axes, rollup, now),

--- a/src/sentry/api/endpoints/timeseries.py
+++ b/src/sentry/api/endpoints/timeseries.py
@@ -23,6 +23,7 @@ class StatsMeta(TypedDict):
     start: float
     end: float
     annotations: NotRequired[list[Annotation]]
+    estimatedIngestionDelaySeconds: NotRequired[float]
 
 
 class Row(TypedDict):

--- a/src/sentry/api/helpers/ingestion_delay.py
+++ b/src/sentry/api/helpers/ingestion_delay.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
+import sentry_sdk
+
 from sentry.ingestion_delay.query import measure_delay_seconds
 from sentry.search.events.types import SnubaParams
 from sentry.snuba.rpc_dataset_common import RPCBase
@@ -14,8 +16,11 @@ def get_ingestion_delay_seconds(dataset: type[RPCBase], snuba_params: SnubaParam
     if snuba_params.organization_id is None:
         return None
 
-    return measure_delay_seconds(
-        organization_id=snuba_params.organization_id,
-        item_type=item_type,
-        now=datetime.now(tz=UTC),
-    )
+    with sentry_sdk.start_span(op="ingestion_delay.get_ingestion_delay_seconds") as span:
+        span.set_data("organization_id", snuba_params.organization_id)
+        span.set_data("item_type", item_type)
+        return measure_delay_seconds(
+            organization_id=snuba_params.organization_id,
+            item_type=item_type,
+            now=datetime.now(tz=UTC),
+        )

--- a/src/sentry/api/helpers/ingestion_delay.py
+++ b/src/sentry/api/helpers/ingestion_delay.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sentry.ingestion_delay.query import measure_delay_seconds
+from sentry.search.events.types import SnubaParams
+from sentry.snuba.rpc_dataset_common import RPCBase
+
+
+def get_ingestion_delay_seconds(dataset: type[RPCBase], snuba_params: SnubaParams) -> float | None:
+    """Measured ingestion delay only for EAP RPC datasets."""
+    item_type = dataset.DEFINITIONS.trace_item_type
+
+    if snuba_params.organization_id is None:
+        return None
+
+    return measure_delay_seconds(
+        organization_id=snuba_params.organization_id,
+        item_type=item_type,
+        now=datetime.now(tz=UTC),
+    )

--- a/src/sentry/ingestion_delay/query.py
+++ b/src/sentry/ingestion_delay/query.py
@@ -101,7 +101,7 @@ def measure_delay_seconds(
     """
     Returns the p99 ingestion time among all items in the last 60 minutes for the given organization and item type.
     """
-    project_ids = (
+    project_ids = list(
         Project.objects.filter(organization_id=organization_id, status=ObjectStatus.ACTIVE)
         .order_by("id")
         .values_list("id", flat=True)

--- a/src/sentry/ingestion_delay/query.py
+++ b/src/sentry/ingestion_delay/query.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta
+
+from google.protobuf.timestamp_pb2 import Timestamp
+from sentry_protos.snuba.v1.attribute_conditional_aggregation_pb2 import (
+    AttributeConditionalAggregation,
+)
+from sentry_protos.snuba.v1.endpoint_trace_item_table_pb2 import (
+    Column,
+    TraceItemTableRequest,
+)
+from sentry_protos.snuba.v1.formula_pb2 import Literal
+from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from sentry_protos.snuba.v1.trace_item_attribute_pb2 import (
+    AttributeKey,
+    AttributeKeyExpression,
+    ExtrapolationMode,
+    Function,
+)
+
+from sentry.constants import ObjectStatus
+from sentry.models.project import Project
+from sentry.snuba.referrer import Referrer
+from sentry.utils import snuba_rpc
+
+logger = logging.getLogger(__name__)
+
+RECEIVED_AT_ATTRIBUTE = "sentry._internal.received_at"
+INGESTED_AT_ATTRIBUTE = "sentry._internal.ingested_at"
+MILLISECONDS_PER_SECOND = 1000.0
+
+RESULT_LABEL = "ingestion_delay_seconds"
+DELAY_AGGREGATE = Function.FUNCTION_P99
+
+# How far back the measurement window reaches.
+MEASUREMENT_LOOKBACK = timedelta(minutes=60)
+
+
+def build_delay_expression() -> AttributeKeyExpression:
+    """(ingested_at / 1000) - received_at, evaluated per row."""
+    return AttributeKeyExpression(
+        formula=AttributeKeyExpression.Formula(
+            op=AttributeKeyExpression.OP_SUB,
+            left=AttributeKeyExpression(
+                formula=AttributeKeyExpression.Formula(
+                    op=AttributeKeyExpression.OP_DIV,
+                    left=AttributeKeyExpression(
+                        key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name=INGESTED_AT_ATTRIBUTE)
+                    ),
+                    right=AttributeKeyExpression(
+                        literal=Literal(
+                            val_double=MILLISECONDS_PER_SECOND
+                        )  # ingested_at is in milliseconds while received_at is in seconds
+                    ),
+                )
+            ),
+            right=AttributeKeyExpression(
+                key=AttributeKey(type=AttributeKey.TYPE_DOUBLE, name=RECEIVED_AT_ATTRIBUTE)
+            ),
+        )
+    )
+
+
+def build_delay_request(
+    organization_id: int,
+    project_ids: list[int],
+    item_type: TraceItemType.ValueType,
+    start: datetime,
+    end: datetime,
+) -> TraceItemTableRequest:
+    return TraceItemTableRequest(
+        meta=RequestMeta(
+            organization_id=organization_id,
+            project_ids=project_ids,
+            referrer=Referrer.INGESTION_DELAY_MEASUREMENT.value,
+            start_timestamp=Timestamp(seconds=int(start.timestamp())),
+            end_timestamp=Timestamp(seconds=int(end.timestamp())),
+            trace_item_type=item_type,
+        ),
+        columns=[
+            Column(
+                label=RESULT_LABEL,
+                conditional_aggregation=AttributeConditionalAggregation(
+                    aggregate=DELAY_AGGREGATE,
+                    expression=build_delay_expression(),
+                    label=RESULT_LABEL,
+                    extrapolation_mode=ExtrapolationMode.EXTRAPOLATION_MODE_NONE,
+                ),
+            ),
+        ],
+    )
+
+
+def measure_delay_seconds(
+    organization_id: int,
+    item_type: TraceItemType.ValueType,
+    now: datetime,
+) -> float | None:
+    """
+    Returns the p99 ingestion time among all items in the last 60 minutes for the given organization and item type.
+    """
+    project_ids = (
+        Project.objects.filter(organization_id=organization_id, status=ObjectStatus.ACTIVE)
+        .order_by("id")
+        .values_list("id", flat=True)
+    )
+
+    if not project_ids:
+        return None
+
+    request = build_delay_request(
+        organization_id=organization_id,
+        project_ids=project_ids,
+        item_type=item_type,
+        start=now - MEASUREMENT_LOOKBACK,
+        end=now,
+    )
+
+    try:
+        responses = snuba_rpc.table_rpc([request])
+    except Exception:
+        logger.exception(
+            "ingestion_delay.query_failed",
+            extra={"organization_id": organization_id, "item_type": item_type},
+        )
+        return None
+
+    if not responses or not responses[0].column_values:
+        return None
+
+    results = responses[0].column_values[0].results
+    if not results:
+        return None
+
+    value = results[0].val_double
+
+    # no rows returns 0, and 0 delay is impossible
+    if value <= 0:
+        return None
+    return value

--- a/src/sentry/ingestion_delay/query.py
+++ b/src/sentry/ingestion_delay/query.py
@@ -128,15 +128,27 @@ def measure_delay_seconds(
         return None
 
     if not responses or not responses[0].column_values:
+        logger.warning(
+            "ingestion_delay.no_responses",
+            extra={"organization_id": organization_id, "item_type": item_type},
+        )
         return None
 
     results = responses[0].column_values[0].results
     if not results:
+        logger.warning(
+            "ingestion_delay.no_results",
+            extra={"organization_id": organization_id, "item_type": item_type},
+        )
         return None
 
     value = results[0].val_double
 
     # no rows returns 0, and 0 delay is impossible
     if value <= 0:
+        logger.warning(
+            "ingestion_delay.no_value",
+            extra={"organization_id": organization_id, "item_type": item_type},
+        )
         return None
     return value

--- a/src/sentry/snuba/referrer.py
+++ b/src/sentry/snuba/referrer.py
@@ -651,6 +651,7 @@ class Referrer(StrEnum):
     DYNAMIC_SAMPLING_DISTRIBUTION_FETCH_PROJECTS_WITH_COUNT_PER_ROOT = (
         "dynamic_sampling.distribution.fetch_projects_with_count_per_root_total_volumes"
     )
+    INGESTION_DELAY_MEASUREMENT = "ingestion_delay.measurement"
     DYNAMIC_SAMPLING_PER_ORG_GET_EAP_ORG_VOLUME = "dynamic_sampling.per_org.get_eap_org_volume"
     DYNAMIC_SAMPLING_PER_ORG_GET_EAP_PROJECT_VOLUMES = (
         "dynamic_sampling.per_org.get_eap_project_volumes"

--- a/tests/sentry/ingestion_delay/test_query.py
+++ b/tests/sentry/ingestion_delay/test_query.py
@@ -42,6 +42,7 @@ class MeasureDelaySecondsTest(OrganizationEventsEndpointTestBase):
         delay = self._measure_delay_seconds()
         # Upper bound is intentionally loose to reduce flakiness.
         # ingested_at timestamp is inserted by snuba and we can't inject it in test.
+        assert delay is not None
         assert 42.5 <= delay < 50
 
     def test_returns_measured_value_multiple_spans(self) -> None:

--- a/tests/sentry/ingestion_delay/test_query.py
+++ b/tests/sentry/ingestion_delay/test_query.py
@@ -6,14 +6,11 @@ from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
 from sentry.ingestion_delay.query import (
     measure_delay_seconds,
 )
-from sentry.testutils.cases import TestCase
+from sentry.testutils.helpers.datetime import before_now
+from tests.snuba.api.endpoints.test_organization_events import OrganizationEventsEndpointTestBase
 
 
-class MeasureDelaySecondsTest(TestCase):
-    def setUp(self) -> None:
-        super().setUp()
-        self.project
-
+class MeasureDelaySecondsTest(OrganizationEventsEndpointTestBase):
     def _measure_delay_seconds(self) -> float | None:
         return measure_delay_seconds(
             organization_id=self.organization.id,
@@ -28,14 +25,33 @@ class MeasureDelaySecondsTest(TestCase):
         response.column_values = [mock.MagicMock(results=[result])]
         return response
 
-    @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
-    def test_returns_measured_value(self, mock_table_rpc: mock.MagicMock) -> None:
-        mock_table_rpc.return_value = [self._response(42.5)]
-        assert self._measure_delay_seconds() == 42.5
+    def _store_span_received_at(self, received_at: datetime) -> None:
+        span = self.create_span(
+            {
+                "description": "foo",
+                "data": {
+                    "sentry._internal.received_at": received_at.timestamp(),
+                },
+            },
+            start_ts=received_at,
+        )
+        self.store_spans([span])
 
-    @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
-    def test_no_result_returns_none(self, mock_table_rpc: mock.MagicMock) -> None:
-        mock_table_rpc.return_value = [self._response(0.0)]  # no result comes back as 0.0
+    def test_returns_measured_value(self) -> None:
+        self._store_span_received_at(before_now(seconds=42.5))
+        delay = self._measure_delay_seconds()
+        # Upper bound is intentionally loose to reduce flakiness.
+        # ingested_at timestamp is inserted by snuba and we can't inject it in test.
+        assert 42.5 <= delay < 50
+
+    def test_returns_measured_value_multiple_spans(self) -> None:
+        for i in range(100):
+            self._store_span_received_at(before_now(seconds=i * 10))
+        delay = self._measure_delay_seconds()
+        assert delay is not None
+        assert 980 <= delay < 1000
+
+    def test_no_result_returns_none(self) -> None:
         assert self._measure_delay_seconds() is None
 
     @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
@@ -45,11 +61,12 @@ class MeasureDelaySecondsTest(TestCase):
 
     @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
     def test_measures_all_projects_in_organization(self, mock_table_rpc: mock.MagicMock) -> None:
+        project = self.project
         other = self.create_project(organization=self.organization)
         mock_table_rpc.return_value = [self._response(1.0)]
         self._measure_delay_seconds()
         request = mock_table_rpc.call_args[0][0][0]
-        assert set(request.meta.project_ids) == {self.project.id, other.id}
+        assert set(request.meta.project_ids) == {project.id, other.id}
 
     @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
     def test_query_failure_does_not_propagate(self, mock_table_rpc: mock.MagicMock) -> None:

--- a/tests/sentry/ingestion_delay/test_query.py
+++ b/tests/sentry/ingestion_delay/test_query.py
@@ -14,14 +14,14 @@ class MeasureDelaySecondsTest(TestCase):
         super().setUp()
         self.project
 
-    def _measure_delay_seconds(self):
+    def _measure_delay_seconds(self) -> float | None:
         return measure_delay_seconds(
             organization_id=self.organization.id,
             item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
             now=datetime.now(tz=UTC),
         )
 
-    def _response(self, value: float):
+    def _response(self, value: float) -> mock.MagicMock:
         response = mock.MagicMock()
         result = mock.MagicMock()
         result.val_double = value
@@ -29,22 +29,22 @@ class MeasureDelaySecondsTest(TestCase):
         return response
 
     @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
-    def test_returns_measured_value(self, mock_table_rpc) -> None:
+    def test_returns_measured_value(self, mock_table_rpc: mock.MagicMock) -> None:
         mock_table_rpc.return_value = [self._response(42.5)]
         assert self._measure_delay_seconds() == 42.5
 
     @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
-    def test_no_result_returns_none(self, mock_table_rpc) -> None:
+    def test_no_result_returns_none(self, mock_table_rpc: mock.MagicMock) -> None:
         mock_table_rpc.return_value = [self._response(0.0)]  # no result comes back as 0.0
         assert self._measure_delay_seconds() is None
 
     @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
-    def test_empty_response_returns_none(self, mock_table_rpc) -> None:
+    def test_empty_response_returns_none(self, mock_table_rpc: mock.MagicMock) -> None:
         mock_table_rpc.return_value = []
         assert self._measure_delay_seconds() is None
 
     @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
-    def test_measures_all_projects_in_organization(self, mock_table_rpc) -> None:
+    def test_measures_all_projects_in_organization(self, mock_table_rpc: mock.MagicMock) -> None:
         other = self.create_project(organization=self.organization)
         mock_table_rpc.return_value = [self._response(1.0)]
         self._measure_delay_seconds()
@@ -52,6 +52,6 @@ class MeasureDelaySecondsTest(TestCase):
         assert set(request.meta.project_ids) == {self.project.id, other.id}
 
     @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
-    def test_query_failure_does_not_propagate(self, mock_table_rpc) -> None:
+    def test_query_failure_does_not_propagate(self, mock_table_rpc: mock.MagicMock) -> None:
         mock_table_rpc.side_effect = Exception("snuba is down")
         assert self._measure_delay_seconds() is None

--- a/tests/sentry/ingestion_delay/test_query.py
+++ b/tests/sentry/ingestion_delay/test_query.py
@@ -1,0 +1,57 @@
+from datetime import UTC, datetime
+from unittest import mock
+
+from sentry_protos.snuba.v1.request_common_pb2 import TraceItemType
+
+from sentry.ingestion_delay.query import (
+    measure_delay_seconds,
+)
+from sentry.testutils.cases import TestCase
+
+
+class MeasureDelaySecondsTest(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.project
+
+    def _measure_delay_seconds(self):
+        return measure_delay_seconds(
+            organization_id=self.organization.id,
+            item_type=TraceItemType.TRACE_ITEM_TYPE_SPAN,
+            now=datetime.now(tz=UTC),
+        )
+
+    def _response(self, value: float):
+        response = mock.MagicMock()
+        result = mock.MagicMock()
+        result.val_double = value
+        response.column_values = [mock.MagicMock(results=[result])]
+        return response
+
+    @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
+    def test_returns_measured_value(self, mock_table_rpc) -> None:
+        mock_table_rpc.return_value = [self._response(42.5)]
+        assert self._measure_delay_seconds() == 42.5
+
+    @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
+    def test_no_result_returns_none(self, mock_table_rpc) -> None:
+        mock_table_rpc.return_value = [self._response(0.0)]  # no result comes back as 0.0
+        assert self._measure_delay_seconds() is None
+
+    @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
+    def test_empty_response_returns_none(self, mock_table_rpc) -> None:
+        mock_table_rpc.return_value = []
+        assert self._measure_delay_seconds() is None
+
+    @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
+    def test_measures_all_projects_in_organization(self, mock_table_rpc) -> None:
+        other = self.create_project(organization=self.organization)
+        mock_table_rpc.return_value = [self._response(1.0)]
+        self._measure_delay_seconds()
+        request = mock_table_rpc.call_args[0][0][0]
+        assert set(request.meta.project_ids) == {self.project.id, other.id}
+
+    @mock.patch("sentry.ingestion_delay.query.snuba_rpc.table_rpc")
+    def test_query_failure_does_not_propagate(self, mock_table_rpc) -> None:
+        mock_table_rpc.side_effect = Exception("snuba is down")
+        assert self._measure_delay_seconds() is None

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -605,3 +605,64 @@ class OrganizationEventsTimeseriesAnnotationsTest(APITestCase, OutcomesSnubaTest
         )
         assert response.status_code == 200, response.content
         assert response.data["meta"]["annotations"] == []
+
+
+class OrganizationEventsTimeseriesIngestionDelayTest(APITestCase):
+    endpoint = "sentry-api-0-organization-events-timeseries"
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.login_as(user=self.user)
+        self.end = before_now(days=1).replace(minute=0, second=0, microsecond=0)
+        self.start = self.end - timedelta(hours=2)
+        self.url = reverse(
+            self.endpoint,
+            kwargs={"organization_id_or_slug": self.organization.slug},
+        )
+
+    def _do_request(self, features: dict[str, bool], dataset: str = "spans"):
+        data: dict[str, Any] = {
+            "start": self.start,
+            "end": self.end,
+            "interval": "1h",
+            "project": [self.project.id],
+            "dataset": dataset,
+        }
+        with self.feature(features):
+            return self.client.get(self.url, data=data, format="json")
+
+    @mock.patch("sentry.api.helpers.ingestion_delay.measure_delay_seconds")
+    def test_ingestion_delay_present(self, mock_measure) -> None:
+        mock_measure.return_value = 42.5
+        response = self._do_request(
+            {
+                "organizations:visibility-explore-view": True,
+                "organizations:measured-ingestion-delay-metadata": True,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert response.data["meta"]["estimatedIngestionDelaySeconds"] == 42.5
+
+    @mock.patch("sentry.api.helpers.ingestion_delay.measure_delay_seconds")
+    def test_ingestion_delay_absent(self, mock_measure) -> None:
+        mock_measure.return_value = None
+        response = self._do_request(
+            {
+                "organizations:visibility-explore-view": True,
+                "organizations:measured-ingestion-delay-metadata": True,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert "estimatedIngestionDelaySeconds" not in response.data["meta"]
+
+    @mock.patch("sentry.api.helpers.ingestion_delay.measure_delay_seconds")
+    def test_ingestion_delay_query_failure_does_not_break_the_response(self, mock_measure) -> None:
+        mock_measure.side_effect = Exception("snuba is down")
+        response = self._do_request(
+            {
+                "organizations:visibility-explore-view": True,
+                "organizations:measured-ingestion-delay-metadata": True,
+            }
+        )
+        assert response.status_code == 200, response.content
+        assert "estimatedIngestionDelaySeconds" not in response.data["meta"]

--- a/tests/snuba/api/endpoints/test_organization_events_timeseries.py
+++ b/tests/snuba/api/endpoints/test_organization_events_timeseries.py
@@ -620,7 +620,12 @@ class OrganizationEventsTimeseriesIngestionDelayTest(APITestCase):
             kwargs={"organization_id_or_slug": self.organization.slug},
         )
 
-    def _do_request(self, features: dict[str, bool], dataset: str = "spans"):
+    def _do_request(
+        self,
+        features: dict[str, bool],
+        dataset: str = "spans",
+        ingestion_delay: bool = True,
+    ):
         data: dict[str, Any] = {
             "start": self.start,
             "end": self.end,
@@ -628,8 +633,32 @@ class OrganizationEventsTimeseriesIngestionDelayTest(APITestCase):
             "project": [self.project.id],
             "dataset": dataset,
         }
+        if ingestion_delay:
+            data["includeMeasuredIngestionDelayMetadata"] = "1"
         with self.feature(features):
             return self.client.get(self.url, data=data, format="json")
+
+    @mock.patch("sentry.api.helpers.ingestion_delay.measure_delay_seconds")
+    def test_ingestion_delay_absent_without_flag(self, mock_measure) -> None:
+        response = self._do_request({"organizations:visibility-explore-view": True})
+        assert response.status_code == 200, response.content
+        assert "estimatedIngestionDelaySeconds" not in response.data["meta"]
+        # The measurement costs a snuba query, so it must not run when unflagged.
+        assert not mock_measure.called
+
+    @mock.patch("sentry.api.helpers.ingestion_delay.measure_delay_seconds")
+    def test_ingestion_delay_with_flag_but_without_query_param(self, mock_measure) -> None:
+        # Flag on, but the endpoint must not enrich unless the caller opts in.
+        response = self._do_request(
+            {
+                "organizations:visibility-explore-view": True,
+                "organizations:measured-ingestion-delay-metadata": True,
+            },
+            ingestion_delay=False,
+        )
+        assert response.status_code == 200, response.content
+        assert "estimatedIngestionDelaySeconds" not in response.data["meta"]
+        assert not mock_measure.called
 
     @mock.patch("sentry.api.helpers.ingestion_delay.measure_delay_seconds")
     def test_ingestion_delay_present(self, mock_measure) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2385,7 +2385,7 @@ requires-dist = [
     { name = "sentry-kafka-schemas", specifier = ">=2.2.0" },
     { name = "sentry-ophio", specifier = ">=1.1.3" },
     { name = "sentry-options", specifier = ">=1.2.8" },
-    { name = "sentry-protos", specifier = ">=0.67.0" },
+    { name = "sentry-protos", specifier = ">=0.69.0" },
     { name = "sentry-redis-tools", specifier = ">=0.5.0" },
     { name = "sentry-relay", specifier = ">=0.9.28" },
     { name = "sentry-scm", specifier = "==1.5.0" },
@@ -2565,7 +2565,7 @@ wheels = [
 
 [[package]]
 name = "sentry-protos"
-version = "0.67.0"
+version = "0.69.0"
 source = { registry = "https://pypi.devinfra.sentry.io/simple" }
 dependencies = [
     { name = "grpc-stubs", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
@@ -2573,7 +2573,7 @@ dependencies = [
     { name = "protobuf", marker = "sys_platform == 'darwin' or sys_platform == 'linux'" },
 ]
 wheels = [
-    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.67.0-py3-none-any.whl", hash = "sha256:e09a083a630e7e58f5599b9c18ac777305077e066ffb4245721ea603eaed616f" },
+    { url = "https://pypi.devinfra.sentry.io/wheels/sentry_protos-0.69.0-py3-none-any.whl", hash = "sha256:5ae4d39464c75ea3382c76c186fa4da952fad927a9f41230a579e91e809010c7" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds two fields to `/events-timeseries/` meta (behind flag and `includeMeasuredIngestionDelayMetadata` param):

`completeThrough` — the timestamp through which data is believed complete:
- In a `healthy` or `idle` state this is calculated as `now - delay`. 
- In a `stalled` state this becomes the `last_ingested_at` timestamp.
- In an `unknown` state, this cannot be determined and is set to None

`status` — the estimated status of the ingestion pipeline, either `healthy`, `stalled`, `idle`, or `unknown`

`completeThrough` and `status` are determined by checking if there are recently written rows within p99 expected delay and checking outcomes to see if pipelines are truly stalled or if projects are just idle. See the decision tree below:

```mermaid
flowchart TD
    A["EAP query:<br/>p99 delay<br/>max(ingested_at)"] --> E{"Is max(ingested_at)<br/>newer than now - p99 delay?"}
    E -->|"yes — pipeline keeping up"| F["✅ HEALTHY<br/>completeThrough<br/>=<br/>now − delay"]
    E -->|"no, or no rows at all"| G["Outcomes query:<br/>sum(accepted)"]

    G --> J{"Outcomes: was anything<br/>ACCEPTED in that window?"}

    J -->|"query failed"| K["❓ UNKNOWN<br/>completeThrough omitted"]
    J -->|"yes — sent but never landed"| L["🔴 STALLED<br/>completeThrough<br/>=<br/>last write"]
    J -->|"no — nothing was sent"| M["💤 IDLE<br/>completeThrough<br/>=<br/>now − delay"]
```

**note:** this tree makes the assumption that `accepted` outcomes of category `span_indexed`, `log_item`, and `trace_metric` always implies a row being stored. This is true the majority of the time, but there are scenarios where events are dropped even after being `accepted`. We'll make this assumption for now, test, and handle the edge scenarios in follow up refinements.
