### PR TITLE
fix(snuba): Delay status retries and record transport failures

### DIFF
--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -4,7 +4,7 @@ import logging
 import os
 from dataclasses import dataclass
 from functools import partial
-from typing import Protocol, TypeVar
+from typing import Protocol, TypeVar, cast
 
 import sentry_sdk
 import sentry_sdk.scope
@@ -52,11 +52,26 @@ from urllib3.response import BaseHTTPResponse
 
 from sentry.utils import json, metrics
 from sentry.utils.concurrent import ContextPropagatingThreadPoolExecutor
-from sentry.utils.snuba import SnubaError, _snuba_pool
+from sentry.utils.snuba import RetrySkipTimeout, SnubaError, _snuba_pool
 from sentry.utils.tracing import set_span_data, set_span_tag, start_span, trace
 
 logger = logging.getLogger(__name__)
 RPCResponseType = TypeVar("RPCResponseType", bound=ProtobufMessage)
+
+_TRANSIENT_UPSTREAM_STATUS_CODES = frozenset({502, 503})
+_READ_ONLY_RPC_ENDPOINTS = frozenset(
+    {
+        "AttributeValuesRequest",
+        "EndpointExportTraceItems",
+        "EndpointGetTrace",
+        "EndpointGetTraces",
+        "EndpointTimeSeries",
+        "EndpointTraceItemAttributeNames",
+        "EndpointTraceItemDetails",
+        "EndpointTraceItemStats",
+        "EndpointTraceItemTable",
+    }
+)
 
 # Show the snuba query params and the corresponding sql or errors in the server logs
 SNUBA_INFO_FILE = os.environ.get("SENTRY_SNUBA_INFO_FILE", "")
@@ -399,6 +414,43 @@ def export_logs_rpc(req: ExportTraceItemsRequest) -> ExportTraceItemsResponse:
     return response
 
 
+def _retry_policy(endpoint_name: str) -> urllib3.Retry:
+    """Add status retries to safe RPCs while preserving default connection retries."""
+    if endpoint_name not in _READ_ONLY_RPC_ENDPOINTS:
+        return cast(urllib3.Retry, _snuba_pool.retries)
+
+    return RetrySkipTimeout(
+        total=5,
+        status=2,
+        allowed_methods={"POST"},
+        status_forcelist=_TRANSIENT_UPSTREAM_STATUS_CODES,
+        backoff_factor=0.25,
+        backoff_max=1.0,
+        backoff_jitter=0.1,
+        raise_on_status=False,
+        respect_retry_after_header=False,
+    )
+
+
+def _record_status_retry_result(endpoint_name: str, http_resp: BaseHTTPResponse) -> None:
+    retries = getattr(http_resp, "retries", None)
+    history = getattr(retries, "history", ())
+    retry_statuses = [
+        item.status for item in history if item.status in _TRANSIENT_UPSTREAM_STATUS_CODES
+    ]
+    if not retry_statuses:
+        return
+
+    metrics.incr(
+        "snuba_rpc.status_retry.result",
+        tags={
+            "endpoint": endpoint_name,
+            "initial_status": retry_statuses[0],
+            "outcome": "recovered" if http_resp.status in (200, 202) else "exhausted",
+        },
+    )
+
+
 @trace
 def _make_rpc_request(
     endpoint_name: str,
@@ -416,8 +468,9 @@ def _make_rpc_request(
             "debug": debug is not False,
         }
         if isinstance(req, ProtobufMessage) and hasattr(req, "meta"):
-            logger_extra["organization_id"] = req.meta.organization_id
-            logger_extra["trace_item_type"] = req.meta.trace_item_type
+            request_meta = cast(SnubaRPCRequest, req).meta
+            logger_extra["organization_id"] = request_meta.organization_id
+            logger_extra["trace_item_type"] = request_meta.trace_item_type
         if isinstance(debug, str):
             logger_extra["debug_msg"] = debug
         logger.info(
@@ -448,19 +501,15 @@ def _make_rpc_request(
                         "POST",
                         f"/rpc/{endpoint_name}/{class_version}",
                         body=req.SerializeToString(),
-                        headers=(
-                            {
-                                "referer": referrer,
-                            }
-                            if referrer
-                            else {}
-                        ),
+                        headers={"referer": referrer} if referrer else {},
+                        retries=_retry_policy(endpoint_name),
                     )
                 except urllib3.exceptions.HTTPError as err:
                     if isinstance(err, urllib3.exceptions.ReadTimeoutError):
                         metrics.incr("snuba_rpc.read_timeout_error", tags={"referrer": referrer})
                         raise SnubaRPCTimeout(err)
                     raise SnubaRPCError(err)
+                _record_status_retry_result(endpoint_name, http_resp)
                 set_span_tag(span, "timeout", "False")
                 if http_resp.status != 200 and http_resp.status != 202:
                     error = _parse_error(http_resp)

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -434,7 +434,10 @@ def _retry_policy(endpoint_name: str) -> urllib3.Retry:
 
 def _record_status_retry_result(endpoint_name: str, http_resp: BaseHTTPResponse) -> None:
     retries = getattr(http_resp, "retries", None)
-    history = getattr(retries, "history", ())
+    if not isinstance(retries, urllib3.Retry):
+        return
+
+    history = retries.history
     retry_statuses = [
         item.status for item in history if item.status in _TRANSIENT_UPSTREAM_STATUS_CODES
     ]

--- a/src/sentry/utils/snuba_rpc.py
+++ b/src/sentry/utils/snuba_rpc.py
@@ -59,19 +59,7 @@ logger = logging.getLogger(__name__)
 RPCResponseType = TypeVar("RPCResponseType", bound=ProtobufMessage)
 
 _TRANSIENT_UPSTREAM_STATUS_CODES = frozenset({502, 503})
-_READ_ONLY_RPC_ENDPOINTS = frozenset(
-    {
-        "AttributeValuesRequest",
-        "EndpointExportTraceItems",
-        "EndpointGetTrace",
-        "EndpointGetTraces",
-        "EndpointTimeSeries",
-        "EndpointTraceItemAttributeNames",
-        "EndpointTraceItemDetails",
-        "EndpointTraceItemStats",
-        "EndpointTraceItemTable",
-    }
-)
+_STATUS_RETRY_RPC_ENDPOINTS = frozenset({"EndpointTraceItemTable"})
 
 # Show the snuba query params and the corresponding sql or errors in the server logs
 SNUBA_INFO_FILE = os.environ.get("SENTRY_SNUBA_INFO_FILE", "")
@@ -416,12 +404,12 @@ def export_logs_rpc(req: ExportTraceItemsRequest) -> ExportTraceItemsResponse:
 
 def _retry_policy(endpoint_name: str) -> urllib3.Retry:
     """Add status retries to safe RPCs while preserving default connection retries."""
-    if endpoint_name not in _READ_ONLY_RPC_ENDPOINTS:
+    if endpoint_name not in _STATUS_RETRY_RPC_ENDPOINTS:
         return cast(urllib3.Retry, _snuba_pool.retries)
 
     return RetrySkipTimeout(
         total=5,
-        status=2,
+        status=1,
         allowed_methods={"POST"},
         status_forcelist=_TRANSIENT_UPSTREAM_STATUS_CODES,
         backoff_factor=0.25,

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -515,7 +515,7 @@ def test_retries() -> None:
     assert connection_mock.request.call_count == 1
 
 
-def test_retries_transient_status_until_success() -> None:
+def test_retries_transient_status_once_until_success() -> None:
     connection_mock = mock.Mock()
     snuba_pool = FakeConnectionPool(
         connection=connection_mock,
@@ -527,12 +527,11 @@ def test_retries_transient_status_until_success() -> None:
     )
     connection_mock.getresponse.side_effect = [
         HTTPResponse(status=503, body=b"no healthy upstream", headers={}),
-        HTTPResponse(status=503, body=b"no healthy upstream", headers={}),
         HTTPResponse(status=200, body=b"ok", headers={}),
     ]
     retry = RetrySkipTimeout(
         total=5,
-        status=2,
+        status=1,
         status_forcelist={502, 503},
         allowed_methods={"POST"},
         backoff_factor=0,
@@ -542,12 +541,12 @@ def test_retries_transient_status_until_success() -> None:
     response = snuba_pool.urlopen("POST", "/rpc/EndpointTraceItemTable/v1", retries=retry)
 
     assert response.status == 200
-    assert connection_mock.request.call_count == 3
+    assert connection_mock.request.call_count == 2
     assert response.retries is not None
-    assert [item.status for item in response.retries.history] == [503, 503]
+    assert [item.status for item in response.retries.history] == [503]
 
 
-def test_exhausted_status_retries_return_final_response() -> None:
+def test_exhausted_status_retry_returns_final_response() -> None:
     connection_mock = mock.Mock()
     snuba_pool = FakeConnectionPool(
         connection=connection_mock,
@@ -558,11 +557,11 @@ def test_exhausted_status_retries_return_final_response() -> None:
         maxsize=10,
     )
     connection_mock.getresponse.side_effect = [
-        HTTPResponse(status=503, body=b"no healthy upstream", headers={}) for _ in range(3)
+        HTTPResponse(status=503, body=b"no healthy upstream", headers={}) for _ in range(2)
     ]
     retry = RetrySkipTimeout(
         total=5,
-        status=2,
+        status=1,
         status_forcelist={502, 503},
         allowed_methods={"POST"},
         backoff_factor=0,
@@ -572,9 +571,9 @@ def test_exhausted_status_retries_return_final_response() -> None:
     response = snuba_pool.urlopen("POST", "/rpc/EndpointTraceItemTable/v1", retries=retry)
 
     assert response.status == 503
-    assert connection_mock.request.call_count == 3
+    assert connection_mock.request.call_count == 2
     assert response.retries is not None
-    assert [item.status for item in response.retries.history] == [503, 503]
+    assert [item.status for item in response.retries.history] == [503]
 
 
 class SnubaQueryRateLimitTest(TestCase):

--- a/tests/sentry/utils/test_snuba.py
+++ b/tests/sentry/utils/test_snuba.py
@@ -515,6 +515,68 @@ def test_retries() -> None:
     assert connection_mock.request.call_count == 1
 
 
+def test_retries_transient_status_until_success() -> None:
+    connection_mock = mock.Mock()
+    snuba_pool = FakeConnectionPool(
+        connection=connection_mock,
+        host="www.test.com",
+        port=80,
+        retries=False,
+        timeout=30,
+        maxsize=10,
+    )
+    connection_mock.getresponse.side_effect = [
+        HTTPResponse(status=503, body=b"no healthy upstream", headers={}),
+        HTTPResponse(status=503, body=b"no healthy upstream", headers={}),
+        HTTPResponse(status=200, body=b"ok", headers={}),
+    ]
+    retry = RetrySkipTimeout(
+        total=5,
+        status=2,
+        status_forcelist={502, 503},
+        allowed_methods={"POST"},
+        backoff_factor=0,
+        raise_on_status=False,
+    )
+
+    response = snuba_pool.urlopen("POST", "/rpc/EndpointTraceItemTable/v1", retries=retry)
+
+    assert response.status == 200
+    assert connection_mock.request.call_count == 3
+    assert response.retries is not None
+    assert [item.status for item in response.retries.history] == [503, 503]
+
+
+def test_exhausted_status_retries_return_final_response() -> None:
+    connection_mock = mock.Mock()
+    snuba_pool = FakeConnectionPool(
+        connection=connection_mock,
+        host="www.test.com",
+        port=80,
+        retries=False,
+        timeout=30,
+        maxsize=10,
+    )
+    connection_mock.getresponse.side_effect = [
+        HTTPResponse(status=503, body=b"no healthy upstream", headers={}) for _ in range(3)
+    ]
+    retry = RetrySkipTimeout(
+        total=5,
+        status=2,
+        status_forcelist={502, 503},
+        allowed_methods={"POST"},
+        backoff_factor=0,
+        raise_on_status=False,
+    )
+
+    response = snuba_pool.urlopen("POST", "/rpc/EndpointTraceItemTable/v1", retries=retry)
+
+    assert response.status == 503
+    assert connection_mock.request.call_count == 3
+    assert response.retries is not None
+    assert [item.status for item in response.retries.history] == [503, 503]
+
+
 class SnubaQueryRateLimitTest(TestCase):
     def setUp(self) -> None:
         mock_request = Request(

--- a/tests/sentry/utils/test_snuba_rpc.py
+++ b/tests/sentry/utils/test_snuba_rpc.py
@@ -300,10 +300,10 @@ def _http_response(
     return HTTPResponse(status=status, body=body, retries=retries)
 
 
-def test_read_only_rpc_retries_transient_upstream_statuses() -> None:
+def test_table_rpc_retries_transient_upstream_status_once() -> None:
     retry = snuba_rpc._retry_policy("EndpointTraceItemTable")
 
-    assert retry.status == 2
+    assert retry.status == 1
     assert retry.status_forcelist == snuba_rpc._TRANSIENT_UPSTREAM_STATUS_CODES
     assert retry.allowed_methods == frozenset({"POST"})
     assert retry.raise_on_status is False
@@ -314,7 +314,12 @@ def test_read_only_rpc_retries_transient_upstream_statuses() -> None:
 
 @pytest.mark.parametrize(
     "endpoint_name",
-    ["EndpointDeleteTraceItems", "EndpointCreateSubscription", "UnknownEndpoint"],
+    [
+        "EndpointDeleteTraceItems",
+        "EndpointCreateSubscription",
+        "EndpointTimeSeries",
+        "UnknownEndpoint",
+    ],
 )
 def test_mutating_and_unknown_rpcs_do_not_retry_statuses(endpoint_name: str) -> None:
     retry = snuba_rpc._retry_policy(endpoint_name)
@@ -330,7 +335,7 @@ def test_make_rpc_request_passes_retry_policy_for_read_only_rpc() -> None:
         snuba_rpc._make_rpc_request("EndpointTraceItemTable", "v1", _meta().referrer, _request())
 
     retry = urlopen.call_args.kwargs["retries"]
-    assert retry.status == 2
+    assert retry.status == 1
     assert retry.status_forcelist == snuba_rpc._TRANSIENT_UPSTREAM_STATUS_CODES
 
 
@@ -346,6 +351,15 @@ def test_make_rpc_request_disables_status_retries_for_mutating_rpc() -> None:
     retry = urlopen.call_args.kwargs["retries"]
     assert retry is _snuba_pool.retries
     assert retry.status_forcelist == set()
+
+
+def test_retry_observability_ignores_response_without_retry_history() -> None:
+    response = mock.Mock(status=429)
+
+    with mock.patch("sentry.utils.snuba_rpc.metrics.incr") as incr:
+        snuba_rpc._record_status_retry_result("EndpointTraceItemTable", response)
+
+    incr.assert_not_called()
 
 
 def test_make_rpc_request_does_not_retry_read_timeout() -> None:

--- a/tests/sentry/utils/test_snuba_rpc.py
+++ b/tests/sentry/utils/test_snuba_rpc.py
@@ -2,6 +2,7 @@ from typing import Any
 from unittest import mock
 
 import pytest
+import urllib3
 from sentry_protos.snuba.v1.endpoint_create_subscription_pb2 import (
     CreateSubscriptionRequest,
     CreateSubscriptionResponse,
@@ -36,8 +37,11 @@ from sentry_protos.snuba.v1.endpoint_trace_items_pb2 import (
     ExportTraceItemsResponse,
 )
 from sentry_protos.snuba.v1.request_common_pb2 import RequestMeta, TraceItemType
+from urllib3 import HTTPResponse
+from urllib3.exceptions import ReadTimeoutError
 
 from sentry.utils import snuba_rpc
+from sentry.utils.snuba import _snuba_pool
 
 
 def _meta() -> RequestMeta:
@@ -286,6 +290,137 @@ def test_timeseries_rpc_logs_trace_item_type_and_row_count() -> None:
     assert extra["rpc_rows"] == 1
     assert extra["trace_item_type"] == TraceItemType.TRACE_ITEM_TYPE_LOG
     assert mock_distribution.call_args == mock.call("snuba_rpc.timeseries_response.length", 1)
+
+
+def _http_response(
+    status: int,
+    body: bytes = b"",
+    retries: urllib3.Retry | None = None,
+) -> HTTPResponse:
+    return HTTPResponse(status=status, body=body, retries=retries)
+
+
+def test_read_only_rpc_retries_transient_upstream_statuses() -> None:
+    retry = snuba_rpc._retry_policy("EndpointTraceItemTable")
+
+    assert retry.status == 2
+    assert retry.status_forcelist == snuba_rpc._TRANSIENT_UPSTREAM_STATUS_CODES
+    assert retry.allowed_methods == frozenset({"POST"})
+    assert retry.raise_on_status is False
+    assert retry.backoff_factor == 0.25
+    assert retry.backoff_max == 1.0
+    assert retry.backoff_jitter == 0.1
+
+
+@pytest.mark.parametrize(
+    "endpoint_name",
+    ["EndpointDeleteTraceItems", "EndpointCreateSubscription", "UnknownEndpoint"],
+)
+def test_mutating_and_unknown_rpcs_do_not_retry_statuses(endpoint_name: str) -> None:
+    retry = snuba_rpc._retry_policy(endpoint_name)
+
+    assert retry is _snuba_pool.retries
+    assert retry.status_forcelist == set()
+
+
+def test_make_rpc_request_passes_retry_policy_for_read_only_rpc() -> None:
+    response = _http_response(200)
+
+    with mock.patch.object(_snuba_pool, "urlopen", return_value=response) as urlopen:
+        snuba_rpc._make_rpc_request("EndpointTraceItemTable", "v1", _meta().referrer, _request())
+
+    retry = urlopen.call_args.kwargs["retries"]
+    assert retry.status == 2
+    assert retry.status_forcelist == snuba_rpc._TRANSIENT_UPSTREAM_STATUS_CODES
+
+
+def test_make_rpc_request_disables_status_retries_for_mutating_rpc() -> None:
+    response = _http_response(200)
+    request = DeleteTraceItemsRequest(meta=_meta())
+
+    with mock.patch.object(_snuba_pool, "urlopen", return_value=response) as urlopen:
+        snuba_rpc._make_rpc_request(
+            "EndpointDeleteTraceItems", "v1", request.meta.referrer, request
+        )
+
+    retry = urlopen.call_args.kwargs["retries"]
+    assert retry is _snuba_pool.retries
+    assert retry.status_forcelist == set()
+
+
+def test_make_rpc_request_does_not_retry_read_timeout() -> None:
+    timeout = ReadTimeoutError(_snuba_pool, "/rpc/EndpointTraceItemTable/v1", "timeout")
+
+    with (
+        mock.patch.object(_snuba_pool, "urlopen", side_effect=timeout),
+        mock.patch("sentry.utils.snuba_rpc.metrics.incr") as incr,
+        pytest.raises(snuba_rpc.SnubaRPCTimeout),
+    ):
+        snuba_rpc._make_rpc_request("EndpointTraceItemTable", "v1", _meta().referrer, _request())
+
+    incr.assert_called_once_with("snuba_rpc.read_timeout_error", tags={"referrer": "test.referrer"})
+
+
+def test_records_recovered_status_retry() -> None:
+    retry = urllib3.Retry(total=2, status=2, status_forcelist={503}, allowed_methods={"POST"})
+    retry = retry.increment(
+        method="POST",
+        url="/rpc/EndpointTraceItemTable/v1",
+        response=_http_response(503),
+    )
+    response = _http_response(200, retries=retry)
+
+    with mock.patch("sentry.utils.snuba_rpc.metrics.incr") as incr:
+        snuba_rpc._record_status_retry_result("EndpointTraceItemTable", response)
+
+    incr.assert_called_once_with(
+        "snuba_rpc.status_retry.result",
+        tags={
+            "endpoint": "EndpointTraceItemTable",
+            "initial_status": 503,
+            "outcome": "recovered",
+        },
+    )
+
+
+def test_records_exhausted_status_retries() -> None:
+    retry = urllib3.Retry(total=2, status=2, status_forcelist={503}, allowed_methods={"POST"})
+    for _ in range(2):
+        retry = retry.increment(
+            method="POST",
+            url="/rpc/EndpointTraceItemTable/v1",
+            response=_http_response(503),
+        )
+    response = _http_response(503, body=b"no healthy upstream", retries=retry)
+
+    with mock.patch("sentry.utils.snuba_rpc.metrics.incr") as incr:
+        snuba_rpc._record_status_retry_result("EndpointTraceItemTable", response)
+
+    incr.assert_called_once_with(
+        "snuba_rpc.status_retry.result",
+        tags={
+            "endpoint": "EndpointTraceItemTable",
+            "initial_status": 503,
+            "outcome": "exhausted",
+        },
+    )
+
+
+def test_plain_text_upstream_error_is_preserved() -> None:
+    response = _http_response(503, body=b"no healthy upstream")
+
+    with pytest.raises(
+        snuba_rpc.SnubaRPCError,
+        match="Snuba RPC returned HTTP 503: no healthy upstream",
+    ):
+        snuba_rpc._parse_error(response)
+
+
+def test_non_transient_status_is_not_retried() -> None:
+    retry = snuba_rpc._retry_policy("EndpointTraceItemTable")
+
+    assert retry.is_retry("POST", 429) is False
+    assert retry.is_retry("POST", 504) is False
 
 
 def test_create_subscription_logs_response() -> None:


### PR DESCRIPTION
Retry 502 and 503 responses from `EndpointTraceItemTable` once, after a random delay of 250 to 350 ms. These queries are read-only, so a retry is safe and may recover from a brief upstream
failure.

This only changes table RPCs. Other RPCs keep their existing retry behavior. We don't retry 429, 504, or read timeouts for table queries, and the status retry counts against the existing
connection-retry budget.

We handle the status retry ourselves because urllib3 doesn't apply backoff or jitter to the first retry. With one retry, those settings would never delay it.

The `snuba_rpc.status_retry.result` metric records the endpoint, initial status, and outcome. A retry that ends in a timeout or connection error counts as `exhausted`, rather than disappearing
from the results.

Tests cover the delay, recovery, failed retries, and retry limits through urllib3's connection pool.
